### PR TITLE
Fix for Issue 169 (problem with importing files with superscripts in header) 

### DIFF
--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -641,6 +641,7 @@ def cache_first_rows(import_file, parser):
         first_row = local_reader.sheet.row_values(local_reader.header_row)        
     elif isinstance(local_reader, reader.CSVParser):
         first_row = local_reader.csvreader.fieldnames        
+        first_row = [local_reader._clean_super(x) for x in first_row]
     else:
         #default to the original behavior if a new type of parser for lack of anything better
         first_row = rows.next().keys()


### PR DESCRIPTION
 MCM parser is doing some processing behind the scenes to replace superscripts.  So when I replaced the code that iterated through the (modified) headers that each row in the parser has with code that uses the original header those original headers had some differences causing a lookup error.  Added a call to the same processing so that now column names from the file are still in file order but have been processed the same so their names agree with the headers for each row again.