### PR TITLE
Issue 83 uploading duplicate data

### DIFF
--- a/seed/migrations/0002_buildingsnapshot_duplicate.py
+++ b/seed/migrations/0002_buildingsnapshot_duplicate.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('seed', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='buildingsnapshot',
+            name='duplicate',
+            field=models.ForeignKey(related_name='+', blank=True, to='seed.BuildingSnapshot', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/seed/models.py
+++ b/seed/models.py
@@ -337,7 +337,7 @@ def save_snapshot_match(
     default_building = b1 if default_pk == b1_pk else b2
 
     new_snapshot = BuildingSnapshot.objects.create()
-    new_snapshot = seed_mapper.merge_building(
+    new_snapshot, changes = seed_mapper.merge_building(
         new_snapshot,
         b1,
         b2,
@@ -358,7 +358,7 @@ def save_snapshot_match(
 
     new_snapshot.save()
 
-    return new_snapshot
+    return new_snapshot, changes
 
 
 def unmatch_snapshot_tree(building_pk):
@@ -443,7 +443,7 @@ def unmatch_snapshot_tree(building_pk):
     bachelor = root
     newborn_child = None
     for bereaved_parent in coparents_to_keep:
-        newborn_child = save_snapshot_match(bachelor.pk, bereaved_parent.pk, default_pk=bereaved_parent.pk)
+        newborn_child, _ = save_snapshot_match(bachelor.pk, bereaved_parent.pk, default_pk=bereaved_parent.pk)
         bachelor = newborn_child
 
     # set canonical_snapshot for root's canonical building
@@ -1258,6 +1258,11 @@ class BuildingSnapshot(TimeStampedModel):
 
     use_description = models.TextField(null=True, blank=True)
     use_description_source = models.ForeignKey(
+        'BuildingSnapshot', related_name='+', null=True, blank=True
+    )
+    
+    #Need a field to indicate that a record is a duplicate of another.  Mainly used for cleaning up.
+    duplicate = models.ForeignKey(
         'BuildingSnapshot', related_name='+', null=True, blank=True
     )
 

--- a/seed/static/seed/js/controllers/data_upload_modal_ctrl.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_ctrl.js
@@ -310,20 +310,36 @@ angular.module('BE.seed.controller.data_upload_modal', [])
                     data.progress_key,
                     0,
                     1.0,
-                    function (data){
+                    function (data){                    
                         building_services.get_PM_filter_by_counts($scope.dataset.import_file_id)
                         .then(function (data){
                             // resolve promise
                             $scope.matched_buildings = data.matched;
                             $scope.unmatched_buildings = data.unmatched;
+                            $scope.duplicate_buildings = data.duplicates;                            
                             $scope.uploader.complete = true;
                             $scope.uploader.in_progress = false;
                             $scope.uploader.progress = 0;
-                            if ($scope.matched_buildings > 0) {
-                                $scope.step.number = 8;
-                            } else {
-                                $scope.step.number = 10;
-                                building_services.get_total_number_of_buildings_for_user();
+                            if($scope.duplicate_buildings > 0)
+                            {
+                            	//alert("Duplicate buildings found, trying to delete");
+                            	building_services.delete_duplicates_from_import_file($scope.dataset.import_file_id).then(function (data){
+                            		if ($scope.matched_buildings > 0) {
+		                                $scope.step.number = 8;
+		                            } else {
+		                                $scope.step.number = 10;
+		                                building_services.get_total_number_of_buildings_for_user();
+		                            }		
+                        		});
+                            }
+                            else
+                            {
+	                            if ($scope.matched_buildings > 0) {
+	                                $scope.step.number = 8;
+	                            } else {
+	                                $scope.step.number = 10;
+	                                building_services.get_total_number_of_buildings_for_user();
+	                            }
                             }
                         });
                     }, function(data) {

--- a/seed/static/seed/js/controllers/mapping_controller.js
+++ b/seed/static/seed/js/controllers/mapping_controller.js
@@ -431,14 +431,14 @@ angular.module('BE.seed.controller.mapping', [])
      * reverse titleCase mappings which were titleCase in the suggestion input
      */
     var get_untitle_cased_mappings = function () {
-        var mappings = $scope.get_mappings().map(function (m) {
-            var mapping = m[0];
+        var mappings = $scope.get_mappings().map(function (m) {        	
+            var mapping = m[0];            
             mapping = angular.lowercase(mapping).replace(/ /g, '_');
-            if (~original_columns.indexOf(mapping)) {
+            if (~original_columns.indexOf(mapping)) {            	
                 m[0] = mapping;
             }
             return m;
-        });
+        });        
         return mappings;
     };
 

--- a/seed/static/seed/js/controllers/matching_controller.js
+++ b/seed/static/seed/js/controllers/matching_controller.js
@@ -332,6 +332,7 @@ angular.module('BE.seed.controller.matching', [])
             // resolve promise
             $scope.matched_buildings = data.matched;
             $scope.unmatched_buildings = data.unmatched;
+            $scope.duplicate_buildings = data.duplicates;
         });
     };
 

--- a/seed/static/seed/js/services/building_service.js
+++ b/seed/static/seed/js/services/building_service.js
@@ -214,6 +214,22 @@ angular.module('BE.seed.service.building', ['BE.seed.services.label_helper'])
         });
         return defer.promise;
     };
+    
+    building_factory.delete_duplicates_from_import_file = function(import_file_id) {
+        var defer = $q.defer();
+        $http({
+            method: 'GET',
+            'url': window.BE.urls.delete_duplicates_from_import_file_url,
+            'params': {
+                'import_file_id': import_file_id
+            }
+        }).success(function(data, status, headers, config) {
+            defer.resolve(data);
+        }).error(function(data, status, headers, config) {
+            defer.reject(data, status);
+        });
+        return defer.promise;
+    };
 
     /**
      * start the delete buildings process

--- a/seed/static/seed/partials/building_audit_log.html
+++ b/seed/static/seed/partials/building_audit_log.html
@@ -27,8 +27,8 @@
                     <tbody>
                         <tr ng-repeat="entry in audit_logs">
                             <td class="align_to_top has_no_min_width">{$ entry.user.first_name $} {$ entry.user.last_name $}</td>
-                            <td class="align_to_top" ng-if="entry.audit_type == 'Log'">{$ entry.action_note || entry.action $}</td>
-                            <td class="align_to_top whitespace note" ng-if="entry.audit_type == 'Note'"><label class="label label-info"><i class="fa fa-comment"></i> note</label> {$ entry.action_note $}  <a href="javascript:void(0);" class="note_edit pull-right" ng-click="open_create_note_modal(entry)" ng-show="user_role !== 'viewer'" ng-if="entry.audit_type == 'Note'">edit</a></td>
+                            <td class="align_to_top" ng-if="entry.audit_type == 'Log'"><pre>{$ entry.action_note || entry.action $}</pre></td>
+                            <td class="align_to_top whitespace note" ng-if="entry.audit_type == 'Note'"><label class="label label-info"><i class="fa fa-comment"></i> note</label> <pre> {$ entry.action_note $} </pre>  <a href="javascript:void(0);" class="note_edit pull-right" ng-click="open_create_note_modal(entry)" ng-show="user_role !== 'viewer'" ng-if="entry.audit_type == 'Note'">edit</a></td>
                             <td class="align_to_top">{$ entry.created | date:"MM/dd/yyyy 'at' h:mma" $}</td>
                         </tr>
                     </tbody>

--- a/seed/static/seed/partials/data_upload_modal.html
+++ b/seed/static/seed/partials/data_upload_modal.html
@@ -119,7 +119,7 @@
         <div class="row">
             <div class="alert alert-success alert-dismissable">
                 <button type="button" class="close" aria-hidden="true" ng-click="uploader.complete = false">&times;</button>
-                SEED successfully matched <strong>{$ matched_buildings|number:0 $}</strong> of the <strong>{$ (matched_buildings + unmatched_buildings)|number:0 $}</strong> buildings from your <strong>{$ dataset.filename $}</strong> file.
+                SEED successfully matched <strong>{$ matched_buildings|number:0 $}</strong> and found <strong>{$ duplicate_buildings|number:0 $} duplicates</strong> of the <strong>{$ (matched_buildings + unmatched_buildings + duplicate_buildings)|number:0 $}</strong> buildings from your <strong>{$ dataset.filename $}</strong> file.  Any duplicates will be removed from consideration from matching.
             </div>
         </div>
     </div>
@@ -137,7 +137,7 @@
             <div class="alert alert-{$ step_10_style $} alert-dismissable">
                 <button type="button" class="close" aria-hidden="true" ng-click="uploader.complete = false">&times;</button>
                     <span ng-show="step_10_error_message">{$ step_10_error_message $}</span>
-                    <span ng-hide="step_10_error_message">SEED could not locate any matches. Would you like to add another file?</span>
+                    <span ng-hide="step_10_error_message">SEED could not locate any non-duplicate matches and found <strong>{$ duplicate_buildings|number:0 $} duplicates</strong>. Would you like to add another file?</span>
             </div>
             <div class="form-group col-lg-12 col-sm-12">
             </div>

--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -775,10 +775,20 @@ def handle_results(results, b_idx, can_rev_idx, unmatched_list, user_pk):
         can_snap_pk, building_pk, confidence=confidence, match_type=match_type, default_pk=building_pk
     )
     canon = bs.canonical_building
+    action_note='System matched building.'
+    if changes:
+            action_note += "  Fields changed in cannonical building:\n"
+            for change in changes:
+                action_note += "\t{field}:\t".format(field = change["field"].replace("_", " ").replace("-",  "").capitalize())
+                if "from" in change:
+                    action_note += "From:\t{prev}\tTo:\t".format(prev = change["from"])
+                
+                action_note += "{value}\n".format(value = change["to"])
+            action_note = action_note[:-1]
     AuditLog.objects.create(
         user_id=user_pk,
         content_object=canon,
-        action_note='System matched building.',
+        action_note=action_note,
         action='save_system_match',
         organization=bs.super_organization,
     )

--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -771,7 +771,7 @@ def handle_results(results, b_idx, can_rev_idx, unmatched_list, user_pk):
     can_snap_pk = can_rev_idx[match_string]
     building_pk = unmatched_list[b_idx][0]  # First element is PK
 
-    bs = save_snapshot_match(
+    bs, changes = save_snapshot_match(
         can_snap_pk, building_pk, confidence=confidence, match_type=match_type, default_pk=building_pk
     )
     canon = bs.canonical_building

--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -852,14 +852,7 @@ def get_canonical_id_matches(org_id, pm_id, tax_id, custom_id):
 
     return canonical_matches
 
-def is_same_snapshot(s1, s2):
-    
-    #fields_to_inspect = ["address_line_1",
-    #                     "address_line_2",
-    #                     "pm_property_id",
-    #                     "super_organization_id",
-    #                     "extra_data"
-    #                     ]
+def is_same_snapshot(s1, s2):    
     
     fields_to_ignore = ["id", 
                         "created", 

--- a/seed/templates/seed/_js_urls.html
+++ b/seed/templates/seed/_js_urls.html
@@ -18,6 +18,7 @@
         window.BE.urls.save_match_url = "{% url "seed:save_match" %}";
         window.BE.urls.get_columns_url = "{% url "seed:get_columns" %}";
         window.BE.urls.get_PM_filter_by_counts_url = "{% url "seed:get_PM_filter_by_counts" %}";
+        window.BE.urls.delete_duplicates_from_import_file_url = "{% url "seed:delete_duplicates_from_import_file" %}";
         window.BE.urls.seed_home = "{% url "seed:home" %}";
 
         window.BE.urls.create_dataset = "{% url "seed:create_dataset" %}";

--- a/seed/tests/test_tasks.py
+++ b/seed/tests/test_tasks.py
@@ -275,6 +275,48 @@ class TestTasks(TestCase):
         self.assertEqual(
             mapped_bs.address_line_1, u'1600 Pennsylvania Ave. Someplace Nice'
         )
+        
+    def test_is_same_snapshot(self):
+        """Test to check if two snapshots are duplicates"""
+        
+        bs_data = {
+            'pm_property_id': 1243,
+            'tax_lot_id': '435/422',
+            'property_name': 'Greenfield Complex',
+            'custom_id_1': 12,
+            'address_line_1': '555 Database LN.',
+            'address_line_2': '',
+            'city': 'Gotham City',
+            'postal_code': 8999,
+        }
+        
+        s1 = util.make_fake_snapshot(
+            self.import_file, bs_data, ASSESSED_BS, is_canon=True,
+            org=self.fake_org
+        )
+        
+        self.assertTrue(tasks.is_same_snapshot(s1, s1), "Matching a snapshot to itself should return True")
+        
+        #Making a different snapshot, now Garfield complex rather than Greenfield complex
+        bs_data_2 = {
+            'pm_property_id': 1243,
+            'tax_lot_id': '435/422',
+            'property_name': 'Garfield Complex',
+            'custom_id_1': 12,
+            'address_line_1': '555 Database LN.',
+            'address_line_2': '',
+            'city': 'Gotham City',
+            'postal_code': 8999,
+        }
+        
+        s2 = util.make_fake_snapshot(
+            self.import_file, bs_data_2, ASSESSED_BS, is_canon=True,
+            org=self.fake_org
+        )
+        
+        self.assertFalse(tasks.is_same_snapshot(s1, s2), "Matching a snapshot to a different snapshot should return False")
+        
+        
 
     def test_match_buildings(self):
         """Good case for testing our matching system."""

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -1194,7 +1194,7 @@ class BuildingDetailViewTests(TestCase):
             information from parent buildings.
         """
         # arrange
-        child = save_snapshot_match(self.parent_1.pk, self.parent_2.pk)
+        child, changelist = save_snapshot_match(self.parent_1.pk, self.parent_2.pk)
 
         url = reverse_lazy("seed:get_building")
         get_data = {
@@ -1250,7 +1250,7 @@ class BuildingDetailViewTests(TestCase):
     def test_get_building_with_project(self):
         """ tests get_building projects payload"""
         # arrange
-        child = save_snapshot_match(self.parent_1.pk, self.parent_2.pk)
+        child, changelist = save_snapshot_match(self.parent_1.pk, self.parent_2.pk)
         # create project wtihout compliance
         project = Project.objects.create(
             name='test project',
@@ -1291,7 +1291,7 @@ class BuildingDetailViewTests(TestCase):
             import files.
         """
         # arrange
-        child = save_snapshot_match(self.parent_1.pk, self.parent_2.pk)
+        child, changelist = save_snapshot_match(self.parent_1.pk, self.parent_2.pk)
 
         url = reverse_lazy("seed:get_building")
         get_data = {
@@ -1336,7 +1336,7 @@ class BuildingDetailViewTests(TestCase):
         # arrange
         self.parent_2.source_type = 6
         self.parent_2.save()
-        child = save_snapshot_match(self.parent_1.pk, self.parent_2.pk)
+        child, changelist = save_snapshot_match(self.parent_1.pk, self.parent_2.pk)
 
         url = reverse_lazy("seed:get_building")
         get_data = {

--- a/seed/urls/main.py
+++ b/seed/urls/main.py
@@ -56,6 +56,7 @@ urlpatterns = patterns(
         'get_PM_filter_by_counts',
         name='get_PM_filter_by_counts'
     ),
+    url(r'^delete_duplicates_from_import_file/$', 'delete_duplicates_from_import_file', name='delete_duplicates_from_import_file'),
     url(r'^create_dataset/$', 'create_dataset', name='create_dataset'),
     url(r'^get_datasets/$', 'get_datasets', name='get_datasets'),
     url(r'^get_dataset/$', 'get_dataset', name='get_dataset'),

--- a/seed/utils/buildings.py
+++ b/seed/utils/buildings.py
@@ -109,6 +109,8 @@ def get_columns(is_project, org_id, all_fields=False):
         'string': 'string',
         'decimal': 'number',
         'datetime': 'date',
+#        'boolean': 'bool',
+#        'foreignkey': 'int',
     }
     field_types = {}
     for k, v in get_mappable_types().items():

--- a/seed/utils/constants.py
+++ b/seed/utils/constants.py
@@ -17,6 +17,7 @@ EXCLUDE_FIELDS = [
     'seed_org',
     'source_type',
     'super_organization',
+    'duplicate',
 ]
 
 META_FIELDS = [


### PR DESCRIPTION
Should have changes for both uploading duplicate data (Issue #83) and providing a changelog for merging buildings.

NOTE:  This involves a database migration so need to do
python manage.py makemigrations --settings=config.settings.dev
python manage.py migrate --settings=config.settings.dev

Added a 'duplicate' column to BuildingSnapshots table. Updated front end to display number of duplicates and tell user they will not be used. Added and modified unit tests. Added API endpoint to delete duplicate records for a given input file. NOTE: The raw import records are not being deleted in order to retain functionality in the review mapping screen.

Note on how rows are added to BuildingSnapshot table when a record is importing (prior to these changes):
1:  Pre-mapping:  A raw BuildingSnapshot record is created with references to the import file.
2:  Post-mapping:  A processed BuildingSnapshot record is created.
3:  If there is a match:  A new canonical building record that is the merge of the post-mapping and the previous canonical building.

Now with these changes #1 is still always created.  If it is a duplicate then the second is created and given the ID of the record it is a duplicate of.  I added a "delete duplicate records from file" api call and changed the javascript code to call that after the matching to remove the duplicate records.  If it is a duplicate there is no changes to the canonical building or new record created.

For the changelog behavior the main changes were to make save_snapshot_match also return a list of any changes to the existing canonical building.  Then the places that call save_snapshot_match (handle_results and handle_id_matches) add the changes to the AuditLog.  In order to get the display to look OK I had to wrap the cell in the table in building_audit_log.html with a pre tag.