### PR TITLE
Issue #20 - Exact and empty matching on search fields.

### DIFF
--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -625,6 +625,120 @@ class SearchViewTests(TestCase):
         self.assertEqual(data['buildings'][1]['year_built'], 6)
         self.assertEqual(data['buildings'][2]['year_built'], 7)
 
+    def test_search_exact_match(self):
+        """
+        Tests search_buidlings method when called with an exact match.
+        """
+
+        # Uppercase address
+        cb1 = CanonicalBuilding(active=True)
+        cb1.save()
+        b1 = SEEDFactory.building_snapshot(
+            canonical_building=cb1,
+            address_line_1="Address"
+        )
+        cb1.canonical_snapshot = b1
+        cb1.save()
+        b1.super_organization = self.org
+        b1.save()
+
+        # Lowercase address
+        cb2 = CanonicalBuilding(active=True)
+        cb2.save()
+        b2 = SEEDFactory.building_snapshot(
+            canonical_building=cb2,
+            address_line_1="address"
+        )
+        cb2.canonical_snapshot = b2
+        cb2.save()
+        b2.super_organization = self.org
+        b2.save()
+
+        url = reverse_lazy("seed:search_buildings")
+        post_data = {
+            'filter_params': {
+                'address_line_1': '"Address"'
+            },
+            'number_per_page': 10,
+            'order_by': '',
+            'page': 1,
+            'q': '',
+            'sort_reverse': False,
+            'project_id': None,
+        }
+
+        # act
+        response = self.client.post(
+            url,
+            content_type='application/json',
+            data=json.dumps(post_data)
+        )
+        json_string = response.content
+        data = json.loads(json_string)
+
+        # assert
+        self.assertEqual(data['status'], 'success')
+        self.assertEqual(data['number_matching_search'], 1)
+        self.assertEqual(len(data['buildings']), 1)
+        self.assertEqual(data['buildings'][0]['address_line_1'], 'Address')
+
+    def test_search_empty_column(self):
+        """
+        Tests search_buidlings method when called with an empty column query.
+        """
+
+        # Empty column
+        cb1 = CanonicalBuilding(active=True)
+        cb1.save()
+        b1 = SEEDFactory.building_snapshot(
+            canonical_building=cb1,
+            address_line_1=""
+        )
+        cb1.canonical_snapshot = b1
+        cb1.save()
+        b1.super_organization = self.org
+        b1.save()
+
+        # Populated column
+        cb2 = CanonicalBuilding(active=True)
+        cb2.save()
+        b2 = SEEDFactory.building_snapshot(
+            canonical_building=cb2,
+            address_line_1="Address"
+        )
+        cb2.canonical_snapshot = b2
+        cb2.save()
+        b2.super_organization = self.org
+        b2.save()
+
+        url = reverse_lazy("seed:search_buildings")
+        post_data = {
+            'filter_params': {
+                'address_line_1': '""'
+            },
+            'number_per_page': 10,
+            'order_by': '',
+            'page': 1,
+            'q': '',
+            'sort_reverse': False,
+            'project_id': None,
+        }
+
+        # act
+        response = self.client.post(
+            url,
+            content_type='application/json',
+            data=json.dumps(post_data)
+        )
+        json_string = response.content
+        data = json.loads(json_string)
+
+        # assert
+        self.assertEqual(data['status'], 'success')
+        self.assertEqual(data['number_matching_search'], 1)
+        self.assertEqual(len(data['buildings']), 1)
+        self.assertEqual(data['buildings'][0]['address_line_1'], '')
+        self.assertEqual(data['buildings'][0]['pk'], b1.pk)
 
     def test_apply_label_to_project_buildings(self):
         """


### PR DESCRIPTION
Allow matching of exact queries by surrounding them in quotes. Allow matching for empty fields by supplying an empty `""` as the search query.

Fixes #20  