### PR TITLE
Issue #634 - Renaming data set fix

### DIFF
--- a/seed/static/seed/js/services/dataset_service.js
+++ b/seed/static/seed/js/services/dataset_service.js
@@ -88,9 +88,12 @@ angular.module('BE.seed.service.dataset', []).factory('dataset_service', [
         var defer = $q.defer();
         $http({
             method: 'PUT',
-            'url': window.BE.urls.update_dataset + '?organization_id=' + user_service.get_organization().id,
+            'url': window.BE.urls.update_dataset,
             'data': {
                 'dataset': dataset
+            },
+            'params': {
+                'organization_id': user_service.get_organization().id
             }
         }).success(function(data, status, headers, config) {
             defer.resolve(data);

--- a/seed/static/seed/js/services/dataset_service.js
+++ b/seed/static/seed/js/services/dataset_service.js
@@ -88,7 +88,7 @@ angular.module('BE.seed.service.dataset', []).factory('dataset_service', [
         var defer = $q.defer();
         $http({
             method: 'PUT',
-            'url': window.BE.urls.update_dataset,
+            'url': window.BE.urls.update_dataset + '?organization_id=' + user_service.get_organization().id,
             'data': {
                 'dataset': dataset
             }


### PR DESCRIPTION
#### What's this PR do?
Renaming data sets was broken unless you were flagged as a Django superuser. The endpoint needs the `organization_id` passed along.

I don't have any tests for this, but it's a good candidate for a selenium test. Not sure if those are ready. 

#### What are the relevant tickets?
Refs #634 
