### PR TITLE
Issue #315 - Address direction normalize

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -75,11 +75,9 @@ six==1.5.2
 South==0.8.4
 street-address==0.2.1
 unicodecsv==0.9.4
+usaddress==0.5.4
 uwsgi==2.0.9
 wsgiref==0.1.2
 xlrd==0.9.3
 xlwt==0.7.5
 xmltodict==0.9.0
-
-
-

--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -958,6 +958,21 @@ def _finish_matching(import_file, progress_key):
     import_file.save()
     cache.set(progress_key, 100)
 
+def _normalize_address_direction(direction):
+    direction = direction.lower()
+    direction_map = {
+        'east' : 'e',
+        'west' : 'w', 
+        'north' : 'n',
+        'south' : 's',
+        'northeast': 'ne',
+        'northwest': 'nw',
+        'southeast': 'se',
+        'southwest': 'sw'
+    }
+    if direction in direction_map:
+        return direction_map[direction]
+    return direction
 
 def _normalize_address_str(address_val):
     """
@@ -984,7 +999,7 @@ def _normalize_address_str(address_val):
         normalized_address = addr['AddressNumber'].lstrip("0")  # some addresses have leading zeros, strip them here
 
     if 'StreetNamePreDirectional' in addr and addr['StreetNamePreDirectional'] is not None:
-        normalized_address = normalized_address + ' ' + addr['StreetNamePreDirectional']
+        normalized_address = normalized_address + ' ' + _normalize_address_direction(addr['StreetNamePreDirectional'])
 
     if 'StreetName' in addr and addr['StreetName'] is not None:
         normalized_address = normalized_address + ' ' + addr['StreetName']
@@ -994,7 +1009,7 @@ def _normalize_address_str(address_val):
         normalized_address = normalized_address + ' ' + addr['StreetNamePostType'].replace('.', '')
 
     if 'StreetNamePostDirectional' in addr and addr['StreetNamePostDirectional'] is not None:
-        normalized_address = normalized_address + ' ' + addr['StreetNamePostDirectional']
+        normalized_address = normalized_address + ' ' + _normalize_address_direction(addr['StreetNamePostDirectional'])
 
     formatter = StreetAddressFormatter()
     normalized_address = formatter.abbrev_street_avenue_etc(normalized_address)

--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -959,7 +959,7 @@ def _finish_matching(import_file, progress_key):
     cache.set(progress_key, 100)
 
 def _normalize_address_direction(direction):
-    direction = direction.lower()
+    direction = direction.lower().replace('.', '')
     direction_map = {
         'east' : 'e',
         'west' : 'w', 

--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -10,6 +10,7 @@ import traceback
 from _csv import Error
 
 from dateutil import parser
+import usaddress
 
 from django.core.mail import send_mail
 from django.conf import settings
@@ -28,7 +29,7 @@ from seed.lib.mcm import cleaners, mapper, reader
 from seed.lib.mcm.data.ESPM import espm as espm_schema
 from seed.lib.mcm.data.SEED import seed as seed_schema
 from seed.lib.mcm.utils import batch
-from streetaddress import StreetAddressParser, StreetAddressFormatter
+from streetaddress import StreetAddressFormatter
 from seed.data_importer.models import (
     ImportFile, ImportRecord, STATUS_READY_TO_MERGE, ROW_DELIMITER
 )
@@ -973,21 +974,27 @@ def _normalize_address_str(address_val):
         return None
 
     # now parse the address into number, street name and street type
-    parser = StreetAddressParser()
-    addr = parser.parse(str(address_val))  # TODO: should probably use unicode()
+    addr = usaddress.tag(str(address_val))[0]  # TODO: should probably use unicode()
     normalized_address = ''
 
     if not addr:
         return None
 
-    if 'house' in addr and addr['house'] is not None:
-        normalized_address = addr['house'].lstrip("0")  # some addresses have leading zeros, strip them here
+    if 'AddressNumber' in addr and addr['AddressNumber'] is not None:
+        normalized_address = addr['AddressNumber'].lstrip("0")  # some addresses have leading zeros, strip them here
 
-    if 'street_name' in addr and addr['street_name'] is not None:
-        normalized_address = normalized_address + ' ' + addr['street_name']
+    if 'StreetNamePreDirectional' in addr and addr['StreetNamePreDirectional'] is not None:
+        normalized_address = normalized_address + ' ' + addr['StreetNamePreDirectional']
 
-    if 'street_type' in addr and addr['street_type'] is not None:
-        normalized_address = normalized_address + ' ' + addr['street_type']
+    if 'StreetName' in addr and addr['StreetName'] is not None:
+        normalized_address = normalized_address + ' ' + addr['StreetName']
+
+    if 'StreetNamePostType' in addr and addr['StreetNamePostType'] is not None:
+        # remove any periods from abbreviations
+        normalized_address = normalized_address + ' ' + addr['StreetNamePostType'].replace('.', '')
+
+    if 'StreetNamePostDirectional' in addr and addr['StreetNamePostDirectional'] is not None:
+        normalized_address = normalized_address + ' ' + addr['StreetNamePostDirectional']
 
     formatter = StreetAddressFormatter()
     normalized_address = formatter.abbrev_street_avenue_etc(normalized_address)

--- a/seed/tests/test_matching.py
+++ b/seed/tests/test_matching.py
@@ -42,4 +42,6 @@ class NormalizeStreetAddressTests(TestCase):
         ('trailing direction', '123 Test St. NE', '123 test st ne'),
         ('prefix direction', '123 South Test St.', '123 south test st'),
         ('verbose direction', '123 Test St. Northeast', '123 test st northeast'),
+        ('two directions', '111 S West Main', '111 s west main'),
+        ('numeric street and direction', '555 11th St. NW', '555 11th st nw'),
     ]

--- a/seed/tests/test_matching.py
+++ b/seed/tests/test_matching.py
@@ -40,8 +40,10 @@ class NormalizeStreetAddressTests(TestCase):
         ('boulevard', 'Boulevard', 'blvd'),
         ('avenue', 'avenue', 'ave'),
         ('trailing direction', '123 Test St. NE', '123 test st ne'),
-        ('prefix direction', '123 South Test St.', '123 south test st'),
-        ('verbose direction', '123 Test St. Northeast', '123 test st northeast'),
+        ('prefix direction', '123 South Test St.', '123 s test st'),
+        ('verbose direction', '123 Test St. Northeast', '123 test st ne'),
         ('two directions', '111 S West Main', '111 s west main'),
         ('numeric street and direction', '555 11th St. NW', '555 11th st nw'),
+        ('direction 1', '100 Main S', '100 main s'),
+        ('direction 2', '100 Main South', '100 main s'),
     ]

--- a/seed/tests/test_matching.py
+++ b/seed/tests/test_matching.py
@@ -2,59 +2,44 @@ from django.test import TestCase
 from seed.tasks import _normalize_address_str
 
 
-class NormalizeStreetAddressTest(TestCase):
-    def setUp(self):
-        pass
+def make_test(message, expected):
+    def run(self):
+        result = _normalize_address_str(message)
+        self.assertEquals(expected, result)
+    return run
 
-    def test_normalize_simple_address(self):
-        normalized_addr = _normalize_address_str("123 Test St.")
-        self.assertEqual(normalized_addr, "123 test st")
 
-    def test_empty_address(self):
-        """
-        Test what happens when we try & normalize a non-existent address.
-        """
-        normalized_addr = _normalize_address_str(None)
-        self.assertEqual(None, normalized_addr)
+# Metaclass to create individual test methods per test case.
+class NormalizeAddressTester(type):
+    def __new__(cls, name, bases, attrs):
+        cases = attrs.get('cases', [])
 
-        normalized_addr = _normalize_address_str('')
-        self.assertEqual(None, normalized_addr)
+        for doc, message, expected in cases:
+            test = make_test(message, expected)
+            test_name = 'test_normalize_address_%s' % doc.lower().replace(' ', '_')
+            test.__doc__ = doc
+            test.__name__ = test_name
+            attrs[test_name] = test
+        return super(NormalizeAddressTester, cls).__new__(cls, name, bases, attrs)
 
-    def test_missing_number(self):
-        normalized_addr = _normalize_address_str("Test St.")
-        self.assertEqual(normalized_addr, "test st")
 
-    def test_missing_street_name(self):
-        normalized_addr = _normalize_address_str("123")
-        self.assertEqual(normalized_addr, "123")
+class NormalizeStreetAddressTests(TestCase):
+    __metaclass__ = NormalizeAddressTester
 
-    def test_integer_address(self):
-        normalized_addr = _normalize_address_str(123)
-        self.assertEqual('123', normalized_addr)
-    
-    def test_strip_leading_zeros(self):
-        """
-        Some of the addresses we receive have leading zeros.
-        E.G. 240102 N Hazel Alley might be 0000240102 N Hazel Alley
-        This tests the change to _normaliz
-        """
-        normalized_addr = _normalize_address_str("0000123")
-        self.assertEqual(normalized_addr, "123")
-        
-        
-    def test_abbrev_street_types(self):
-        """
-        Catches the spelled out street types e.g., "Street" == "St"  
-        """
-
-        normalized_addr = _normalize_address_str("STREET")
-        self.assertEqual(normalized_addr, "st")
-    
-        normalized_addr = _normalize_address_str("Street")
-        self.assertEqual(normalized_addr, "st")
-
-        normalized_addr = _normalize_address_str("Boulevard")
-        self.assertEqual(normalized_addr, "blvd")
-    
-        normalized_addr = _normalize_address_str("avenue")
-        self.assertEqual(normalized_addr, "ave")
+    # test name, input, expected output
+    cases = [
+        ('simple', '123 Test St.', '123 test st'),
+        ('none input', None, None),
+        ('empty input', '', None),
+        ('missing number', 'Test St.', 'test st'),
+        ('missing street', '123', '123'),
+        ('integer address', 123, '123'),
+        ('strip leading zeros', '0000123', '123'),
+        ('street 1', 'STREET', 'st'),
+        ('street 2', 'Street', 'st'),
+        ('boulevard', 'Boulevard', 'blvd'),
+        ('avenue', 'avenue', 'ave'),
+        ('trailing direction', '123 Test St. NE', '123 test st ne'),
+        ('prefix direction', '123 South Test St.', '123 south test st'),
+        ('verbose direction', '123 Test St. Northeast', '123 test st northeast'),
+    ]

--- a/seed/tests/test_matching.py
+++ b/seed/tests/test_matching.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from seed.tasks import _normalize_address_str
 
 
-def make_test(message, expected):
+def make_method(message, expected):
     def run(self):
         result = _normalize_address_str(message)
         self.assertEquals(expected, result)
@@ -15,10 +15,10 @@ class NormalizeAddressTester(type):
         cases = attrs.get('cases', [])
 
         for doc, message, expected in cases:
-            test = make_test(message, expected)
+            test = make_method(message, expected)
             test_name = 'test_normalize_address_%s' % doc.lower().replace(' ', '_')
-            test.__doc__ = doc
             test.__name__ = test_name
+            test.__doc__ = doc
             attrs[test_name] = test
         return super(NormalizeAddressTester, cls).__new__(cls, name, bases, attrs)
 

--- a/seed/tests/test_matching.py
+++ b/seed/tests/test_matching.py
@@ -46,4 +46,6 @@ class NormalizeStreetAddressTests(TestCase):
         ('numeric street and direction', '555 11th St. NW', '555 11th st nw'),
         ('direction 1', '100 Main S', '100 main s'),
         ('direction 2', '100 Main South', '100 main s'),
+        ('direction 3', '100 Main S.', '100 main s'),
+        ('direction 4', '100 Main', '100 main'),
     ]


### PR DESCRIPTION
Handle directions in address normalization. Probably still some odd cases that need worked out, but this gets the basics. Eg both `100 Main S` and `100 Main South` will return the same result, but `100 Main` and `100 Main S` will be different.

Reworked the tests using a metaclass so you can simply add cases, and they will register as separate test methods and fail independently. 

refs #315 