### PR TITLE
Fix for private issue 81 organizations too slow to load

### DIFF
--- a/seed/models.py
+++ b/seed/models.py
@@ -1327,6 +1327,9 @@ class BuildingSnapshot(TimeStampedModel):
 
     objects = JsonManager()
 
+    class Meta:
+        index_together = ("super_organization", "id")
+
     def save(self, *args, **kwargs):
         if self.tax_lot_id and isinstance(self.tax_lot_id, types.StringTypes):
             self.tax_lot_id = self.tax_lot_id[:128]


### PR DESCRIPTION
PR for private issue https://github.com/SEED-platform/seed-lbnl/issues/81

What was wrong?

When trying to view organizations as a superuser the pages were timing out due to a call to get_organizations taking too long.  The major bottleneck was getting a count of buildings for each organization.

How was it fixed.

Added a composite index (super_organization_id, id) to the BuildingSnapshots table.  Daniel also added a configurable timeout in https://github.com/SEED-platform/seed/tree/457-increase-timeout-get-orgs that can be adjusted if needed.  

I did some crude timings on my machine and the production database was taking a bit over a minute to load on average (1:45, 0:54, 1:06).  When I added a composite index on the BuildingSnapshot table I got that number down to between 10 and 15 seconds (0:10, 0:12, 0:15).  Still not great but maybe it is enough of an improvement for now.

How to apply:
In order to apply this patch you will need to do a couple extra steps aside from just getting the code.
1:  Migrate the database:
./manage.py makemigrations –settings=config.settings.dev
./manage.py migrate –settings=config.settings.dev

2:  Vacuum the BuildingSnapshots table.  I do this via pgadmin3 and just running the query “VACUUM seed_buildingsnapshot.  This can potentially take a while, like 10 minutes.

Anyone know if AUTOVACUUM is set to run on either seed or seedtest?


