### PR TITLE
Account for null values in the normalized connonical building address

### DIFF
--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -1098,6 +1098,8 @@ def _find_matches(un_m_address, canonical_buildings_addresses):
     if not un_m_address:
         return match_list
     for cb in canonical_buildings_addresses:
+        if cb is None:
+            continue
         if un_m_address.lower() == cb.lower():  # this second lower may be obsolete now
             match_list.append((un_m_address, 1))
     return match_list


### PR DESCRIPTION
I encountered this bug while doing investigatory work on #386 

### What was wrong.

When trying to execute the building matching phase of data import, I was getting an error because `lower()` was being called on `None` in the `_find_matches` function.

```
[2015-09-23 12:20:33,918: ERROR/MainProcess] Task seed.tasks._match_buildings[626978cc-7f2d-4c4d-941e-9bc5e854f937] raised unexpected: AttributeError("'NoneType' object has no attribute 'lower'",)
Traceback (most recent call last):
  File "/Users/piper/python-environments/seed/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/Users/piper/python-environments/seed/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/Users/piper/sites/seed/seed/decorators.py", line 50, in _wrapped
    response = fn(import_file_pk, *args, **kwargs)
  File "/Users/piper/sites/seed/seed/tasks.py", line 1208, in _match_buildings
    results = _find_matches(un_m_address, canonical_buildings_addresses)
  File "/Users/piper/sites/seed/seed/tasks.py", line 1101, in _find_matches
    if un_m_address.lower() == cb.lower():  # this second lower may be obsolete now
AttributeError: 'NoneType' object has no attribute 'lower'
```

When the [`_match_buildings`](https://github.com/SEED-platform/seed/blob/2070456678b07bbe73f99f94a414928a021c5a23/seed/tasks.py#L1108) task is run it creates a list of address pieces called [`canonical_buildings_addresses`](https://github.com/SEED-platform/seed/blob/2070456678b07bbe73f99f94a414928a021c5a23/seed/tasks.py#L1193) via the [`_normalize_address_str`](https://github.com/SEED-platform/seed/blob/2070456678b07bbe73f99f94a414928a021c5a23/seed/tasks.py#L1053) function.  Later, this list is passed into the [`_find_matches`](https://github.com/SEED-platform/seed/blob/2070456678b07bbe73f99f94a414928a021c5a23/seed/tasks.py#L1208) function, which assumes all of the list values are strings, and calls `lower` on them.

This blows up, because the `_normalize_address_str` function returns `None` on [line 1065](https://github.com/SEED-platform/seed/blob/2070456678b07bbe73f99f94a414928a021c5a23/seed/tasks.py#L1065) if the address value is falsy.

### How was it fixed.

I adjusted the `_find_matches` function to check whether the value is `None` and to just continue on with the next loop iteration when this is the case.

#### Cute animal picture.

![goat-on-a-horse](https://cloud.githubusercontent.com/assets/824194/10056353/f8a34ea2-61f7-11e5-8fc4-7c1e0b490955.jpg)
