### PR TITLE
Fix for issue #51(plus a fix to search.py)

### DIFF
--- a/seed/search.py
+++ b/seed/search.py
@@ -158,7 +158,7 @@ def is_not_whitelist_building(parent_org, building, whitelist_orgs):
     """
     return (parent_org and building.super_organization not in whitelist_orgs)
 
-import pdb
+
 def filter_other_params(queryset, other_params, db_columns):
     """applyes a dictionary filter to the query set. Does some domain specific
     parsing,
@@ -224,9 +224,7 @@ def filter_other_params(queryset, other_params, db_columns):
             else:
                 query_filters &= Q(**{"%s__icontains" % k: v})
 
-    
     queryset = queryset.filter(query_filters)
-    
 
     # handle extra_data with json_query
     for k, v in other_params.iteritems():
@@ -272,7 +270,6 @@ def filter_other_params(queryset, other_params, db_columns):
 
             queryset = queryset.json_query(k, **conditions)
 
-    
     return queryset
 
 

--- a/seed/search.py
+++ b/seed/search.py
@@ -158,7 +158,7 @@ def is_not_whitelist_building(parent_org, building, whitelist_orgs):
     """
     return (parent_org and building.super_organization not in whitelist_orgs)
 
-
+import pdb
 def filter_other_params(queryset, other_params, db_columns):
     """applyes a dictionary filter to the query set. Does some domain specific
     parsing,
@@ -204,8 +204,8 @@ def filter_other_params(queryset, other_params, db_columns):
     query_filters = Q()
     for k, v in other_params.iteritems():
         in_columns = is_column(k, db_columns)
-        if in_columns and k != 'q' and v:
-
+        #if in_columns and k != 'q' and v:
+        if in_columns and k != 'q' and v is not None:
             # Is this query surrounded by matching quotes?
             exact_match = is_exact_match(v)
             empty_match = is_empty_match(v)
@@ -224,7 +224,9 @@ def filter_other_params(queryset, other_params, db_columns):
             else:
                 query_filters &= Q(**{"%s__icontains" % k: v})
 
+    
     queryset = queryset.filter(query_filters)
+    
 
     # handle extra_data with json_query
     for k, v in other_params.iteritems():
@@ -270,6 +272,7 @@ def filter_other_params(queryset, other_params, db_columns):
 
             queryset = queryset.json_query(k, **conditions)
 
+    
     return queryset
 
 

--- a/seed/static/seed/js/controllers/matching_controller.js
+++ b/seed/static/seed/js/controllers/matching_controller.js
@@ -93,27 +93,53 @@ angular.module('BE.seed.controller.matching', [])
         );
     };
 
+
      $scope.closeAlert = function(index) {
         $scope.alerts.splice(index, 1);
     };
 
-    $scope.filter_by_matched = function() {
-        // only show matched buildings
-        $scope.filter_params.children__isnull = false;
+    /**
+    *  Code for filter dropdown
+    */
+
+    var SHOW_ALL = "Show All";
+    var SHOW_MATCHED = "Show Matched";
+    var SHOW_UNMATCHED = "Show Unmatched";
+
+    $scope.filter_options = [
+        {id:SHOW_ALL, value:SHOW_ALL},
+        {id:SHOW_MATCHED, value:SHOW_MATCHED},
+        {id:SHOW_UNMATCHED, value:SHOW_UNMATCHED}
+    ];
+
+    $scope.filter_selection = {selected: SHOW_ALL};     //default setting
+
+    $scope.update_show_filter = function(optionValue) {
+
+        switch(optionValue){
+            case SHOW_ALL:               
+                $scope.filter_params.children__isnull = undefined;
+                break;
+            case SHOW_MATCHED:
+                $scope.filter_params.children__isnull = false;  //has children therefore is matched               
+                break;
+            case SHOW_UNMATCHED:
+                $scope.filter_params.children__isnull = true;   //does not have children therefore is unmatched
+                break;
+            default:
+                $log.error("#matching_controller: unexpected filter value: ", optionValue);
+                return;
+        }
+
         $scope.current_page = 1;
         $scope.filter_search();
-    };
 
-    $scope.filter_by_unmatched = function() {
-        // only show unmatched buildings
-        $scope.current_page = 1;
-        $scope.filter_params.children__isnull = true;
-        $scope.filter_search();
-    };
+    }
 
-     /**
-     * Pagination code
-     */
+
+    /**
+    * Pagination code
+    */
     $scope.pagination.update_number_per_page = function() {
         $scope.number_per_page = $scope.pagination.number_per_page_options_model;
         $scope.filter_search();

--- a/seed/static/seed/partials/matching_list_table.html
+++ b/seed/static/seed/partials/matching_list_table.html
@@ -1,5 +1,5 @@
 <div class="section_content_container">
-        <div class="section_content with_padding">
+        <div class="section_content">
             <div class="table_list_container matching" ng-cloak>
                 <table class="table table-striped">
                     <thead>

--- a/seed/static/seed/partials/matching_list_table.html
+++ b/seed/static/seed/partials/matching_list_table.html
@@ -1,5 +1,5 @@
 <div class="section_content_container">
-        <div class="section_content">
+        <div class="section_content with_padding">
             <div class="table_list_container matching" ng-cloak>
                 <table class="table table-striped">
                     <thead>
@@ -14,13 +14,33 @@
                                         <div class="form-group">
 
                                             <div class="col-sm-10 matching_toggle">
+
+                                                 <select    id="showHideFilterSelect" 
+                                                            ng-init="filter_options.selected = filter_options[0].id"
+                                                            ng-model="filter_options.selected" 
+                                                            ng-options="option.id as option.value for option in filter_options"
+                                                            ng-change="update_show_filter(filter_options.selected)">
+                                                </select>
+
+                                                <!--
+                                                <select ng-model="show_filter_selection" ng-change="update_show_filter()">                                                
+                                                  <option value="0">Show All</option>
+                                                  <option value="1">Show Matched</option>
+                                                  <option value="2">Show Unmatched</option>
+                                                </select>
+                                                -->
+
+                                                <!--
                                                 <label class="radio-inline" ng-click="filter_by_unmatched()">
                                                     <input type="radio" name="matchingRadios" id="matchingRadios1" value="unmatched"> <strong>{$ unmatched_buildings $}</strong> Unmatched
                                                 </label>
                                                 <label class="radio-inline" ng-click="filter_by_matched()">
                                                     <input type="radio" name="matchingRadios" id="matchingRadios2" value="matched"> <strong>{$ matched_buildings $}</strong> Matched
                                                 </label>
+                                                -->
                                             </div>
+
+
                                         </div>
                                     </form>
                                 </div>

--- a/seed/static/seed/partials/matching_list_table.html
+++ b/seed/static/seed/partials/matching_list_table.html
@@ -9,13 +9,17 @@
                                     <form class="form-inline" role="form">
                                         <div class="form-group">
                                             <label class="control-label">File Source:</label>
-                                            <select ng-model="file_select.file" ng-options="f.name for f in import_file.dataset.importfiles" ng-change="filter_search()"></select>
+                                            <select     ng-model="file_select.file" 
+                                                        ng-options="f.name for f in import_file.dataset.importfiles" 
+                                                        class="form-control" 
+                                                        ng-change="filter_search()"></select>
                                         </div>
                                         <div class="form-group">
 
                                             <div class="col-sm-10 matching_toggle">
 
                                                  <select    id="showHideFilterSelect" 
+                                                            class="form-control" 
                                                             ng-init="filter_options.selected = filter_options[0].id"
                                                             ng-model="filter_options.selected" 
                                                             ng-options="option.id as option.value for option in filter_options"

--- a/seed/static/seed/partials/matching_list_table.html
+++ b/seed/static/seed/partials/matching_list_table.html
@@ -22,22 +22,6 @@
                                                             ng-change="update_show_filter(filter_options.selected)">
                                                 </select>
 
-                                                <!--
-                                                <select ng-model="show_filter_selection" ng-change="update_show_filter()">                                                
-                                                  <option value="0">Show All</option>
-                                                  <option value="1">Show Matched</option>
-                                                  <option value="2">Show Unmatched</option>
-                                                </select>
-                                                -->
-
-                                                <!--
-                                                <label class="radio-inline" ng-click="filter_by_unmatched()">
-                                                    <input type="radio" name="matchingRadios" id="matchingRadios1" value="unmatched"> <strong>{$ unmatched_buildings $}</strong> Unmatched
-                                                </label>
-                                                <label class="radio-inline" ng-click="filter_by_matched()">
-                                                    <input type="radio" name="matchingRadios" id="matchingRadios2" value="matched"> <strong>{$ matched_buildings $}</strong> Matched
-                                                </label>
-                                                -->
                                             </div>
 
 


### PR DESCRIPTION
This series of commits implement a drop-down component (i.e. select element) on the "matching" page. 
Included is a fix for a method in search.py, which was preventing the filter from working correctly (regardless of whether we used the old radio buttons or new pulldown).

Also included is a series of tests added to the units tests for the controller in matching_controller.spec.js. These three tests exercise the update_show_filter function in the controller. I'm not sure yet how to write an integration test to actually update the pulldown directly in the UI and confirm the resulting data shown on the page.