### PR TITLE
Issue #325 - Handle extra data fields on matching table

### DIFF
--- a/seed/static/seed/partials/matching_list_table.html
+++ b/seed/static/seed/partials/matching_list_table.html
@@ -69,13 +69,16 @@
                             <td ng-repeat="c in columns">
                                 <span ng-switch on="c.type">
                                   <span ng-switch-when="string">
-                                    <a ng-href="#/data/matching/{$ import_file.id $}" ng-click="match_building(b)">{$ b[c.sort_column] $}</a>
+                                    <a ng-if="c.is_extra_data" ng-href="#/data/matching/{$ import_file.id $}" ng-click="match_building(b)">{$ b.extra_data[c.sort_column] $}</a>
+                                    <a ng-if="!c.is_extra_data" ng-href="#/data/matching/{$ import_file.id $}" ng-click="match_building(b)">{$ b[c.sort_column] $}</a>
                                   </span>
                                   <span ng-switch-when="floor_area" class="is_aligned_right">
-                                    <a ng-href="#/data/matching/{$ import_file.id $}" ng-click="match_building(b)">{$ b[c.sort_column] | number:0 $}</a>
+                                    <a ng-if="c.is_extra_data" ng-href="#/data/matching/{$ import_file.id $}" ng-click="match_building(b)">{$ b.extra_data[c.sort_column] | number:0 $}</a>
+                                    <a ng-if="!c.is_extra_data" ng-href="#/data/matching/{$ import_file.id $}" ng-click="match_building(b)">{$ b[c.sort_column] | number:0 $}</a>
                                   </span>
                                   <span ng-switch-when="number" class="is_aligned_right">
-                                    <a ng-href="#/data/matching/{$ import_file.id $}" ng-click="match_building(b)">{$ b[c.sort_column] | number:0 $}</a>
+                                    <a ng-if="c.is_extra_data" ng-href="#/data/matching/{$ import_file.id $}" ng-click="match_building(b)">{$ b.extra_data[c.sort_column] | number:0 $}</a>
+                                    <a ng-if="!c.is_extra_data" ng-href="#/data/matching/{$ import_file.id $}" ng-click="match_building(b)">{$ b[c.sort_column] | number:0 $}</a>
                                   </span>
                                   <span ng-switch-when="link" class="is_aligned_right">
                                     <a ng-href="#/data/matching/{$ import_file.id $}" ng-click="match_building(b)">{$ b[c.sort_column] | stripImportPrefix $}</a>


### PR DESCRIPTION
Extra data fields were not handled correctly in the DOM for the matching view table. I added checks to handle both string and numeric cases of the JSON data. 

Energy star & organization extra data fields shown:
![screen shot 2015-08-18 at 5 12 03 pm](https://cloud.githubusercontent.com/assets/512288/9343078/cd4bdcf6-45cd-11e5-842c-0eb8c3b11801.png)

Zip extra data field shown:
![screen shot 2015-08-18 at 5 12 12 pm](https://cloud.githubusercontent.com/assets/512288/9343096/e271fdf4-45cd-11e5-8fed-2e760feefc49.png)

Refs #325 