### PR TITLE
Stop-gap solution for django-pgjson bug

### DIFF
--- a/seed/views/labels.py
+++ b/seed/views/labels.py
@@ -112,7 +112,11 @@ class UpdateBuildingLabelsAPIView(generics.GenericAPIView):
         """
         building_snapshots = self.filter_queryset(self.get_queryset())
         queryset = CanonicalBuilding.objects.filter(
-            id__in=building_snapshots.values_list('canonical_building', flat=True),
+            # This is a stop-gap solution for a bug in django-pgjson
+            # https://github.com/djangonauts/django-pgjson/issues/35
+            # - once a release has been made with this fixed the 'tuple'
+            # casting can be removed.
+            id__in=tuple(building_snapshots.values_list('canonical_building', flat=True)),
         )
         serializer = self.get_serializer(
             data=self.request.data,


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/627

### What was wrong?

A bug in django-pgjson was resulting in a query that *should* have worked failing.

https://github.com/djangonauts/django-pgjson/issues/35

### How was it fixed

Instead of letting the django orm do it's magic, I cast the subquery to a tuple to force evaluation and bypass the bad code.

It's worth noting that if we can get switched over to Django 1.8 we can drop this 3rd-party dependency entirely in favor of `django.contrib.postgres` based fields which are likely to be more reliable.

#### Cute animal picture

![6d2d35001417b44df88ee66f908dfdc4](https://cloud.githubusercontent.com/assets/824194/12761566/af952438-c9a8-11e5-9601-1db8bde2c9f4.jpg)