### PR TITLE
Issue #465 - Update postgres json field package & fix hacks

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,7 +51,7 @@ dbf==0.95.004
 dj-database-url==0.2.1
 djorm-ext-core==0.7
 djorm-ext-expressions==0.6
--e git+https://github.com/niwibe/djorm-ext-pgjson@8fd70a13cb2597b56d1042539917784170569b40#egg=djorm_pgjson
+django-pgjson==0.3.1
 -e hg+https://bitbucket.org/david/django-storages@e27c8b61ab57e5afaf21cccfee005c980d89480f#egg=django_storages
 -e git+https://github.com/wellfire/django-organizations.git@f9da9778c212b253ebda49453cc57fe199020f51#egg=django_organizations
 fuzzywuzzy>=0.3.1

--- a/seed/audit_logs/migrations/0001_initial.py
+++ b/seed/audit_logs/migrations/0001_initial.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 import django.utils.timezone
-import djorm_pgjson.fields
+import django_pgjson.fields
 import django_extensions.db.fields
 
 
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
                 ('object_id', models.PositiveIntegerField(null=True)),
                 ('audit_type', models.IntegerField(default=0, choices=[(0, b'Log'), (1, b'Note')])),
                 ('action', models.CharField(help_text=b'method triggering audit', max_length=128, null=True, db_index=True, blank=True)),
-                ('action_response', djorm_pgjson.fields.JSONField(default={}, help_text=b'HTTP response from action', null=True, blank=True)),
+                ('action_response', django_pgjson.fields.JsonField(default={}, help_text=b'HTTP response from action', null=True, blank=True)),
                 ('action_note', models.TextField(help_text=b'either the note text or a description of the action', null=True, blank=True)),
                 ('content_type', models.ForeignKey(blank=True, to='contenttypes.ContentType', null=True)),
                 ('organization', models.ForeignKey(related_name='audit_logs', to='orgs.Organization')),

--- a/seed/audit_logs/migrations/0003_auto_20151105_1539.py
+++ b/seed/audit_logs/migrations/0003_auto_20151105_1539.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django_pgjson.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('audit_logs', '0002_auditlog_user'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='auditlog',
+            name='action_response',
+            field=django_pgjson.fields.JsonField(default={}, help_text=b'HTTP response from action'),
+            preserve_default=True,
+        ),
+    ]

--- a/seed/audit_logs/models.py
+++ b/seed/audit_logs/models.py
@@ -13,7 +13,7 @@ from django.db import models
 # vendor imports
 from django_extensions.db.models import TimeStampedModel
 from djorm_expressions.models import ExpressionManager, ExpressionQuerySet
-from djorm_pgjson.fields import JSONField
+from django_pgjson.fields import JsonField
 from seed.lib.superperms.orgs.models import Organization
 
 USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', User)
@@ -78,7 +78,7 @@ class AuditLog(TimeStampedModel):
         help_text='method triggering audit',
         db_index=True,
     )
-    action_response = JSONField(help_text='HTTP response from action')
+    action_response = JsonField(default={}, help_text='HTTP response from action')
     action_note = models.TextField(
         blank=True,
         null=True,

--- a/seed/landing/migrations/0001_initial.py
+++ b/seed/landing/migrations/0001_initial.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 import django.utils.timezone
-import djorm_pgjson.fields
+import django_pgjson.fields
 
 
 class Migration(migrations.Migration):
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
                 ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
                 ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', verbose_name='active')),
                 ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
-                ('default_custom_columns', djorm_pgjson.fields.JSONField(default={}, null=True, blank=True)),
+                ('default_custom_columns', django_pgjson.fields.JsonField(default={}, null=True, blank=True)),
                 ('show_shared_buildings', models.BooleanField(default=False, help_text='shows shared buildings within search results', verbose_name='active')),
                 ('api_key', models.CharField(default=b'', max_length=128, verbose_name='api key', db_index=True, blank=True)),
                 ('default_organization', models.ForeignKey(related_name='default_users', blank=True, to='orgs.Organization', null=True)),

--- a/seed/landing/migrations/0002_auto_20151105_1539.py
+++ b/seed/landing/migrations/0002_auto_20151105_1539.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django_pgjson.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('landing', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='seeduser',
+            name='default_custom_columns',
+            field=django_pgjson.fields.JsonField(default={}),
+            preserve_default=True,
+        ),
+    ]

--- a/seed/landing/models.py
+++ b/seed/landing/models.py
@@ -25,7 +25,7 @@ from django.utils.http import urlquote
 from django.core.mail import send_mail
 from django.core.exceptions import ImproperlyConfigured
 
-from djorm_pgjson.fields import JSONField
+from django_pgjson.fields import JsonField
 
 from seed.lib.superperms.orgs.models import Organization
 
@@ -53,7 +53,7 @@ class SEEDUser(AbstractBaseUser, PermissionsMixin):
                     'active. Unselect this instead of deleting accounts.'))
     date_joined = models.DateTimeField(_('date joined'), default=timezone.now)
 
-    default_custom_columns = JSONField()
+    default_custom_columns = JsonField(default={})
     show_shared_buildings = models.BooleanField(
         _('active'), default=False,
         help_text=_('shows shared buildings within search results'))

--- a/seed/lib/exporter.py
+++ b/seed/lib/exporter.py
@@ -195,7 +195,7 @@ class Exporter:
         try:
             return getattr(par, components[-1]) if par else None
         except AttributeError:
-            # try extra_data JSONField
+            # try extra_data JsonField
             return par.extra_data.get(components[-1])
 
     def export_csv(self, qs, fields=[], cb=None):

--- a/seed/managers/json.py
+++ b/seed/managers/json.py
@@ -92,7 +92,7 @@ class JsonQuerySet(QuerySet):
 
     def json_query(self, key, value=None, cond=None,
                    key_cast='text', unit=None, **kw):
-        """Query JSONField data using simplified syntax.
+        """Query JsonField data using simplified syntax.
 
         See ``build_extra`` for parameter definitions.
         optional parameters pulled from kwargs:

--- a/seed/migrations/0001_initial.py
+++ b/seed/migrations/0001_initial.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import djorm_pgjson.fields
+import django_pgjson.fields
 import django_extensions.db.fields
 import autoslug.fields
 import django.utils.timezone
@@ -87,8 +87,8 @@ class Migration(migrations.Migration):
                 ('match_type', models.IntegerField(blank=True, null=True, db_index=True, choices=[(1, b'System Match'), (2, b'User Match'), (3, b'Possible Match')])),
                 ('confidence', models.FloatField(db_index=True, null=True, blank=True)),
                 ('source_type', models.IntegerField(blank=True, null=True, db_index=True, choices=[(0, b'Assessed Raw'), (2, b'Assessed'), (1, b'Portfolio Raw'), (3, b'Portfolio'), (4, b'BuildingSnapshot'), (5, b'Green Button Raw')])),
-                ('extra_data', djorm_pgjson.fields.JSONField(default={}, null=True, blank=True)),
-                ('extra_data_sources', djorm_pgjson.fields.JSONField(default={}, null=True, blank=True)),
+                ('extra_data', django_pgjson.fields.JsonField(default={}, null=True, blank=True)),
+                ('extra_data_sources', django_pgjson.fields.JsonField(default={}, null=True, blank=True)),
                 ('address_line_1_source', models.ForeignKey(related_name='+', blank=True, to='seed.BuildingSnapshot', null=True)),
                 ('address_line_2_source', models.ForeignKey(related_name='+', blank=True, to='seed.BuildingSnapshot', null=True)),
             ],
@@ -157,7 +157,7 @@ class Migration(migrations.Migration):
             name='CustomBuildingHeaders',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('building_headers', djorm_pgjson.fields.JSONField(default={}, null=True, blank=True)),
+                ('building_headers', django_pgjson.fields.JsonField(default={}, null=True, blank=True)),
                 ('super_organization', models.ForeignKey(related_name='custom_headers', verbose_name='SeedOrg', blank=True, to='orgs.Organization', null=True)),
             ],
             options={

--- a/seed/migrations/0003_auto_20151105_1539.py
+++ b/seed/migrations/0003_auto_20151105_1539.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django_pgjson.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('seed', '0002_buildingsnapshot_duplicate'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='buildingsnapshot',
+            name='extra_data',
+            field=django_pgjson.fields.JsonField(default={}),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='buildingsnapshot',
+            name='extra_data_sources',
+            field=django_pgjson.fields.JsonField(default={}),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='custombuildingheaders',
+            name='building_headers',
+            field=django_pgjson.fields.JsonField(default={}),
+            preserve_default=True,
+        ),
+    ]

--- a/seed/models.py
+++ b/seed/models.py
@@ -14,7 +14,7 @@ from autoslug import AutoSlugField
 from seed.audit_logs.models import AuditLog, LOG
 from seed.landing.models import SEEDUser as User
 from django_extensions.db.models import TimeStampedModel
-from djorm_pgjson.fields import JSONField
+from django_pgjson.fields import JsonField
 from seed.data_importer.models import ImportFile, ImportRecord
 from seed.lib.mcm import mapper
 from seed.lib.superperms.orgs.models import Organization as SuperOrganization
@@ -190,7 +190,7 @@ def find_canonical_building_values(org):
 
 def obj_to_dict(obj):
     """serializes obj for a JSON friendly version
-        tries to serialize JSONField
+        tries to serialize JsonField
 
     """
     data = serializers.serialize('json', [obj, ])
@@ -198,9 +198,9 @@ def obj_to_dict(obj):
     response = struct['fields']
     response[u'id'] = response[u'pk'] = struct['pk']
     response[u'model'] = struct['model']
-    # JSONField doesn't get serialized by `serialize`
+    # JsonField doesn't get serialized by `serialize`
     for f in obj._meta.fields:
-        if type(f) == JSONField:
+        if type(f) == JsonField:
             e = getattr(obj, f.name)
             # postgres < 9.3 support
             while type(e) == unicode:
@@ -836,7 +836,7 @@ class CustomBuildingHeaders(models.Model):
 
     # 'existing, normalized name' -> 'preferred display name'
     # e.g. {'district': 'Boro'}
-    building_headers = JSONField()
+    building_headers = JsonField(default={})
 
     objects = JsonManager()
 
@@ -1321,9 +1321,9 @@ class BuildingSnapshot(TimeStampedModel):
     ###
 
     # 'key' -> 'value'
-    extra_data = JSONField()
+    extra_data = JsonField(default={})
     # 'key' -> ['model', 'fk'], what was the model and its FK?
-    extra_data_sources = JSONField()
+    extra_data_sources = JsonField(default={})
 
     objects = JsonManager()
 

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -923,7 +923,9 @@ class SearchViewTests(TestCase):
         self.assertEqual(data['buildings'][0]['pk'], b1.pk)
 
     def test_search_extra_data_non_existent_column(self):
-        """Empty match on extra_data json keys"""
+        """
+        Empty column query on extra_data key should match key not existing in jsonfield.
+        """
         # Empty column
         cb1 = CanonicalBuilding(active=True)
         cb1.save()
@@ -977,7 +979,10 @@ class SearchViewTests(TestCase):
         self.assertEqual(data['buildings'][0]['pk'], b1.pk)
 
     def test_search_extra_data_empty_column(self):
-        """Empty match on extra_data json keys"""
+        """
+        Empty column query on extra_data key should match key's value being empty
+        in jsonfield.
+        """
         # Empty column
         cb1 = CanonicalBuilding(active=True)
         cb1.save()
@@ -1031,7 +1036,9 @@ class SearchViewTests(TestCase):
         self.assertEqual(data['buildings'][0]['pk'], b1.pk)
 
     def test_search_extra_data_non_empty_column(self):
-        """Not Empty match on extra_data json keys"""
+        """
+        Not-empty column query on extra_data key.
+        """
         # Empty column
         cb1 = CanonicalBuilding(active=True)
         cb1.save()

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -780,7 +780,7 @@ def get_default_columns(request):
     else:
         initial_columns = False
     if type(columns) == unicode:
-        # postgres 9.1 stores JSONField as unicode
+        # postgres 9.1 stores JsonField as unicode
         columns = json.loads(columns)
 
     return {


### PR DESCRIPTION
Upgrade from an unmaintained postgres json field package to a newer one. Fix some hacks I had to do because of the old package and lack of support for fancy queries on json fields.

- Old migrations were updated to use the newer package. This feels dirty, but I don't see any other way because the old package was being imported.
- Added a `default={}` to any JsonFields used. Old package did this automatically as far as I can tell.
- Added new migrations for the changes. These won't change data. They're just for housekeeping.

Refs #465 