### PR TITLE
Updating caching methods for project control via api.

### DIFF
--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -149,11 +149,11 @@ angular.module('BE.seed.controller.building_list', [])
         var stop = $timeout(function(){
             project_service.add_buildings_status(cache_key).then(function(data) {
                 // resolve promise
-                if (typeof data.progress_object !== "undefined" && data.progress_object !== null && typeof data.progress_object.percentage_done !== "undefined") {
-                    $scope.progress_percentage = data.progress_object.percentage_done;
+                if (typeof data.progress_object !== "undefined" && data.progress_object !== null && typeof data.progress_object.progress !== "undefined") {
+                    $scope.progress_percentage = data.progress_object.progress;
                     $scope.progress_numerator = data.progress_object.numerator;
                     $scope.progress_denominator = data.progress_object.denominator;
-                    if (data.progress_object.percentage_done < 100) {
+                    if (data.progress_object.progress < 100) {
                         monitor_adding_buildings(cache_key);
                     } else {
                         $scope.create_project_state = 'success';

--- a/seed/views/projects.py
+++ b/seed/views/projects.py
@@ -433,7 +433,9 @@ def get_adding_buildings_to_project_status_percentage(request):
     Returns::
         {'status': 'success',
          'progress_object': {
-             'percentage_done': percent job done,
+             'status': job status,
+             'progress': percent job done (out of 100),
+             'progress_key': progress_key for job,
              'numerator': number buildings added,
              'denominator': total number of building to add
          }


### PR DESCRIPTION
### What was wrong?

API requests for creating projects, adding building to projects, and removing buildings from projects relied on a cache which could be initialized without a status using [`set_cache_raw`](https://github.com/SEED-platform/seed/blob/develop/seed/utils/cache.py#L9) but then would later be reset using [`set_cache`](https://github.com/SEED-platform/seed/blob/develop/seed/utils/cache.py#L17). This lead to an error when [line 30](https://github.com/SEED-platform/seed/blob/develop/seed/utils/cache.py#L30) was executed, assuming that the key had been created using `set_cache` and that it thus had a dictionary key for 'status'. This is noted in issue #527. The behavior of not being able to add projects is noted in issue #497. 

### How was it fixed?

Issue #527 is still outstanding. There are a number of ways of addressing this issue, and I'm not at all sure which is the optimal route. What this PR does address is the specific instance of this generalized bug in issue #497. The code for managing the caching has been updated in seed/tasks.py to follow the same standard used in the data-upload process, which should be immune to async / sync issues. Additionally, the projects view documentation has been updated, and the building list controller has been updated to access the renamed key progress, in favor of the previously used percentage_done. 

### Other issues uncovered:

Exporting is currently having a sync / async problem. I'll resolve this tomorrow.