### PR TITLE
Fixing MCM and progress cache test failures

### DIFF
--- a/mcm/tests/test_reader.py
+++ b/mcm/tests/test_reader.py
@@ -3,6 +3,7 @@
 """
 from unittest import TestCase
 
+import os
 import unicodecsv
 
 from mcm import reader
@@ -11,7 +12,8 @@ from mcm.tests import utils
 
 class TestCSVParser(TestCase):
     def setUp(self):
-        self.csv_f = open('test_data/test_espm.csv', 'rb')
+        test_file = os.path.dirname(os.path.realpath(__file__)) + '/test_data/test_espm.csv'
+        self.csv_f = open(test_file, 'rb')
         self.parser = reader.CSVParser(self.csv_f)
 
     def tearDown(self):
@@ -52,7 +54,8 @@ class TestCSVParser(TestCase):
 
 class TestMCMParserCSV(TestCase):
     def setUp(self):
-        self.csv_f = open('test_data/test_espm.csv', 'rb')
+        test_file = os.path.dirname(os.path.realpath(__file__)) + '/test_data/test_espm.csv'
+        self.csv_f = open(test_file, 'rb')
         self.parser = reader.MCMParser(self.csv_f)
         self.total_callbacks = 0
 
@@ -83,13 +86,14 @@ class TestMCMParserCSV(TestCase):
         # There's always at least one batch per file.
         self.assertEqual(self.total_callbacks, 1)
 
-    def test_num_colums(self):
+    def test_num_columns(self):
         self.assertEqual(self.parser.num_columns(), 250)
 
 
 class TestMCMParserXLS(TestCase):
     def setUp(self):
-        self.xls_f = open('test_data/test_espm.xls', 'rb')
+        test_file = os.path.dirname(os.path.realpath(__file__)) + '/test_data/test_espm.xls'
+        self.xls_f = open(test_file, 'rb')
         self.parser = reader.MCMParser(self.xls_f)
         self.total_callbacks = 0
 
@@ -120,13 +124,14 @@ class TestMCMParserXLS(TestCase):
         # There's always at least one batch per file.
         self.assertEqual(self.total_callbacks, 1)
 
-    def test_num_colums(self):
+    def test_num_columns(self):
         self.assertEqual(self.parser.num_columns(), 250)
 
 
 class TestMCMParserXLSX(TestCase):
     def setUp(self):
-        self.xlsx_f = open('test_data/test_espm.xlsx', 'rb')
+        test_file = os.path.dirname(os.path.realpath(__file__)) + '/test_data/test_espm.xlsx'
+        self.xlsx_f = open(test_file, 'rb')
         self.parser = reader.MCMParser(self.xlsx_f)
         self.total_callbacks = 0
 
@@ -157,5 +162,5 @@ class TestMCMParserXLSX(TestCase):
         # There's always at least one batch per file.
         self.assertEqual(self.total_callbacks, 1)
 
-    def test_num_colums(self):
+    def test_num_columns(self):
         self.assertEqual(self.parser.num_columns(), 250)

--- a/seed/tests/test_decorators.py
+++ b/seed/tests/test_decorators.py
@@ -38,19 +38,19 @@ class TestDecorators(TestCase):
         increment = 25.0
         # Fresh increment, this initializes the value.
         decorators.increment_cache(test_key, increment)
-        self.assertEqual(float(cache.get(test_key)), expected)
+        self.assertEqual(float(cache.get(test_key)['progress']), expected)
 
         # Increment an existing key
         decorators.increment_cache(test_key, increment)
         expected = 50.0
-        self.assertEqual(float(cache.get(test_key)), expected)
+        self.assertEqual(float(cache.get(test_key)['progress']), expected)
 
         # This should put us well over 100.0 in incrementation w/o bounds check.
         for i in range(10):
             decorators.increment_cache(test_key, increment)
 
         expected = 100.0
-        self.assertEqual(float(cache.get(test_key)), expected)
+        self.assertEqual(float(cache.get(test_key)['progress']), expected)
 
     #
     ## Tests for decorators themselves.
@@ -94,4 +94,4 @@ class TestDecorators(TestCase):
 
         fake_func(self.pk)
 
-        self.assertEqual(float(cache.get(key, 0.0)), expected)
+        self.assertEqual(float(cache.get(key, 0.0)['progress']), expected)


### PR DESCRIPTION
This updates the MCM tests to correctly locate the test files, and updates the progress cache tests