### PR TITLE
Piper/issue 530 default labels for new orgs

### DIFF
--- a/config/management/commands/create_default_user.py
+++ b/config/management/commands/create_default_user.py
@@ -7,8 +7,9 @@ from optparse import make_option
 from django.core.management.base import BaseCommand
 
 # app
+from seed.utils.organizations import create_organization
 from seed.landing.models import SEEDUser as User
-from seed.lib.superperms.orgs.models import Organization, OrganizationUser
+from seed.lib.superperms.orgs.models import Organization
 
 
 class Command(BaseCommand):
@@ -55,20 +56,20 @@ class Command(BaseCommand):
             )
             self.stdout.write('Created!', ending='\n')
 
-        org, created = Organization.objects.get_or_create(
-            name=options['organization'])
-        if created:
+        if Organization.objects.filter(name=options['organization']).exists():
+            org, _, _ = create_organization(u, options['organization'])
+            self.stdout.write(
+                'Org <%s> aleady exists' % options['organization'], ending='\n'
+            )
+        else:
+            org, _, user_added = create_organization(u, options['organization'])
             self.stdout.write(
                 'Creating org <%s> ... Created!' % options['organization'],
                 ending='\n'
             )
-        else:
-            self.stdout.write(
-                'Org <%s> aleady exists' % options['organization'], ending='\n'
-            )
+            if user_added:
+                self.stdout.write(
+                    'Creating org user ...', ending=' '
+                )
 
-        self.stdout.write(
-            'Creating org user ...', ending=' '
-        )
-        OrganizationUser.objects.create(user=u, organization=org)
         self.stdout.write('Created!', ending='\n')

--- a/seed/views/accounts.py
+++ b/seed/views/accounts.py
@@ -21,7 +21,6 @@ from seed.lib.superperms.orgs.models import (
 from passwords.validators import (
     validate_length, common_sequences, dictionary_words, complexity
 )
-from seed.utils.organizations import create_organization
 from seed.utils.buildings import get_columns as utils_get_columns
 from seed.models import CanonicalBuilding
 from seed.landing.models import SEEDUser as User

--- a/seed/views/accounts.py
+++ b/seed/views/accounts.py
@@ -29,6 +29,7 @@ from seed.tasks import (
     invite_to_seed,
 )
 from seed.utils.api import api_endpoint
+from seed.utils.organizations import create_organization
 from seed.public.models import INTERNAL, PUBLIC, SharedBuildingField
 
 
@@ -442,17 +443,18 @@ def add_user(request):
                 'message': 'Choose either an existing org or provide a new one'
             }
 
-    if org_id:
-        org = Organization.objects.get(pk=org_id)
-        org_created = False
-    else:
-        org, org_created = Organization.objects.get_or_create(name=org_name)
-
     first_name = body['first_name']
     last_name = body['last_name']
     email = body['email']
     username = body['email']
     user, created = User.objects.get_or_create(username=username.lower())
+
+    if org_id:
+        org = Organization.objects.get(pk=org_id)
+        org_created = False
+    else:
+        org, _, _ = create_organization(user, org_name)
+        org_created = True
 
     # Add the user to the org.  If this is the org's first user,
     # the user becomes the owner/admin automatically.


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/596

### What was wrong?

Organizations created as a result of either the management command `create_default_user` or the api endpoint `add_user` were not populating the default set of labels.

### How was it fixed?

Changed both of these to use `seed.utils.organizations.create_organization` which contains the code to populate the default label set.

#### Cute animal picture

![0319](https://cloud.githubusercontent.com/assets/824194/11907098/79cc3046-a58e-11e5-9218-9d490f92d28a.jpg)
