### PR TITLE
Make organization creation also populate default labels

### DIFF
--- a/seed/migrations/0010_auto_20151204_1337.py
+++ b/seed/migrations/0010_auto_20151204_1337.py
@@ -33,8 +33,8 @@ def populate_default_labels(app, schema_editor, **kwargs):
         for label in DEFAULT_LABELS:
             Label.objects.get_or_create(
                 name=label,
-                color='blue',
                 super_organization=org,
+                defaults={'color': 'blue'},
             )
 
 

--- a/seed/migrations/0011_auto_20151209_0821.py
+++ b/seed/migrations/0011_auto_20151209_0821.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('seed', '0010_auto_20151204_1337'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='statuslabel',
+            name='super_organization',
+            field=models.ForeignKey(related_name='labels', verbose_name='SeedOrg', blank=True, to='orgs.Organization', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/seed/models.py
+++ b/seed/models.py
@@ -782,8 +782,25 @@ class StatusLabel(TimeStampedModel):
         verbose_name=_('SeedOrg'),
         blank=True,
         null=True,
-        related_name='status_labels'
+        related_name='labels'
     )
+
+    DEFAULT_LABELS = [
+        "Residential",
+        "Non-Residential",
+        "Violation",
+        "Compliant",
+        "Missing Data",
+        "Questionable Report",
+        "Update Bldg Info",
+        "Call",
+        "Email",
+        "High EUI",
+        "Low EUI",
+        "Exempted",
+        "Extension",
+        "Change of Ownership",
+    ]
 
     class Meta:
         unique_together = ('name', 'super_organization')

--- a/seed/tests/test_organization_utils.py
+++ b/seed/tests/test_organization_utils.py
@@ -1,0 +1,28 @@
+"""
+Tests for organization utility functions.
+:copyright (c) 2015, The Regents of the University of California, Department of Energy contract-operators of the Lawrence Berkeley National Laboratory.
+:author Piper Merriam
+"""
+from django.test import TestCase
+
+from seed.utils.organizations import (
+    create_organization
+)
+from seed.landing.models import SEEDUser as User
+from seed.models import (
+    StatusLabel as Label,
+)
+
+
+class TestOrganizationCreation(TestCase):
+    def test_organization_creation_creates_default_labels(self):
+        """Make sure last organization user is change to owner."""
+        user = User.objects.create(email='test-user@example.com')
+        org, org_user, user_added = create_organization(
+            user=user,
+            org_name='test-organization',
+        )
+        self.assertEqual(
+            org.labels.count(),
+            len(Label.DEFAULT_LABELS),
+        )

--- a/seed/utils/organizations.py
+++ b/seed/utils/organizations.py
@@ -12,11 +12,21 @@ def create_organization(user, org_name='', *args, **kwargs):
     :param (optional) kwargs: 'role', int; 'status', str.
 
     """
+    from seed.models import (
+        StatusLabel as Label,
+    )
     org = SuperOrganization.objects.create(
         name=org_name
     )
     org_user, user_added = SuperOrganizationUser.objects.get_or_create(
         user=user, organization=org
     )
+
+    for label in Label.DEFAULT_LABELS:
+        Label.objects.get_or_create(
+            name=label,
+            super_organization=org,
+            defaults={'color': 'blue'},
+        )
 
     return org, org_user, user_added


### PR DESCRIPTION
### What was wrong?

Each organization needs to have a set of default labels created for it.  This was implemented as a data migration initially which created all of the default labels for existing organizations.  Newly created organizations after this migration has run however would not have any labels.

### How was it fixed.

Added creation of the default labels to the `seed.utils.organizations.create_organization` utility function.  This function is to create organizations from the API endpoint through which organizations are created.

> Note that I chose this method over using something like a `post_save` signal because of my experience in the past with signals creating highly complex interactions between applications that are difficult to diagnose.  Since this functionality's primary use case is to populate a default set of labels for organizations, and organizations are created through the API which uses this utility function, this should cover the intended use case.

#### Cute animal picture.

![corgi-herding](https://cloud.githubusercontent.com/assets/824194/11691191/2ba53324-9e57-11e5-8690-8ba5e874733b.jpg)
