### PR TITLE
Removes pagination from labels list view

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -283,4 +283,5 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 25,
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }

--- a/seed/pagination.py
+++ b/seed/pagination.py
@@ -1,0 +1,19 @@
+from rest_framework import pagination
+from rest_framework import response
+
+
+class FakePaginiation(pagination.PageNumberPagination):
+    """
+    DRF Paginator class that presents results in the same format as
+    `PageNumberPagination` but always includes all results on the first page.
+    """
+    def get_paginated_response(self, data):
+        return response.Response({
+            "next": None,
+            "previous": None,
+            "count": len(data),
+            "results": data,
+        })
+
+    def paginate_queryset(self, queryset, request, view=None):
+        return queryset

--- a/seed/static/seed/partials/buildings.html
+++ b/seed/static/seed/partials/buildings.html
@@ -65,6 +65,7 @@
                             replace-spaces-with-dashes="false"
                             add-from-autocomplete-only="true">
                     <auto-complete  source="loadLabelsForFilter($query)"
+                                    max-results-to-show="25"
                                     min-length="0"
                                     load-on-empty="true"
                                     load-on-focus="true"

--- a/seed/tests/test_labels_api_views.py
+++ b/seed/tests/test_labels_api_views.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for seed/views/labels.py
+"""
+__author__ = 'Piper Merriam <pipermerriam@gmail.com>'
+__date__ = '2015/12/18'
+
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+
+from rest_framework.test import APIClient
+from rest_framework import status
+
+from seed.utils.organizations import (
+    create_organization,
+)
+from seed.models import (
+    StatusLabel as Label,
+)
+from seed.landing.models import SEEDUser as User
+
+
+class TestLabelsViewSet(TestCase):
+    """Test the label DRF viewset"""
+
+    def test_results_are_not_actually_paginated(self):
+        """
+        Ensure that labels are not actually paginated.
+        """
+        user = User.objects.create_superuser(
+            email='test_user@demo.com',
+            username='test_user@demo.com',
+            password='secret',
+        )
+        organization, _, _ = create_organization(user, "test-organization")
+
+        # Create 101 labels.  This should be pretty future proof against any
+        # reasonable default pagination settings as well as realistic number of
+        # labels.
+        for i in range(101):
+            Label.objects.create(
+                color="red",
+                name="test_label-{0}".format(i),
+                super_organization=organization,
+            )
+
+        client = APIClient()
+        client.login(username=user.username, password='secret')
+
+        url = reverse('labels:label-list')
+
+        response = client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], organization.labels.count())
+
+        results = response.data['results']
+
+        self.assertEqual(len(results), organization.labels.count())
+
+    def test_organization_query_param_is_used(self):
+        """
+        Ensure that when the organization_id query parameter is provided, that
+        the endpoint returns the appropriate labels for that organization.
+        """
+        user = User.objects.create_superuser(
+            email='test_user@demo.com',
+            username='test_user@demo.com',
+            password='secret',
+        )
+        organization_a, _, _ = create_organization(user, "test-organization-a")
+        organization_b, _, _ = create_organization(user, "test-organization-b")
+
+        # Ensures that at least a single label exists to ensure that we aren't
+        # relying on auto-creation of labels for this test to pass.
+        Label.objects.create(
+            color="red",
+            name="test_label-a",
+            super_organization=organization_a,
+        )
+
+        Label.objects.create(
+            color="red",
+            name="test_label-b",
+            super_organization=organization_b,
+        )
+
+        client = APIClient()
+        client.login(username=user.username, password='secret')
+
+        url = reverse('labels:label-list')
+
+        response_a = client.get(url, {'organization_id': organization_a.pk})
+        response_b = client.get(url, {'organization_id': organization_b.pk})
+
+        self.assertEqual(response_a.status_code, status.HTTP_200_OK)
+        self.assertEqual(response_b.status_code, status.HTTP_200_OK)
+
+        results_a = set(result['organization_id'] for result in response_a.data['results'])
+        results_b = set(result['organization_id'] for result in response_b.data['results'])
+
+        assert results_a == {organization_a.pk}
+        assert results_b == {organization_b.pk}

--- a/seed/views/labels.py
+++ b/seed/views/labels.py
@@ -11,6 +11,9 @@ from seed.filters import (
     LabelFilterBackend,
     BuildingFilterBackend,
 )
+from seed.pagination import (
+    FakePaginiation,
+)
 from seed.utils.api import (
     drf_api_endpoint,
 )
@@ -30,6 +33,7 @@ class LabelViewSet(DecoratorMixin(drf_api_endpoint),
     serializer_class = LabelSerializer
     queryset = Label.objects.none()
     filter_backends = (LabelFilterBackend,)
+    pagination_class = FakePaginiation
 
     _organization = None
 


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/601

### What was wrong?

The response from the `get_labels` api was being paginated.  This kept the front end from seeing any labels that weren't on the first page.

### How was it fixed.

Removed the pagination since this endpoint should *in theory* not have an overly large number of results.

#### Cute animal picture

![221](https://cloud.githubusercontent.com/assets/824194/11906704/d1b02a68-a58b-11e5-9f4d-7b72e0906bc1.jpg)
