### PR TITLE
Account for null addresses during matching

### DIFF
--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -1370,7 +1370,12 @@ def _match_buildings(file_pk, user_pk):
     import_file.save()
     # this section spencer changed to make the exact match
     for i, un_m_address in enumerate(unmatched_normalized_addresses):
-        results = _find_matches(un_m_address, canonical_buildings_addresses)
+        # If we have an address, try to match it
+        if un_m_address is not None:
+            results = _find_matches(un_m_address, canonical_buildings_addresses)
+        else:
+            results = []
+
         if results:
             handle_results(
                 results, i, can_rev_idx, unmatched_buildings, user_pk


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/273

### What was wrong?

Some of the code within `seed.tasks._match_buildings` didn't account for a possible null value, and was treating it as if it was a string.

### How was it fixed

Simple conditional statement.  The location of this code is pretty deep in a big method.  This is a pretty strait forward fix so I opted to just toss it in without the large overhead that would go into covering this with a test.  Alternatively, this code could be injected into the `_find_matches` function, but I was a little hesitant to change it's behavior.

#### Cute animal picture

![cute-corgi-stuffed-squid-400x300](https://cloud.githubusercontent.com/assets/824194/11641586/3be7aa3a-9cf6-11e5-97f6-8a0c3031d69b.jpg)
