### PR TITLE
Changing get_column_matching_suggestions 

### DIFF
--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -1259,11 +1259,16 @@ def get_column_mapping_suggestions(request):
         _log.info("map Portfolio Manager input file")
         suggested_mappings = {}
         ver = import_file.source_program_version
+        
+        #if there is no pm mapping found but the file has already been matched
+        #then effectively the mappings are already known with a confidence of 100
+        no_pm_mappings_confience = 100 if import_file.matching_done else 0
+        
         for col, item in simple_mapper.get_pm_mapping(
                 ver, import_file.first_row_columns,
                 include_none=True).items():
             if item is None:
-                suggested_mappings[col] = (col, 0)
+                suggested_mappings[col] = (col, no_pm_mappings_confience)
             else:
                 cleaned_field = item.field
                 suggested_mappings[col] = (cleaned_field, 100)


### PR DESCRIPTION
to return a confidence of 100 on fields for a file that has already been matched.  Otherwise non-pm fields in a PM file would have a confidence of 0 even after matching causing them to not be displayed at the review mappings screne.  This should make reviewing the mappings behave as expected and since users can not re-map files that have been matched then hopefully any other impact will be minimal.