### PR TITLE
Adds a couple lines to set_initial_project_state to reset the error s…

### DIFF
--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -225,6 +225,8 @@ angular.module('BE.seed.controller.building_list', [])
         });
     };
     $scope.set_initial_project_state = function() {
+        $scope.create_project_error = false;
+        $scope.create_project_error_message = "";
         $scope.create_project_state = 'create';
         $scope.project.compliance_type = null;
         $scope.project.name = null;


### PR DESCRIPTION
What was broken?

The modal window for creating a project, shown in the app/#/buildings view. This modal is shown after the user selects "Create a New Project" from the pulldown. Error message from past state of modal wasn't getting cleared.

How was it fixed.

Added a couple lines to init the error state and message in building_list_controller : set_initial_project_state()