### PR TITLE
Handle users with multiple organizations correctly with labels

### DIFF
--- a/seed/static/seed/js/controllers/menu_controller.js
+++ b/seed/static/seed/js/controllers/menu_controller.js
@@ -339,6 +339,7 @@ angular.module('BE.seed.controller.menu', [])
         organization_service.get_organizations().then(function (data) {
             // resolve promise
             $scope.organizations_count = data.organizations.length;
+            $scope.menu.user.organizations = data.organizations;
         });
     };
     init();

--- a/seed/static/seed/js/services/label_service.js
+++ b/seed/static/seed/js/services/label_service.js
@@ -100,7 +100,10 @@ angular.module('BE.seed.service.label',
         $http({
             method: 'POST',
             'url': window.BE.urls.label_list,
-            'data': label
+            'data': label,
+            'params': {
+                'organization_id': user_service.get_organization().id
+            }
         }).success(function(data, status, headers, config) {
             if(data){
                 data = update_label_w_local_props(data);
@@ -129,6 +132,9 @@ angular.module('BE.seed.service.label',
             method: 'PUT',
             'url': window.BE.urls.label_list + label.id + '/',
             'data': label,
+            'params': {
+                'organization_id': user_service.get_organization().id
+            }
         }).success(function(data, status, headers, config) {
             if(data){
                 data = update_label_w_local_props(data);
@@ -153,6 +159,9 @@ angular.module('BE.seed.service.label',
         $http({
             method: 'DELETE',
             'url': window.BE.urls.label_list + label.id + '/',
+            'params': {
+                'organization_id': user_service.get_organization().id
+            }
         }).success(function(data, status, headers, config) {
             defer.resolve(data);
         }).error(function(data, status, headers, config) {
@@ -188,7 +197,8 @@ angular.module('BE.seed.service.label',
             'url': window.BE.urls.update_building_labels,
             'params': _.extend({
                 'selected_buildings' : selected_buildings,
-                'select_all_checkbox': select_all_checkbox
+                'select_all_checkbox': select_all_checkbox,
+                'organization_id': user_service.get_organization().id
             }, search_params),
             'data': {
                 'add_label_ids': add_label_ids,


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/560

### What was wrong

The new labeling functionality didn't handle users with multiple organizations correctly.  It was always using `user.orgs.first()` when it should have really been using the `organization_id` that was currently active for the user.

### How was it fixed.

Fixed the organization selector to actually work, after which I modified the `label_service` to always send through `organization_id` as a query parameter.  Then within the two label api views, the organization used is fetched from that organization id.

#### Cuter animal picture

![baby-pangolin-riding-mothers-tail](https://cloud.githubusercontent.com/assets/824194/11826467/d989f8ae-a342-11e5-97fd-3609e13212d1.gif)
