### PR TITLE
Update controller and view fix missing .project bug

### DIFF
--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -60,10 +60,7 @@ angular.module('BE.seed.controller.building_list', [])
     $scope.create_project_error = false;
     $scope.create_project_error_message = "";
     $scope.selected_existing_project = null;
-    
-    $scope.$watch('project', function(newValue, oldValue) {
-      $log.debug("project changed to ", newValue);
-    });
+   
 
     /**
     * SEARCH CODE

--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -59,7 +59,11 @@ angular.module('BE.seed.controller.building_list', [])
     $scope.assessor_fields = [];
     $scope.create_project_error = false;
     $scope.create_project_error_message = "";
+    $scope.selected_existing_project = null;
     
+    $scope.$watch('project', function(newValue, oldValue) {
+      $log.debug("project changed to ", newValue);
+    });
 
     /**
     * SEARCH CODE
@@ -188,6 +192,17 @@ angular.module('BE.seed.controller.building_list', [])
     /**
      * PROJECTS CODE
      */
+
+    $scope.begin_add_buildings_to_new_project = function() {
+        $scope.set_initial_project_state();
+    };
+
+    $scope.begin_add_buildings_to_existing_project = function(){
+        $scope.selected_existing_project = null;
+        $scope.create_project_state='create';
+    };
+
+
     $scope.nothing_selected = function() {
         if ($scope.search.selected_buildings.length === 0 &&
             $scope.search.select_all_checkbox === false) {

--- a/seed/static/seed/partials/buildings.html
+++ b/seed/static/seed/partials/buildings.html
@@ -38,12 +38,12 @@
                     <li ng-hide="menu.user.organization.user_role === 'viewer'">
                         <a  data-toggle="modal" 
                             data-target="#newProjectModal" 
-                            ng-click="set_initial_project_state()">
+                            ng-click="begin_add_buildings_to_new_project()">
                             Create a new project</a></li>
                     <li ng-hide="menu.user.organization.user_role === 'viewer'">
                         <a  data-toggle="modal" 
                             data-target="#existingProjectModal" 
-                            ng-click="create_project_state='create'">
+                            ng-click="begin_add_buildings_to_existing_project()">
                             Add to an existing project</a></li>
                     <li ng-hide="menu.user.organization.user_role === 'viewer'">
                         <a ng-click="open_delete_modal()">Delete Buildings</a></li>
@@ -209,7 +209,10 @@
         <div class="form-group" ng-show="create_project_state == 'create'">
             <label class="sr-only" for="projectName">Project Name</label>
             <div class="col-sm-8">
-                <select class="form-control" id="existingProjectName" ng-options="p as p.name for p in projects" ng-model="project"></select>
+                <select class="form-control" 
+                        id="existingProjectName" 
+                        ng-options="p as p.name for p in projects" 
+                        ng-model="selected_existing_project"></select>
             </div>
         </div>
         <div class="col-sm-7" ng-show="create_project_state == 'adding'">
@@ -231,7 +234,7 @@
                 Cancel</button>
         <button type="button" 
                 class="btn btn-primary" 
-                ng-click="add_buildings(project.slug)" 
+                ng-click="add_buildings(selected_existing_project.slug)" 
                 ng-show="create_project_state == 'create'">
                 Add to Project</button>
         <button type="button" 


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/593

### What went wrong
In the latest SEED build, at the end of the 'Add to existing project' process on the buildings list, the "View project" button wasn't showing the updated project view when clicked.

To the best of my knowledge, what is happening is that the pulldown shown in the 'select existing project' modal is nulling out the $scope.project property. It does this after the entire add process is complete and the controller has called the project_service to reload the projects. When that happens, the UI select control reloads and nulls out the $scope.project due via its binding.

This behavior is not seen in the current production build, but that could be because of changes to Angular and related libraries in the newer versions we are now using.

### How it was fixed
I created a model on the $scope whose sole purpose is to remember the selected existing project. This avoids clobbering the $scope.project property via an unintended change via binding.

I also updated the way both the "Create a new project" and "Add to existing project" actions are first started after a click event -- having each call a method specific to the action -- to help improve the code clarity a bit.

### To Do
The modals used in this view and the interaction between them and the controller need to be refactored, as the current setup isn't very clear.


