### PR TITLE
Piper/issue 386 fix bug when unmerging snapshots

### DIFF
--- a/seed/models.py
+++ b/seed/models.py
@@ -1274,7 +1274,7 @@ class BuildingSnapshot(TimeStampedModel):
     use_description_source = models.ForeignKey(
         'BuildingSnapshot', related_name='+', null=True, blank=True
     )
-    
+
     #Need a field to indicate that a record is a duplicate of another.  Mainly used for cleaning up.
     duplicate = models.ForeignKey(
         'BuildingSnapshot', related_name='+', null=True, blank=True

--- a/seed/models.py
+++ b/seed/models.py
@@ -437,6 +437,19 @@ def unmatch_snapshot_tree(building_pk):
 
     # delete all sub-children of the unmatched snapshot
     for child in children_to_murder:
+        # If the child we're about to delete is set as the canonical snapshop,
+        # we should update the canonical_building to point at a different node
+        # if possible.
+        canons_to_update = CanonicalBuilding.objects.filter(
+            canonical_snapshot=child,
+        )
+        for cb in canons_to_update:
+            sibling = cb.buildingsnapshot_set.exclude(
+                pk=child.pk,
+            ).first()
+            if sibling:
+                cb.canonical_snapshot = sibling.tip
+                cb.save()
         child.delete()
 
     # re-merge parents whose children have been taken from them
@@ -450,6 +463,7 @@ def unmatch_snapshot_tree(building_pk):
     tip = newborn_child or root
     canon = root.canonical_building
     canon.canonical_snapshot = tip
+    canon.active = True
     canon.save()
 
 

--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -1098,6 +1098,8 @@ def _find_matches(un_m_address, canonical_buildings_addresses):
     if not un_m_address:
         return match_list
     for cb in canonical_buildings_addresses:
+        if cb is None:
+            continue
         if un_m_address.lower() == cb.lower():  # this second lower may be obsolete now
             match_list.append((un_m_address, 1))
     return match_list

--- a/seed/tests/test_models.py
+++ b/seed/tests/test_models.py
@@ -247,7 +247,7 @@ class TestBuildingSnapshot(TestCase):
 
         test_mapping, _ = seed_models.get_column_mappings(org)
         self.assertDictEqual(test_mapping, expected)
-        
+
     def _check_save_snapshot_match_with_default(self, default_pk):
         """Test good case for saving a snapshot match."""
         self.assertEqual(seed_models.BuildingSnapshot.objects.all().count(), 2)
@@ -257,7 +257,7 @@ class TestBuildingSnapshot(TestCase):
 
         self.bs2.canonical_building = bs2_canon
         self.bs2.save()
-        
+
         default_building = self.bs1 if default_pk == self.bs1.pk else self.bs2
 
         seed_models.save_snapshot_match(
@@ -291,7 +291,7 @@ class TestBuildingSnapshot(TestCase):
     def test_save_snapshot_match_default_to_first_building(self):
         """Test good case for saving a snapshot match with the first building as default."""
         self._check_save_snapshot_match_with_default(self.bs1.pk)
-        
+
     def test_save_snapshot_match_default_to_second_building(self):
         """Test good case for saving a snapshot match with the second building as default."""
         self._check_save_snapshot_match_with_default(self.bs2.pk)

--- a/seed/utils/visualization.py
+++ b/seed/utils/visualization.py
@@ -1,0 +1,77 @@
+from graphviz import Digraph
+
+
+def c_node_name(bs):
+    status = 'active' if bs.canonical_building.active else 'inactive'
+    return "C-{bs.custom_id_1} ({bs.canonical_building_id} - {status})".format(
+        bs=bs,
+        status=status,
+    )
+
+
+def bs_node_name(bs):
+    return "{bs.custom_id_1} ({bs.pk})".format(bs=bs)
+
+
+def c_node_id(bs):
+    return "C-{bs.canonical_building_id}".format(bs=bs)
+
+
+def bs_node_id(bs):
+    return str(bs.pk)
+
+
+def s_node_id(c):
+    return "S-{c.canonical_snapshot.pk}".format(c=c)
+
+
+def s_node_name(c):
+    return "S-{c.canonical_snapshot.custom_id_1} ({c.canonical_snapshot_id})".format(c=c)
+
+
+def create_tree(queryset):
+    """
+    Given a queryset of BuildingSnapshots, construct a graphviz dot graph of
+    the tree structure.  This can be useful for visually inspecting the tree.
+    """
+    seen_nodes = set()
+
+    dot = Digraph(comment="Building Snapshot Visualization")
+    for bs in queryset:
+        if bs.canonical_building_id is None:
+            continue
+        bs_id, bs_name = bs_node_id(bs), bs_node_name(bs)
+        c_id, c_name = c_node_id(bs), c_node_name(bs)
+        dot.node(c_id, c_name)
+        dot.node(bs_id, bs_name)
+        dot.edge(c_id, bs_id)
+        seen_nodes.add(bs_id)
+        seen_nodes.add((c_id, bs_id))
+
+        if bs.canonical_building.canonical_snapshot_id is not None:
+            s_id, s_name = s_node_id(bs.canonical_building), s_node_name(bs.canonical_building)
+            dot.node(s_id, s_name)
+            dot.edge(s_id, c_id)
+
+        create_bs_tree(bs, dot, seen_nodes)
+
+    return dot
+
+
+def create_bs_tree(bs, dot, seen_nodes):
+    """
+    Recursively crawl down the tree and add the nodes and edges.
+    """
+    parent_id = bs_node_id(bs)
+
+    for child in bs.children.all():
+        child_id, child_name = bs_node_id(child), bs_node_name(child)
+        if child_id not in seen_nodes:
+            dot.node(child_id, child_name)
+            seen_nodes.add(child_id)
+
+        if (parent_id, child_id) not in seen_nodes:
+            dot.edge(parent_id, child_id)
+            seen_nodes.add((parent_id, child_id))
+
+        create_bs_tree(child, dot, seen_nodes)

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -1131,7 +1131,7 @@ def get_PM_filter_by_counts(request):
         'unmatched': unmatched,
         'duplicates': duplicates,
     }
-    
+
 @api_endpoint
 @ajax_request
 @login_required
@@ -1145,12 +1145,12 @@ def delete_duplicates_from_import_file(request):
     Returns::
 
         {'status': 'success',
-         'deleted': Number of duplicates deleted         
+         'deleted': Number of duplicates deleted
         }
     """
     import_file_id = request.GET.get('import_file_id', '')
 
-    
+
     orig_duplicate_ct = BuildingSnapshot.objects.filter(
         import_file__pk=import_file_id,
         source_type__in=[2, 3],
@@ -1168,7 +1168,7 @@ def delete_duplicates_from_import_file(request):
     ).count()
     return {
         'status': 'success',
-        'deleted': orig_duplicate_ct - new_duplicate_ct,        
+        'deleted': orig_duplicate_ct - new_duplicate_ct,
     }
 
 
@@ -1259,11 +1259,11 @@ def get_column_mapping_suggestions(request):
         _log.info("map Portfolio Manager input file")
         suggested_mappings = {}
         ver = import_file.source_program_version
-        
+
         #if there is no pm mapping found but the file has already been matched
         #then effectively the mappings are already known with a confidence of 100
         no_pm_mappings_confience = 100 if import_file.matching_done else 0
-        
+
         for col, item in simple_mapper.get_pm_mapping(
                 ver, import_file.first_row_columns,
                 include_none=True).items():
@@ -2014,7 +2014,7 @@ def progress(request):
         # The following if statement can be removed once all progress endpoints have been updated to the new json syntax
         if type(result) != dict:
             result = {'progress': result}
-        result['progress_key'] = progress_key        
+        result['progress_key'] = progress_key
         return result
     else:
         return {


### PR DESCRIPTION
PR for issue #386 

Is based off of PR #389 though the merge order should not matter.

### What was wrong?

When unmerging buildings, it was possible for the building to get left in an error state.

In the case where the building which is being removed from a set of other builds happens to be the one that has the active canonical building (within the tree of building snapshots), then when that building snapshot is unmerged from the tree, it's canonical building will end up with no canonical snapshot.  When this happens, it stops being returned in queries for buildings, and thus disappears from the frontend.

### How was it fixed.

The error state occurs when the orphan'd children get deleted, and one of those children happens to be a canonical snapshot.  When this happens, now it goes and finds a *sibling* of the child and sets the tip of that sibling's tree as the canonical snapshot prior to deletion of the orphaned child.

#### Cute animal picture.

![518889810_c_294_220](https://cloud.githubusercontent.com/assets/824194/10089072/f9f39c86-62dc-11e5-83da-32a2891cb2a5.jpg)
