### PR TITLE
Fix building of the documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -261,6 +261,9 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 # formatters for API autodocumentation
+import django
+django.setup()
+
 from seed.utils.api import get_api_endpoints
 api_endpoints = get_api_endpoints()
 


### PR DESCRIPTION
### What was wrong

The documentation configuration hadn't been updated since the AppRegistry was introduced in django 1.7.  This was causing some automated imports to trigger the registry not ready exception.

### How was it fixed.

Manually imported and called `django.setup`

#### Cute animal picture

![e8e62ec49afa5c1893096e80cdfb9ad0](https://cloud.githubusercontent.com/assets/824194/11486483/a554b13c-9776-11e5-97a2-1ce8cc631ef5.jpg)
