### PR TITLE
Issue #432 - Custom celery JSON serializer to handle datetimes

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -6,7 +6,12 @@ from __future__ import absolute_import
 import os
 import sys  # Needed for coverage
 from os.path import abspath, join, dirname
+
 from kombu import Exchange, Queue
+from kombu.serialization import register
+
+from seed.serializers.celery import CeleryDatetimeSerializer
+
 
 SITE_ROOT = abspath(join(dirname(__file__), "..", ".."))
 
@@ -221,9 +226,14 @@ CELERY_QUEUES = (
         routing_key=CELERY_DEFAULT_QUEUE
     ),
 )
-CELERY_ACCEPT_CONTENT = ['json']
-CELERY_TASK_SERIALIZER = 'json'
-CELERY_RESULT_SERIALIZER = 'json'
+
+# Register our custom JSON serializer so we can serialize datetime objects in celery.
+register('seed_json', CeleryDatetimeSerializer.seed_dumps, CeleryDatetimeSerializer.seed_loads,
+    content_type='application/json', content_encoding='utf-8')
+
+CELERY_ACCEPT_CONTENT = ['seed_json']
+CELERY_TASK_SERIALIZER = 'seed_json'
+CELERY_RESULT_SERIALIZER = 'seed_json'
 CELERY_TASK_RESULT_EXPIRES = 18000  # 5 hours
 
 SOUTH_TESTS_MIGRATE = False

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -229,7 +229,7 @@ CELERY_QUEUES = (
 
 # Register our custom JSON serializer so we can serialize datetime objects in celery.
 register('seed_json', CeleryDatetimeSerializer.seed_dumps, CeleryDatetimeSerializer.seed_loads,
-    content_type='application/json', content_encoding='utf-8')
+         content_type='application/json', content_encoding='utf-8')
 
 CELERY_ACCEPT_CONTENT = ['seed_json']
 CELERY_TASK_SERIALIZER = 'seed_json'

--- a/seed/serializers/celery.py
+++ b/seed/serializers/celery.py
@@ -13,7 +13,7 @@ class CeleryDatetimeSerializer(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime):
             return {
-                '__type__': '__datetime__', 
+                '__type__': '__datetime__',
                 'iso8601': obj.isoformat()
             }
         else:

--- a/seed/serializers/celery.py
+++ b/seed/serializers/celery.py
@@ -1,0 +1,37 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+import dateutil
+import json
+from datetime import datetime
+
+
+class CeleryDatetimeSerializer(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return {
+                '__type__': '__datetime__', 
+                'iso8601': obj.isoformat()
+            }
+        else:
+            return json.JSONEncoder.default(self, obj)
+
+    @staticmethod
+    def seed_decoder(obj):
+        if '__type__' in obj:
+            if obj['__type__'] == '__datetime__':
+                return dateutil.parser.parse(obj['iso8601'])
+        return obj
+
+    # Encoder function
+    @staticmethod
+    def seed_dumps(obj):
+        return json.dumps(obj, cls=CeleryDatetimeSerializer)
+
+    # Decoder function
+    @staticmethod
+    def seed_loads(obj):
+        return json.loads(obj, object_hook=CeleryDatetimeSerializer.seed_decoder)

--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -721,7 +721,7 @@ def _save_raw_data_chunk(chunk, file_pk, prog_key, increment, *args, **kwargs):
 
 
 @shared_task
-def finish_raw_save(results, file_pk):
+def finish_raw_save(file_pk):
     """
     Finish importing the raw file.
 
@@ -871,7 +871,7 @@ def _save_raw_data(file_pk, *args, **kwargs):
         logger.debug('Added caching increment')
         if tasks:
             logger.debug('Adding chord to queue')
-            chord(tasks, interval=15)(finish_raw_save.s(file_pk))
+            chord(tasks, interval=15)(finish_raw_save.si(file_pk))
         else:
             logger.debug('Skipped chord')
             finish_raw_save.s(file_pk)


### PR DESCRIPTION
#### Any background context you want to provide?
PR #669 switched celery's serialization from pickle to JSON. A case was missed where datetime objects sometimes need to be serialized.

#### What's this PR do?
Adds a custom JSON serializer to handle datetimes, and use this serializer in celery tasks. Datetimes are encoded as ISO8601 in this implementation.

#### How should this be manually tested?
Upload a spreadsheet with date objects.

#### What are the relevant tickets?
Refs #432 #669 
