### PR TITLE
Issue #90 - Remove woopra

### DIFF
--- a/config/settings/main.py
+++ b/config/settings/main.py
@@ -23,9 +23,6 @@ DEBUG = os.environ.get('DEBUG', 'False') == 'True'
 TEMPLATE_DEBUG = DEBUG
 DOMAIN_URLCONFS[STACK_OUTPUTS.get('HostName')] = 'config.urls'
 
-# django-analytics
-WOOPRA_DOMAIN = os.environ.get('WOOPRA_DOMAIN')
-
 # Handle SSL with django-sslify
 ONLY_HTTPS = os.environ.get('ONLY_HTTPS', 'True') == 'True'
 SESSION_COOKIE_SECURE = ONLY_HTTPS


### PR DESCRIPTION
Remove the config for the Woopra domain. This stops django-analytical from putting the tracking code in the DOM. I don't see any dependency issues, as local dev never includes it anyway.

Refs #90  