### PR TITLE
Making the progress API backwards compatible

### DIFF
--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -1930,6 +1930,9 @@ def progress(request):
 
     if cache.get(progress_key):
         result = cache.get(progress_key)
+        # The following if statement can be removed once all progress endpoints have been updated to the new json syntax
+        if type(result) != dict:
+            result = {'progress': result}
         result['progress_key'] = progress_key
         return result
     else:


### PR DESCRIPTION
@RDmitchell 

I didn't previously notice our changes affecting the progress requests of any actions other than uploading, but this change will allow any functions expecting the old format to continue to function.

Basically, the cache previously stored only a number to represent progress, e.g. 100, but now it stores a dictionary in order to communicate additional information asynchronously to the front end.  This change allows it to continue to accept ints or floats for the time being.

Fixes #232 