### PR TITLE
Centralized caching

### DIFF
--- a/seed/search.py
+++ b/seed/search.py
@@ -150,11 +150,11 @@ def is_not_whitelist_building(parent_org, building, whitelist_orgs):
     :param whitelist_orgs: queryset of Organization insts.
     :returns: bool
     """
-    return (parent_org and building.super_organization not in whitelist_orgs)
+    return parent_org and building.super_organization not in whitelist_orgs
 
 
 def filter_other_params(queryset, other_params, db_columns):
-    """applyes a dictionary filter to the query set. Does some domain specific
+    """applies a dictionary filter to the query set. Does some domain specific
     parsing,
        mostly to remove extra query params and deal with ranges.
        Ranges should be passed in as '<field name>__lte' or '<field name>__gte'

--- a/seed/static/seed/js/directives/beUploader.js
+++ b/seed/static/seed/js/directives/beUploader.js
@@ -60,7 +60,7 @@ var makeS3Uploader = function(scope, element, attrs, filename) {
      * uploadSuccess: makes a POST to `data/s3_upload_complete` with the 
      * params. `source_type` is set as an HTML element attribute and should
      * semantically define the source type of the file. In the case of 
-     * SEED: a Porfolio Manager file or a covered assessor buildings file
+     * SEED: a Portfolio Manager file or a covered assessor buildings file
      */
     uploadSuccess: {
         endpoint: window.BE.urls.uploader_success_endpoint,

--- a/seed/static/seed/partials/data_upload_modal.html
+++ b/seed/static/seed/partials/data_upload_modal.html
@@ -18,7 +18,7 @@
         <div class="alert alert-danger alert-dismissable" ng-show="dataset.alert">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             The data set <strong>name "{$ dataset.name $}" already exists</strong>. Please select a new one.
-        </div>   
+        </div>
         <div class="form-group" ng-class="{'has-error': dataset.alert, 'has-feedback': dataset.alert}">
             <label class="control-label col-lg-3 col-sm-3" for="inputDataUploadName">Data Set Name</label>
             <div class="col-lg-8 col-sm-8">
@@ -37,8 +37,7 @@
                 <div class="row">
                     <div class="col-lg-4" be-uploader sourcetype="Assessed Raw" sourceprog="" sourcever="" importrecord="dataset.id" buttontext="Upload a spreadsheet" eventfunc="uploaderfunc(message, file, progress)" ng-hide="uploader.in_progress"></div>
                     <div class="col-lg-4 orange_button" be-uploader sourcetype="Assessed Raw" sourceprog="PortfolioManager" sourcever="1.0" importrecord="dataset.id" buttontext="Upload Portfolio Manager data" eventfunc="uploaderfunc(message, file, progress)" ng-hide="uploader.in_progress"></div>
-                    <div class="col-lg-8 green_button" be-uploader sourcetype="Green Button Raw"
-                         sourceprog="" sourcever="" importrecord="dataset.id" buttontext="Upload Green Button Data" eventfunc="uploaderfunc(message, file, progress)" ng-hide="uploader.in_progress"></div>
+                    <div class="col-lg-8 green_button" be-uploader sourcetype="Green Button Raw" sourceprog="" sourcever="" importrecord="dataset.id" buttontext="Upload Green Button Data" eventfunc="uploaderfunc(message, file, progress)" ng-hide="uploader.in_progress"></div>
                 </div>
                 <div class="progress_bar_container" ng-show="uploader.in_progress">
                     <div class="progress_bar_copy_top">Uploading <strong>{$ dataset.filename $}</strong></div>
@@ -169,7 +168,7 @@
     <div ng-switch-when="1">
         <div class="row text-center">
            <button type="button" class="btn btn-primary col-sm-6 col-lg-6 col-md-6 center-block" ng-click="create_dataset(dataset.name)" ng-disabled="dataset.disabled()">Create Data Set</button>
-        </div>    
+        </div>
     </div>
     <div ng-switch-when="2">
     </div>

--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -16,7 +16,6 @@ from django.conf import settings
 from django.utils.http import urlsafe_base64_encode
 from django.utils.encoding import force_bytes
 from django.template import loader
-from django.core.cache import cache
 from django.db.models import Q
 from django.db.models.loading import get_model
 from django.core.urlresolvers import reverse_lazy
@@ -57,8 +56,9 @@ from seed.models import (
     Project,
     ProjectBuilding,
 )
-from seed.decorators import lock_and_track, get_prog_key, increment_cache
+from seed.decorators import lock_and_track, get_prog_key
 from seed.utils.buildings import get_source_type, get_search_query
+from seed.utils.cache import set_cache_raw, set_cache, increment_cache
 from seed.utils.mapping import get_mappable_columns
 from seed.lib.superperms.orgs.models import Organization
 from seed.lib.exporter import Exporter
@@ -86,7 +86,7 @@ def export_buildings(export_id, export_name, export_type,
     selected_buildings = model.objects.filter(pk__in=building_ids)
 
     def _row_cb(i):
-        cache.set("export_buildings__%s" % export_id, i)
+        set_cache_raw("export_buildings__%s" % export_id, i)
 
     exporter = Exporter(export_id, export_name, export_type)
     if not exporter.valid_export_type():
@@ -103,7 +103,7 @@ def export_buildings(export_id, export_name, export_type,
 def invite_to_seed(domain, email_address, token, user_pk, first_name):
     signup_url = reverse_lazy('landing:signup', kwargs={
         'uidb64': urlsafe_base64_encode(force_bytes(user_pk)),
-        "token": token
+        'token': token
     })
     context = {
         'email': email_address,
@@ -144,7 +144,7 @@ def add_buildings(project_slug, project_dict, user_pk):
 
     selected_buildings = project_dict.get('selected_buildings', [])
 
-    cache.set(
+    set_cache_raw(
         project.adding_buildings_status_percentage_cache_key,
         {'percentage_done': 0, 'numerator': 0, 'denominator': 0}
     )
@@ -155,7 +155,7 @@ def add_buildings(project_slug, project_dict, user_pk):
             i += 1
             denominator = len(selected_buildings)
             try:
-                cache.set(
+                set_cache_raw(
                     project.adding_buildings_status_percentage_cache_key,
                     {
                         'percentage_done': (
@@ -173,7 +173,7 @@ def add_buildings(project_slug, project_dict, user_pk):
     else:
         query_buildings = get_search_query(user, project_dict)
         denominator = query_buildings.count() - len(selected_buildings)
-        cache.set(
+        set_cache_raw(
             project.adding_buildings_status_percentage_cache_key,
             {'percentage_done': 10, 'numerator': i, 'denominator': denominator}
         )
@@ -186,7 +186,7 @@ def add_buildings(project_slug, project_dict, user_pk):
             ProjectBuilding.objects.get_or_create(
                 project=project, building_snapshot=b
             )
-            cache.set(
+            set_cache_raw(
                 project.adding_buildings_status_percentage_cache_key,
                 {
                     'percentage_done': float(i) / denominator * 100,
@@ -198,7 +198,7 @@ def add_buildings(project_slug, project_dict, user_pk):
             project.building_snapshots.remove(
                 BuildingSnapshot.objects.get(pk=building)
             )
-            cache.set(
+            set_cache_raw(
                 project.adding_buildings_status_percentage_cache_key,
                 {
                     'percentage_done': (
@@ -210,7 +210,7 @@ def add_buildings(project_slug, project_dict, user_pk):
                 }
             )
 
-    cache.set(
+    set_cache_raw(
         project.adding_buildings_status_percentage_cache_key,
         {'percentage_done': 100, 'numerator': i, 'denominator': denominator}
     )
@@ -265,7 +265,7 @@ def remove_buildings(project_slug, project_dict, user_pk):
 
     selected_buildings = project_dict.get('selected_buildings', [])
 
-    cache.set(
+    set_cache_raw(
         project.removing_buildings_status_percentage_cache_key,
         {'percentage_done': 0, 'numerator': 0, 'denominator': 0}
     )
@@ -275,7 +275,7 @@ def remove_buildings(project_slug, project_dict, user_pk):
         for sfid in selected_buildings:
             i += 1
             denominator = len(selected_buildings)
-            cache.set(
+            set_cache_raw(
                 project.removing_buildings_status_percentage_cache_key,
                 {
                     'percentage_done': (
@@ -292,7 +292,7 @@ def remove_buildings(project_slug, project_dict, user_pk):
     else:
         query_buildings = get_search_query(user, project_dict)
         denominator = query_buildings.count() - len(selected_buildings)
-        cache.set(
+        set_cache_raw(
             project.adding_buildings_status_percentage_cache_key,
             {
                 'percentage_done': 10,
@@ -304,7 +304,7 @@ def remove_buildings(project_slug, project_dict, user_pk):
             ProjectBuilding.objects.get(
                 project=project, building_snapshot=b
             ).delete()
-        cache.set(
+        set_cache_raw(
             project.adding_buildings_status_percentage_cache_key,
             {
                 'percentage_done': 50,
@@ -318,7 +318,7 @@ def remove_buildings(project_slug, project_dict, user_pk):
             ProjectBuilding.objects.create(
                 project=project, building_snapshot=ab
             )
-            cache.set(
+            set_cache_raw(
                 project.adding_buildings_status_percentage_cache_key,
                 {
                     'percentage_done': (
@@ -330,7 +330,7 @@ def remove_buildings(project_slug, project_dict, user_pk):
                 }
             )
 
-    cache.set(
+    set_cache_raw(
         project.removing_buildings_status_percentage_cache_key,
         {'percentage_done': 100, 'numerator': i, 'denominator': denominator}
     )
@@ -378,7 +378,7 @@ def finish_mapping(results, file_pk):
     import_file.save()
     finish_import_record(import_file.import_record.pk)
     prog_key = get_prog_key('map_data', file_pk)
-    cache.set(prog_key, 100)
+    set_cache(prog_key, 'success', 100)
 
 
 def _translate_unit_to_type(unit):
@@ -513,8 +513,13 @@ def _map_data(file_pk, *args, **kwargs):
     # Don't perform this task if it's already been completed.
     if import_file.mapping_done:
         prog_key = get_prog_key('map_data', file_pk)
-        cache.set(prog_key, 100)
-        return {'status': 'warning', 'message': 'mapping already complete'}
+        result = {
+            'status': 'warning',
+            'progress': 100,
+            'message': 'mapping already complete'
+        }
+        set_cache(prog_key, result['status'], result)
+        return result
 
     # If we haven't finished saving, we shouldn't proceed with mapping
     # Re-queue this task.
@@ -590,7 +595,7 @@ def finish_raw_save(results, file_pk):
     import_file.raw_save_done = True
     import_file.save()
     prog_key = get_prog_key('save_raw_data', file_pk)
-    cache.set(prog_key, {'status': 'success', 'progress': 100})
+    set_cache(prog_key, 'success', 100)
 
 
 def cache_first_rows(import_file, parser):
@@ -665,10 +670,10 @@ def _save_raw_green_button_data(file_pk, *args, **kwargs):
     res = xml_importer.import_xml(import_file)
 
     prog_key = get_prog_key('save_raw_data', file_pk)
-    cache.set(prog_key, 100)
+    set_cache(prog_key, 'success', 100)
 
     if res:
-        return {'status': 'success'}
+        return {'status': 'success', 'progress': 100}
 
     return {
         'status': 'error',
@@ -689,7 +694,7 @@ def _save_raw_data(file_pk, *args, **kwargs):
         if import_file.raw_save_done:
             result['status'] = 'warning'
             result['message'] = 'Raw data already saved'
-            cache.set(prog_key, result)
+            set_cache(prog_key, result['status'], result)
             return result
 
         if import_file.source_type == "Green Button Raw":
@@ -731,7 +736,7 @@ def _save_raw_data(file_pk, *args, **kwargs):
         result['message'] = 'Unhandled Error: ' + e.message
         result['stacktrace'] = traceback.format_exc()
 
-    cache.set(prog_key, result)
+    set_cache(prog_key, result['status'], result)
     return result
 
 
@@ -790,7 +795,7 @@ def match_buildings(file_pk, user_pk):
     import_file = ImportFile.objects.get(pk=file_pk)
     if import_file.matching_done:
         prog_key = get_prog_key('match_buildings', file_pk)
-        cache.set(prog_key, 100)
+        set_cache(prog_key, 'warning', 100)
         return {'status': 'warning', 'message': 'matching already complete'}
 
     if not import_file.mapping_done:
@@ -887,7 +892,7 @@ def _finish_matching(import_file, progress_key):
     import_file.matching_done = True
     import_file.mapping_completion = 100
     import_file.save()
-    cache.set(progress_key, 100)
+    set_cache(progress_key, 'success', 100)
 
 
 def _normalize_address_str(address_val):
@@ -1076,18 +1081,29 @@ def remap_data(import_file_pk):
     # Check to ensure that the building has not already been merged.
     mapping_cache_key = get_prog_key('map_data', import_file.pk)
     if import_file.matching_done or import_file.matching_completion:
-        cache.set(mapping_cache_key, 100)
-        return {
-            'status': 'warning', 'message': 'Mapped buildings already merged'
+        result = {
+            'status': 'warning',
+            'progress': 100,
+            'message': 'Mapped buildings already merged'
         }
+        set_cache(mapping_cache_key, result['status'], result)
+        return result
 
     _remap_data.delay(import_file_pk)
 
     # Make sure that our mapping cache progress is reset.
-    cache.set(mapping_cache_key, 0)
+    result = {
+        'status': 'warning',
+        'progress': 0,
+        'message': 'Mapped buildings already merged'
+    }
+    set_cache(mapping_cache_key, result['status'], result)
     # Here we also return the mapping_prog_key so that the front end can
     # follow the progress.
-    return {'status': 'success', 'progress_key': mapping_cache_key}
+    return {
+        'status': 'success',
+        'progress_key': mapping_cache_key
+    }
 
 
 @task
@@ -1116,7 +1132,7 @@ def _delete_organization_buildings(org_pk, chunk_size=100, *args, **kwargs):
         org_pk
     )
     if not ids:
-        cache.set(deleting_cache_key, 100)
+        set_cache(deleting_cache_key, 'success', 100)
         return
 
     # delete the canonical buildings
@@ -1126,7 +1142,7 @@ def _delete_organization_buildings(org_pk, chunk_size=100, *args, **kwargs):
     _delete_canonical_buildings.delay(can_ids)
 
     step = float(chunk_size) / len(ids)
-    cache.set(deleting_cache_key, 0)
+    set_cache(deleting_cache_key, 'success', 0)
     tasks = []
     for del_ids in batch(ids, chunk_size):
         # we could also use .s instead of .subtask and not wrap the *args
@@ -1150,7 +1166,7 @@ def _delete_organization_buildings_chunk(del_ids, prog_key, increment,
 @task
 def finish_delete(results, org_pk):
     prog_key = get_prog_key('delete_organization_buildings', org_pk)
-    cache.set(prog_key, 100)
+    set_cache(prog_key, 'success', 100)
 
 
 @task

--- a/seed/templates/seed/base.html
+++ b/seed/templates/seed/base.html
@@ -70,7 +70,7 @@
             {# js vendor imports #}
             {# todo: switch angular.js to minified version, same with the rest #}
             <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
-            <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.1/js/bootstrap.min.js"></script>
+            <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
             <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.14/angular.js"></script>
             <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.14/angular-cookies.min.js"></script>
             <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.14/angular-route.min.js"></script>

--- a/seed/tests/test_decorators.py
+++ b/seed/tests/test_decorators.py
@@ -1,25 +1,25 @@
 """
 :copyright: (c) 2014 Building Energy Inc
 """
-from django.core.cache import cache
 from django.test import TestCase
 
-
 from seed import decorators
+from seed.utils.cache import make_key, get_cache, get_lock, increment_cache, clear_cache
 
 
 class TestException(Exception):
     pass
+
 
 class TestDecorators(TestCase):
     """Tests for locking tasks and reporting progress."""
 
     locked = 1
     unlocked = 0
-    pk = 34 # Arbitrary PK value to test with.
+    pk = 34  # Arbitrary PK value to test with.
 
     def setUp(self):
-        cache.clear()
+        clear_cache()
 
     #
     ## Tests for decorators utility functions
@@ -27,29 +27,29 @@ class TestDecorators(TestCase):
 
     def test_get_prog_key(self):
         """We format our cache key properly."""
-        expected = cache.make_key('SEED:fun_func:PROG:34')
-        self.assertEqual(decorators.get_prog_key('fun_func', 34), expected)
+        expected = make_key('SEED:fun_func:PROG:' + str(self.pk))
+        self.assertEqual(decorators.get_prog_key('fun_func', self.pk), expected)
 
     def test_increment_cache(self):
         """Sum our progress by increments properly."""
         expected = 25.0
-        test_key = cache.make_key('increment_test')
+        test_key = make_key('increment_test')
         increment = 25.0
         # Fresh increment, this initializes the value.
-        decorators.increment_cache(test_key, increment)
-        self.assertEqual(float(cache.get(test_key)['progress']), expected)
+        increment_cache(test_key, increment)
+        self.assertEqual(float(get_cache(test_key)['progress']), expected)
 
         # Increment an existing key
-        decorators.increment_cache(test_key, increment)
+        increment_cache(test_key, increment)
         expected = 50.0
-        self.assertEqual(float(cache.get(test_key)['progress']), expected)
+        self.assertEqual(float(get_cache(test_key)['progress']), expected)
 
         # This should put us well over 100.0 in incrementation w/o bounds check.
         for i in range(10):
-            decorators.increment_cache(test_key, increment)
+            increment_cache(test_key, increment)
 
         expected = 100.0
-        self.assertEqual(float(cache.get(test_key)['progress']), expected)
+        self.assertEqual(float(get_cache(test_key)['progress']), expected)
 
     #
     ## Tests for decorators themselves.
@@ -58,15 +58,15 @@ class TestDecorators(TestCase):
     def test_locking(self):
         """Make sure we indicate we're locked iff we're inside the function."""
         key = decorators._get_lock_key('fake_func', self.pk)
-        self.assertEqual(int(cache.get(key, 0)), self.unlocked)
+        self.assertEqual(int(get_lock(key)), self.unlocked)
 
         @decorators.lock_and_track
         def fake_func(import_file_pk):
-            self.assertEqual(int(cache.get(key, 0)), self.locked)
+            self.assertEqual(int(get_lock(key)), self.locked)
 
         fake_func(self.pk)
 
-        self.assertEqual(int(cache.get(key, 0)), self.unlocked)
+        self.assertEqual(int(get_lock(key)), self.unlocked)
 
     def test_locking_w_exception(self):
         """Make sure we release our lock if we've had an exception."""
@@ -74,23 +74,23 @@ class TestDecorators(TestCase):
 
         @decorators.lock_and_track
         def fake_func(import_file_pk):
-            self.assertEqual(int(cache.get(key, 0)), self.locked)
+            self.assertEqual(int(get_lock(key)), self.locked)
             raise TestException('Test exception!')
 
         self.assertRaises(TestException, fake_func, self.pk)
         # Even though execution failed part way through a call, we unlock.
-        self.assertEqual(int(cache.get(key, 0)), self.unlocked)
+        self.assertEqual(int(get_lock(key)), self.unlocked)
 
     def test_progress(self):
         """When a task finishes, it increments the progress counter properly."""
         increment = expected = 25.0
         key = decorators.get_prog_key('fake_func', self.pk)
-        self.assertEqual(float(cache.get(key, 0.0)), 0.0)
+        self.assertEqual(float(get_cache(key, 0.0)['progress']), 0.0)
 
         @decorators.lock_and_track
         def fake_func(import_file_pk):
-            decorators.increment_cache(key, increment)
+            increment_cache(key, increment)
 
         fake_func(self.pk)
 
-        self.assertEqual(float(cache.get(key, 0.0)['progress']), expected)
+        self.assertEqual(float(get_cache(key, 0.0)['progress']), expected)

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -5,7 +5,6 @@ import copy
 import json
 from unittest import skip
 
-from django.core.cache import cache
 from django.core.urlresolvers import reverse_lazy
 from django.test import TestCase
 from seed.lib.superperms.orgs.models import Organization, OrganizationUser
@@ -34,6 +33,7 @@ from seed.views.main import (
     DEFAULT_CUSTOM_COLUMNS,
     _parent_tree_coparents,
 )
+from seed.utils.cache import set_cache, get_cache
 from seed.utils.mapping import _get_column_names
 from seed.tests import util as test_util
 
@@ -1924,7 +1924,7 @@ class TestMCMViews(TestCase):
         """Make sure we retrieve data from cache properly."""
         progress_key = decorators.get_prog_key('fun_func', 23)
         expected = 50.0
-        cache.set(progress_key, expected)
+        set_cache(progress_key, 'parsing', expected)
         resp = self.client.post(
             reverse_lazy("seed:progress"),
             data=json.dumps({
@@ -1955,7 +1955,7 @@ class TestMCMViews(TestCase):
 
         # Set cache like we're done mapping.
         cache_key = decorators.get_prog_key('map_data', self.import_file.pk)
-        cache.set(cache_key, 100)
+        set_cache(cache_key, 'success', 100)
 
         resp = self.client.post(
             reverse_lazy("seed:remap_buildings"),
@@ -1981,7 +1981,7 @@ class TestMCMViews(TestCase):
             10
         )
 
-        self.assertEqual(cache.get(cache_key), 0)
+        self.assertEqual(get_cache(cache_key)['progress'], 0)
 
     def test_reset_mapped_w_previous_matches(self):
         """Ensure we ignore mapped buildings with children BSes."""
@@ -2047,7 +2047,8 @@ class TestMCMViews(TestCase):
 
         expected = {
             'status': 'warning',
-            'message': 'Mapped buildings already merged'
+            'message': 'Mapped buildings already merged',
+            'progress': 100
         }
 
         resp = self.client.post(

--- a/seed/utils/buildings.py
+++ b/seed/utils/buildings.py
@@ -84,7 +84,7 @@ def get_search_query(user, params):
 
 
 def get_columns(is_project, org_id, all_fields=False):
-    """gets default columns, to be overriden in future
+    """gets default columns, to be overridden in future
 
         title: HTML presented title of column
         sort_column: semantic name used by js and for searching DB
@@ -117,7 +117,6 @@ def get_columns(is_project, org_id, all_fields=False):
             "sort_column": k,
             "type": translator[v],
             "class": "is_aligned_right",
-            "field_type": "assessor",
             "sortable": True,
             "checked": False,
             "static": False,

--- a/seed/utils/cache.py
+++ b/seed/utils/cache.py
@@ -1,0 +1,63 @@
+from django.core.cache import cache as django_cache
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
+
+
+def make_key(key):
+    return unicode(django_cache.make_key(key))
+
+
+def set_cache_raw(progress_key, data, timeout=DEFAULT_TIMEOUT):
+    django_cache.set(progress_key, data, timeout)
+
+
+def get_cache_raw(progress_key):
+    return django_cache.get(progress_key)
+
+
+def set_cache(progress_key, status, data):
+    """Sets the cache key to a pickled dictionary containing at least status and progress. If data is not a dict, it is assumed to be a progress percentage."""
+    if type(status) != str:
+        raise ValueError('Invalid value for status; must be a string')
+    if not data:
+        raise ValueError('Data argument not found')
+
+    result = {}
+    if type(data) != dict:
+        result['progress'] = data
+    else:
+        result = data
+    result['status'] = status
+    set_cache_raw(progress_key, result, DEFAULT_TIMEOUT)
+
+
+def get_cache(progress_key):
+    """Unpickles the cache key to a dictionary and resets the timeout"""
+    data = django_cache.get(progress_key)
+    set_cache(progress_key, data['status'], data)
+    return data
+
+
+def lock_cache(progress_key, timeout=60):
+    """Set the lock with a default timeout of 1 minute"""
+    set_cache_raw(progress_key, 1, timeout)
+
+
+def unlock_cache(progress_key, timeout=DEFAULT_TIMEOUT):
+    """Unset the lock"""
+    set_cache_raw(progress_key, 0, timeout)
+
+
+def get_lock(progress_key):
+    return get_cache_raw(progress_key)
+
+
+def increment_cache(key, increment):
+    """Increment cache by value increment, never exceed 100."""
+    value = get_cache(key) or {'status': 'parsing', 'progress': 0.0}
+    value = float(value['progress'])
+    if value + increment >= 100.0:
+        value = 100.0
+    else:
+        value += increment
+
+    set_cache(key, 'parsing', value)

--- a/seed/utils/cache.py
+++ b/seed/utils/cache.py
@@ -6,20 +6,21 @@ def make_key(key):
     return unicode(django_cache.make_key(key))
 
 
-def set_cache_raw(progress_key, data, timeout=DEFAULT_TIMEOUT):
-    django_cache.set(progress_key, data, timeout)
+def set_cache_raw(key, data, timeout=DEFAULT_TIMEOUT):
+    django_cache.set(key, data, timeout)
 
 
-def get_cache_raw(progress_key):
-    return django_cache.get(progress_key)
+def get_cache_raw(key, default=None):
+    return django_cache.get(key, default)
 
 
 def set_cache(progress_key, status, data):
-    """Sets the cache key to a pickled dictionary containing at least status and progress. If data is not a dict, it is assumed to be a progress percentage."""
+    """
+    Sets the cache key to a pickled dictionary containing at least status and progress.
+    If data is not a dict, it is assumed to be a progress percentage.
+    """
     if type(status) != str:
         raise ValueError('Invalid value for status; must be a string')
-    if not data:
-        raise ValueError('Data argument not found')
 
     result = {}
     if type(data) != dict:
@@ -30,10 +31,18 @@ def set_cache(progress_key, status, data):
     set_cache_raw(progress_key, result, DEFAULT_TIMEOUT)
 
 
-def get_cache(progress_key):
+def get_cache(progress_key, default=None):
     """Unpickles the cache key to a dictionary and resets the timeout"""
-    data = django_cache.get(progress_key)
-    set_cache(progress_key, data['status'], data)
+    if default is not None:
+        if type(default) != dict:
+            default = {'status': 'Unknown', 'progress': default}
+    data = get_cache_raw(progress_key, default)
+    if data is None:
+        # Cache accessed before it was created
+        data = {'status': 'parsing', 'progress': 0.0}
+    else:
+        # Set cache to same value to reset timeout
+        set_cache(progress_key, data['status'], data)
     return data
 
 
@@ -47,13 +56,14 @@ def unlock_cache(progress_key, timeout=DEFAULT_TIMEOUT):
     set_cache_raw(progress_key, 0, timeout)
 
 
-def get_lock(progress_key):
-    return get_cache_raw(progress_key)
+def get_lock(lock_key, default=0):
+    """Return the locked status. If the lock key does not exist, return 0"""
+    return get_cache_raw(lock_key, default)
 
 
 def increment_cache(key, increment):
     """Increment cache by value increment, never exceed 100."""
-    value = get_cache(key) or {'status': 'parsing', 'progress': 0.0}
+    value = get_cache(key)
     value = float(value['progress'])
     if value + increment >= 100.0:
         value = 100.0
@@ -61,3 +71,7 @@ def increment_cache(key, increment):
         value += increment
 
     set_cache(key, 'parsing', value)
+
+
+def clear_cache():
+    django_cache.clear()


### PR DESCRIPTION
This PR removed the vast majority of direct cache.set/cache.get calls, and centralized them in a new cache utility that standardizes format, functionality, and let's us easily debug any time the cache is modified.

It also lets us control timeouts, if desired, and has one new functional change - any time a progress key is read, the timeout is reset to keep the key alive.

Please run through the normal tests and make sure I didn't break any caches - I ran the tests and haven't seen any issues myself.