### PR TITLE
fix non-deterministic test case

### DIFF
--- a/seed/cleansing/tests.py
+++ b/seed/cleansing/tests.py
@@ -109,7 +109,7 @@ class CleansingDataTestCoveredBuilding(TestCase):
                {'field': u'gross_floor_area', 'message': 'Value [10000000000.0] > 7000000', 'severity': u'error'},
                {'field': u'custom_id_1', 'message': 'Value is missing', 'severity': 'error'},
                {'field': u'pm_property_id', 'message': 'Value is missing', 'severity': 'error'}]
-        self.assertEqual(res, result['cleansing_results'])
+        self.assertItemsEqual(res, result['cleansing_results'])
 
         result = [v for v in c.results.values() if v['address_line_1'] == '1234 Peach Tree Avenue']
         self.assertEqual(len(result), 0)


### PR DESCRIPTION
### What was wrong?

The test `seed/cleansing/tests.py::test_cleanse` was constructing a list using `[v for v in some_dict.values()]`.  Since dictionaries are not ordered, when this was later checked to be equal to another list of the expected values, the items didn't end up being in the same order and thus the equality check failed.

### How was it fixed

Instead of using `self.assertEqual` which requires true equality, the test now uses [`self.assertItemsEqual`](https://docs.python.org/2/library/unittest.html#unittest.TestCase.assertItemsEqual) which ensures that the items in the two iterables are the same (independent of ordering).

#### Cute animal picture

![4894-sleeping-puppy-1920x1080-animal-wallpaper](https://cloud.githubusercontent.com/assets/824194/11907938/34a72974-a595-11e5-8690-b6f1bf9f55c5.jpg)
