### PR TITLE
Piper/issue 367 expression based filtering of numeric columns

### DIFF
--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -365,6 +365,9 @@ angular.module('BE.seed.controller.building_list', [])
         $scope.search.query = $scope.search.filter_params.q || "";
         $scope.search.update_results(search_payload);
 
+        // intitialize tooltips
+        $('[data-toggle="popover"]').popover();
+
         if (typeof $scope.user.project_id !== "undefined") {
             $scope.is_project = true;
             $scope.search.filter_params.project__slug = $scope.user.project_id;

--- a/seed/static/seed/partials/buildings_table.html
+++ b/seed/static/seed/partials/buildings_table.html
@@ -11,17 +11,15 @@
             <tr class="sub_head">
                 <th class="sub_head check_row" ng-if="search.has_checkbox"></th>
                 <th class="sub_head" ng-repeat="c in columns" style="min-width: 110px;">
-                    <!-- for string filters -->
-                    <input ng-if="c.type == 'string' || c.type == 'link'" type="text" class="form-control input-sm show" ng-class="{active: search.filter_params[c.sort_column].length > 0}" placeholder="{$ c.title $}" ng-change="search.filter_search()" ng-model="search.filter_params[c.sort_column]">
+                    <!-- for string & numeric filters -->
+                    <input ng-if="c.type == 'string' || c.type == 'link' || c.type == 'number' || c.type == 'floor_area'" type="text" class="form-control input-sm show" ng-class="{active: search.filter_params[c.sort_column].length > 0}" placeholder="{$ c.title $}" ng-change="search.filter_search()" ng-model="search.filter_params[c.sort_column]">
 
-                    <!-- for range filters -->
-                    <div ng-if="c.type == 'number' || c.type == 'date' || c.type == 'floor_area'" class="col-xs-6">
+                    <!-- for date range filters -->
+                    <div ng-if="c.type == 'date'" class="col-xs-6">
                         <input ng-if="c.type == 'date'" type="date" class="form-control input-sm" placeholder="Min" ng-change="search.filter_search()" ng-model="search.filter_params[c.min]" ng-class="{active: search.filter_params[c.min].length > 0}">
-                        <input ng-if="c.type != 'date'" type="number" class="form-control input-sm" placeholder="Min" ng-change="search.filter_search()" ng-model="search.filter_params[c.min]" ng-class="{active: search.filter_params[c.min].length > 0}">
                     </div>
-                    <div ng-if="c.type == 'number' || c.type == 'date' || c.type == 'floor_area'" class="col-xs-6">
+                    <div ng-if="c.type == 'date'" class="col-xs-6">
                         <input ng-if="c.type == 'date'" type="date" class="form-control input-sm" placeholder="Max" ng-change="search.filter_search()" ng-model="search.filter_params[c.max]" ng-class="{active: search.filter_params[c.max].length > 0}">
-                        <input ng-if="c.type != 'date'" type="number" class="form-control input-sm" placeholder="Max" ng-change="search.filter_search()" ng-model="search.filter_params[c.max]" ng-class="{active: search.filter_params[c.max].length > 0}">
                     </div>
                 </th>
             </tr>

--- a/seed/static/seed/partials/cleansing_modal.html
+++ b/seed/static/seed/partials/cleansing_modal.html
@@ -25,17 +25,15 @@
                                 </tr>
                                 <tr class="sub_head">
                                     <th class="sub_head" ng-repeat="c in columns" style="min-width: 140px;">
-                                        <!-- for string filters -->
-                                        <input ng-if="c.type == 'string' || c.type == 'link'" type="text" class="form-control input-sm show" ng-class="{active: search.filter_params[c.sort_column].length > 0}" placeholder="{$ c.title $}" ng-change="search.filter_search()" ng-model="search.filter_params[c.sort_column]">
+                                        <!-- for string & numeric filters -->
+                                        <input ng-if="c.type == 'string' || c.type == 'link' || c.type == 'number' || c.type == 'floor_area'" type="text" class="form-control input-sm show" ng-class="{active: search.filter_params[c.sort_column].length > 0}" placeholder="{$ c.title $}" ng-change="search.filter_search()" ng-model="search.filter_params[c.sort_column]">
 
                                         <!-- for range filters -->
-                                        <div ng-if="c.type == 'number' || c.type == 'date' || c.type == 'floor_area'" class="col-xs-6">
+                                        <div ng-if="c.type == 'date'" class="col-xs-6">
                                             <input ng-if="c.type == 'date'" type="date" class="form-control input-sm" placeholder="Min" ng-change="search.filter_search()" ng-model="search.filter_params[c.min]" ng-class="{active: search.filter_params[c.min].length > 0}">
-                                            <input ng-if="c.type != 'date'" type="number" class="form-control input-sm" placeholder="Min" ng-change="search.filter_search()" ng-model="search.filter_params[c.min]" ng-class="{active: search.filter_params[c.min].length > 0}">
                                         </div>
-                                        <div ng-if="c.type == 'number' || c.type == 'date' || c.type == 'floor_area'" class="col-xs-6">
+                                        <div ng-if="c.type == 'date'" class="col-xs-6">
                                             <input ng-if="c.type == 'date'" type="date" class="form-control input-sm" placeholder="Max" ng-change="search.filter_search()" ng-model="search.filter_params[c.max]" ng-class="{active: search.filter_params[c.max].length > 0}">
-                                            <input ng-if="c.type != 'date'" type="number" class="form-control input-sm" placeholder="Max" ng-change="search.filter_search()" ng-model="search.filter_params[c.max]" ng-class="{active: search.filter_params[c.max].length > 0}">
                                         </div>
                                     </th>
                                 </tr>

--- a/seed/static/seed/partials/matching_detail_table.html
+++ b/seed/static/seed/partials/matching_detail_table.html
@@ -10,14 +10,14 @@
                     <tr>
                         <th class="sub_head"></th>
                         <th class="sub_head" ng-repeat="c in columns">
-                            <!-- for string filters -->
-                            <input ng-if="c.type == 'string' || c.type == 'link'" type="text" class="form-control input-sm show" ng-class="{active: search.filter_params[c.sort_column].length > 0}" placeholder="{$ c.title $}" ng-change="search.filter_search()" ng-model="search.filter_params[c.sort_column]">
+                            <!-- for string & numeric filters -->
+                            <input ng-if="c.type == 'string' || c.type == 'link' || c.type == 'number' || c.type == 'floor_area'" type="text" class="form-control input-sm show" ng-class="{active: search.filter_params[c.sort_column].length > 0}" placeholder="{$ c.title $}" ng-change="search.filter_search()" ng-model="search.filter_params[c.sort_column]">
 
                             <!-- for range filters -->
-                            <div ng-if="c.type == 'number' || c.type == 'date' || c.type == 'floor_area'" class="col-xs-6">
+                            <div ng-if="c.type == 'date'" class="col-xs-6">
                                 <input type="text" class="form-control input-sm" placeholder="Min" ng-change="search.filter_search()" ng-model="search.filter_params[c.min]" ng-class="{active: search.filter_params[c.min].length > 0}">
                             </div>
-                            <div ng-if="c.type == 'number' || c.type == 'date' || c.type == 'floor_area'" class="col-xs-6">
+                            <div ng-if="c.type == 'date'" class="col-xs-6">
                                 <input type="text" class="form-control input-sm" placeholder="Max" ng-change="search.filter_search()" ng-model="search.filter_params[c.max]" ng-class="{active: search.filter_params[c.max].length > 0}">
                             </div>
                         </th>

--- a/seed/tests/test_expression_parser.py
+++ b/seed/tests/test_expression_parser.py
@@ -1,0 +1,142 @@
+"""
+:copyright: (c) 2014 Building Energy Inc
+"""
+import itertools
+from django.test import TestCase
+
+from seed.utils.search import (
+    is_expression,
+    parse_expression,
+)
+
+
+# Metaclass to create individual test methods per test case.
+class TestCaseFactory(type):
+    def __new__(cls, name, bases, attrs):
+        cases = attrs['cases']
+        method_maker = attrs['method_maker']
+        prefix = attrs['prefix']
+
+        for doc, value, expected in cases:
+            test = method_maker(value, expected)
+            test_name = '{0}_{1}'.format(prefix, doc.lower().replace(' ', '_'))
+            if test_name in attrs:
+                raise KeyError("Test name {0} duplicated".format(test_name))
+            test.__name__ = test_name
+            test.__doc__ = doc
+            attrs[test_name] = test
+        return super(TestCaseFactory, cls).__new__(cls, name, bases, attrs)
+
+
+def make_is_expression_method(value, expected):
+    def run(self):
+        result = is_expression(value)
+        self.assertEquals(bool(expected), bool(result))
+    return run
+
+
+class IsExpressionTests(TestCase):
+    __metaclass__ = TestCaseFactory
+    method_maker = make_is_expression_method
+    prefix = "test_is_expression"
+
+    # test name, input, expected output
+    cases = [
+        # Non expressions
+        ('not_expression_1', '1234', False),
+        ('not_expression_2', '', False),
+        ('not_expression_3', None, False),
+        # Incomplete expressions
+        ('not_expression_4', "=", False),
+        ('not_expression_5', "==", False),
+        ('not_expression_6', "!=", False),
+        ('not_expression_7', "!", False),
+        ('not_expression_8', "<>", False),
+        ('not_expression_9', "<", False),
+        ('not_expression_10', "<=", False),
+        ('not_expression_11', ">", False),
+        ('not_expression_12', ">=", False),
+        # Basic expressions
+        ('equality_1', "=1234", True),
+        ('equality_2', "==1234", True),
+        ('inequality_1', "!=1234", True),
+        ('inequality_2', "!1234", True),
+        ('inequality_3', "<>1234", True),
+        ('less_than', "<1234", True),
+        ('less_than_or_equal', "<=1234", True),
+        ('greater_than', ">1234", True),
+        ('greater_than_or_equal', ">=1234", True),
+        # Whitespace
+        ('whitespace_1', "=  1234", True),
+        ('whitespace_2', " == 1234 ", True),
+        # Nulls checks
+        ('is_null_1', "=null", True),
+        ('is_null_2', "==null", True),
+        ('is_not_null_1', "!=null", True),
+        ('is_not_null_2', "!null", True),
+        ('is_not_null_3', "<>null", True),
+        # Complex Expressions
+        ('complex_1', ">123,<456", True),
+        ('complex_2', ">123, <456", True),
+        ('complex_3', ">123 , <456", True),
+        ('complex_4', ">123,<456,!null", True),
+        ('complex_5', ">123,<", True),
+    ]
+
+
+def query_to_child_tuples(query):
+    """
+    Takes a Q object and extracts the underlying queries.  Returns an iterable
+    of 3-tuples who's values are (negated, field_lookup, value)
+    """
+    if isinstance(query, tuple):
+        return query
+    return list(itertools.chain.from_iterable((
+        (
+            [tuple(itertools.chain.from_iterable(([query.negated], c)))]
+            if isinstance(c, tuple)
+            else query_to_child_tuples(c)
+        )
+        for c in query.children
+    )))
+
+
+def make_parse_expression_method(value, expected):
+    def run(self):
+        result = parse_expression("field", value)
+        query_children = query_to_child_tuples(result)
+        self.assertEquals(expected, query_children)
+    return run
+
+
+class ExpressionParserTests(TestCase):
+    __metaclass__ = TestCaseFactory
+    method_maker = make_parse_expression_method
+    prefix = "test_expression_parser"
+
+    # test name, input, expected output
+    cases = [
+        ("equality_1", "=1234", [(False, "field", "1234")]),
+        ("equality_2", "==1234", [(False, "field", "1234")]),
+        ("inequality_1", "!=1234", [(True, "field", "1234")]),
+        ("inequality_2", "!1234", [(True, "field", "1234")]),
+        ("inequality_3", "<>1234", [(True, "field", "1234")]),
+        ("greater_than", ">1234", [(False, "field__gt", "1234")]),
+        ("greater_than_or_equal", ">=1234", [(False, "field__gte", "1234")]),
+        ("less_than", "<1234", [(False, "field__lt", "1234")]),
+        ("less_than_or_equal", "<=1234", [(False, "field__lte", "1234")]),
+        # null
+        ("is_null_1", "=null", [(False, "field__isnull", True)]),
+        ("is_null_2", "==null", [(False, "field__isnull", True)]),
+        ("is_not_null_1", "!null", [(False, "field__isnull", False)]),
+        ("is_not_null_2", "!=null", [(False, "field__isnull", False)]),
+        ("is_not_null_3", "<>null", [(False, "field__isnull", False)]),
+        # complex expressions
+        ("complex_1", "!=1234,<1234", [(True, "field", "1234"), (False, "field__lt", "1234")]),
+        ("complex_2", ">1234,<4567", [(False, "field__gt", "1234"), (False, "field__lt", "4567")]),
+        # invalid
+        ("invalid_null_1", ">null", []),
+        ("invalid_null_2", ">=null", []),
+        ("invalid_null_3", "<null", []),
+        ("invalid_null_4", "<=null", []),
+    ]

--- a/seed/tests/test_matching.py
+++ b/seed/tests/test_matching.py
@@ -17,6 +17,8 @@ class NormalizeAddressTester(type):
         for doc, message, expected in cases:
             test = make_method(message, expected)
             test_name = 'test_normalize_address_%s' % doc.lower().replace(' ', '_')
+            if test_name in attrs:
+                raise KeyError("Test name {0} duplicated".format(test_name))
             test.__name__ = test_name
             test.__doc__ = doc
             attrs[test_name] = test
@@ -51,7 +53,7 @@ class NormalizeStreetAddressTests(TestCase):
         # Found edge cases
         # https://github.com/SEED-platform/seed/issues/378
         ('regression 1', '100 Peach Ave. East', '100 peach ave e'),
-        ('regression 1', '100 Peach Avenue E.', '100 peach ave e'),
+        ('regression 2', '100 Peach Avenue E.', '100 peach ave e'),
         ('multiple addresses', 'M St., N St., 4th St., Delaware St., SW', 'm st., n st., 4th st., delaware st., sw'),
         # House numbers declared as ranges
         ('no range separator', '300 322 S Green St', '300-322 s green st'),

--- a/seed/utils/search.py
+++ b/seed/utils/search.py
@@ -1,0 +1,128 @@
+import re
+import operator
+
+from django.db.models import Q
+
+
+def strip_suffix(k, suffix):
+    match = k.find(suffix)
+    if match >= 0:
+        return k[:match]
+    else:
+        return k
+
+
+def strip_suffixes(k, suffixes):
+    return reduce(strip_suffix, suffixes, k)
+
+
+def is_column(k, columns):
+    sanitized = strip_suffixes(k, ['__lt', '__gt', '__lte', '__gte'])
+    if sanitized in columns:
+        return True
+    return False
+
+
+def is_string_query(q):
+    return isinstance(q, basestring)
+
+
+def is_exact_match(q):
+    # Surrounded by matching quotes?
+    if is_string_query(q):
+        return re.match(r"""^(["'])(.+)\1$""", q)
+    return False
+
+
+def is_empty_match(q):
+    # Empty matching quotes?
+    if is_string_query(q):
+        return re.match(r"""^(["'])\1$""", q)
+    return False
+
+
+def is_not_empty_match(q):
+    # Exclamation mark and empty matching quotes?
+    if is_string_query(q):
+        return re.match(r"""^!(["'])\1$""", q)
+    return False
+
+
+EXPRESSION_REGEX = re.compile((
+    r'('                                     # open expression grp
+    r'(?P<operator>==|=|>|>=|<|<=|<>|!|!=)'  # operator
+    r'\s*'                                   # whitespace
+    r'(?P<value>(?:-?[0-9]+)|(?:null))'        # numeric value or the string null
+    r')'                                     # close expression grp
+))
+
+
+def is_expression(q):
+    """
+    Checks whether a value looks like an expression, meaning that it contains a
+    substring that begins with a comparison operator followed by a numeric
+    value, optionally separated by whitespace.
+    """
+    if is_string_query(q):
+        return EXPRESSION_REGEX.findall(q)
+    return False
+
+
+OPERATOR_MAP = {
+    "==": ("", False),
+    "=": ("", False),
+    ">": ("__gt", False),
+    ">=": ("__gte", False),
+    "<": ("__lt", False),
+    "<=": ("__lte", False),
+    "!": ("", True),
+    "!=": ("", True),
+    "<>": ("", True),
+}
+
+NULL_OPERATORS = {"=", "==", "!", "!=", "<>"}
+EQUALITY_OPERATORS = {"=", "=="}
+
+
+def _translate_expression_parts(op, val):
+    """
+    Given the string representation of a mathematical operator, return the
+    django orm query suffix (__lt, __isnull, etc) and appropriate value to be
+    used for the query.
+
+    Returns `None` if the comparison is invalid ("> null").
+    """
+    if val == "null":
+        if op not in NULL_OPERATORS:
+            raise ValueError("Invalid operation on null")
+        elif op in EQUALITY_OPERATORS:
+            return "__isnull", True, None
+        else:
+            return "__isnull", False, None
+
+    suffix, is_negated = OPERATOR_MAP[op]
+    return suffix, val, is_negated
+
+
+def parse_expression(k, v):
+    """
+    Parse a complex expression into a Q object.
+    """
+    query_filters = []
+    parts = EXPRESSION_REGEX.findall(v)
+
+    for src, op, val in parts:
+        try:
+            suffix, q_val, is_negated = _translate_expression_parts(op, val)
+        except ValueError:
+            continue
+        lookup = "{field}{suffix}".format(
+            field=k,
+            suffix=suffix,
+        )
+        q_object = Q(**{lookup: q_val})
+        if is_negated:
+            query_filters.append(~q_object)
+        else:
+            query_filters.append(q_object)
+    return reduce(operator.and_, query_filters, Q())

--- a/seed/utils/search.py
+++ b/seed/utils/search.py
@@ -1,3 +1,8 @@
+"""
+Utility functions for searching
+:copyright (c) 2015, The Regents of the University of California, Department of Energy contract-operators of the Lawrence Berkeley National Laboratory.
+:author Piper Merriam
+"""
 import re
 import operator
 


### PR DESCRIPTION
Implements feature for #367 

### What was wrong?

Numeric field filtering was restricted to a min/max style filtering.  This interface was not powerful enough to serve the needs of users.

### How was it fixed?

Implemented expression based filtering.  The filter field is now a single field that can parse a number of expression formats.

An expression is one of the following operators.

* `=`, `==` equality
* `!=`, `!`, `<>` inequality
* `<`, `<=` less than and less than or equal to
* `>`, `>=` greater than and greater than or equal to

Followed by either a numeric value or the string 'null'

> `null` can only be used with the equality or inequality operators.

The filtering field accepts multiple expressions separated by a comma.  Intermixed whitespace is stripped and ignored.

### What this does not implement (yet)

- [ ] help text of any kind in the interface to inform users on how to use this feature.

I spent some time trying to fit this into the interface with little luck.  The area available is extremely limited. It seems like it will take a small paragraph and a few examples to satisfactorily explain this feature.  Here is the text I would use.

```
You may use complex expressions to filter this field.  An expression is one of the following operators followed by a number or the string 'null'.  (null can only be used with equality and inequality operators).

Operators: =, ==, !=, !, <>, <, <=, >, >=

Multiple expressions should be separated by commas.

Examples:
- ">100"  greater than 100
- ">1984,<1990 greater than 1984 and less than 1990
- "!null, !0" not null and not equal to 0
```

#### Cute animal picture

![219b2214c8c644a4b9fff3267fa4cb62](https://cloud.githubusercontent.com/assets/824194/11284829/25305534-8ec9-11e5-8b3c-e9f221ffdbd4.jpg)
