### PR TITLE
ensure that tax_lot_id is stringified before normalization

### DIFF
--- a/seed/cleansing/tests.py
+++ b/seed/cleansing/tests.py
@@ -109,7 +109,7 @@ class CleansingDataTestCoveredBuilding(TestCase):
                {'field': u'gross_floor_area', 'message': 'Value [10000000000.0] > 7000000', 'severity': u'error'},
                {'field': u'custom_id_1', 'message': 'Value is missing', 'severity': 'error'},
                {'field': u'pm_property_id', 'message': 'Value is missing', 'severity': 'error'}]
-        self.assertEqual(res, result['cleansing_results'])
+        self.assertItemsEqual(res, result['cleansing_results'])
 
         result = [v for v in c.results.values() if v['address_line_1'] == '1234 Peach Tree Avenue']
         self.assertEqual(len(result), 0)

--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -553,7 +553,7 @@ def map_row_chunk(chunk, file_pk, source_type, prog_key, increment, *args, **kwa
         )
 
         if model.tax_lot_id:
-            model.tax_lot_id = _normalize_tax_lot_id(model.tax_lot_id)
+            model.tax_lot_id = _normalize_tax_lot_id(str(model.tax_lot_id))
 
         model.import_file = import_file
         model.source_type = save_type


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/603

### What was wrong.

Tax lot ID needs to be cast to a string prior to normalization

### How was it fixed?

I cast it to a string

#### Cute animal picture

![1791778](https://cloud.githubusercontent.com/assets/824194/11907726/ac31f494-a593-11e5-88e4-24c375bf9aa9.jpg)
