### PR TITLE
Issue #581 - Matching dropdown should respect sessionStorage

### DIFF
--- a/seed/static/seed/partials/buildings.html
+++ b/seed/static/seed/partials/buildings.html
@@ -58,7 +58,7 @@
 
              <select    id="showHideFilterSelect" 
                         class="form-control" 
-                        ng-init="matching_filter_options.selected = matching_filter_options[0].id"
+                        ng-init="matching_filter_options.selected = matching_filter_options_init"
                         ng-model="matching_filter_options.selected" 
                         ng-options="option.id as option.value for option in matching_filter_options"
                         ng-change="update_show_matching_filter(matching_filter_options.selected)">


### PR DESCRIPTION
#### What's this PR do?
New matched/unmatched dropdown on building list page was not respecting cached sessionStorage filter params. This fixes the issue.

#### What are the relevant tickets?
Refs #581
