### PR TITLE
Issue #546 - Case insensitive match with carat symbol

### DIFF
--- a/seed/search.py
+++ b/seed/search.py
@@ -180,11 +180,14 @@ def filter_other_params(queryset, other_params, db_columns):
             exact_match = search_utils.is_exact_match(v)
             empty_match = search_utils.is_empty_match(v)
             not_empty_match = search_utils.is_not_empty_match(v)
+            case_insensitive_match = search_utils.is_case_insensitive_match(v)
             is_numeric_expression = search_utils.is_numeric_expression(v)
             is_string_expression = search_utils.is_string_expression(v)
 
             if exact_match:
                 query_filters &= Q(**{"%s__exact" % k: exact_match.group(2)})
+            elif case_insensitive_match:
+                query_filters &= Q(**{"%s__iexact" % k: case_insensitive_match.group(2)})
             elif empty_match:
                 query_filters &= Q(**{"%s__exact" % k: ''}) | Q(**{"%s__isnull" % k: True})
             elif not_empty_match:
@@ -219,6 +222,7 @@ def filter_other_params(queryset, other_params, db_columns):
             exact_match = search_utils.is_exact_match(v)
             empty_match = search_utils.is_empty_match(v)
             not_empty_match = search_utils.is_not_empty_match(v)
+            case_insensitive_match = search_utils.is_case_insensitive_match(v)
 
             if empty_match:
                 # Filter for records that DO NOT contain this field OR
@@ -243,6 +247,10 @@ def filter_other_params(queryset, other_params, db_columns):
             if exact_match:
                 conditions['value'] = exact_match.group(2)
                 conditions['key_cast'] = 'text'
+            elif case_insensitive_match:
+                conditions['value'] = case_insensitive_match.group(2)
+                conditions['key_cast'] = 'text'
+                conditions['case_insensitive'] = True
             elif k.endswith(('__gt', '__gte')):
                 k = search_utils.strip_suffixes(k, ['__gt', '__gte'])
                 conditions['cond'] = '>'

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -688,6 +688,76 @@ class SearchViewTests(TestCase):
         self.assertEqual(len(data['buildings']), 1)
         self.assertEqual(data['buildings'][0]['address_line_1'], 'Address')
 
+    def test_search_case_insensitive_exact_match(self):
+        """
+        Tests search_buidlings method when called with a case insensitive exact match.
+        """
+
+        # Uppercase address
+        cb1 = CanonicalBuilding(active=True)
+        cb1.save()
+        b1 = SEEDFactory.building_snapshot(
+            canonical_building=cb1,
+            address_line_1="Address"
+        )
+        cb1.canonical_snapshot = b1
+        cb1.save()
+        b1.super_organization = self.org
+        b1.save()
+
+        # Lowercase address
+        cb2 = CanonicalBuilding(active=True)
+        cb2.save()
+        b2 = SEEDFactory.building_snapshot(
+            canonical_building=cb2,
+            address_line_1="address"
+        )
+        cb2.canonical_snapshot = b2
+        cb2.save()
+        b2.super_organization = self.org
+        b2.save()
+
+        # Additional words
+        cb3 = CanonicalBuilding(active=True)
+        cb3.save()
+        b3 = SEEDFactory.building_snapshot(
+            canonical_building=cb3,
+            address_line_1="fake address"
+        )
+        cb3.canonical_snapshot = b3
+        cb3.save()
+        b3.super_organization = self.org
+        b3.save()
+
+        url = reverse_lazy("seed:search_buildings")
+        post_data = {
+            'filter_params': {
+                'address_line_1': '^"Address"'
+            },
+            'number_per_page': 10,
+            'order_by': '',
+            'page': 1,
+            'q': '',
+            'sort_reverse': False,
+            'project_id': None,
+        }
+
+        # act
+        response = self.client.post(
+            url,
+            content_type='application/json',
+            data=json.dumps(post_data)
+        )
+        json_string = response.content
+        data = json.loads(json_string)
+
+        # assert
+        self.assertEqual(data['status'], 'success')
+        self.assertEqual(data['number_matching_search'], 2)
+        self.assertEqual(len(data['buildings']), 2)
+        self.assertEqual(data['buildings'][0]['address_line_1'], 'Address')
+        self.assertEqual(data['buildings'][1]['address_line_1'], 'address')
+
     def test_search_empty_column(self):
         """
         Tests search_buidlings method when called with an empty column query.

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -755,8 +755,15 @@ class SearchViewTests(TestCase):
         self.assertEqual(data['status'], 'success')
         self.assertEqual(data['number_matching_search'], 2)
         self.assertEqual(len(data['buildings']), 2)
-        self.assertEqual(data['buildings'][0]['address_line_1'], 'Address')
-        self.assertEqual(data['buildings'][1]['address_line_1'], 'address')
+
+        addresses = []
+
+        addresses.append(data['buildings'][0]['address_line_1'])
+        addresses.append(data['buildings'][1]['address_line_1'])
+
+        self.assertIn('address', addresses)
+        self.assertIn('Address', addresses)
+        self.assertNotIn('fake address', addresses)
 
     def test_search_empty_column(self):
         """

--- a/seed/utils/search.py
+++ b/seed/utils/search.py
@@ -54,6 +54,13 @@ def is_not_empty_match(q):
     return False
 
 
+def is_case_insensitive_match(q):
+    # Carat and matching quotes? eg ^"sacramento"
+    if is_string_query(q):
+        return re.match(r"""^\^(["'])(.+)\1$""", q)
+    return False
+
+
 NUMERIC_EXPRESSION_REGEX = re.compile((
     r'('                                     # open expression grp
     r'(?P<operator>==|=|>|>=|<|<=|<>|!|!=)'  # operator


### PR DESCRIPTION
#### What's this PR do?
Enables case insensitive filtering on building list via `^""` carat syntax. `^"test"` would match any case of `test`.

#### What are the relevant tickets?
Refs #546 
