### PR TITLE
Fix 'unseen selected buildings' issue after filters are updated

### DIFF
--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -65,16 +65,21 @@ angular.module('BE.seed.controller.building_list', [])
     * SEARCH CODE
     */
 
-     $scope.do_update_buildings_filters = function(){
-        refresh_search();
-    };
-
-    $scope.do_update_projects_filters = function(){
-        refresh_search();
-    };
-
-    var refresh_search = function() {
+    /* Called by 'Update Filters' click in buidings list UI */
+    $scope.do_update_buildings_filters = function(){
         $scope.search.deselect_all_buildings();
+        refresh_search();
+    };
+
+    /* Called by 'Update Filters' click in projects buildings list UI */
+    $scope.do_update_projects_filters = function(){
+        $scope.search.deselect_all_buildings();
+        refresh_search();
+    };
+
+    /*  private function to refresh search, called by UI event handlers
+        or internal methods */
+    var refresh_search = function() {
         $scope.search.search_buildings();
     };
 

--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -72,7 +72,7 @@ angular.module('BE.seed.controller.building_list', [])
     };
 
     /* Called by 'Update Filters' click in projects buildings list UI */
-    $scope.do_update_projects_filters = function(){
+    $scope.do_update_project_buildings_filters = function(){
         $scope.search.deselect_all_buildings();
         refresh_search();
     };

--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -74,6 +74,7 @@ angular.module('BE.seed.controller.building_list', [])
     };
 
     var refresh_search = function() {
+        $scope.search.deselect_all_buildings();
         $scope.search.search_buildings();
     };
 

--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -65,7 +65,7 @@ angular.module('BE.seed.controller.building_list', [])
     * SEARCH CODE
     */
 
-    /* Called by 'Update Filters' click in buidings list UI */
+    /* Called by 'Update Filters' click in buildings list UI */
     $scope.do_update_buildings_filters = function(){
         $scope.search.deselect_all_buildings();
         refresh_search();

--- a/seed/static/seed/js/controllers/mapping_controller.js
+++ b/seed/static/seed/js/controllers/mapping_controller.js
@@ -99,6 +99,7 @@ angular.module('BE.seed.controller.mapping', [])
     $scope.search.update_results();
 
     $scope.do_update_filters = function(){
+      $scope.search.deselect_all_buildings();
       $scope.search.search_buildings();
     };
 

--- a/seed/static/seed/js/controllers/mapping_controller.js
+++ b/seed/static/seed/js/controllers/mapping_controller.js
@@ -99,7 +99,6 @@ angular.module('BE.seed.controller.mapping', [])
     $scope.search.update_results();
 
     $scope.do_update_filters = function(){
-      $scope.search.deselect_all_buildings();
       $scope.search.search_buildings();
     };
 

--- a/seed/static/seed/js/services/search_service.js
+++ b/seed/static/seed/js/services/search_service.js
@@ -354,6 +354,19 @@ angular.module('BE.seed.service.search', [])
      * end checkbox logic
      */
 
+     /** deselect_all_buildings: Force a deselection of all buildings
+     * 
+     */
+    search_service.deselect_all_buildings = function() {
+      var len = this.buildings.length;
+      for (var bldg_index = 0; bldg_index < len; bldg_index++) {
+        this.buildings[bldg_index].checked = false;
+      }
+      this.selected_buildings = [];
+      this.select_all_checkbox = false;
+    };
+
+
     /**
      * table columns logic
      */

--- a/seed/static/seed/partials/project_detail.html
+++ b/seed/static/seed/partials/project_detail.html
@@ -41,7 +41,7 @@
                 <div class="btn-group" style="margin-left:20px;">
                     <button type="button" 
                             class="btn btn-primary btn-sm"
-                            ng-click="do_update_projects_filters()"  >
+                            ng-click="do_update_project_buildings_filters()"  >
                         Update Filters
                     </button>
                 </div>   


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/553

### What was wrong

Selected buildings that fall outside of a new filter change were not being deselected.

For example, a user might filter once and see four buildings (rows). They might select all four, filter again, and then see two buildings (rows) that are selected. The user might then assume only two buildings were selected, when in fact all four were still selected.

### How was it fixed.

Added a method to `search_service` to explicitly deselect all selected buildings, in the process clearing out the `selected_buildings` array and setting `select_all_checkbox` to false.

This method is now called by controllers after the user updates filters and before the controller calls for a new search.

### To Do
It was agreed that, in a future iteration, we should revisit the concept of updating selections after filters are changed, since we might want to preserve selections that still fall within the new filtered subset. The fix in this PR just removes the potential for error and is probably not an optimum solution.


![image](https://cloud.githubusercontent.com/assets/119496/11857612/054a6f8e-a4ae-11e5-9f2d-16c76fcbd97c.png)

