### PR TITLE
Fix overmatching of buildings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 cache:
   directories: 
-    - node_modules
-    - seed/static/vendors/bower_components
     - $HOME/.pip-cache/
 
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 cache:
   directories: 
     - node_modules

--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -1036,25 +1036,17 @@ def get_canonical_id_matches(org_id, pm_id, tax_id, custom_id):
     params = []
     can_snapshots = get_canonical_snapshots(org_id)
     if pm_id:
-        params.append(Q(pm_property_id=pm_id))
-        params.append(Q(tax_lot_id=pm_id))
-        params.append(Q(custom_id_1=pm_id))
+        params.append(Q(pm_property_id=pm_id) | Q(pm_property_id__isnull=True))
     if tax_id:
-        params.append(Q(pm_property_id=tax_id))
-        params.append(Q(tax_lot_id=tax_id))
-        params.append(Q(custom_id_1=tax_id))
+        params.append(Q(tax_lot_id=tax_id) | Q(tax_lot_id__isnull=True))
     if custom_id:
-        params.append(Q(pm_property_id=custom_id))
-        params.append(Q(tax_lot_id=custom_id))
-        params.append(Q(custom_id_1=custom_id))
+        params.append(Q(custom_id_1=custom_id) | Q(custom_id_1__isnull=True))
 
     if not params:
         # Return an empty QuerySet if we don't have any params.
         return can_snapshots.none()
 
-    canonical_matches = can_snapshots.filter(
-        reduce(operator.or_, params)
-    )
+    canonical_matches = can_snapshots.filter(*params)
 
     return canonical_matches
 

--- a/seed/tests/test_tasks.py
+++ b/seed/tests/test_tasks.py
@@ -275,10 +275,10 @@ class TestTasks(TestCase):
         self.assertEqual(
             mapped_bs.address_line_1, u'1600 Pennsylvania Ave. Someplace Nice'
         )
-        
+
     def test_is_same_snapshot(self):
         """Test to check if two snapshots are duplicates"""
-        
+
         bs_data = {
             'pm_property_id': 1243,
             'tax_lot_id': '435/422',
@@ -289,14 +289,14 @@ class TestTasks(TestCase):
             'city': 'Gotham City',
             'postal_code': 8999,
         }
-        
+
         s1 = util.make_fake_snapshot(
             self.import_file, bs_data, ASSESSED_BS, is_canon=True,
             org=self.fake_org
         )
-        
+
         self.assertTrue(tasks.is_same_snapshot(s1, s1), "Matching a snapshot to itself should return True")
-        
+
         #Making a different snapshot, now Garfield complex rather than Greenfield complex
         bs_data_2 = {
             'pm_property_id': 1243,
@@ -308,15 +308,15 @@ class TestTasks(TestCase):
             'city': 'Gotham City',
             'postal_code': 8999,
         }
-        
+
         s2 = util.make_fake_snapshot(
             self.import_file, bs_data_2, ASSESSED_BS, is_canon=True,
             org=self.fake_org
         )
-        
+
         self.assertFalse(tasks.is_same_snapshot(s1, s2), "Matching a snapshot to a different snapshot should return False")
-        
-        
+
+
 
     def test_match_buildings(self):
         """Good case for testing our matching system."""
@@ -330,7 +330,7 @@ class TestTasks(TestCase):
             'city': 'Gotham City',
             'postal_code': 8999,
         }
-        
+
         #Since the change to not match duplicates there needs to be a second record that isn't exactly the same
         #to run this test.  In this case address_line_2 now has a value of 'A' rather than ''
         bs_data_2 = {
@@ -378,7 +378,7 @@ class TestTasks(TestCase):
             AuditLog.objects.first().action_note,
             'System matched building ID.'
         )
-    
+
 
     def test_match_duplicate_buildings(self):
         """
@@ -394,12 +394,12 @@ class TestTasks(TestCase):
             'city': 'Gotham City',
             'postal_code': "8999",
         }
-        
+
         import_file = ImportFile.objects.create(
             import_record=self.import_record,
             mapping_done=True
         )
-        
+
         # Setup mapped PM snapshot.
         snapshot = util.make_fake_snapshot(
             import_file, bs_data, PORTFOLIO_BS, is_canon=True,
@@ -419,10 +419,10 @@ class TestTasks(TestCase):
 
         tasks.match_buildings(import_file.pk, self.fake_user.pk)
         tasks.match_buildings(new_import_file.pk, self.fake_user.pk)
-        
+
         self.assertEqual(len(BuildingSnapshot.objects.all()), 2)
-        
-        
+
+
     def test_handle_id_matches_duplicate_data(self):
         """
         Test for handle_id_matches behavior when matching duplicate data
@@ -437,7 +437,7 @@ class TestTasks(TestCase):
             'city': 'Cartoon City',
             'postal_code': "54321",
         }
-        
+
         # Setup mapped AS snapshot.
         snapshot = util.make_fake_snapshot(
             self.import_file, bs_data, ASSESSED_BS, is_canon=True,
@@ -450,9 +450,9 @@ class TestTasks(TestCase):
             import_record=self.import_record,
             mapping_done=True
         )
-        
+
         tasks.match_buildings(new_import_file.pk, self.fake_user.pk)
-        
+
         duplicate_import_file = ImportFile.objects.create(
             import_record=self.import_record,
             mapping_done=True
@@ -461,10 +461,10 @@ class TestTasks(TestCase):
         new_snapshot = util.make_fake_snapshot(
             duplicate_import_file, bs_data, PORTFOLIO_BS, org=self.fake_org
         )
-        
+
         self.assertRaises(tasks.DuplicateDataError, tasks.handle_id_matches, new_snapshot, duplicate_import_file, self.fake_user.pk)
-                
-        
+
+
 
     def test_match_no_matches(self):
         """When a canonical exists, but doesn't match, we create a new one."""
@@ -633,7 +633,7 @@ class TestTasks(TestCase):
            'city': 'Gotham City',
            'postal_code': 8999,
         }
-        
+
         #Since we changed to not match duplicate data make a second record that matches with something slighty changed
         #In this case appended a 'A' to the end of address_line_1
         bs_data_2 = {

--- a/seed/tests/test_tasks.py
+++ b/seed/tests/test_tasks.py
@@ -577,7 +577,7 @@ class TestTasks(TestCase):
     def test_separates_system_and_possible_match_types(self):
         """We save possible matches separately."""
         bs1_data = {
-           'pm_property_id': 123,
+           'pm_property_id': 1243,
            'tax_lot_id': '435/422',
            'property_name': 'Greenfield Complex',
            'custom_id_1': 1243,


### PR DESCRIPTION
A possible fix for #521

DO_NOT_MERGE

### What was wrong?

The function `seed.tasks.get_canonical_id_matches` is responsible for looking up other building snapshots which are a match based on the three fields `pm_property_id`, `tax_lot_id`, and `custom_id_1`.  The current implementation is written such that it will match buildings that have *any* of these fields in common, or even snapshots which have a `pm_property_id` that is equal to another snapshot's `tax_lot_id`.

### How was it fixed?

I'm not actually sure that the logic is *wrong*, but I do know that it is wrong for the desired functionality of #487 since it will always result in buildings that were split based on their tax id being re-merged due to something like a common `pm_property_id` or `custom_id_1`.

Instead of doing a query that matches any of these, the query has been adjusted such that it matches records which have *all* of the fields in common *(or the record being matched has a null value)*

#### Cute animal picture

![planking_corgi1](https://cloud.githubusercontent.com/assets/824194/11668883/c2c4dfa8-9db6-11e5-9fef-59042688fb45.jpg)
