### PR TITLE
Fix for issue where some records may have leading zeros in address causing match to fail.

### DIFF
--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -888,7 +888,7 @@ def _normalize_address_str(address_val):
         return None
 
     if 'house' in addr and addr['house'] is not None:
-        normalized_address = addr['house']
+        normalized_address = addr['house'].lstrip("0") #some addresses have leading zeros, strip them here
 
     if 'street_name' in addr and addr['street_name'] is not None:
         normalized_address = normalized_address + ' ' + addr['street_name']

--- a/seed/tests/test_matching.py
+++ b/seed/tests/test_matching.py
@@ -31,4 +31,13 @@ class NormalizeStreetAddressTest(TestCase):
     def test_integer_address(self):
         normalized_addr = _normalize_address_str(123)
         self.assertEqual('123', normalized_addr)
-
+    
+    def test_strip_leading_zeros(self):
+        """
+        Some of the addresses we receive have leading zeros.
+        E.G. 240102 N Hazel Alley might be 0000240102 N Hazel Alley
+        This tests the change to _normaliz
+        """
+        normalized_addr = _normalize_address_str("0000123")
+        self.assertEqual(normalized_addr, "123")
+        


### PR DESCRIPTION
There was an issue with some addresses having leading zeros.  After talking with Robin added a change to _normalize_address_str to do a lstrip(0) on the house field to remove leading zeros from the normalized address.  Leading zeros still appear in building data just not used for matching.  Added a test to test_strip_leading_zeros to test for this: test_strip_leading_zeros