### PR TITLE
Piper/issue 531 travis failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,3 @@ script:
 
 after_script:
   - coveralls
-

--- a/seed/tests/functional/test_firefox.py
+++ b/seed/tests/functional/test_firefox.py
@@ -1,6 +1,8 @@
 import time
 import json
 import os
+import unittest
+
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchAttributeException, StaleElementReferenceException, NoSuchElementException
@@ -21,6 +23,7 @@ class LogIn(StaticLiveServerTestCase):
         cls.selenium.quit()
         super(LogIn, cls).tearDownClass()
 
+    @unittest.skipIf(os.environ.get("TRAVIS") == "true", "https://github.com/SEED-platform/seed/issues/531")
     def test_login(self):
 
         # Test LogIn Process


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/531

### What was wrong?

The selenium tests were failing on travis and nowhere else.

### How was it fixed

Skip the test if it's running on Travis-ci.  Done by checking if the `TRAVIS` env variable is set to `'true'`.  This was decided as the proper first step to fixing this during the December developer call.  The plan is to re-visit this during the next scope of work

#### cute animal picture

![e6f7byll](https://cloud.githubusercontent.com/assets/824194/11846516/34255450-a3d6-11e5-8fb8-971e83459779.jpg)
