### PR TITLE
Clear out selected_buildings when select_or_deselect_all_buildings

### DIFF
--- a/seed/static/seed/js/services/search_service.js
+++ b/seed/static/seed/js/services/search_service.js
@@ -324,6 +324,7 @@ angular.module('BE.seed.service.search', [])
      *   should **always** be called before load_state_from_selected_buildings.
      */
     search_service.select_or_deselect_all_buildings = function() {
+        this.selected_buildings = [];
         for (var i = 0; i < this.buildings.length; i++) {
             this.buildings[i].checked = this.select_all_checkbox;
         }
@@ -334,7 +335,6 @@ angular.module('BE.seed.service.search', [])
      *   checked
      */
     search_service.select_all_changed = function(){
-        this.selected_buildings = [];
         this.select_or_deselect_all_buildings();
     };
 


### PR DESCRIPTION
### Background

On the FE, the `search_service` service calls its method `select_or_deselect_all_buildings` whenever A) the select all checkbox is toggled or B) `search_buildings` is called in order to get results from the server, after which (if successfully returned) the `update_results` method is called, which in turn calls `select_or_deselect_all_buildings`

Meanwhile, the `selected_buildings` array holds a list of building IDs for buildings that have been selected. By definition is should be empty if no buildings are selected **or** if the 'select all' checkbox has been selected.

### What was wrong

In the A case above, the `selected_buildings` array is always initialized to an empty array before calling `select_or_deselect_all_buildings`, but in case B this array isn't set to empty even though `select_or_deselect_all_buildings` is being called. 

The `selected_buildings` array holds the ids of the currently selected buildings, so in the latter case this array was eventually getting out of sync with the state of the UI.

### How was it fixed

A line to clear out the selected_buildings array was moved from the `select_all_changed` method into the `select_or_deselect_all_buildings` so it would always happen when "checked" status was updated to all false or all true. 

Note: this fix assumes that the correct functionality after a search call is to **always** deselect all "selected" checkboxes.

### Animal pic
![funny-animal](https://cloud.githubusercontent.com/assets/119496/11771184/e34388e8-a260-11e5-8b0a-307cbd389264.jpg)



