### PR TITLE
Piper/issue 611 populate extra data fields that were overwritten

### DIFF
--- a/seed/mappings/mapper.py
+++ b/seed/mappings/mapper.py
@@ -75,14 +75,20 @@ def merge_extra_data(b1, b2, default=None):
     extra_data_sources = {}
     default_extra_data = getattr(default, 'extra_data', {})
     non_default_extra_data = getattr(non_default, 'extra_data', {})
-    extra_data = copy.deepcopy(non_default_extra_data)
-    extra_data.update(default_extra_data)
+
+    all_keys = set(default_extra_data.keys() + non_default_extra_data.keys())
+    extra_data = {
+        k: default_extra_data.get(k) or non_default_extra_data.get(k)
+        for k in all_keys
+    }
 
     for item in extra_data:
-        if item in default_extra_data:
+        if item in default_extra_data and default_extra_data[item]:
             extra_data_sources[item] = default.pk
-        elif item in non_default_extra_data:
+        elif item in non_default_extra_data and non_default_extra_data[item]:
             extra_data_sources[item] = non_default.pk
+        else:
+            extra_data_sources[item] = default.pk
 
     return extra_data, extra_data_sources
 

--- a/seed/mappings/mapper.py
+++ b/seed/mappings/mapper.py
@@ -1,7 +1,6 @@
 """
 :copyright: (c) 2014 Building Energy Inc
 """
-import copy
 from collections import defaultdict
 
 from seed.mappings import seed_mappings

--- a/seed/migrations/0012_auto_20151222_1031.py
+++ b/seed/migrations/0012_auto_20151222_1031.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def merge_extra_data(b1, b2, default=None):
+    """
+    This is a frozen version of `seed.mappings.mapper.merge_extra_data`
+    """
+    default = default or b1
+    non_default = b2
+    if default != b1:
+        non_default = b1
+
+    extra_data_sources = {}
+    default_extra_data = getattr(default, 'extra_data', {})
+    non_default_extra_data = getattr(non_default, 'extra_data', {})
+
+    all_keys = set(default_extra_data.keys() + non_default_extra_data.keys())
+    extra_data = {
+        k: default_extra_data.get(k) or non_default_extra_data.get(k)
+        for k in all_keys
+    }
+
+    for item in extra_data:
+        if item in default_extra_data and default_extra_data[item]:
+            extra_data_sources[item] = default.pk
+        elif item in non_default_extra_data and non_default_extra_data[item]:
+            extra_data_sources[item] = non_default.pk
+        else:
+            extra_data_sources[item] = default.pk
+
+    return extra_data, extra_data_sources
+
+
+def recover_extra_data(app, schema_editor, **kwargs):
+    """
+    Populate the default labels for each organization.
+    """
+    BuildingSnapshot = app.get_model("seed", "BuildingSnapshot")
+
+    # Get all snapshots which are the canonical snapshot which also have parent
+    # buildings and which DO NOT have any children.
+    leaves = BuildingSnapshot.objects.filter(
+        pk__in=BuildingSnapshot.objects.filter(
+            parents__isnull=False,
+            children__isnull=True,
+            canonicalbuilding__isnull=False,
+        ).values_list('pk', flat=True),
+    )
+    for leaf_snapshot in leaves:
+        merge_extra_data_from_parents(leaf_snapshot)
+
+
+def merge_extra_data_from_parents(bs):
+    for parent in bs.parents.all():
+        # First do a recursive call to do a recursive merge of all extra_data
+        # fields deeper down the tree.
+        print "recursive merge on: ", parent.pk
+        merge_extra_data_from_parents(parent)
+
+        # Now do a merge with this bs, prioritizing the data that is already in
+        # place which will merge in any non-blank data from deeper down the
+        # tree.
+        print "merging: ", bs.pk, parent.pk
+        extra_data, extra_data_sources = merge_extra_data(bs, parent)
+        bs.extra_data = extra_data
+        bs.extra_data_sources = extra_data_sources
+        bs.save()
+
+
+def stub(*args, **kwargs):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('seed', '0011_auto_20151209_0821'),
+    ]
+
+    operations = [
+        migrations.RunPython(recover_extra_data, stub),
+    ]

--- a/seed/migrations/0012_auto_20151222_1031.py
+++ b/seed/migrations/0012_auto_20151222_1031.py
@@ -57,13 +57,11 @@ def merge_extra_data_from_parents(bs):
     for parent in bs.parents.order_by('created').all():
         # First do a recursive call to do a recursive merge of all extra_data
         # fields deeper down the tree.
-        print "recursive merge on: ", parent.pk
         merge_extra_data_from_parents(parent)
 
         # Now do a merge with this bs, prioritizing the data that is already in
         # place which will merge in any non-blank data from deeper down the
         # tree.
-        print "merging: ", bs.pk, parent.pk
         extra_data, extra_data_sources = merge_extra_data(bs, parent)
         bs.extra_data = extra_data
         bs.extra_data_sources = extra_data_sources

--- a/seed/migrations/0012_auto_20151222_1031.py
+++ b/seed/migrations/0012_auto_20151222_1031.py
@@ -54,7 +54,7 @@ def recover_extra_data(app, schema_editor, **kwargs):
 
 
 def merge_extra_data_from_parents(bs):
-    for parent in bs.parents.all():
+    for parent in bs.parents.order_by('created').all():
         # First do a recursive call to do a recursive merge of all extra_data
         # fields deeper down the tree.
         print "recursive merge on: ", parent.pk

--- a/seed/tests/test_models.py
+++ b/seed/tests/test_models.py
@@ -321,6 +321,38 @@ class TestBuildingSnapshot(TestCase):
         self.assertDictEqual(test_extra, expected_extra)
         self.assertDictEqual(test_sources, expected_sources)
 
+    def test_merge_extra_data_does_not_override_with_blank_data(self):
+        """Test that blank fields in extra data don't override real data"""
+        self.bs1.extra_data = {
+            'field_a': 'data-1a',
+            'field_b': '',
+            'field_c': '',
+        }
+        self.bs1.save()
+
+        self.bs2.extra_data = {
+            'field_a': 'data-2a',
+            'field_b': 'data-2b',
+            'field_c': '',
+        }
+        self.bs2.save()
+
+        expected_extra = {
+            'field_a': 'data-1a',
+            'field_b': 'data-2b',
+            'field_c': '',
+        }
+        expected_sources = {
+            'field_a': self.bs1.pk,
+            'field_b': self.bs2.pk,
+            'field_c': self.bs1.pk,
+        }
+
+        actual_extra, actual_sources = mapper.merge_extra_data(self.bs1, self.bs2)
+
+        self.assertDictEqual(actual_extra, expected_extra)
+        self.assertDictEqual(actual_sources, expected_sources)
+
     def test_update_building(self):
         """Good case for updating a building."""
         fake_building_extra = {


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/611

This PR is based off of #624 

### What was wrong?

Historically, if new data was imported with `extra_data` which contained blank values, those values would overwrite existing values that were not blank.  This has caused data losses.

### How was this fixed?

Since the data model saves all historical states all of the *lost* data is recoverable.  This PR includes a data migration that does the following.

* Finds all building snapshots which are:
    * A canonical snapshot.
    * Has parent snapshots (is the result of merging two snapshots)
    * Has no child snapshots (has not been merged with other snapshots)
* For each of these canonical snapshots:
    * Recursively perform this merge algorithm.
    * For each parent, merge the extra data, prioritizing the *latest* snapshot's data.

With the new extra data merging logic, this will result in any non-blank values that were overridden at some point propagating through the tree towards their canonical snapshot

#### Cute animal picture

![msg-126083882108-3](https://cloud.githubusercontent.com/assets/824194/11963428/196647c8-a8a4-11e5-8bba-4a289f6d1772.jpg)

