### PR TITLE
Fix travis status image for develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Each message that is written to the logger is a Log Record. The log record is st
 Copyright ©  2014 Building Energy Inc.
 
 
-[travis-img]: https://api.travis-ci.org/SEED-platform/seed.svg
+[travis-img]: https://travis-ci.org/SEED-platform/seed.svg?branch=develop
 [travis-url]: https://travis-ci.org/SEED-platform/seed
 [coveralls-img]: https://coveralls.io/repos/SEED-platform/seed/badge.svg
 [coveralls-url]: https://coveralls.io/github/SEED-platform/seed


### PR DESCRIPTION
Pin the travis status image to develop branch. Currently, the image just shows the status of the last build, which isn't really helpful when it's from a random PR or branch. 