### PR TITLE
Better coverage reporting settings

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,34 @@
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+    def __unicode__
+    def __repr__
+    if settings.DEBUG
+    raise NotImplementedError
+    from django\.
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
 [run]
-include = ./seed/*, ./green_button/*, ./public/*, ./audit_logs/*
-omit = ./seed/migrations/*
+omit =
+    *tests*
+    *migrations*
+    *urls*
+    *site-packages*
+    *django-*
+    *src*
+    *settings*
+    *config*
+    *test_helpers*


### PR DESCRIPTION
Made some changes to our coverage config to get a more accurate report. Basically don't check test files, migrations, or debug code. Looks like we're close to 70% coverage. 