### PR TITLE
Issue #437 - API endpoint status codes

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,8 +11,6 @@ whitenoise==2.0
 # Forms
 django-analytical==0.17.1
 django-angular==0.7.2
-django-annoying==0.8.3
-# django-annoying==0.7.6
 django_compressor==1.5
 # django-compressor==1.3
 # django-extensions==1.3.3

--- a/samples/demo_app/requirements.txt
+++ b/samples/demo_app/requirements.txt
@@ -2,4 +2,3 @@ Django>=1.4
 nose==1.3.3
 wsgiref==0.1.2
 flake8==2.2.0
-django-annoying==0.7.6

--- a/samples/demo_app/setup.py
+++ b/samples/demo_app/setup.py
@@ -17,7 +17,6 @@ setup(
     include_package_data=True,
     install_requires=[
          'django<1.7',
-         'django-annoying',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/samples/demo_app/stats/views.py
+++ b/samples/demo_app/stats/views.py
@@ -3,13 +3,14 @@
 """
 
 from django.contrib.auth.decorators import login_required
-from annoying.decorators import render_to
-from seed.models import BuildingSnapshot
 from django.db.models import Avg, Min, Max, StdDev
+from django.shortcuts import render_to_response
+from django.template import RequestContext
+
+from seed.models import BuildingSnapshot
 
 
 @login_required
-@render_to('stats/stats.html')
 def stats(request):
     """get a couple averages to display"""
     stats_dict = BuildingSnapshot.objects.filter(
@@ -21,4 +22,5 @@ def stats(request):
         StdDev('gross_floor_area'),
     )
 
-    return locals()
+    return render_to_response('stats/stats.html',
+        locals(), context_instance=RequestContext(request))

--- a/seed/audit_logs/views.py
+++ b/seed/audit_logs/views.py
@@ -7,10 +7,8 @@ import json
 # django imports
 from django.contrib.auth.decorators import login_required
 
-# vendor imports
-from annoying.decorators import ajax_request
-
 # app imports
+from seed.decorators import ajax_request
 from seed.lib.superperms.orgs.decorators import has_perm
 from seed.utils.api import api_endpoint
 from seed.models import CanonicalBuilding

--- a/seed/cleansing/views.py
+++ b/seed/cleansing/views.py
@@ -1,9 +1,9 @@
 import csv
-from annoying.decorators import ajax_request
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse
 from seed.cleansing.models import Cleansing
+from seed.decorators import ajax_request
 from seed.utils.api import api_endpoint
 
 # TODO The API is returning on both a POST and GET. Make sure to authenticate.

--- a/seed/data_importer/views.py
+++ b/seed/data_importer/views.py
@@ -8,7 +8,6 @@ import hmac
 import hashlib
 import logging
 
-from annoying.decorators import ajax_request
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from ajaxuploader.views import AjaxFileUploader
@@ -16,6 +15,7 @@ from seed.data_importer.models import (
     ImportFile,
     ImportRecord,
 )
+from seed.decorators import ajax_request
 from ajaxuploader.backends.local import LocalUploadBackend
 from seed.utils.api import api_endpoint
 from django.core.urlresolvers import reverse

--- a/seed/decorators.py
+++ b/seed/decorators.py
@@ -97,9 +97,14 @@ def ajax_request(func):
         else:
             format_type = 'application/json'
         response = func(request, *args, **kwargs)
+
+        status_code = 200
+        if response.get('status') == 'error' or response.get('success') == False:
+            status_code = 400
+
         if not isinstance(response, HttpResponse):
             data = FORMAT_TYPES[format_type](response)
-            response = HttpResponse(data, content_type=format_type)
+            response = HttpResponse(data, content_type=format_type, status=status_code)
             response['content-length'] = len(data)
         return response
     return wrapper

--- a/seed/decorators.py
+++ b/seed/decorators.py
@@ -1,7 +1,12 @@
 """
 :copyright: (c) 2014 Building Energy Inc
 """
+import json
+
 from functools import wraps
+
+from django.core.serializers.json import DjangoJSONEncoder
+from django.http import HttpResponse
 
 from seed.utils.cache import make_key, lock_cache, unlock_cache, get_lock
 
@@ -9,6 +14,10 @@ SEED_CACHE_PREFIX = 'SEED:{0}'
 LOCK_CACHE_PREFIX = SEED_CACHE_PREFIX + ':LOCK'
 PROGRESS_CACHE_PREFIX = SEED_CACHE_PREFIX + ':PROG'
 
+FORMAT_TYPES = {
+    'application/json': lambda response: json.dumps(response, cls=DjangoJSONEncoder),
+    'text/json':        lambda response: json.dumps(response, cls=DjangoJSONEncoder),
+}
 
 def _get_cache_key(prefix, import_file_pk):
     """Makes a key like 'SEED:save_raw_data:LOCK:45'."""
@@ -59,3 +68,38 @@ def lock_and_track(fn, *args, **kwargs):
         return response
 
     return _wrapped
+
+
+def ajax_request(func):
+    """
+    * Copied from django-annoying, with a small modification. Now we also check
+    * for 'status' or 'success' keys and return correct status codes
+
+    If view returned serializable dict, returns response in a format requested
+    by HTTP_ACCEPT header. Defaults to JSON if none requested or match.
+
+    Currently supports JSON or YAML (if installed), but can easily be extended.
+
+    example:
+
+        @ajax_request
+        def my_view(request):
+            news = News.objects.all()
+            news_titles = [entry.title for entry in news]
+            return {'news_titles': news_titles}
+    """
+    @wraps(func)
+    def wrapper(request, *args, **kwargs):
+        for accepted_type in request.META.get('HTTP_ACCEPT', '').split(','):
+            if accepted_type in FORMAT_TYPES.keys():
+                format_type = accepted_type
+                break
+        else:
+            format_type = 'application/json'
+        response = func(request, *args, **kwargs)
+        if not isinstance(response, HttpResponse):
+            data = FORMAT_TYPES[format_type](response)
+            response = HttpResponse(data, content_type=format_type)
+            response['content-length'] = len(data)
+        return response
+    return wrapper

--- a/seed/landing/views.py
+++ b/seed/landing/views.py
@@ -3,7 +3,6 @@
 """
 import logging
 
-from annoying.decorators import render_to
 from django.contrib import auth
 from django.contrib.auth import authenticate, login
 from django.conf import settings
@@ -21,15 +20,15 @@ from forms import LoginForm, SetStrongPasswordForm
 logger = logging.getLogger(__name__)
 
 
-@render_to('landing/home.html')
 def landing_page(request):
     if request.user.is_authenticated():
         return HttpResponseRedirect(reverse('seed:home'))
     login_form = LoginForm()
-    return locals()
+    return render_to_response('landing/home.html',
+        locals(), context_instance=RequestContext(request))
 
 
-def _login_view(request):
+def login_view(request):
     """
     Standard Django login, with additions:
         Lowercase the login email (username)
@@ -76,9 +75,8 @@ def _login_view(request):
                 errors.append('Username and/or password were invalid.')
     else:
         form = LoginForm()
-
-    return locals()
-login_view = render_to('landing/login.html')(_login_view)
+    return render_to_response('landing/login.html',
+        locals(), context_instance=RequestContext(request))
 
 
 def password_set(request, uidb64=None, token=None):
@@ -120,9 +118,9 @@ def password_reset_confirm(request, uidb64=None, token=None):
     )
 
 
-@render_to("landing/password_reset_complete.html")
 def password_reset_complete(request):
-    return locals()
+    return render_to_response("landing/password_reset_complete.html",
+        {}, context_instance=RequestContext(request))
 
 
 def signup(request, uidb64=None, token=None):

--- a/seed/static/seed/js/services/auth_service.js
+++ b/seed/static/seed/js/services/auth_service.js
@@ -36,9 +36,6 @@ angular.module('BE.seed.service.auth', []).factory('auth_service', [
                 'organization_id': organization_id
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            }
             defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
@@ -56,9 +53,6 @@ angular.module('BE.seed.service.auth', []).factory('auth_service', [
             method: 'GET',
             'url': urls.accounts.get_actions
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            }
             defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);

--- a/seed/static/seed/js/services/organization_service.js
+++ b/seed/static/seed/js/services/organization_service.js
@@ -34,12 +34,7 @@ angular.module('BE.seed.service.organization', []).factory('organization_service
             'url': urls.accounts.add_org,
             'data': {'user_id': org.email.user_id, 'organization_name': org.name}
         }).success(function(data, status, headers, config) {
-            if (data.status === 'error') {
-                defer.reject(data);
-            } else {
-               defer.resolve(data);
-            }
-
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -81,9 +76,6 @@ angular.module('BE.seed.service.organization', []).factory('organization_service
             'url': urls.accounts.remove_user_from_org,
             'data': {'organization_id': org_id, 'user_id':user_id}
         }).success(function(data, status, headers, config) {
-            if (data.status === 'error') {
-                defer.reject(data, status);
-            }
             defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
@@ -145,9 +137,6 @@ angular.module('BE.seed.service.organization', []).factory('organization_service
                 'organization': org
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            }
             defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
@@ -209,12 +198,8 @@ angular.module('BE.seed.service.organization', []).factory('organization_service
                 'sub_org': sub_org
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            }
             defer.resolve(data);
         }).error(function(data, status, headers, config) {
-            console.log(data);
             defer.reject(data, status);
         });
         return defer.promise;

--- a/seed/static/seed/js/services/project_service.js
+++ b/seed/static/seed/js/services/project_service.js
@@ -42,11 +42,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
                 'organization_id': user_service.get_organization().id
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -63,11 +59,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
                 'organization_id': user_service.get_organization().id
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -84,11 +76,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
                 'organization_id': user_service.get_organization().id
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -105,11 +93,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
                 'organization_id': user_service.get_organization().id
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -126,11 +110,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
                 'organization_id': user_service.get_organization().id
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -144,11 +124,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
             'url': urls.projects.get_adding_buildings_to_project_status_percentage,
             'data': {'project_loading_cache_key': project_loading_cache_key}
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -165,11 +141,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
                 'organization_id': user_service.get_organization().id
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -267,11 +239,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
                 'label': label
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -289,11 +257,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
                 'label': label
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -311,11 +275,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
                 'label': label
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -333,11 +293,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
                 'label': label
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -356,11 +312,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
                 'building': building
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -382,11 +334,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
                 'search_params': search_params
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });
@@ -409,11 +357,7 @@ angular.module('BE.seed.service.project', ['BE.seed.services.label_helper'])
                 'copy': copy
             }
         }).success(function(data, status, headers, config) {
-            if (data.status === "error") {
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status, headers, config) {
             defer.reject(data, status);
         });

--- a/seed/static/seed/js/services/uploader_service.js
+++ b/seed/static/seed/js/services/uploader_service.js
@@ -49,11 +49,7 @@ angular.module('BE.seed.service.uploader', []).factory('uploader_service', [
                 'organization_id': user_service.get_organization().id
             }
         }).success(function(data, status) {
-            if (data.status === "error"){
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status) {
             defer.reject(data, status);
         });
@@ -76,11 +72,7 @@ angular.module('BE.seed.service.uploader', []).factory('uploader_service', [
               'organization_id': user_service.get_organization().id
             }
         }).success(function(data, status) {
-            if (data.status === "error"){
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status) {
             defer.reject(data, status);
         });
@@ -98,11 +90,7 @@ angular.module('BE.seed.service.uploader', []).factory('uploader_service', [
             url: window.BE.urls.progress,
             'data': {'progress_key': progress_key}
         }).success(function(data, status) {
-            if (data.status === "error"){
-                defer.reject(data, status);
-            } else {
-                defer.resolve(data);
-            }
+            defer.resolve(data);
         }).error(function(data, status) {
             defer.reject(data, status);
         });

--- a/seed/static/seed/js/services/user_service.js
+++ b/seed/static/seed/js/services/user_service.js
@@ -43,9 +43,6 @@ angular.module('BE.seed.service.user', []).factory('user_service', [
                 'organization': org
             }
         }).success(function(data) {
-            if (data.status === 'error') {
-                defer.reject(data);
-            }
             defer.resolve(data);
         }).error(function(data, status) {
             defer.reject(data, status);
@@ -83,9 +80,6 @@ angular.module('BE.seed.service.user', []).factory('user_service', [
             'url': urls.accounts.add_user,
             'data': new_user_details
         }).success(function(data) {
-            if (data.status === 'error') {
-                defer.reject(data);
-            }
             defer.resolve(data);
         }).error(function(data, status) {
             defer.reject(data, status);
@@ -99,9 +93,6 @@ angular.module('BE.seed.service.user', []).factory('user_service', [
             method: 'GET',
             'url': urls.seed.get_default_columns
         }).success(function(data) {
-            if (data.status === 'error') {
-                defer.reject(data);
-            }
             defer.resolve(data);
         }).error(function(data, status) {
             defer.reject(data, status);
@@ -115,9 +106,6 @@ angular.module('BE.seed.service.user', []).factory('user_service', [
             method: 'GET',
             'url': urls.accounts.get_shared_buildings
         }).success(function(data) {
-            if (data.status === 'error') {
-                defer.reject(data);
-            }
             defer.resolve(data);
         }).error(function(data, status) {
             defer.reject(data, status);
@@ -135,9 +123,6 @@ angular.module('BE.seed.service.user', []).factory('user_service', [
             method: 'GET',
             'url': urls.accounts.get_user_profile
         }).success(function(data) {
-            if (data.status === 'error') {
-                defer.reject(data);
-            }
             defer.resolve(data);
         }).error(function(data, status) {
             defer.reject(data, status);
@@ -155,9 +140,6 @@ angular.module('BE.seed.service.user', []).factory('user_service', [
             method: 'POST',
             'url': urls.accounts.generate_api_key
         }).success(function(data) {
-            if (data.status === 'error') {
-                defer.reject(data);
-            }
             defer.resolve(data);
         }).error(function(data, status) {
             defer.reject(data, status);
@@ -172,9 +154,6 @@ angular.module('BE.seed.service.user', []).factory('user_service', [
             'url': urls.seed.set_default_columns,
             'data': {'columns': columns, 'show_shared_buildings': show_shared_buildings}
         }).success(function(data) {
-            if (data.status === 'error') {
-                defer.reject(data);
-            }
             defer.resolve(data);
         }).error(function(data, status) {
             defer.reject(data, status);
@@ -193,9 +172,6 @@ angular.module('BE.seed.service.user', []).factory('user_service', [
             'url': urls.accounts.update_user,
             'data': {user: user}
         }).success(function(data) {
-            if (data.status === 'error') {
-                defer.reject(data);
-            }
             defer.resolve(data);
         }).error(function(data, status) {
             defer.reject(data, status);
@@ -220,9 +196,6 @@ angular.module('BE.seed.service.user', []).factory('user_service', [
                 'password_2': password_2
             }
         }).success(function(data) {
-            if (data.status === 'error') {
-                defer.reject(data);
-            }
             defer.resolve(data);
         }).error(function(data, status) {
             defer.reject(data, status);

--- a/seed/views/accounts.py
+++ b/seed/views/accounts.py
@@ -8,7 +8,7 @@ import logging
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
-from annoying.decorators import ajax_request
+from seed.decorators import ajax_request
 from seed.lib.superperms.orgs.decorators import has_perm, PERMS
 from seed.lib.superperms.orgs.exceptions import TooManyNestedOrgs
 from seed.lib.superperms.orgs.models import (

--- a/seed/views/api.py
+++ b/seed/views/api.py
@@ -1,4 +1,4 @@
-from annoying.decorators import ajax_request
+from seed.decorators import ajax_request
 from seed.utils.api import (
     get_api_endpoints, format_api_docstring, api_endpoint
 )

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -14,7 +14,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 from django.core.files.storage import DefaultStorage
 from django.db.models import Q
-from annoying.decorators import render_to, ajax_request
 from django.shortcuts import render_to_response
 from django.template.context import RequestContext
 from seed.lib.mcm import mapper
@@ -26,6 +25,7 @@ from seed.tasks import (
     match_buildings,
     save_raw_data as task_save_raw,
 )
+from seed.decorators import ajax_request
 from seed.lib.superperms.orgs.decorators import has_perm
 from seed import models, tasks
 from seed.models import (

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -15,6 +15,8 @@ from django.conf import settings
 from django.core.files.storage import DefaultStorage
 from django.db.models import Q
 from annoying.decorators import render_to, ajax_request
+from django.shortcuts import render_to_response
+from django.template.context import RequestContext
 from seed.lib.mcm import mapper
 from seed.audit_logs.models import AuditLog
 from seed.data_importer.models import ImportFile, ImportRecord, ROW_DELIMITER
@@ -75,13 +77,13 @@ DEFAULT_CUSTOM_COLUMNS = [
 _log = logging.getLogger(__name__)
 
 
-@render_to('seed/jasmine_tests/AngularJSTests.html')
 def angular_js_tests(request):
     """Jasmine JS unit test code covering AngularJS unit tests and ran
        by ./manage.py harvest
 
     """
-    return locals()
+    return render_to_response('seed/jasmine_tests/AngularJSTests.html',
+        locals(), context_instance=RequestContext(request))
 
 
 def _get_default_org(user):
@@ -112,7 +114,6 @@ def _get_default_org(user):
         return "", "", ""
 
 
-@render_to('seed/index.html')
 @login_required
 def home(request):
     """the main view for the app
@@ -139,7 +140,8 @@ def home(request):
         request.user
     )
 
-    return locals()
+    return render_to_response('seed/index.html',
+        locals(), context_instance=RequestContext(request))
 
 
 @api_endpoint

--- a/seed/views/meters.py
+++ b/seed/views/meters.py
@@ -1,8 +1,8 @@
 import json
 
 from seed.lib.superperms.orgs.decorators import has_perm
-from annoying.decorators import ajax_request
 from django.contrib.auth.decorators import login_required
+from seed.decorators import ajax_request
 from seed.models import (
     ENERGY_TYPES,
     ENERGY_UNITS,

--- a/seed/views/projects.py
+++ b/seed/views/projects.py
@@ -10,9 +10,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 
 # vendor imports
-from annoying.decorators import ajax_request
 from dateutil import parser
-
 
 # config imports
 from seed.tasks import (
@@ -20,6 +18,7 @@ from seed.tasks import (
     remove_buildings,
 )
 
+from seed.decorators import ajax_request
 from seed.lib.superperms.orgs.decorators import has_perm
 from seed.models import (
     Compliance,


### PR DESCRIPTION
Add some logic to the `ajax_request` decorator to check status responses, and return correct status codes. I also removed the `render_to` import from `django-annoying`, and was able to remove `django-annoying` entirely.

On the FE, remove all the redundant status message checks. These are no longer necessary because the error method should now be triggered.

On the BE, it seems that two styles for status are used:
- `'status':'success'`
- `'success':True`

I didn't try to normalize all of these yet, as I feel like it would take me down a long rabbit hole of test fixing. But this is something we should keep in mind.

Refs #437 