### PR TITLE
Fix multi-label filtering

### DIFF
--- a/seed/search.py
+++ b/seed/search.py
@@ -201,7 +201,9 @@ def filter_other_params(queryset, other_params, db_columns):
                 query_filters &= Q(**{"%s" % k: v})
             elif k == 'canonical_building__labels':
                 for l in v:
-                    query_filters &= Q(**{k: l})
+                    queryset &= queryset.filter(**{
+                        'canonical_building__labels': l
+                    })
             else:
                 query_filters &= Q(**{"%s__icontains" % k: v})
 


### PR DESCRIPTION
### What was wrong

The query being performed when filtering by multiple labels was not working as expected.  Even if a building had both labels assigned, the query would not return that building.

### How was it fixed

After some basic experimentation an alternate way of querying via AND-ing querysets together did produce a database query that returned the appropriate results.

Here is a gist of the SQL produced by the two different query methods.  https://gist.github.com/pipermerriam/afd2a87a1b17ad10efc4

#### Cute animal picture

![pangolin6](https://cloud.githubusercontent.com/assets/824194/11770038/03b53892-a1b2-11e5-96cd-584cbb3b8c33.jpg)
