### PR TITLE
Fix for issue 65 : On import, match master to newest data, not oldest.  ...

### DIFF
--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -745,7 +745,7 @@ def handle_results(results, b_idx, can_rev_idx, unmatched_list, user_pk):
     building_pk = unmatched_list[b_idx][0]  # First element is PK
 
     bs = save_snapshot_match(
-        can_snap_pk, building_pk, confidence=confidence, match_type=match_type
+        can_snap_pk, building_pk, confidence=confidence, match_type=match_type, default_pk=building_pk
     )
     canon = bs.canonical_building
     AuditLog.objects.create(
@@ -839,7 +839,8 @@ def handle_id_matches(unmatched_bs, import_file, user_pk):
             unmatched_bs.pk,
             confidence=0.9,  # TODO(gavin) represent conf better.
             match_type=SYSTEM_MATCH,
-            user=import_file.import_record.owner
+            user=import_file.import_record.owner,
+            default_pk=unmatched_bs.pk
         )
         canon = unmatched_bs.canonical_building
         canon.canonical_snapshot = unmatched_bs

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -798,7 +798,7 @@ def save_match(request):
 
     if create:
         child_id = save_snapshot_match(
-            b1_pk, b2_pk, user=request.user, match_type=2
+            b1_pk, b2_pk, user=request.user, match_type=2, default_pk=b2_pk
         )
         child_id = child_id.pk
         cb = CanonicalBuilding.objects.get(buildingsnapshot__id=child_id)


### PR DESCRIPTION
...Changed save_snapshot_match in models.py to have a default_pk parameter and use that as the default.  Modified test_save_snapshot_match to perform two tests one with the first building as default and one with the second.  Changed existing calls to save_snapshot_match to specify the second building as the default.