### PR TITLE
Issue #12 - Save building sort column and order in sessionStorage

### DIFF
--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -66,6 +66,7 @@ angular.module('BE.seed.controller.building_list', [])
      */
     var get_columns = function() {
         $scope.assessor_fields = all_columns.fields;
+        $scope.search.init_storage();
         $scope.columns = $scope.search.generate_columns(
             all_columns.fields,
             default_columns.columns,

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -256,8 +256,16 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                 'search_payload': ['building_services', '$route', function(building_services, $route){
                     var params = $route.current.params;
                     var q = params.q || "";
+
+                    // Check session storage for order and sort values.
+                    var orderBy = (typeof(Storage) !== "undefined" && sessionStorage.getItem('seedBuildingOrderBy') !== null) ?
+                        sessionStorage.getItem('seedBuildingOrderBy') : "";
+
+                    var sortReverse = (typeof(Storage) !== "undefined" && sessionStorage.getItem('seedBuildingSortReverse') !== null) ?
+                        JSON.parse(sessionStorage.getItem('seedBuildingSortReverse')) : false;
+
                     // params: (query, number_per_page, page_number, order_by, sort_reverse, other_params, project_id)
-                    return building_services.search_buildings(q, 10, 1, "", false, params, null);
+                    return building_services.search_buildings(q, 10, 1, orderBy, sortReverse, params, null);
                 }],
                 'default_columns': ['user_service', function(user_service){
                     return user_service.get_default_columns();

--- a/seed/static/seed/js/services/search_service.js
+++ b/seed/static/seed/js/services/search_service.js
@@ -78,6 +78,18 @@ angular.module('BE.seed.service.search', [])
      * functions
      */
 
+    search_service.init_storage = function () {
+        // Check session storage for order and sort values.
+        if (typeof(Storage) !== "undefined" && sessionStorage.getItem('seedBuildingOrderBy') !== null) {
+            saas.order_by = sessionStorage.getItem('seedBuildingOrderBy');
+            saas.sort_column = sessionStorage.getItem('seedBuildingOrderBy');
+        }
+
+        if (typeof(Storage) !== "undefined" && sessionStorage.getItem('seedBuildingSortReverse') !== null) {
+            saas.sort_reverse = JSON.parse(sessionStorage.getItem('seedBuildingSortReverse'));
+        }
+    };
+
     /**
      * sanitize_params: removes filter params with null or undefined values
      */
@@ -306,6 +318,12 @@ angular.module('BE.seed.service.search', [])
                     saas.sort_column = this.sort_column;
                 }
             }
+
+            if (typeof(Storage) !== "undefined") {
+                sessionStorage.setItem('seedBuildingOrderBy', saas.sort_column);
+                sessionStorage.setItem('seedBuildingSortReverse', saas.sort_reverse);
+            }
+
             saas.order_by = this.sort_column;
             saas.current_page = 1;
             saas.search_buildings();


### PR DESCRIPTION
Save the building sort column and sort order selections in sessionStorage, so they aren't lost when navigating back and forth between building list and detail views.

Refs #12 
