### PR TITLE
Piper/issue 378 normalize street type

### DIFF
--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -1039,6 +1039,17 @@ def _normalize_address_direction(direction):
         return direction_map[direction]
     return direction
 
+
+POST_TYPE_MAP = {
+    'avenue': 'ave',
+}
+
+
+def _normalize_address_post_type(post_type):
+    value = post_type.lower().replace('.', '')
+    return POST_TYPE_MAP.get(value, value)
+
+
 def _normalize_address_str(address_val):
     """
     Normalize the address to conform to short abbreviations.
@@ -1071,7 +1082,7 @@ def _normalize_address_str(address_val):
 
     if 'StreetNamePostType' in addr and addr['StreetNamePostType'] is not None:
         # remove any periods from abbreviations
-        normalized_address = normalized_address + ' ' + addr['StreetNamePostType'].replace('.', '')
+        normalized_address = normalized_address + ' ' + _normalize_address_post_type(addr['StreetNamePostType'])
 
     if 'StreetNamePostDirectional' in addr and addr['StreetNamePostDirectional'] is not None:
         normalized_address = normalized_address + ' ' + _normalize_address_direction(addr['StreetNamePostDirectional'])

--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -1027,7 +1027,7 @@ def _normalize_address_direction(direction):
     direction = direction.lower().replace('.', '')
     direction_map = {
         'east' : 'e',
-        'west' : 'w', 
+        'west' : 'w',
         'north' : 'n',
         'south' : 's',
         'northeast': 'ne',

--- a/seed/tests/test_matching.py
+++ b/seed/tests/test_matching.py
@@ -48,4 +48,8 @@ class NormalizeStreetAddressTests(TestCase):
         ('direction 2', '100 Main South', '100 main s'),
         ('direction 3', '100 Main S.', '100 main s'),
         ('direction 4', '100 Main', '100 main'),
+        # Found edge cases
+        # https://github.com/SEED-platform/seed/issues/378
+        ('regression 1', '100 Peach Ave. East', '100 peach ave e'),
+        ('regression 1', '100 Peach Avenue E.', '100 peach ave e'),
     ]


### PR DESCRIPTION
ref #378 

based on pr #379 (will rebase this PR if that pr gets merged first)

### What was wrong

The two addresses `Peach Ave. East` and `Peach Avenue E.` were not being normalized to the same values, and thus were being detected as different addresses when they should have been handled as the same address.

### How was it fixed.

New normalization function for the `StreetNamePostType` value of the deconstructed address so that the longhand street type `Avenue` is normalized to the desired shorthand `ave`.

#### Cute animal picture

![baby-goats-09](https://cloud.githubusercontent.com/assets/824194/9860168/aa5f6b16-5ae7-11e5-9724-acec89e1aee5.jpg)
