### PR TITLE
Issue #12 - Remember filter settings redo

### DIFF
--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -66,7 +66,7 @@ angular.module('BE.seed.controller.building_list', [])
      */
     var get_columns = function() {
         $scope.assessor_fields = all_columns.fields;
-        $scope.search.init_storage();
+        $scope.search.init_storage($location.$$path);
         $scope.columns = $scope.search.generate_columns(
             all_columns.fields,
             default_columns.columns,

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -254,17 +254,26 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
             templateUrl: static_url + 'seed/partials/buildings.html',
             resolve: {
                 'search_payload': ['building_services', '$route', function(building_services, $route){
-                    var params = $route.current.params;
-                    var q = params.q || "";
+                    // Defaults
+                    var q = $route.current.params.q || "";
+                    var orderBy = "";
+                    var sortReverse = false;
+                    var params = {};
 
-                    // Check session storage for order and sort values.
-                    var orderBy = (typeof(Storage) !== "undefined" && sessionStorage.getItem('seedBuildingOrderBy') !== null) ?
-                        sessionStorage.getItem('seedBuildingOrderBy') : "";
+                    // Check session storage for order, sort, and filter values.
+                    if (typeof(Storage) !== "undefined") {
+                        if (sessionStorage.getItem('seedBuildingOrderBy') !== null) {
+                            orderBy = sessionStorage.getItem('seedBuildingOrderBy');
+                        }
+                        if (sessionStorage.getItem('seedBuildingSortReverse') !== null) {
+                            sortReverse = JSON.parse(sessionStorage.getItem('seedBuildingSortReverse'));
+                        }
+                        if (sessionStorage.getItem('seedBuildingFilterParams') !== null) {
+                            params = JSON.parse(sessionStorage.getItem('seedBuildingFilterParams'));
+                        }
+                    }
 
-                    var sortReverse = (typeof(Storage) !== "undefined" && sessionStorage.getItem('seedBuildingSortReverse') !== null) ?
-                        JSON.parse(sessionStorage.getItem('seedBuildingSortReverse')) : false;
-
-                    // params: (query, number_per_page, page_number, order_by, sort_reverse, other_params, project_id)
+                    // params: (query, number_per_page, page_number, order_by, sort_reverse, filter_params, project_id)
                     return building_services.search_buildings(q, 10, 1, orderBy, sortReverse, params, null);
                 }],
                 'default_columns': ['user_service', function(user_service){

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -262,14 +262,16 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
 
                     // Check session storage for order, sort, and filter values.
                     if (typeof(Storage) !== "undefined") {
-                        if (sessionStorage.getItem('seedBuildingOrderBy') !== null) {
-                            orderBy = sessionStorage.getItem('seedBuildingOrderBy');
+
+                        var prefix = $route.current.$$route.originalPath;
+                        if (sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy') !== null) {
+                            orderBy = sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy');
                         }
-                        if (sessionStorage.getItem('seedBuildingSortReverse') !== null) {
-                            sortReverse = JSON.parse(sessionStorage.getItem('seedBuildingSortReverse'));
+                        if (sessionStorage.getItem(prefix + ':' + 'seedBuildingSortReverse') !== null) {
+                            sortReverse = JSON.parse(sessionStorage.getItem(prefix + ':' + 'seedBuildingSortReverse'));
                         }
-                        if (sessionStorage.getItem('seedBuildingFilterParams') !== null) {
-                            params = JSON.parse(sessionStorage.getItem('seedBuildingFilterParams'));
+                        if (sessionStorage.getItem(prefix + ':' + 'seedBuildingFilterParams') !== null) {
+                            params = JSON.parse(sessionStorage.getItem(prefix + ':' + 'seedBuildingFilterParams'));
                         }
                     }
 

--- a/seed/static/seed/js/services/search_service.js
+++ b/seed/static/seed/js/services/search_service.js
@@ -63,7 +63,8 @@ angular.module('BE.seed.service.search', [])
         number_per_page_options_model: 10,
         filter_params: {},
         prev_page_disabled: true,
-        has_checkbox: true
+        has_checkbox: true,
+        prefix: ''
     };
     search_service.next_page_disabled = (
         search_service.number_matching_search <= 10);
@@ -78,20 +79,21 @@ angular.module('BE.seed.service.search', [])
      * functions
      */
 
-    search_service.init_storage = function () {
+    search_service.init_storage = function (prefix) {
         // Check session storage for order and sort values.
         if (typeof(Storage) !== "undefined") {
-            if (sessionStorage.getItem('seedBuildingOrderBy') !== null){
-                saas.order_by = sessionStorage.getItem('seedBuildingOrderBy');
-                saas.sort_column = sessionStorage.getItem('seedBuildingOrderBy');
+            saas.prefix = prefix;
+            if (sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy') !== null){
+                saas.order_by = sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy');
+                saas.sort_column = sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy');
             }
 
-            if (sessionStorage.getItem('seedBuildingSortReverse') !== null) {
-                saas.sort_reverse = JSON.parse(sessionStorage.getItem('seedBuildingSortReverse'));
+            if (sessionStorage.getItem(prefix + ':' + 'seedBuildingSortReverse') !== null) {
+                saas.sort_reverse = JSON.parse(sessionStorage.getItem(prefix + ':' + 'seedBuildingSortReverse'));
             }
 
-            if (sessionStorage.getItem('seedBuildingFilterParams') !== null) {
-                saas.filter_params = JSON.parse(sessionStorage.getItem('seedBuildingFilterParams'));
+            if (sessionStorage.getItem(prefix + ':' + 'seedBuildingFilterParams') !== null) {
+                saas.filter_params = JSON.parse(sessionStorage.getItem(prefix + ':' + 'seedBuildingFilterParams'));
             }
         }
     };
@@ -180,7 +182,7 @@ angular.module('BE.seed.service.search', [])
         this.current_page = 1;
         this.search_buildings();
         if (typeof(Storage) !== "undefined") {
-            sessionStorage.setItem('seedBuildingFilterParams', JSON.stringify(this.filter_params));
+            sessionStorage.setItem(this.prefix + ':' + 'seedBuildingFilterParams', JSON.stringify(this.filter_params));
         }
     };
 
@@ -347,8 +349,8 @@ angular.module('BE.seed.service.search', [])
             }
 
             if (typeof(Storage) !== "undefined") {
-                sessionStorage.setItem('seedBuildingOrderBy', saas.sort_column);
-                sessionStorage.setItem('seedBuildingSortReverse', saas.sort_reverse);
+                sessionStorage.setItem(saas.prefix + ':' + 'seedBuildingOrderBy', saas.sort_column);
+                sessionStorage.setItem(saas.prefix + ':' + 'seedBuildingSortReverse', saas.sort_reverse);
             }
 
             saas.order_by = this.sort_column;

--- a/seed/static/seed/js/services/search_service.js
+++ b/seed/static/seed/js/services/search_service.js
@@ -80,13 +80,19 @@ angular.module('BE.seed.service.search', [])
 
     search_service.init_storage = function () {
         // Check session storage for order and sort values.
-        if (typeof(Storage) !== "undefined" && sessionStorage.getItem('seedBuildingOrderBy') !== null) {
-            saas.order_by = sessionStorage.getItem('seedBuildingOrderBy');
-            saas.sort_column = sessionStorage.getItem('seedBuildingOrderBy');
-        }
+        if (typeof(Storage) !== "undefined") {
+            if (sessionStorage.getItem('seedBuildingOrderBy') !== null){
+                saas.order_by = sessionStorage.getItem('seedBuildingOrderBy');
+                saas.sort_column = sessionStorage.getItem('seedBuildingOrderBy');
+            }
 
-        if (typeof(Storage) !== "undefined" && sessionStorage.getItem('seedBuildingSortReverse') !== null) {
-            saas.sort_reverse = JSON.parse(sessionStorage.getItem('seedBuildingSortReverse'));
+            if (sessionStorage.getItem('seedBuildingSortReverse') !== null) {
+                saas.sort_reverse = JSON.parse(sessionStorage.getItem('seedBuildingSortReverse'));
+            }
+
+            if (sessionStorage.getItem('seedBuildingFilterParams') !== null) {
+                saas.filter_params = JSON.parse(sessionStorage.getItem('seedBuildingFilterParams'));
+            }
         }
     };
 
@@ -171,8 +177,11 @@ angular.module('BE.seed.service.search', [])
      * filter_search: triggerd when a filter param changes
      */
     search_service.filter_search = function() {
-       this.current_page = 1;
-       this.search_buildings();
+        this.current_page = 1;
+        this.search_buildings();
+        if (typeof(Storage) !== "undefined") {
+            sessionStorage.setItem('seedBuildingFilterParams', JSON.stringify(this.filter_params));
+        }
     };
 
 


### PR DESCRIPTION
This PR reintroduces the saving of filters from PR #235 , but takes care of the issues in #243 by prepending a prefix based off the current url. This makes it so that saved filters will be different when on the buildings page vs individual project pages. 

As this deals with the complex filtering params, this needs solid testing around all filtering and ordering. I tried with buildings and with individual projects with success.

Refs #12 