### PR TITLE
Removing the "duplicate" field was being displayed in the building details

### DIFF
--- a/seed/static/seed/js/controllers/building_detail_controller.js
+++ b/seed/static/seed/js/controllers/building_detail_controller.js
@@ -237,7 +237,8 @@ angular.module('BE.seed.controller.building_detail', [])
             'parents',
             'pk',
             'super_organization',
-            'source_type'
+            'source_type',
+            'duplicate'
         ];
         var no_invalid_key = known_invalid_keys.indexOf(key) === -1;
 

--- a/seed/utils.py
+++ b/seed/utils.py
@@ -37,6 +37,7 @@ EXCLUDE_FIELDS = [
     'seed_org',
     'source_type',
     'super_organization',
+    'duplicate',
 ]
 
 META_FIELDS = [


### PR DESCRIPTION
There are a few different lists of fields to ignore that govern which fields from the BuildingSnapshot table are processed/displayed.  Missed a couple in the last commit, adding them here.