### PR TITLE
Speed up tests runs on travis by caching pip requirements and using Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+sudo: false
+
+cache:
+  directories: 
+    - node_modules
+    - seed/static/vendors/bower_components
+    - $HOME/.pip-cache/
+
 language: python
 
 python:


### PR DESCRIPTION
### What was wrong?

The project was not taking advantage of some easy to implement changes to speed up travis-ci test runs.

- [caching pip downloads](https://docs.travis-ci.com/user/caching/)
- [using docker-container based builds](https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure)

### How was it fixed.

Added two lines to the travis-ci configuration to enable these features.

Worth looking at the test runs to see what the actual increase in speed is before blindly merging this.

#### Cute animal picture

![baby-corgis-running-wallpaper-1](https://cloud.githubusercontent.com/assets/824194/11576524/78e3b6a6-99d4-11e5-8b31-4ffe3c46ee33.jpg)
