### PR TITLE
Uses cookies to set expanded/collapsed state of sidebar nav

### DIFF
--- a/seed/static/seed/js/controllers/menu_controller.js
+++ b/seed/static/seed/js/controllers/menu_controller.js
@@ -17,6 +17,7 @@ angular.module('BE.seed.controller.menu', [])
   'user_service',
   '$timeout',
   '$route',
+  '$cookies',
   function(
     $scope,
     $http,
@@ -31,7 +32,8 @@ angular.module('BE.seed.controller.menu', [])
     organization_service,
     user_service,
     $timeout,
-    $route) {
+    $route,
+    $cookies) {
 
     // initial state of css classes for menu and sidebar
     $scope.expanded_controller = false;
@@ -53,9 +55,10 @@ angular.module('BE.seed.controller.menu', [])
     $scope.menu.loading = false;
     $scope.menu.route_load_error = false;
     $scope.menu.user = {};
+    $scope.is_initial_state = $scope.expanded_controller === $scope.collapsed_controller;
 
     $scope.$on("$routeChangeError", function(event, current, previous, rejection) {
-	$scope.menu.loading = false;
+	   $scope.menu.loading = false;
         $scope.menu.route_load_error = true;
         if (rejection === "not authorized" || rejection === "Your page could not be located!") {
             $scope.menu.error_message = rejection;
@@ -132,6 +135,15 @@ angular.module('BE.seed.controller.menu', [])
         $scope.search_input = "";
     };
 
+    //Sets initial expanded/collapse state of sidebar menu
+    function init_menu(){
+        //Default to false but use cookie value if one has been set
+        var isNavExpanded = $cookies.seed_nav_is_expanded === "true";
+        $scope.expanded_controller = isNavExpanded;
+        $scope.collapsed_controller = !isNavExpanded;
+        $scope.narrow_controller = isNavExpanded;
+        $scope.wide_controller = !isNavExpanded; 
+    }
 
     // returns true if menu toggle has never been clicked, i.e. first run, else returns false
     $scope.menu_toggle_has_never_been_clicked = function () {
@@ -148,17 +160,18 @@ angular.module('BE.seed.controller.menu', [])
 
     // expands and collapses the sidebar menu
     $scope.toggle_menu = function() {
-        if ($scope.menu_toggle_has_never_been_clicked()) {
-            $scope.expanded_controller = true;
-            $scope.collapsed_controller = false;
-            $scope.narrow_controller = true;
-            $scope.wide_controller = false;
+        $scope.is_initial_state = false; //we can now turn on animations
+        $scope.expanded_controller = !$scope.expanded_controller;
+        $scope.collapsed_controller = !$scope.collapsed_controller;
+        $scope.narrow_controller = !$scope.narrow_controller;
+        $scope.wide_controller = !$scope.wide_controller;   
+        try{
+            //TODO : refactor to put() when we move to Angular 1.3 or greater
+            $cookies.seed_nav_is_expanded = $scope.expanded_controller.toString(); 
         }
-        else {
-            $scope.expanded_controller = !$scope.expanded_controller;
-            $scope.collapsed_controller = !$scope.collapsed_controller;
-            $scope.narrow_controller = !$scope.narrow_controller;
-            $scope.wide_controller = !$scope.wide_controller;
+        catch(err){
+            //it's ok if the cookie can't be written, so just report in the log and move along.
+            $log.error("Couldn't write cookie for nav state. Error: ", err);
         }
     };
 
@@ -289,4 +302,5 @@ angular.module('BE.seed.controller.menu', [])
         });
     };
     init();
+    init_menu();
 }]);

--- a/seed/static/seed/less/style.less
+++ b/seed/static/seed/less/style.less
@@ -91,6 +91,16 @@
   -webkit-transition: @transition;
           transition: @transition;
 }
+/* Hide transition when setting initial state of nav */
+.hide_transition{
+  transition: none !important;   
+  -webkit-transition: none !important;
+  animation: none !important;
+  -webkit-animation: none !important;  
+  -moz-animation: none !important;  
+  -o-animation: none !important;  
+}
+
 // Box Shadows
 .box-shadow(@shadow) {
   -webkit-box-shadow: @shadow; // iOS <4.3 & Android <4.1
@@ -1823,3 +1833,4 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 		}
 	}
 }
+

--- a/seed/templates/seed/_sidebar.html
+++ b/seed/templates/seed/_sidebar.html
@@ -1,6 +1,6 @@
 {% load compress %}
 {# requires seed_menu_controller angularjs controller and menu_controller.js #}
-    <div ng-class="{expanded: expanded_controller, collapsed: collapsed_controller, sidebar: true}">
+    <div ng-class="{expanded: expanded_controller, collapsed: collapsed_controller, sidebar: true, hide_transition:is_initial_state}">
         <div class="menu" ng-click="reset_search_field()">
             <a ng-class="{item: true, active: is_active('/profile')}" href="{% url "seed:home" %}#/profile">
                 <div class="icon"><i class="fa fa-cog"></i></div>

--- a/seed/templates/seed/index.html
+++ b/seed/templates/seed/index.html
@@ -9,7 +9,7 @@
 	{% include "seed/_sidebar.html" %}
     
     <div class="display">
-        <div ng-class="{narrow: narrow_controller, wide: wide_controller, content: true}">
+        <div ng-class="{narrow: narrow_controller, wide: wide_controller, content: true, hide_transition:is_initial_state}">
 
             {% include "seed/_header.html" %}
 


### PR DESCRIPTION
This update adds a cookie value to remember the expanded/collapsed state of the sidenav bar. 

It tweaks the existing way sidenav state is stored in the *menu_controller.js*, and adds an extra style to styles.less to turn off animations when first showing the page. 

The *_sidebar.html* and *index.html* files are updated to use this style to turn off the animations when first loading. 