### PR TITLE
Add normalization rules for address ranges

### DIFF
--- a/seed/tests/test_matching.py
+++ b/seed/tests/test_matching.py
@@ -52,5 +52,15 @@ class NormalizeStreetAddressTests(TestCase):
         # https://github.com/SEED-platform/seed/issues/378
         ('regression 1', '100 Peach Ave. East', '100 peach ave e'),
         ('regression 1', '100 Peach Avenue E.', '100 peach ave e'),
-        ('multiple addresses', 'M St., N St., 4th St., Delaware St., SW', 'm st., n st., 4th st., delaware st., sw')
+        ('multiple addresses', 'M St., N St., 4th St., Delaware St., SW', 'm st., n st., 4th st., delaware st., sw'),
+        # House numbers declared as ranges
+        ('no range separator', '300 322 S Green St', '300-322 s green st'),
+        ('- as separator no whitespace', '300-322 S Green St', '300-322 s green st'),
+        ('/ as separator no whitespace', '300/322 S Green St', '300-322 s green st'),
+        ('\\ as separator no whitespace', '300\\322 S Green St', '300-322 s green st'),
+        ('- as separator whitespace', '300 - 322 S Green St', '300-322 s green st'),
+        ('/ as separator whitespace', '300 / 322 S Green St', '300-322 s green st'),
+        ('\\ as separator whitespace', '300 \\ 322 S Green St', '300-322 s green st'),
+        # Ranges which leave off common prefix.
+        ('end of range leaves off common prefix', '300-22 S Green St', '300-322 s green st'),
     ]


### PR DESCRIPTION
Fixes https://github.com/SEED-platform/seed/issues/317

### What was wrong.

Addresses that are declared as ranges were not being normalized or parsed correctly.

All of the following should be normalized to the same canonical form `310-310 green st`

* `300-310 green st`
* `300 - 310 green st`
* `300/310 green st`
* `300 310 green st`
* `300-10` green st`  (omits the leading digit on the second number)

### How was it fixed.

The numeric portion of the address is now passed through a normalization function `seed.tasks._normalize_address_number` which uses a regex to detect numeric ranges and normalize them.

#### Cute animal picture

![2828e45400000578-0-image-a-74_1430678167323](https://cloud.githubusercontent.com/assets/824194/11248367/0221ba60-8dde-11e5-99e1-b03bf7ad47c5.jpg)
