### PR TITLE
Issue #595 - Catch invalid operator errors and return nothing.

### DIFF
--- a/seed/search.py
+++ b/seed/search.py
@@ -209,7 +209,12 @@ def filter_other_params(queryset, other_params, db_columns):
             else:
                 query_filters &= Q(**{"%s__icontains" % k: v})
 
-    queryset = queryset.filter(query_filters)
+    try:
+        queryset = queryset.filter(query_filters)
+    except ValueError:
+        # Return nothing if invalid queries happen. Most likely
+        # this is caused by using operators in the wrong fields.
+        queryset = queryset.none()
 
     # handle extra_data with json_query
     for k, v in other_params.iteritems():


### PR DESCRIPTION
#### What's this PR do?
Incorrect null syntax in filter fields will throw an error. This is a first step patch to at least not give a 500 back from the server. Return no results on invalid syntax.

#### What are the relevant tickets?
Refs #595 
