### PR TITLE
Removed href='javascript:void(0);' attributes from 'a' tags

### DIFF
--- a/seed/static/seed/less/style.less
+++ b/seed/static/seed/less/style.less
@@ -149,6 +149,12 @@ body {
 h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 	font-family: @font-family-base;
 }
+
+/* placeholder hyperlinks */
+a:not([href]) {
+    cursor: pointer;
+}
+
 .label {
 	padding-bottom: 0.2em;
 	font-size: 100%;

--- a/seed/static/seed/partials/accounts.html
+++ b/seed/static/seed/partials/accounts.html
@@ -61,11 +61,11 @@
                         </tr>
                         <tr ng-show="org.is_parent">
                             <th class="sub_head sub_org">Sub-Organizations</th>
-                            <th class="sub_head sub_org right"><a href="javascript:void(0);" ng-click="create_organization_modal(org)"><i class="fa fa-plus"></i>Create new sub-organization</a> <i class="fa fa-cog"></i></th>
+                            <th class="sub_head sub_org right"><a ng-click="create_organization_modal(org)"><i class="fa fa-plus"></i>Create new sub-organization</a> <i class="fa fa-cog"></i></th>
                         </tr>
                         <tr ng-repeat="sub_org in org.sub_orgs">
                             <td class="account_org left"><a ng-href="#/accounts/{$ sub_org.id $}/members">{$ sub_org.name $}</td>
-                            <td class="account_org right"><a ng-href="#/accounts/{$ sub_org.id $}/members"><i class="fa fa-user"></i>Members</a> <a href="javascript:void(0);" ng-click="remove_sub_org(sub_org)" ng-if="false"><i class="fa fa-times"></i>Remove</a> <i class="fa fa-cog"></i></td>
+                            <td class="account_org right"><a ng-href="#/accounts/{$ sub_org.id $}/members"><i class="fa fa-user"></i>Members</a> <a ng-click="remove_sub_org(sub_org)" ng-if="false"><i class="fa fa-times"></i>Remove</a> <i class="fa fa-cog"></i></td>
                         </tr>
                     </tbody>
                 </table>

--- a/seed/static/seed/partials/building_area_section.html
+++ b/seed/static/seed/partials/building_area_section.html
@@ -5,11 +5,11 @@
                 <h2><i class="fa fa-th-large"></i> Area</h2>
             </div>
             <div class="section_action_container right" ng-hide="building.edit_form_showing">
-                <a href="javascript:void(0);" ng-click="building.edit_form_showing = true; save_building_state()" ng-show="user_role !== 'viewer'" ><i class="fa fa-pencil"></i> Edit</a>
+                <a ng-click="building.edit_form_showing = true; save_building_state()" ng-show="user_role !== 'viewer'" ><i class="fa fa-pencil"></i> Edit</a>
             </div>
             <div class="section_action_container right section_action_btn" ng-show="building.edit_form_showing">
-                <a roll="button" class="btn btn-default btn-sm" href="javascript:void(0);" ng-click="building.edit_form_showing = false; restore_building()">Cancel</a>
-                <a roll="button" class="btn btn-primary btn-sm" href="javascript:void(0);" ng-click="building.edit_form_showing = false; save_building()">Save Changes</a>
+                <a roll="button" class="btn btn-default btn-sm" ng-click="building.edit_form_showing = false; restore_building()">Cancel</a>
+                <a roll="button" class="btn btn-primary btn-sm" ng-click="building.edit_form_showing = false; save_building()">Save Changes</a>
             </div>
         </div>
     </div>
@@ -24,7 +24,7 @@
                             <th>Master</th>
                             <th ng-repeat="i in imported_buildings" ng-class="{'is_not_master': !i.is_master && building.edit_form_showing, 'is_master': i.is_master && building.edit_form_showing}">
                                 <span ng-hide="building.edit_form_showing">{$ i.import_file_name $}</span>
-                                <a href="javascript:void(0);" ng-click="make_source_default(i)" ng-show="building.edit_form_showing">
+                                <a ng-click="make_source_default(i)" ng-show="building.edit_form_showing">
                                     <span>{$ i.import_file_name $}</span>
                                 </a>
                             </th>
@@ -46,11 +46,11 @@
                             <td ng-repeat="i in imported_buildings" ng-class="{'is_not_master': building[f.sort_column + '_source'] != i.id && building.edit_form_showing, 'is_master':building[f.sort_column + '_source'] == i.id && building.edit_form_showing }">
                                 <span ng-hide="building.edit_form_showing" ng-if="!f.extra_data">{$ i[f.sort_column] | number:0 $}</span>
                                 <span ng-hide="building.edit_form_showing" ng-if="f.extra_data">{$ get_number(i.extra_data[f.sort_column]) | number:0 $}</span>
-                                <a ng-if="!f.extra_data" href="javascript:void(0);" ng-show="building.edit_form_showing && i[f.sort_column]"  ng-click="set_building_attribute(i, f.sort_column)">
+                                <a ng-if="!f.extra_data" ng-show="building.edit_form_showing && i[f.sort_column]"  ng-click="set_building_attribute(i, f.sort_column)">
                                     <span ng-if="f.type != 'date'">{$ i[f.sort_column] $}</span>
                                 <span ng-if="f.type == 'date'">{$ i[f.sort_column] | date:'MM/dd/yyyy' $}</span>
                                 </a>
-                                <a ng-if="f.extra_data" href="javascript:void(0);" ng-show="building.edit_form_showing && i.extra_data[f.sort_column]" ng-click="set_building_attribute(i, f.sort_column, true)">
+                                <a ng-if="f.extra_data" ng-show="building.edit_form_showing && i.extra_data[f.sort_column]" ng-click="set_building_attribute(i, f.sort_column, true)">
                                     <span ng-if="f.type != 'date'" ng-show="building.extra_data_sources[f.sort_column] == i.id">{$ i[f.sort_column] $}</span>
                                 <span ng-if="f.type == 'date'" ng-show="building.extra_data_sources[f.sort_column] != i.id">{$ i[f.sort_column] | date:'MM/dd/yyyy' $}</span>
                                 </a>

--- a/seed/static/seed/partials/building_audit_log.html
+++ b/seed/static/seed/partials/building_audit_log.html
@@ -5,11 +5,11 @@
                 <h2><i class="fa fa-list-ul"></i> Audit Log &amp; Notes </h2>
             </div>
             <div class="section_action_container right" ng-hide="building.edit_form_showing">
-                <a href="javascript:void(0);" ng-click="open_create_note_modal()" ng-show="user_role !== 'viewer'"><i class="fa fa-comment"></i> Add a note</a>
+                <a ng-click="open_create_note_modal()" ng-show="user_role !== 'viewer'"><i class="fa fa-comment"></i> Add a note</a>
             </div>
             <div class="section_action_container right section_action_btn" ng-show="building.edit_form_showing">
-                <a roll="button" class="btn btn-default btn-sm" href="javascript:void(0);" ng-click="building.edit_form_showing = false; restore_building()">Cancel</a>
-                <a roll="button" class="btn btn-primary btn-sm" href="javascript:void(0);" ng-click="building.edit_form_showing = false; save_building()">Save Changes</a>
+                <a roll="button" class="btn btn-default btn-sm" ng-click="building.edit_form_showing = false; restore_building()">Cancel</a>
+                <a roll="button" class="btn btn-primary btn-sm" ng-click="building.edit_form_showing = false; save_building()">Save Changes</a>
             </div>
         </div>
     </div>
@@ -28,7 +28,7 @@
                         <tr ng-repeat="entry in audit_logs">
                             <td class="align_to_top has_no_min_width">{$ entry.user.first_name $} {$ entry.user.last_name $}</td>
                             <td class="align_to_top" ng-if="entry.audit_type == 'Log'"><pre>{$ entry.action_note || entry.action $}</pre></td>
-                            <td class="align_to_top whitespace note" ng-if="entry.audit_type == 'Note'"><label class="label label-info"><i class="fa fa-comment"></i> note</label> <pre> {$ entry.action_note $} </pre>  <a href="javascript:void(0);" class="note_edit pull-right" ng-click="open_create_note_modal(entry)" ng-show="user_role !== 'viewer'" ng-if="entry.audit_type == 'Note'">edit</a></td>
+                            <td class="align_to_top whitespace note" ng-if="entry.audit_type == 'Note'"><label class="label label-info"><i class="fa fa-comment"></i> note</label> <pre> {$ entry.action_note $} </pre>  <a class="note_edit pull-right" ng-click="open_create_note_modal(entry)" ng-show="user_role !== 'viewer'" ng-if="entry.audit_type == 'Note'">edit</a></td>
                             <td class="align_to_top">{$ entry.created | date:"MM/dd/yyyy 'at' h:mma" $}</td>
                         </tr>
                     </tbody>

--- a/seed/static/seed/partials/building_contacts_section.html
+++ b/seed/static/seed/partials/building_contacts_section.html
@@ -5,11 +5,11 @@
                 <h2><i class="fa fa-user"></i> Contact Information</h2>
             </div>
             <div class="section_action_container right" ng-hide="building.edit_form_showing">
-                <a href="javascript:void(0);" ng-click="building.edit_form_showing = true; save_building_state()" ng-show="user_role !== 'viewer'" ><i class="fa fa-pencil"></i> Edit</a>
+                <a ng-click="building.edit_form_showing = true; save_building_state()" ng-show="user_role !== 'viewer'" ><i class="fa fa-pencil"></i> Edit</a>
             </div>
             <div class="section_action_container right section_action_btn" ng-show="building.edit_form_showing">
-                <a roll="button" class="btn btn-default btn-sm" href="javascript:void(0);" ng-click="building.edit_form_showing = false; restore_building()">Cancel</a>
-                <a roll="button" class="btn btn-primary btn-sm" href="javascript:void(0);" ng-click="building.edit_form_showing = false; save_building()">Save Changes</a>
+                <a roll="button" class="btn btn-default btn-sm" ng-click="building.edit_form_showing = false; restore_building()">Cancel</a>
+                <a roll="button" class="btn btn-primary btn-sm" ng-click="building.edit_form_showing = false; save_building()">Save Changes</a>
             </div>
         </div>
     </div>
@@ -23,7 +23,7 @@
                             <th>Master</th>
                             <th ng-repeat="i in imported_buildings" ng-class="{'is_not_master': !i.is_master && building.edit_form_showing, 'is_master': i.is_master && building.edit_form_showing}">
                                 <span ng-hide="building.edit_form_showing">{$ i.import_file_name $}</span> 
-                                <a href="javascript:void(0);" ng-click="make_source_default(i)" ng-show="building.edit_form_showing">
+                                <a ng-click="make_source_default(i)" ng-show="building.edit_form_showing">
                                     <span>{$ i.import_file_name $}</span> 
                                 </a>
                             </th>
@@ -40,7 +40,7 @@
                             <td ng-repeat="i in imported_buildings" ng-class="{'is_not_master': building[f.sort_column + '_source'] != i.id && building.edit_form_showing, 'is_master':building[f.sort_column + '_source'] == i.id && building.edit_form_showing }">
                                 <span ng-hide="building.edit_form_showing" ng-if="f.type != 'date'">{$ i[f.sort_column] $}</span>
                                 <span ng-hide="building.edit_form_showing" ng-if="f.type == 'date'">{$ i[f.sort_column] | date:'MM/dd/yyyy' $}</span>
-                                <a href="javascript:void(0);" ng-show="building.edit_form_showing && i[f.sort_column]"  ng-click="set_building_attribute(i, f.sort_column)">
+                                <a ng-show="building.edit_form_showing && i[f.sort_column]"  ng-click="set_building_attribute(i, f.sort_column)">
                                     <span ng-if="f.type != 'date'">{$ i[f.sort_column] $}</span>
                                 <span ng-if="f.type == 'date'">{$ i[f.sort_column] | date:'MM/dd/yyyy' $}</span>
                                 </a>

--- a/seed/static/seed/partials/building_detail_section.html
+++ b/seed/static/seed/partials/building_detail_section.html
@@ -5,11 +5,11 @@
                 <h2><i class="fa fa-building-o"></i> Building Information</h2>
             </div>
             <div class="section_action_container right" ng-hide="building.edit_form_showing">
-                <a href="javascript:void(0);" ng-click="building.edit_form_showing = true; save_building_state()" ng-show="user_role !== 'viewer'" ><i class="fa fa-pencil"></i> Edit</a>
+                <a ng-click="building.edit_form_showing = true; save_building_state()" ng-show="user_role !== 'viewer'" ><i class="fa fa-pencil"></i> Edit</a>
             </div>
             <div class="section_action_container right section_action_btn" ng-show="building.edit_form_showing">
-                <a roll="button" class="btn btn-default btn-sm" href="javascript:void(0);" ng-click="building.edit_form_showing = false; restore_building()">Cancel</a>
-                <a roll="button" class="btn btn-primary btn-sm" href="javascript:void(0);" ng-click="building.edit_form_showing = false; save_building()">Save Changes</a>
+                <a roll="button" class="btn btn-default btn-sm" ng-click="building.edit_form_showing = false; restore_building()">Cancel</a>
+                <a roll="button" class="btn btn-primary btn-sm" ng-click="building.edit_form_showing = false; save_building()">Save Changes</a>
             </div>
         </div>
     </div>
@@ -23,7 +23,7 @@
                             <th>Master</th>
                             <th ng-repeat="i in imported_buildings" ng-class="{'is_not_master': !i.is_master && building.edit_form_showing, 'is_master': i.is_master && building.edit_form_showing}">
                                 <span ng-hide="building.edit_form_showing">{$ i.import_file_name $}</span>
-                                <a href="javascript:void(0);" ng-click="make_source_default(i)" ng-show="building.edit_form_showing">
+                                <a ng-click="make_source_default(i)" ng-show="building.edit_form_showing">
                                     <span>{$ i.import_file_name $}</span>
                                 </a>
                             </th>
@@ -44,13 +44,13 @@
                             </td>
                             <td ng-repeat="i in imported_buildings" ng-class="{'is_not_master': building.extra_data_sources[f.key] != i.id && building.edit_form_showing, 'is_master':building.extra_data_sources[f.key] == i.id && building.edit_form_showing }" ng-if="f.type === 'extra_data'">
                                 <span ng-hide="building.edit_form_showing">{$ i.extra_data[f.key] $}</span>
-                                <a href="javascript:void(0);" ng-show="building.edit_form_showing && i.extra_data[f.key]" ng-click="set_building_attribute(i, f, true)">
+                                <a ng-show="building.edit_form_showing && i.extra_data[f.key]" ng-click="set_building_attribute(i, f, true)">
                                    <span>{$ i.extra_data[f.key] $}</span>
                                 </a>
                             </td>
                             <td ng-repeat="i in imported_buildings" ng-class="{'is_not_master': building[f.key + '_source'] != i.id && building.edit_form_showing, 'is_master':building[f.key + '_source'] == i.id && building.edit_form_showing }" ng-if="f.type !== 'extra_data'">
                                 <span ng-hide="building.edit_form_showing">{$ i[f.key] $}</span>
-                                <a href="javascript:void(0);" ng-show="building.edit_form_showing && i[f.key]" ng-click="set_building_attribute(i, f.key, false)">
+                                <a ng-show="building.edit_form_showing && i[f.key]" ng-click="set_building_attribute(i, f.key, false)">
                                    <span>{$ i[f.key] $}</span>
                                 </a>
                             </td>

--- a/seed/static/seed/partials/building_energy_section.html
+++ b/seed/static/seed/partials/building_energy_section.html
@@ -5,11 +5,11 @@
                 <h2><i class="fa fa-lightbulb-o"></i> Energy Data</h2>
             </div>
             <div class="section_action_container right" ng-hide="building.edit_form_showing">
-                <a href="javascript:void(0);" ng-click="building.edit_form_showing = true; save_building_state()" ng-show="user_role !== 'viewer'" ><i class="fa fa-pencil"></i> Edit</a>
+                <a ng-click="building.edit_form_showing = true; save_building_state()" ng-show="user_role !== 'viewer'" ><i class="fa fa-pencil"></i> Edit</a>
             </div>
             <div class="section_action_container right section_action_btn" ng-show="building.edit_form_showing">
-                <a roll="button" class="btn btn-default btn-sm" href="javascript:void(0);" ng-click="building.edit_form_showing = false; restore_building()">Cancel</a>
-                <a roll="button" class="btn btn-primary btn-sm" href="javascript:void(0);" ng-click="building.edit_form_showing = false; save_building()">Save Changes</a>
+                <a roll="button" class="btn btn-default btn-sm" ng-click="building.edit_form_showing = false; restore_building()">Cancel</a>
+                <a roll="button" class="btn btn-primary btn-sm" ng-click="building.edit_form_showing = false; save_building()">Save Changes</a>
             </div>
         </div>
     </div>

--- a/seed/static/seed/partials/building_projects_section.html
+++ b/seed/static/seed/partials/building_projects_section.html
@@ -5,11 +5,11 @@
                 <h2><i class="fa fa-folder-o"></i> Projects That Include This Building</h2>
             </div>
             <div class="section_action_container right" ng-hide="building.edit_form_showing">
-                <a href="javascript:void(0);" ng-click="building.edit_form_showing = true; save_building_state()" ng-show="user_role !== 'viewer'" ><i class="fa fa-pencil"></i> Edit</a>
+                <a ng-click="building.edit_form_showing = true; save_building_state()" ng-show="user_role !== 'viewer'" ><i class="fa fa-pencil"></i> Edit</a>
             </div>
             <div class="section_action_container right section_action_btn" ng-show="building.edit_form_showing">
-                <a roll="button" class="btn btn-default btn-sm" href="javascript:void(0);" ng-click="building.edit_form_showing = false; restore_building()">Cancel</a>
-                <a roll="button" class="btn btn-primary btn-sm" href="javascript:void(0);" ng-click="building.edit_form_showing = false; save_building()">Save Changes</a>
+                <a roll="button" class="btn btn-default btn-sm" ng-click="building.edit_form_showing = false; restore_building()">Cancel</a>
+                <a roll="button" class="btn btn-primary btn-sm" ng-click="building.edit_form_showing = false; save_building()">Save Changes</a>
             </div>
         </div>
     </div>
@@ -52,8 +52,8 @@
                                     <ul class="uib-dropdown-menu" role="menu">
                                         <li ng-repeat="label in labels"><a ng-click="update_project_building(p, label)"><span class="label label-{$ label.label $}">{$ label.name $}</span></a></li>
                                         <li class="divider"></li>
-                                        <li><a href="javascript:void(0);" ng-click="remove_label(p)">Remove label</a></li>
-                                        <li><a href="javascript:void(0);" ng-click="open_edit_label_modal()">Manage labels</a></li>
+                                        <li><a ng-click="remove_label(p)">Remove label</a></li>
+                                        <li><a ng-click="open_edit_label_modal()">Manage labels</a></li>
                                     </ul>
                                 </div>
                             </td>

--- a/seed/static/seed/partials/buildings.html
+++ b/seed/static/seed/partials/buildings.html
@@ -10,6 +10,7 @@
             
         </div>
     </div>
+    
 </div>
 <div class="section_nav_container">
     <div class="section_nav">
@@ -34,10 +35,10 @@
                         Building Actions <span class="caret"></span>
                       </button>
                       <ul class="uib-dropdown-menu" role="menu">
-                        <li ng-hide="menu.user.organization.user_role === 'viewer'"><a href="javascript:void(0);" data-toggle="modal" data-target="#newProjectModal" ng-click="set_initial_project_state()">Create a new project</a></li>
-                        <li ng-hide="menu.user.organization.user_role === 'viewer'"><a href="javascript:void(0);" data-toggle="modal" data-target="#existingProjectModal" ng-click="create_project_state='create'">Add to an existing project</a></li>
-                      <li ng-hide="menu.user.organization.user_role === 'viewer'"><a href="javascript:void(0);" ng-click="open_delete_modal()">Delete Buildings</a></li>
-                      <li><a href="javascript:void(0);" ng-click="open_export_modal()">Export Buildings</a></li>
+                        <li ng-hide="menu.user.organization.user_role === 'viewer'"><a data-toggle="modal" data-target="#newProjectModal" ng-click="set_initial_project_state()">Create a new project</a></li>
+                        <li ng-hide="menu.user.organization.user_role === 'viewer'"><a data-toggle="modal" data-target="#existingProjectModal" ng-click="create_project_state='create'">Add to an existing project</a></li>
+                      <li ng-hide="menu.user.organization.user_role === 'viewer'"><a ng-click="open_delete_modal()">Delete Buildings</a></li>
+                      <li><a ng-click="open_export_modal()">Export Buildings</a></li>
                       </ul>
                     </div>
                 </div>

--- a/seed/static/seed/partials/buildings_table.html
+++ b/seed/static/seed/partials/buildings_table.html
@@ -80,11 +80,11 @@
     </div>
     <div class="pager_container col-sm-5 col-md-5">
         <ul class="pager">
-            <li ng-class="{disabled: search.prev_page_disabled}"><a href="javascript:void(0);" ng-click="search.first_page()"><i class="fa fa-angle-double-left"></i> First Record</a></li>
-            <li ng-class="{disabled: search.prev_page_disabled}"><a href="javascript:void(0);" ng-click="search.prev_page()"><i class="fa fa-angle-left"></i> Previous</a></li>
+            <li ng-class="{disabled: search.prev_page_disabled}"><a ng-click="search.first_page()"><i class="fa fa-angle-double-left"></i> First Record</a></li>
+            <li ng-class="{disabled: search.prev_page_disabled}"><a ng-click="search.prev_page()"><i class="fa fa-angle-left"></i> Previous</a></li>
 
-            <li ng-class="{disabled: search.next_page_disabled}"><a href="javascript:void(0);" ng-click="search.next_page()">Next <i class="fa fa-angle-right"></i></a></li>
-            <li ng-class="{disabled: search.next_page_disabled}"><a href="javascript:void(0);" ng-click="search.last_page()">Last Record <i class="fa fa-angle-double-right"></i></a></li>
+            <li ng-class="{disabled: search.next_page_disabled}"><a ng-click="search.next_page()">Next <i class="fa fa-angle-right"></i></a></li>
+            <li ng-class="{disabled: search.next_page_disabled}"><a ng-click="search.last_page()">Last Record <i class="fa fa-angle-double-right"></i></a></li>
         </ul>
     </div>
 </div>

--- a/seed/static/seed/partials/dataset_detail.html
+++ b/seed/static/seed/partials/dataset_detail.html
@@ -8,7 +8,7 @@
             <h1>{$ dataset.name $}</h1>
         </div>
         <div class="right page_action_container">
-            <a href="javascript:void(0);" data-toggle="modal" data-target="#dataUploadModal" ng-click="open_data_upload_modal()">Add more data files</a>
+            <a data-toggle="modal" data-target="#dataUploadModal" ng-click="open_data_upload_modal()">Add more data files</a>
         </div>
     </div>
 </div>
@@ -31,7 +31,7 @@
                             <tr ng-repeat="f in dataset.importfiles" class="file_to_import " ng-class="f.status_classes">
                                 <td class="data_file_name">{$ f.name $}</td>
                                 <td>    
-                                    <a href="javascript:void(0);" class="delete_link" ng-click="confirm_delete(f)"><i class="fa fa-trash-o"></i></a>
+                                    <a class="delete_link" ng-click="confirm_delete(f)"><i class="fa fa-trash-o"></i></a>
                                 </td>
                                 <td class="is_aligned_right">{$ f.num_rows || 0 $}</td>
                                 <td><a role="button" class="btn btn-sm btn-primary" ng-href="#/data/mapping/{$ f.id $}" ng-disabled="!f.num_rows">{$ f.number_of_mappings $} Data Mapping</a></td>

--- a/seed/static/seed/partials/home.html
+++ b/seed/static/seed/partials/home.html
@@ -19,7 +19,7 @@
           building energy performance information about large
           portfolios. Upload your buildings list to get started.</p>
           
-          <p><a href="javascript:void(0);" data-toggle="modal" data-target="#dataUploadModal" ng-click="open_data_upload_modal()" class="btn btn-primary btn-lg" role="button" ng-hide="menu.user.organization.user_role === 'viewer'"><i class="fa fa-cloud-upload"></i>&nbsp;&nbsp;Upload your buildings list</a> <a ng-href="{$ urls.static_url $}seed/pdf/SEED_Platform_V1.1_Getting_Started_Guide.pdf" target="_blank" title="SEED_v1.1_User_Guide" class="btn btn-warning btn-lg" role="button"><i class="fa fa-file-text"></i>&nbsp;&nbsp;Getting Started Guide</a></p>
+          <p><a data-toggle="modal" data-target="#dataUploadModal" ng-click="open_data_upload_modal()" class="btn btn-primary btn-lg" role="button" ng-hide="menu.user.organization.user_role === 'viewer'"><i class="fa fa-cloud-upload"></i>&nbsp;&nbsp;Upload your buildings list</a> <a ng-href="{$ urls.static_url $}seed/pdf/SEED_Platform_V1.1_Getting_Started_Guide.pdf" target="_blank" title="SEED_v1.1_User_Guide" class="btn btn-warning btn-lg" role="button"><i class="fa fa-file-text"></i>&nbsp;&nbsp;Getting Started Guide</a></p>
         </div>
       </div>
       <div class="whats_new_container">

--- a/seed/static/seed/partials/matching_detail_table.html
+++ b/seed/static/seed/partials/matching_detail_table.html
@@ -75,11 +75,11 @@
             </div>
             <div class="pager_container col-sm-5 col-md-5" ng-hide="false">
                 <ul class="pager">
-                    <li ng-class="{disabled: search.prev_page_disabled}"><a href="javascript:void(0);" ng-click="search.first_page()"><i class="fa fa-angle-double-left"></i> First Record</a></li>
-                    <li ng-class="{disabled: search.prev_page_disabled}"><a href="javascript:void(0);" ng-click="search.prev_page()"><i class="fa fa-angle-left"></i> Previous</a></li>
+                    <li ng-class="{disabled: search.prev_page_disabled}"><a ng-click="search.first_page()"><i class="fa fa-angle-double-left"></i> First Record</a></li>
+                    <li ng-class="{disabled: search.prev_page_disabled}"><a ng-click="search.prev_page()"><i class="fa fa-angle-left"></i> Previous</a></li>
 
-                    <li ng-class="{disabled: search.next_page_disabled}"><a href="javascript:void(0);" ng-click="search.next_page()">Next <i class="fa fa-angle-right"></i></a></li>
-                    <li ng-class="{disabled: search.next_page_disabled}"><a href="javascript:void(0);" ng-click="search.last_page()">Last Record <i class="fa fa-angle-double-right"></i></a></li>
+                    <li ng-class="{disabled: search.next_page_disabled}"><a ng-click="search.next_page()">Next <i class="fa fa-angle-right"></i></a></li>
+                    <li ng-class="{disabled: search.next_page_disabled}"><a ng-click="search.last_page()">Last Record <i class="fa fa-angle-double-right"></i></a></li>
                 </ul>
             </div>
         </div>

--- a/seed/static/seed/partials/matching_list_table.html
+++ b/seed/static/seed/partials/matching_list_table.html
@@ -144,11 +144,11 @@
             </div>
             <div class="pager_container col-sm-5 col-md-5">
                 <ul class="pager">
-                    <li ng-class="{disabled: prev_page_disabled}"><a href="javascript:void(0);" ng-click="pagination.first_page()"><i class="fa fa-angle-double-left"></i> First Record</a></li>
-                    <li ng-class="{disabled: prev_page_disabled}"><a href="javascript:void(0);" ng-click="pagination.prev_page()"><i class="fa fa-angle-left"></i> Previous</a></li>
+                    <li ng-class="{disabled: prev_page_disabled}"><a ng-click="pagination.first_page()"><i class="fa fa-angle-double-left"></i> First Record</a></li>
+                    <li ng-class="{disabled: prev_page_disabled}"><a ng-click="pagination.prev_page()"><i class="fa fa-angle-left"></i> Previous</a></li>
 
-                    <li ng-class="{disabled: next_page_disabled}"><a href="javascript:void(0);" ng-click="pagination.next_page()">Next <i class="fa fa-angle-right"></i></a></li>
-                    <li ng-class="{disabled: next_page_disabled}"><a href="javascript:void(0);" ng-click="pagination.last_page()">Last Record <i class="fa fa-angle-double-right"></i></a></li>
+                    <li ng-class="{disabled: next_page_disabled}"><a ng-click="pagination.next_page()">Next <i class="fa fa-angle-right"></i></a></li>
+                    <li ng-class="{disabled: next_page_disabled}"><a ng-click="pagination.last_page()">Last Record <i class="fa fa-angle-double-right"></i></a></li>
                 </ul>
             </div>
         </div>

--- a/seed/static/seed/partials/members.html
+++ b/seed/static/seed/partials/members.html
@@ -20,7 +20,7 @@
     <div class="section_header_container">
         <div class="section_header fixed_height_short">
             <div class="left section_action_container"><h2><i class="fa fa-user"></i> Members</h2></div>
-            <div class="right_wide section_action_container"><a href="javascript:void(0);" ng-click="new_member_modal()" ng-if="auth.can_invite_member">Invite a new member</a><span ng-hide="true">&nbsp;&nbsp;|&nbsp;&nbsp;<a href="javascript:void(0);" ng-click="existing_members_modal()">Add members from a list</a></span></div>
+            <div class="right_wide section_action_container"><a ng-click="new_member_modal()" ng-if="auth.can_invite_member">Invite a new member</a><span ng-hide="true">&nbsp;&nbsp;|&nbsp;&nbsp;<a ng-click="existing_members_modal()">Add members from a list</a></span></div>
         </div>
     </div>
         <div class="section_content_container">
@@ -67,7 +67,7 @@
                                 </div>
                             </td>
                             <td ng-if="auth.can_remove_member">
-                                <a href="javascript:void(0);" ng-click="remove_member(u)">Remove</a>
+                                <a ng-click="remove_member(u)">Remove</a>
                             </td>
                         </tr>
                     </tbody>

--- a/seed/static/seed/partials/project_detail.html
+++ b/seed/static/seed/partials/project_detail.html
@@ -31,16 +31,16 @@
                           Project Actions <span class="caret"></span>
                         </button>
                         <ul class="uib-dropdown-menu" role="menu">
-                            <li ng-show="menu.user.organization.user_role !== 'viewer'"><a href="javascript:void(0);" data-toggle="modal" data-target="#myModal" ng-click="create_project_state='create'">Remove buildings from project</a></li>
+                            <li ng-show="menu.user.organization.user_role !== 'viewer'"><a data-toggle="modal" data-target="#myModal" ng-click="create_project_state='create'">Remove buildings from project</a></li>
                             
-                            <li ng-show="menu.user.organization.user_role !== 'viewer'"><a href="javascript:void(0);" data-toggle="modal" data-target="#existingProjectModal" ng-click="create_project_state='create'">Move/copy buildings to another project</a></li>
+                            <li ng-show="menu.user.organization.user_role !== 'viewer'"><a data-toggle="modal" data-target="#existingProjectModal" ng-click="create_project_state='create'">Move/copy buildings to another project</a></li>
                             <li class="divider" ng-show="project.is_compliance && menu.user.organization.user_role !== 'viewer'"></li>
                             <li ng-show="menu.user.organization.user_role !== 'viewer'"><span class="dropdown_menu_title" >Add a label:</span></li>
-                            <li ng-show="menu.user.organization.user_role !== 'viewer'"><a href="javascript:void(0);" ng-repeat="l in labels" ng-click="apply_label(l)"><be-label name="{$ l.name $}" color="{$ l.color $}"></be-label></a></li>
+                            <li ng-show="menu.user.organization.user_role !== 'viewer'"><a ng-repeat="l in labels" ng-click="apply_label(l)"><be-label name="{$ l.name $}" color="{$ l.color $}"></be-label></a></li>
                             <li class="divider" ng-show="menu.user.organization.user_role !== 'viewer'"></li>
-                            <li ng-show="menu.user.organization.user_role !== 'viewer'"><a href="javascript:void(0);" ng-click="remove_label()">Remove labels</a></li>
-                            <li ng-show="menu.user.organization.user_role !== 'viewer'"><a href="javascript:void(0);" ng-click="open_edit_label_modal()">Manage labels</a></li>
-                            <li><a href="javascript:void(0);" ng-click="open_export_modal()">Export Buildings</a></li>
+                            <li ng-show="menu.user.organization.user_role !== 'viewer'"><a ng-click="remove_label()">Remove labels</a></li>
+                            <li ng-show="menu.user.organization.user_role !== 'viewer'"><a ng-click="open_edit_label_modal()">Manage labels</a></li>
+                            <li><a ng-click="open_export_modal()">Export Buildings</a></li>
                         </ul>
                     </div>
                 </div>

--- a/seed/static/seed/partials/sub_org.html
+++ b/seed/static/seed/partials/sub_org.html
@@ -20,7 +20,7 @@
     <div class="section_header_container">
         <div class="section_header fixed_height_short">
             <div class="left section_action_container"><h2><i class="fa fa-users"></i> Sub-Organizations</h2></div>
-            <div class="right_wide section_action_container"><a href="javascript:void(0);" ng-click="create_organization_modal()">Create a new sub-organization</a></div>
+            <div class="right_wide section_action_container"><a ng-click="create_organization_modal()">Create a new sub-organization</a></div>
         </div>
     </div>
         <div class="section_content_container">
@@ -47,7 +47,7 @@
                                 <span ng-repeat="owner in sub_org.owners">{$ owner.email $}<br /></span>
                             </td>
                             <td ng-if="false">
-                                <a href="javascript:void(0);" ng-click="remove_sub_org(sub_org)">Remove</a>
+                                <a ng-click="remove_sub_org(sub_org)">Remove</a>
                             </td>
                         </tr>
                     </tbody>

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -41,9 +41,9 @@
 			    <ul class="uib-dropdown-menu pull-right" role="menu">
 			    	<li class="dropdown_header">Create a New...</li>
 			    	<li class="divider"></li>
-			    	<li><a href="javascript:void(0);" data-toggle="modal" data-target="#newProjectModalIndex" ng-click="open_create_project_modal()">Project</a></li>
+			    	<li><a data-toggle="modal" data-target="#newProjectModalIndex" ng-click="open_create_project_modal()">Project</a></li>
 			    	<li class="divider" ng-show="menu.user.organization.user_role !== 'viewer'"></li>
-			    	<li ng-show="menu.user.organization.user_role !== 'viewer'"><a href="javascript:void(0);" data-toggle="modal" data-target="#dataUploadModal" ng-click="open_data_upload_modal()">Data Set</a></li>
+			    	<li ng-show="menu.user.organization.user_role !== 'viewer'"><a data-toggle="modal" data-target="#dataUploadModal" ng-click="open_data_upload_modal()">Data Set</a></li>
 			    </ul>
 			</div>
 	    </div>


### PR DESCRIPTION
A lof of 'a' tags have unnecessary href='javascript:void(0);" attributes alongside things link ng-click. These void calls are causing problems with jquery. 

According to Angular documentation, we can just get rid of the href in these instances as they're not needed. (See "Example" section here https://docs.angularjs.org/api/ng/directive/ngHref)