### PR TITLE
Fixes pytest.ini to point to the correct DJANGO_SETTINGS_MODULE

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=BE.settings.test
+DJANGO_SETTINGS_MODULE=config.settings.test


### PR DESCRIPTION
### What was broken?

The `pytest.ini` file which is used for running the test suite using `pytest` was still pointing at the `BE` python module.

### How was it fixed.

I updated the `DJANGO_SETTINGS_MODULE` value to point to `config.settings.test` which is the correct python path for the test settings

#### Cute animal picture

![16877158047_5cf10c3a14_z](https://cloud.githubusercontent.com/assets/824194/9859254/d126c460-5ae2-11e5-81f3-3827142d26d6.jpg)
