### PR TITLE
Issue #515 - Building detail page edit labels

### DIFF
--- a/seed/static/seed/js/controllers/building_detail_controller.js
+++ b/seed/static/seed/js/controllers/building_detail_controller.js
@@ -49,14 +49,14 @@ angular.module('BE.seed.controller.building_detail', [])
         isopen: false
     };
 
-    var get_labels = function() {
-        return _.map(building_payload.labels, function(lbl) {
+    var get_labels = function(building) {
+        return _.map(building.labels, function(lbl) {
           lbl.label = label_helper_service.lookup_label(lbl.color);
           return lbl;
         });
     };
 
-    $scope.labels = get_labels();
+    $scope.labels = get_labels(building_payload);
 
     /**
      * is_project: returns true is building breadcrumb is from a project, used
@@ -356,9 +356,12 @@ angular.module('BE.seed.controller.building_detail', [])
         });
         modalInstance.result.then(
             function () {
-                //dialog was closed with 'Done' button.
-                $scope.labels = get_labels();
-            }, 
+                // Grab fresh building data for get_labels()
+                var canonical_id = $scope.building.canonical_building;
+                building_services.get_building(canonical_id).then(function(building_refresh) {
+                    $scope.labels = get_labels(building_refresh);
+                });
+            },
             function (message) {
                //dialog was 'dismissed,' which means it was cancelled...so nothing to do. 
             }

--- a/seed/static/seed/js/controllers/building_detail_controller.js
+++ b/seed/static/seed/js/controllers/building_detail_controller.js
@@ -23,10 +23,6 @@ angular.module('BE.seed.controller.building_detail', [])
     $scope.user.building_id = $routeParams.building_id;
     $scope.user.project_slug = $routeParams.project_id;
     $scope.projects = [];
-    $scope.labels = _.map(building_payload.labels, function(lbl) {
-      lbl.label = label_helper_service.lookup_label(lbl.color);
-      return lbl;
-    });
     $scope.building = building_payload.building;
     $scope.user_role = building_payload.user_role;
     $scope.user_org_id = building_payload.user_org_id;
@@ -48,12 +44,19 @@ angular.module('BE.seed.controller.building_detail', [])
 
     // set the tab
     $scope.section = $location.hash();
-    
+
     $scope.status = {
         isopen: false
     };
 
-      
+    var get_labels = function() {
+        return _.map(building_payload.labels, function(lbl) {
+          lbl.label = label_helper_service.lookup_label(lbl.color);
+          return lbl;
+        });
+    };
+
+    $scope.labels = get_labels();
 
     /**
      * is_project: returns true is building breadcrumb is from a project, used
@@ -354,6 +357,7 @@ angular.module('BE.seed.controller.building_detail', [])
         modalInstance.result.then(
             function () {
                 //dialog was closed with 'Done' button.
+                $scope.labels = get_labels();
             }, 
             function (message) {
                //dialog was 'dismissed,' which means it was cancelled...so nothing to do. 

--- a/seed/static/seed/js/controllers/building_detail_controller.js
+++ b/seed/static/seed/js/controllers/building_detail_controller.js
@@ -341,6 +341,26 @@ angular.module('BE.seed.controller.building_detail', [])
         return num;
     };
 
+    $scope.open_update_building_labels_modal = function() {
+        var modalInstance = $uibModal.open({
+            templateUrl: urls.static_url + 'seed/partials/building_detail_update_labels_modal.html',
+            controller: 'building_detail_update_labels_modal_ctrl',
+            resolve: {
+                building: function () {
+                    return $scope.building;
+                }
+            }
+        });
+        modalInstance.result.then(
+            function () {
+                //dialog was closed with 'Done' button.
+            }, 
+            function (message) {
+               //dialog was 'dismissed,' which means it was cancelled...so nothing to do. 
+            }
+        );
+    };
+
     /**
      * init: sets default state of building detail page, gets the breadcrumb
      *   project if exists, sets the field arrays for each section, performs

--- a/seed/static/seed/js/controllers/building_detail_update_labels_modal_ctrl.js
+++ b/seed/static/seed/js/controllers/building_detail_update_labels_modal_ctrl.js
@@ -1,0 +1,130 @@
+/*
+ * :copyright (c) 2014 - 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.
+ * :author
+ */
+angular.module('BE.seed.controller.building_detail_update_labels_modal_ctrl', [])
+.controller('building_detail_update_labels_modal_ctrl', [
+  '$scope',
+  '$uibModalInstance',
+  'label_service',
+  'building',
+  'Notification',
+  function ($scope, $uibModalInstance, label_service, building, notification) {
+
+    //Controller for the Update Building Labels modal window.
+    //Manages applying labels to a single buildings, as
+    //well as allowing for the creation of new labels.
+
+    //keep track of status of service call
+    $scope.loading = false;
+
+    //An array of all available labels in the system.
+    //These label objects should have the is_applied property set so 
+    //the modal can show the Remove button if necessary. (Populated
+    //during init function below.)
+    $scope.labels = [];
+
+    //new_label serves as model for the "Create a new label" UI
+    $scope.new_label = {};
+
+    //list of colors for the create label UI
+    $scope.available_colors = label_service.get_available_colors();
+
+    /* Initialize the label props for a 'new' label */
+    $scope.initialize_new_label = function() {
+       $scope.new_label = {color:"gray", label:"default", name:""};
+    };
+
+    /* Create a new label based on user input */
+    $scope.submitNewLabelForm = function(form){
+        $scope.createdLabel = null;
+        if (form.$invalid) {
+            return;
+        }
+        label_service.create_label($scope.new_label).then(
+            function(data){
+
+                //promise completed successfully
+                var createdLabel = data;
+
+                //Assume that user wants to apply a label they just created
+                //in this modal...
+                createdLabel.is_checked_add = true;
+
+                $scope.newLabelForm.$setPristine();
+                $scope.labels.unshift(createdLabel);
+                $scope.initialize_new_label();
+            },
+            function(data, status) {
+                // reject promise
+                // label name already exists
+                if (data.message==='label already exists'){
+                    alert('label already exists');
+                } else {
+                    alert('error creating new label');
+                }
+            }
+        );
+    };
+
+    /* Toggle the add button for a label */
+    $scope.toggle_add = function(label){
+        if (label.is_checked_remove && label.is_checked_add) {
+            label.is_checked_remove = false;
+        }
+    };
+
+    /* Toggle the remove button for a label */
+    $scope.toggle_remove = function(label){
+        if (label.is_checked_remove && label.is_checked_add) {
+            label.is_checked_add = false;
+        }
+    };
+
+    /* User has indicated 'Done' so perform selected label operations */
+    $scope.done = function () {
+
+        var addLabelIDs = _.chain($scope.labels)
+            .filter(function(lbl) {
+                return lbl.is_checked_add;
+            })
+            .pluck("id")
+            .value();
+        var removeLabelIDs = _.chain($scope.labels)
+            .filter(function(lbl) {
+                return lbl.is_checked_remove;
+            })
+            .pluck("id")
+            .value();
+
+        label_service.update_building_labels(addLabelIDs, removeLabelIDs, [building.pk], false, {}).then(
+            function(data){
+                var msg = data.num_buildings_updated.toString() + " buildings updated.";
+                notification.primary(msg);
+                $uibModalInstance.close();
+            },
+            function(data, status) {
+            }
+        );
+    };
+
+    /* User has cancelled dialog */
+    $scope.cancel = function () {
+        //don't do anything, just close modal.
+        $uibModalInstance.dismiss('cancel');
+    };
+
+    /* init: Gets the list of labels. Sets up new label object. */
+    var init = function() {
+        $scope.initialize_new_label();
+        //get labels with 'is_applied' property by passing in current search state
+        $scope.loading = true;
+        label_service.get_labels([building.pk], false, {}).then(function(data){
+             $scope.labels = data.results;
+             $scope.loading = false;
+        });
+    };
+
+    init();
+
+}]);

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -22,6 +22,7 @@ angular.module('BE.seed.controllers', [
     'BE.seed.controller.accounts',
     'BE.seed.controller.admin',
     'BE.seed.controller.building_detail',
+    'BE.seed.controller.building_detail_update_labels_modal_ctrl',
     'BE.seed.controller.building_list',
     'BE.seed.controller.buildings_reports',
     'BE.seed.controller.buildings_settings',

--- a/seed/static/seed/partials/building_detail_section.html
+++ b/seed/static/seed/partials/building_detail_section.html
@@ -18,7 +18,8 @@
 
 
             <div style="margin:10px 0px; padding:0px 10px;">
-                <span style="padding-right:5px;"><strong>Labels:</strong></span>
+                <span ng-hide="building.edit_form_showing" style="padding-right:5px;"><strong>Labels:</strong></span>
+                <button ng-show="building.edit_form_showing" type="button" class="btn btn-default" ng-click="()"><i class="fa fa-tag"></i>Add/Remove Labels</button>
                 <span ng-show="labels.length === 0" style="color:#999">(no labels applied)</span>
                 <span ng-repeat="label in labels" class="label label-{$ label.label $}">{$ label.name $}</span>
             </div>

--- a/seed/static/seed/partials/building_detail_section.html
+++ b/seed/static/seed/partials/building_detail_section.html
@@ -19,7 +19,7 @@
 
             <div style="margin:10px 0px; padding:0px 10px;">
                 <span ng-hide="building.edit_form_showing" style="padding-right:5px;"><strong>Labels:</strong></span>
-                <button ng-show="building.edit_form_showing" type="button" class="btn btn-default" ng-click="()"><i class="fa fa-tag"></i>Add/Remove Labels</button>
+                <button ng-show="building.edit_form_showing" type="button" class="btn btn-default" ng-click="open_update_building_labels_modal()"><i class="fa fa-tag"></i>Add/Remove Labels</button>
                 <span ng-show="labels.length === 0" style="color:#999">(no labels applied)</span>
                 <span ng-repeat="label in labels" class="label label-{$ label.label $}">{$ label.name $}</span>
             </div>

--- a/seed/static/seed/partials/building_detail_section.html
+++ b/seed/static/seed/partials/building_detail_section.html
@@ -18,8 +18,8 @@
 
 
             <div style="margin:10px 0px; padding:0px 10px;">
-                <span ng-hide="building.edit_form_showing" style="padding-right:5px;"><strong>Labels:</strong></span>
-                <button ng-show="building.edit_form_showing" type="button" class="btn btn-default" ng-click="open_update_building_labels_modal()"><i class="fa fa-tag"></i>Add/Remove Labels</button>
+                <button type="button" class="btn btn-default" ng-click="open_update_building_labels_modal()"><i class="fa fa-tag"></i>Add/Remove Labels</button>
+                <span style="padding-right:5px;"><strong>Labels:</strong></span>
                 <span ng-show="labels.length === 0" style="color:#999">(no labels applied)</span>
                 <span ng-repeat="label in labels" class="label label-{$ label.label $}">{$ label.name $}</span>
             </div>

--- a/seed/static/seed/partials/building_detail_update_labels_modal.html
+++ b/seed/static/seed/partials/building_detail_update_labels_modal.html
@@ -1,0 +1,127 @@
+<div  id="update-building-labels-modal">
+    <div class="modal-header" >
+        <button type="button"
+                class="close"
+                aria-hidden="true"
+                ng-click="cancel()">
+                <i class="fa fa-times"></i></button>
+        <h4 class="modal-title"
+            id="manageLabelsModalLabel">
+            Add/Remove Labels</h4>
+    </div>
+    <div class="modal-body">
+        <div class="newLabelInput" style="margin-top:0px;">
+            <form   name="newLabelForm"
+                    class="form-inline"
+                    role="form"
+                    ng-submit="submitNewLabelForm(newLabelForm)"
+                    novalidate>
+                <div    class="form-group"
+                        ng-class="{'has-error': newLabelForm.name.$invalid &&
+                                                newLabelForm.name.$dirty }">
+                    <label  class="control-label sectionLabel"
+                            style="padding-right:20px;">
+                            Create new label</label>
+                    <div    class="input-group"
+                            style="padding-right:20px;">
+                        <input  id="labelName" 
+                                type="text"
+                                name="name"
+                                class="form-control" 
+                                ng-model="new_label.name"
+                                placeholder="Label Name"
+                                check-label-exists="labels"
+                                required>
+                        <div uib-dropdown class="input-group-btn">
+                            <button type="button"
+                                    class="btn btn-{$ new_label.label $} dropdown-toggle"
+                                    data-toggle="dropdown">{$ new_label.color $} 
+                                <span class="caret"></span>
+                            </button>
+                            <ul class="uib-dropdown-menu pull-right" role="menu">
+                                <li ng-repeat="label in available_colors" 
+                                    ng-click="new_label.label = label.label; new_label.color = label.color">
+                                    <a>
+                                        <span class="label label-{$ label.label $}">{$ label.color $}</span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <button type="submit"
+                            class="btn btn-primary" 
+                            ng-disabled="newLabelForm.$invalid">
+                        Create label
+                    </button>
+                    <div class="help-block">
+                        <span   class="has-error" 
+                                ng-show="newLabelForm.name.$error.checkLabelExists">
+                                This label name is already taken.
+                        </span>
+                    </div>
+                </div>
+            </form>
+        </div>
+
+        <div class="edit_text">Add or remove labels from this building.</div>
+
+        <div class="table-list-container"  >
+
+            <div class="labels-status-msg" 
+                 ng-show="loading==true || labels.length == 0">
+                <div ng-show="loading">
+                    <p>Loading labels...</p>
+                </div>
+                <div ng-show="loading==false && labels.length == 0">
+                    <p>No labels available. Add a label above to get started.</p>
+                </div>
+            </div>
+
+            <table ng-show="labels.length > 0" class="table table-striped">
+                <tr ng-repeat="label in labels">
+                    <td class="label_column">
+                        <span class="label label-{$ label.label $}">{$ label.name $}</span>
+                    </td>
+                    <td align="right">
+
+                        <button type="button" 
+                                uib-btn-checkbox 
+                                ng-model="label.is_checked_remove"
+                                ng-show="label.is_applied"
+                                btn-checkbox-true="true" 
+                                btn-checkbox-false="false"
+                                class="btn btn-sm btn-default action_link" 
+                                ng-class="{'btn-danger':label.is_checked_remove}"
+                                ng-click="toggle_remove(label)"
+                                >Remove
+                        </button>
+
+                        <button type="button"
+                                uib-btn-checkbox 
+                                ng-model="label.is_checked_add"
+                                ng-hide="label.is_applied"
+                                btn-checkbox-true="true" 
+                                btn-checkbox-false="false"
+                                class="btn btn-sm btn-default action_link" 
+                                ng-class="{'btn-primary':label.is_checked_add}"
+                                ng-click="toggle_add(label)"
+                                >Add
+                        </button>
+                    </td>
+                </tr>
+            </table>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button type="button" 
+                class="btn btn-primary" 
+                style="min-width:90px;"
+                ng-click="done()">
+                Done</button>
+        <button type="button" 
+                class="btn btn-default" 
+                style="min-width:90px;"
+                ng-click="cancel()">
+                Cancel</button>
+    </div>
+</div>

--- a/seed/templates/seed/_scripts.html
+++ b/seed/templates/seed/_scripts.html
@@ -21,6 +21,7 @@
 <script src="{{STATIC_URL}}seed/js/controllers/admin_controller.js"></script>
 <script src="{{STATIC_URL}}seed/js/controllers/building_list_controller.js"></script>
 <script src="{{STATIC_URL}}seed/js/controllers/building_detail_controller.js"></script>
+<script src="{{STATIC_URL}}seed/js/controllers/building_detail_update_labels_modal_ctrl.js"></script>
 <script src="{{STATIC_URL}}seed/js/controllers/buildings_reports_controller.js"></script>
 <script src="{{STATIC_URL}}seed/js/controllers/buildings_settings_controller.js"></script>
 <script src="{{STATIC_URL}}seed/js/controllers/buildings_label_admin_controller.js"></script>


### PR DESCRIPTION
#### Any background context you want to provide?
We wanted a way to edit labels for a specific building on the building detail page.

#### What's this PR do?
Adds editing label functionality on the building detail page. Uses the same assets and modal and flow as the list page.

I posed a question [here](https://github.com/SEED-platform/seed/issues/515#issuecomment-173778067) about when the add/remove labels button should be shown. I implemented it in a way that shows the "add/remove labels" button as soon as you land on the building detail page. I think this feels correct.

#### How should this be manually tested?
Edit labels on building detail page.

#### What are the relevant tickets?
Refs #515

#### Screenshots (if appropriate)
![gif](http://g.recordit.co/Jd5J36Z837.gif)