### PR TITLE
Don't override extra data with blank data

### DIFF
--- a/seed/mappings/mapper.py
+++ b/seed/mappings/mapper.py
@@ -75,14 +75,20 @@ def merge_extra_data(b1, b2, default=None):
     extra_data_sources = {}
     default_extra_data = getattr(default, 'extra_data', {})
     non_default_extra_data = getattr(non_default, 'extra_data', {})
-    extra_data = copy.deepcopy(non_default_extra_data)
-    extra_data.update(default_extra_data)
+
+    all_keys = set(default_extra_data.keys() + non_default_extra_data.keys())
+    extra_data = {
+        k: default_extra_data.get(k) or non_default_extra_data.get(k)
+        for k in all_keys
+    }
 
     for item in extra_data:
-        if item in default_extra_data:
+        if item in default_extra_data and default_extra_data[item]:
             extra_data_sources[item] = default.pk
-        elif item in non_default_extra_data:
+        elif item in non_default_extra_data and non_default_extra_data[item]:
             extra_data_sources[item] = non_default.pk
+        else:
+            extra_data_sources[item] = default.pk
 
     return extra_data, extra_data_sources
 

--- a/seed/mappings/mapper.py
+++ b/seed/mappings/mapper.py
@@ -1,7 +1,6 @@
 """
 :copyright: (c) 2014 Building Energy Inc
 """
-import copy
 from collections import defaultdict
 
 from seed.mappings import seed_mappings

--- a/seed/tests/test_models.py
+++ b/seed/tests/test_models.py
@@ -321,6 +321,38 @@ class TestBuildingSnapshot(TestCase):
         self.assertDictEqual(test_extra, expected_extra)
         self.assertDictEqual(test_sources, expected_sources)
 
+    def test_merge_extra_data_does_not_override_with_blank_data(self):
+        """Test that blank fields in extra data don't override real data"""
+        self.bs1.extra_data = {
+            'field_a': 'data-1a',
+            'field_b': '',
+            'field_c': '',
+        }
+        self.bs1.save()
+
+        self.bs2.extra_data = {
+            'field_a': 'data-2a',
+            'field_b': 'data-2b',
+            'field_c': '',
+        }
+        self.bs2.save()
+
+        expected_extra = {
+            'field_a': 'data-1a',
+            'field_b': 'data-2b',
+            'field_c': '',
+        }
+        expected_sources = {
+            'field_a': self.bs1.pk,
+            'field_b': self.bs2.pk,
+            'field_c': self.bs1.pk,
+        }
+
+        actual_extra, actual_sources = mapper.merge_extra_data(self.bs1, self.bs2)
+
+        self.assertDictEqual(actual_extra, expected_extra)
+        self.assertDictEqual(actual_sources, expected_sources)
+
     def test_update_building(self):
         """Good case for updating a building."""
         fake_building_extra = {


### PR DESCRIPTION
### What was wrong?

Data found in the `extra_data` field(s) would be overridden if new data was uploaded that contained blank values.

### How was it fixed

Changed the logic in `seed.utils.mapper.merge_extra_data` to not clobber existing data with blank data.

#### Cute animal picture

![412187-dogs-cute-sleeping-puppy-in-a-bathroom](https://cloud.githubusercontent.com/assets/824194/11959051/8348fe22-a888-11e5-933b-ec1372ebfcad.jpg)
