### PR TITLE
Fix 500 error when fetching labels

### DIFF
--- a/seed/filters.py
+++ b/seed/filters.py
@@ -41,6 +41,7 @@ class BuildingFilterBackend(filters.BaseFilterBackend):
         buildings_queryset = search.orchestrate_search_filter_sort(
             params=params,
             user=request.user,
+            skip_sort=True,
         )
 
         if request.query_params.get('select_all_checkbox', 'false') == 'true':

--- a/seed/managers/json.py
+++ b/seed/managers/json.py
@@ -3,8 +3,7 @@
 """
 :copyright (c) 2014 - 2015, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
-"""
-"""
+
 Query JSON data from Postgres JsonFields.
 
 ::

--- a/seed/mappings/seed_mappings.py
+++ b/seed/mappings/seed_mappings.py
@@ -3,16 +3,13 @@
 """
 :copyright (c) 2014 - 2015, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
-"""
-"""
+
 How to map dataset attributes to CanonicalBuilding.
 
 If the first element in the tuple is a callable, it will be passed
 a model instance for that type of mapping (AssessedBuilding for
 AssessedBuilding_to_CanonicalBuilding, etc.)
-
 """
-
 from seed.utils.mapping import get_mappable_columns
 
 

--- a/seed/public/models.py
+++ b/seed/public/models.py
@@ -3,13 +3,11 @@
 """
 :copyright (c) 2014 - 2015, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
-"""
-"""
+
 Because migrations are complicated, we're keeping our public fields here.
 
 This deals with circular dependency issues between LANDINGUser and Organization
 """
-
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
 

--- a/seed/search.py
+++ b/seed/search.py
@@ -319,6 +319,8 @@ def process_search_params(params, user, is_api_request=False):
     if order_by == '':
         order_by = 'tax_lot_id'
     sort_reverse = params.get('sort_reverse', False)
+    if isinstance(sort_reverse, basestring):
+        sort_reverse = sort_reverse == 'true'
     page = int(params.get('page', 1))
     number_per_page = int(params.get('number_per_page', 10))
     if 'show_shared_buildings' in params:
@@ -565,7 +567,7 @@ def mask_results(search_results):
     return results
 
 
-def orchestrate_search_filter_sort(params, user):
+def orchestrate_search_filter_sort(params, user, skip_sort=False):
     """
     Given a parsed set of params, perform the search, filter, and sort for
     BuildingSnapshot's
@@ -600,7 +602,7 @@ def orchestrate_search_filter_sort(params, user):
     )
 
     # sorting
-    if extra_data_sort:
+    if extra_data_sort and not skip_sort:
         ed_mapping = ColumnMapping.objects.filter(
             super_organization__in=orgs,
             column_mapped__column_name=params['order_by'],

--- a/seed/search.py
+++ b/seed/search.py
@@ -3,8 +3,7 @@
 """
 :copyright (c) 2014 - 2015, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
-"""
-"""
+
 Search methods pertaining to buildings.
 
 """
@@ -231,8 +230,9 @@ def filter_other_params(queryset, other_params, db_columns):
             elif not_empty_match:
                 # Only return records that have the key in extra_data, but the value is not empty.
                 queryset = queryset.filter(
-                    Q(**{'extra_data__at_%s__isnull' % k: False})
-                    & ~Q(**{'extra_data__at_%s' % k: ''})
+                    Q(
+                        **{'extra_data__at_%s__isnull' % k: False}
+                    ) & ~Q(**{'extra_data__at_%s' % k: ''})
                 )
                 continue
 

--- a/seed/token_generators.py
+++ b/seed/token_generators.py
@@ -3,8 +3,7 @@
 """
 :copyright (c) 2014 - 2015, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
-"""
-"""
+
 token_generator.py
 Aleck Landgraf, taken from django core master branch
 
@@ -56,11 +55,11 @@ class SignupTokenGenerator(object):
             return False
 
         # Check the timestamp is within limit
-        if (
-            (self._num_days(self._today()) - ts) >
-            settings.PASSWORD_RESET_TIMEOUT_DAYS
-            and token_expires
-        ):
+        token_is_expired = all(
+            token_expires,
+            (self._num_days(self._today()) - ts) > settings.PASSWORD_RESET_TIMEOUT_DAYS,
+        )
+        if token_is_expired:
             return False
 
         return True

--- a/seed/urls/labels.py
+++ b/seed/urls/labels.py
@@ -3,11 +3,9 @@
 """
 :copyright (c) 2014 - 2015, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author 'Piper Merriam <pmerriam@quickleft.com>'
-"""
-"""
+
 Url patterns for endpoints associated with Labels
 """
-
 from django.conf.urls import url
 
 from rest_framework import routers

--- a/seed/utils/api_client.py
+++ b/seed/utils/api_client.py
@@ -3,8 +3,7 @@
 """
 :copyright (c) 2014 - 2015, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
-"""
-"""
+
 Demo and testing features for interacting with a SEED API.
 """
 from datetime import datetime, timedelta
@@ -110,7 +109,8 @@ class APIClient(object):
                 continue
 
             def make_function(name):
-                fn = lambda obj, **args: obj._request(name=name, **args)
+                def fn(obj, **kwargs):
+                    return obj._request(name=name, **kwargs)
                 endpoint = self._get_endpoint_by_name(name)
                 fn.__doc__ = endpoint['description']
                 fn.__name__ = str(endpoint['name'])  # de-unicode it

--- a/seed/utils/visualization.py
+++ b/seed/utils/visualization.py
@@ -3,8 +3,7 @@
 """
 :copyright (c) 2014 - 2015, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author 'Piper Merriam <pmerriam@quickleft.com>'
-"""
-"""
+
 Utilities for visualizing the BuildingSnapshot tree.
 """
 from graphviz import Digraph

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -265,8 +265,7 @@ def export_buildings(request):
         _selected_fields = []
         for field in selected_fields:
             components = field.split("__", 1)
-            if (components[0] == 'project_building_snapshots'
-                    and len(components) > 1):
+            if (components[0] == 'project_building_snapshots' and len(components) > 1):
                 _selected_fields.append(components[1])
             else:
                 _selected_fields.append("building_snapshot__%s" % field)
@@ -2336,7 +2335,8 @@ def get_raw_report_data(from_date, end_date, orgs, x_var, y_var):
     # in the future if it should search extra_data but extra_data is still not
     # searchable directly then this can be adjusted by replacing the last None with
     # obj.extra_data[attr] if hasattr(obj, "extra_data") and attr in obj.extra_data else None
-    get_attr_f = lambda obj, attr: getattr(obj, attr) if hasattr(obj, attr) else None
+    def get_attr_f(obj, attr):
+        return getattr(obj, attr, None)
 
     bldg_counts = {}
 

--- a/seed/views/projects.py
+++ b/seed/views/projects.py
@@ -264,9 +264,7 @@ def create_project(request):
     compliance_type = project_json.get('compliance_type', None)
     end_date = project_json.get('end_date', None)
     deadline_date = project_json.get('deadline_date', None)
-    if ((compliance_type is not None
-         and end_date is not None
-         and deadline_date is not None)):
+    if all(v is not None for v in (compliance_type, end_date, deadline_date)):
         c = Compliance(project=project)
         c.compliance_type = compliance_type
         c.end_date = parser.parse(project_json['end_date'])


### PR DESCRIPTION
Issue #627 

### What was wrong?

If you were trying to add a label while sorting on a field that was in the `extra_data` section of the building a 500 was thrown.  This was due to how sorting was implemented on extra-data fields which results in a `list` type being returned.

Later in the code, it was have `.filter()` called on it which resulted in an `AttributeError`

### How was it fixed.

Sidestepped the bug by adding a new parameter to the `orchestrate_search_filter_sort` helper function to allow skipping the sort portion of that function's logic.

#### Cute animal picture

![2772f037b04aae5a1a394e9184e3dda8](https://cloud.githubusercontent.com/assets/824194/12311743/b266c082-ba16-11e5-8697-dcb110458ced.jpg)
