### PR TITLE
make the label query use the AND operator

### DIFF
--- a/seed/search.py
+++ b/seed/search.py
@@ -195,7 +195,8 @@ def filter_other_params(queryset, other_params, db_columns):
                           k == 'import_file_id' or k == 'source_type'):
                 query_filters &= Q(**{"%s" % k: v})
             elif k == 'canonical_building__labels':
-                query_filters &= Q(**{"%s__in" % k: v})
+                for l in v:
+                    query_filters &= Q(**{k: l})
             else:
                 query_filters &= Q(**{"%s__icontains" % k: v})
 


### PR DESCRIPTION
This makes the query use the `AND` operator on the supplied labels.

![95d23b2415e1caa68cad08446f123131](https://cloud.githubusercontent.com/assets/824194/11577137/bafdb2ae-99d8-11e5-964c-8d9d9461c8c5.jpg)
