### PR TITLE
Issue 81 get_organizations is slow improvement

### DIFF
--- a/seed/migrations/0003_auto_20151102_1801.py
+++ b/seed/migrations/0003_auto_20151102_1801.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('seed', '0002_buildingsnapshot_duplicate'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='buildingsnapshot',
+            options={'ordering': ['-id']},
+        ),
+        migrations.AlterIndexTogether(
+            name='buildingsnapshot',
+            index_together=set([('super_organization', 'id')]),
+        ),
+    ]

--- a/seed/models.py
+++ b/seed/models.py
@@ -1327,6 +1327,10 @@ class BuildingSnapshot(TimeStampedModel):
 
     objects = JsonManager()
 
+    class Meta:
+        index_together = ("super_organization", "id")
+        ordering = ['-id']
+
     def save(self, *args, **kwargs):
         if self.tax_lot_id and isinstance(self.tax_lot_id, types.StringTypes):
             self.tax_lot_id = self.tax_lot_id[:128]


### PR DESCRIPTION
What was wrong?

When trying to view organizations as a superuser the pages were timing out due to a call to get_organizations taking too long. The major bottleneck was getting a count of buildings for each organization.

How was it fixed.

Added a composite index (super_organization_id, id) to the BuildingSnapshots table. Daniel also added a configurable timeout in https://github.com/SEED-platform/seed/tree/457-increase-timeout-get-orgs that can be adjusted if needed.

I did some crude timings on my machine and the production database was taking a bit over a minute to load on average (1:45, 0:54, 1:06). When I added a composite index on the BuildingSnapshot table I got that number down to between 10 and 15 seconds (0:10, 0:12, 0:15). Still not great but maybe it is enough of an improvement for now.

NOTE:  I had to introduce a descending ordering by id to get the tests to pass (ordering = ["-id"]).  There are 6 tests that otherwise will fail due to assuming an ordering in the results set.  I think it would be better if someone (myself or someone else) looked through the places the models are being used and try to identify anything that might depend on the order of the results.  However I wanted to get some fix in for testing so that at least some functionality can be restored in the meantime.  If it ends up that we don't need this immediately after all I can check through the places where the models are being used and see if it seems OK to alter the tests to pass without inducing the new order and call it good.

How to apply:
In order to apply this patch you will need to do a couple extra steps aside from just getting the code.
1: Migrate the database:
./manage.py makemigrations –settings=config.settings.dev
./manage.py migrate –settings=config.settings.dev

2: Vacuum the BuildingSnapshots table. I do this via pgadmin3 and just running the query “VACUUM seed_buildingsnapshot. This can potentially take a while, like 10 minutes.  Probably wouldn't hurt to vacuum canonicalbuilding either, that one only takes a few seconds to run.

Anyone know if AUTOVACUUM is set to run on either seed or seedtest?
