### PR TITLE
Issue 247 - Rework of JSON Blob extra_data field

### DIFF
--- a/seed/lib/mcm/mapper.py
+++ b/seed/lib/mcm/mapper.py
@@ -179,7 +179,7 @@ def map_row(row, mapping, model_class, cleaner=None, concat=None, **kwargs):
         # then, send_apply_func will reference this function and be sent
         # to the ``apply_column_value`` function.
         send_apply_func = apply_func if item in apply_columns else None
-        if value and value != '':
+        if value != None:
             model = apply_column_value(
                 item, value, model, mapping, cleaner,
                 apply_func=send_apply_func

--- a/seed/lib/mcm/tests/test_mapper.py
+++ b/seed/lib/mcm/tests/test_mapper.py
@@ -66,8 +66,7 @@ class TestMapper(TestCase):
             fake_row, self.fake_mapping, fake_model_class
         )
 
-        # empty columns should not result in entries in extra_data
-        expected_extra = {u'heading3': u'value3'}
+        expected_extra = {u'heading3': u'value3', u'heading4': u''}
 
         self.assertEqual(getattr(modified_model, u'property_id'), u'234235423')
         self.assertEqual(
@@ -75,6 +74,25 @@ class TestMapper(TestCase):
         )
         self.assertEqual(getattr(modified_model, u'heading_1'), u'value1')
         self.assertEqual(getattr(modified_model, u'heading_2'), u'value2')
+        self.assertTrue(
+            isinstance(getattr(modified_model, 'extra_data'), dict)
+        )
+        self.assertEqual(modified_model.extra_data, expected_extra)
+
+    def test_map_row_extra_data_empty_columns(self):
+        """map_row should include empty columns in extra_data"""
+        fake_row = {
+            u'heading3': u'value3',
+            u'heading4': u'',
+        }
+        fake_model_class = FakeModel
+
+        modified_model = mapper.map_row(
+            fake_row, self.fake_mapping, fake_model_class
+        )
+
+        expected_extra = {u'heading3': u'value3', u'heading4': u''}
+
         self.assertTrue(
             isinstance(getattr(modified_model, 'extra_data'), dict)
         )

--- a/seed/search.py
+++ b/seed/search.py
@@ -239,7 +239,11 @@ def filter_other_params(queryset, other_params, db_columns):
             # django-pgjson package, and use the new "HAS" operator syntax.
             # - nicholasserra
             if empty_match:
-                queryset = queryset.exclude(extra_data__contains='"%s":' % k)
+                # Filter for records that DO NOT contain this field OR
+                # contain a blank value for this field.
+                queryset = queryset.filter(
+                    ~Q(extra_data__contains='"%s":' % k) | Q(extra_data__contains='"%s": ""' % k)
+                )
                 continue
 
             conditions = {

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -853,6 +853,60 @@ class SearchViewTests(TestCase):
         self.assertEqual(len(data['buildings']), 1)
         self.assertEqual(data['buildings'][0]['pk'], b1.pk)
 
+    def test_search_extra_data_empty_column(self):
+        """Empty match on extra_data json keys"""
+        # Empty column
+        cb1 = CanonicalBuilding(active=True)
+        cb1.save()
+        b1 = SEEDFactory.building_snapshot(
+            canonical_building=cb1,
+            extra_data={'testing': ''}
+        )
+        cb1.canonical_snapshot = b1
+        cb1.save()
+        b1.super_organization = self.org
+        b1.save()
+
+        # Populated column
+        cb2 = CanonicalBuilding(active=True)
+        cb2.save()
+        b2 = SEEDFactory.building_snapshot(
+            canonical_building=cb2,
+            extra_data={'testing': 'test'}
+        )
+        cb2.canonical_snapshot = b2
+        cb2.save()
+        b2.super_organization = self.org
+        b2.save()
+
+        url = reverse_lazy("seed:search_buildings")
+        post_data = {
+            'filter_params': {
+                'testing': '""'
+            },
+            'number_per_page': 10,
+            'order_by': '',
+            'page': 1,
+            'q': '',
+            'sort_reverse': False,
+            'project_id': None,
+        }
+
+        # act
+        response = self.client.post(
+            url,
+            content_type='application/json',
+            data=json.dumps(post_data)
+        )
+        json_string = response.content
+        data = json.loads(json_string)
+
+        # assert
+        self.assertEqual(data['status'], 'success')
+        self.assertEqual(data['number_matching_search'], 1)
+        self.assertEqual(len(data['buildings']), 1)
+        self.assertEqual(data['buildings'][0]['pk'], b1.pk)
+
     def test_apply_label_to_project_buildings(self):
         """
         Tests applying a label to each building in a project. In the UI


### PR DESCRIPTION
Add blank fields to building extra data json data. Previously, empty fields were excluded from the json data. This patch also updates the null filtering on json data to handle this new case and be backwards compatible with old data.

Fixes #247 