### PR TITLE
Issue #12 - Save building filter params in sessionStorage

### DIFF
--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -254,17 +254,26 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
             templateUrl: static_url + 'seed/partials/buildings.html',
             resolve: {
                 'search_payload': ['building_services', '$route', function(building_services, $route){
-                    var params = $route.current.params;
-                    var q = params.q || "";
+                    // Defaults
+                    var q = $route.current.params.q || "";
+                    var orderBy = "";
+                    var sortReverse = false;
+                    var params = {};
 
-                    // Check session storage for order and sort values.
-                    var orderBy = (typeof(Storage) !== "undefined" && sessionStorage.getItem('seedBuildingOrderBy') !== null) ?
-                        sessionStorage.getItem('seedBuildingOrderBy') : "";
+                    // Check session storage for order, sort, and filter values.
+                    if (typeof(Storage) !== "undefined") {
+                        if (sessionStorage.getItem('seedBuildingOrderBy') !== null) {
+                            orderBy = sessionStorage.getItem('seedBuildingOrderBy');
+                        }
+                        if (sessionStorage.getItem('seedBuildingSortReverse') !== null) {
+                            sortReverse = JSON.parse(sessionStorage.getItem('seedBuildingSortReverse'));
+                        }
+                        if (sessionStorage.getItem('seedBuildingFilterParams') !== null) {
+                            params = JSON.parse(sessionStorage.getItem('seedBuildingFilterParams'));
+                        }
+                    }
 
-                    var sortReverse = (typeof(Storage) !== "undefined" && sessionStorage.getItem('seedBuildingSortReverse') !== null) ?
-                        JSON.parse(sessionStorage.getItem('seedBuildingSortReverse')) : false;
-
-                    // params: (query, number_per_page, page_number, order_by, sort_reverse, other_params, project_id)
+                    // params: (query, number_per_page, page_number, order_by, sort_reverse, filter_params, project_id)
                     return building_services.search_buildings(q, 10, 1, orderBy, sortReverse, params, null);
                 }],
                 'default_columns': ['user_service', function(user_service){

--- a/seed/static/seed/js/services/search_service.js
+++ b/seed/static/seed/js/services/search_service.js
@@ -80,13 +80,19 @@ angular.module('BE.seed.service.search', [])
 
     search_service.init_storage = function () {
         // Check session storage for order and sort values.
-        if (typeof(Storage) !== "undefined" && sessionStorage.getItem('seedBuildingOrderBy') !== null) {
-            saas.order_by = sessionStorage.getItem('seedBuildingOrderBy');
-            saas.sort_column = sessionStorage.getItem('seedBuildingOrderBy');
-        }
+        if (typeof(Storage) !== "undefined") {
+            if (sessionStorage.getItem('seedBuildingOrderBy') !== null){
+                saas.order_by = sessionStorage.getItem('seedBuildingOrderBy');
+                saas.sort_column = sessionStorage.getItem('seedBuildingOrderBy');
+            }
 
-        if (typeof(Storage) !== "undefined" && sessionStorage.getItem('seedBuildingSortReverse') !== null) {
-            saas.sort_reverse = JSON.parse(sessionStorage.getItem('seedBuildingSortReverse'));
+            if (sessionStorage.getItem('seedBuildingSortReverse') !== null) {
+                saas.sort_reverse = JSON.parse(sessionStorage.getItem('seedBuildingSortReverse'));
+            }
+
+            if (sessionStorage.getItem('seedBuildingFilterParams') !== null) {
+                saas.filter_params = JSON.parse(sessionStorage.getItem('seedBuildingFilterParams'));
+            }
         }
     };
 
@@ -171,8 +177,11 @@ angular.module('BE.seed.service.search', [])
      * filter_search: triggerd when a filter param changes
      */
     search_service.filter_search = function() {
-       this.current_page = 1;
-       this.search_buildings();
+        this.current_page = 1;
+        this.search_buildings();
+        if (typeof(Storage) !== "undefined") {
+            sessionStorage.setItem('seedBuildingFilterParams', JSON.stringify(this.filter_params));
+        }
     };
 
 


### PR DESCRIPTION
Builds off of PR #222 

Save the building filter parameters in sessionStorage, so they aren't lost when navigating back and forth between building list and detail views.

Refs #12