### PR TITLE
Fix Automated ReadTheDocs Builds

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -116,6 +116,11 @@ if "COMPRESS_ENABLED" not in locals() or not COMPRESS_ENABLED:
 
 ALLOWED_HOSTS = ['*']
 
+# ReadTheDocs won't have a local_untracked, so even here in dev, there needs to be a few initializations
+DOMAIN_URLCONFS = {}
+DOMAIN_URLCONFS['default'] = 'config.urls'
+
+
 # use imp module to find the local_untracked file rather than a hard-coded path
 # TODO: There seems to be a bunch of loading of other files in these settings. First this loads the common, then this, then anything in the untracked file
 try:


### PR DESCRIPTION
Automated builds with ReadTheDocs were closer with the merge of #496, but it was failing due to the DOMAIN_URLCONFS not being defined in the Settings dictionary.  This wasn't defined because on ReadTheDocs, there won't be a local_untracked.py file, and the dev.py file did not include an initialization of this variable.  For development/deployment, when local_untracked.py _is actually present_, the value will be overwritten with whatever the dev has defined in local_untracked.py.

To complete the RTD automated builds, the following steps are needed if they aren't already present:
 - [ ] This PR will need to be merged, or some other solution found for the uninitialized variable issue
 - [ ] In the Github repo settings: Webhooks -> Add Webhook -> ReadTheDocs -> Yes/Accept
 - [ ] In the ReadTheDocs project settings: Check the "Install your project inside a virtualenv" box, and add `requirements/local.txt` in the "Requirements file:" box.
 - [ ] Since develop is the default branch in Git, you shouldn't need to update the "Default branch:" entry unless you have some preference to use a different branch.

I believe that is it.  At that point, each commit to https://github.com/SEED-platform/seed will trigger a new build of the docs.  

Thanks

FYI @nllong 