### PR TITLE
Add formatter for normalized address to compare abbreviations.

### DIFF
--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -29,7 +29,7 @@ from mcm.data.ESPM import espm as espm_schema
 from mcm.data.SEED import seed as seed_schema
 from mcm.utils import batch
 # import ngram
-from streetaddress import StreetAddressParser
+from streetaddress import StreetAddressParser, StreetAddressFormatter
 
 from data_importer.models import (
     ImportFile, ImportRecord, STATUS_READY_TO_MERGE, ROW_DELIMITER
@@ -912,6 +912,9 @@ def _normalize_address_str(address_val):
     if 'street_type' in addr and addr['street_type'] is not None:
         normalized_address = normalized_address + ' ' + addr['street_type']
 
+    formatter = StreetAddressFormatter()
+    normalized_address = formatter.abbrev_street_avenue_etc(normalized_address)
+ 
     return normalized_address.lower().strip()
 
 

--- a/seed/tests/test_matching.py
+++ b/seed/tests/test_matching.py
@@ -41,3 +41,20 @@ class NormalizeStreetAddressTest(TestCase):
         normalized_addr = _normalize_address_str("0000123")
         self.assertEqual(normalized_addr, "123")
         
+        
+    def test_abbrev_street_types(self):
+        """
+	Catches the spelled out street types e.g., "Street" == "St"  
+	"""
+
+	normalized_addr = _normalize_address_str("STREET")
+        self.assertEqual(normalized_addr, "st")
+	
+        normalized_addr = _normalize_address_str("Street")
+        self.assertEqual(normalized_addr, "st")
+
+	normalized_addr = _normalize_address_str("Boulevard")
+        self.assertEqual(normalized_addr, "blvd")
+	
+        normalized_addr = _normalize_address_str("avenue")
+        self.assertEqual(normalized_addr, "ave")


### PR DESCRIPTION
Formats address to use the abbreviated street type names, e.g. "Street" to "St". 
As described in pull request [https://github.com/SEED-platform/seed/pull/163], also see Issue[https://github.com/SEED-platform/seed/issues/25].