### PR TITLE
Issue #577 - Building Detail show/hide/reorder columns

### DIFF
--- a/seed/landing/migrations/0003_seeduser_default_building_detail_custom_columns.py
+++ b/seed/landing/migrations/0003_seeduser_default_building_detail_custom_columns.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django_pgjson.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('landing', '0002_auto_20151105_1539'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='seeduser',
+            name='default_building_detail_custom_columns',
+            field=django_pgjson.fields.JsonField(default={}),
+            preserve_default=True,
+        ),
+    ]

--- a/seed/landing/models.py
+++ b/seed/landing/models.py
@@ -54,6 +54,7 @@ class SEEDUser(AbstractBaseUser, PermissionsMixin):
     date_joined = models.DateTimeField(_('date joined'), default=timezone.now)
 
     default_custom_columns = JsonField(default={})
+    default_building_detail_custom_columns = JsonField(default={})
     show_shared_buildings = models.BooleanField(
         _('active'), default=False,
         help_text=_('shows shared buildings within search results'))

--- a/seed/static/seed/js/controllers/building_detail_controller.js
+++ b/seed/static/seed/js/controllers/building_detail_controller.js
@@ -31,7 +31,7 @@ angular.module('BE.seed.controller.building_detail', [])
     $scope.imported_buildings = building_payload.imported_buildings;
     $scope.projects = building_payload.projects;
     $scope.fields = all_columns.fields;
-    $scope.default_columns = default_columns.columns
+    $scope.default_columns = default_columns.columns;
     $scope.building_copy = {};
     $scope.data_columns = [];
     $scope.audit_logs = audit_payload.audit_logs;
@@ -273,34 +273,48 @@ angular.module('BE.seed.controller.building_detail', [])
      * @param {Array} buildings: concatenated list of buildings
      */
     $scope.generate_data_columns = function(buildings) {
+        var data_columns = [];
         var key_list = [];
         var check_defaults = !!$scope.default_columns.length;
+
         // handle extra_data
         angular.forEach(buildings, function(b){
             angular.forEach(b.extra_data, function (val, key){
                 // Duplicate check and check if default_columns is used and if field in columns
                 if (key_list.indexOf(key) === -1 && (!check_defaults || (check_defaults && $scope.default_columns.indexOf(key) > -1))) {
                     key_list.push(key);
-                    $scope.data_columns.push({
+                    data_columns.push({
                         "key": key,
                         "type": "extra_data"
                     });
                 }
             });
         });
-        // hanlde building properties
+
+        // handle building properties
         angular.forEach($scope.building, function ( val, key ) {
             // Duplicate check and check if default_columns is used and if field in columns
             if ( $scope.is_valid_key(key) && typeof val !== "undefined" && key_list.indexOf(key) === -1 && 
                 (!check_defaults || (check_defaults && $scope.default_columns.indexOf(key) > -1))) {
-
                 key_list.push(key);
-                $scope.data_columns.push({
+                data_columns.push({
                     "key": key,
                     "type": "fixed_column"
                 });
             }
         });
+
+        if (check_defaults) {
+            data_columns.sort(function(a,b) {
+                if ($scope.default_columns.indexOf(a.key) < $scope.default_columns.indexOf(b.key)) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            });
+        }
+
+        $scope.data_columns = data_columns;
     };
 
     /**

--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -484,6 +484,9 @@ angular.module('BE.seed.controller.building_list', [])
                 },
                 'project_payload': function() {
                     return {project: {}};
+                },
+                'building_payload': function() {
+                    return {'building': {}};
                 }
             }
         });

--- a/seed/static/seed/js/controllers/buildings_settings_controller.js
+++ b/seed/static/seed/js/controllers/buildings_settings_controller.js
@@ -13,7 +13,8 @@ angular.module('BE.seed.controller.buildings_settings', [])
   '$filter',
   '$routeParams',
   'project_payload',
-  function(
+  'building_payload',
+    function(
     $scope,
     $uibModalInstance,
     all_columns,
@@ -22,7 +23,8 @@ angular.module('BE.seed.controller.buildings_settings', [])
     user_service,
     $filter,
     $routeParams,
-    project_payload
+    project_payload,
+    building_payload
   ) {
     $scope.user = {};
     $scope.user.project_slug = $routeParams.project_id;
@@ -31,7 +33,7 @@ angular.module('BE.seed.controller.buildings_settings', [])
       select_all: false
     };
     $scope.project = project_payload.project;
-
+    $scope.building = building_payload.building;
     $scope.fields = all_columns.fields;
     // re-check the user's selected columns
     $scope.fields = $scope.fields.map(function(c){
@@ -98,9 +100,15 @@ angular.module('BE.seed.controller.buildings_settings', [])
         columns = columns.map(function(field) {
             return field.sort_column;
         });
-        // save the array of column names for the user
-        user_service.set_default_columns(columns, $scope.user.show_shared_buildings)
-        .then(function (data) {
+        // Save the array of column names for the user. If $scope.building exists,
+        // this is for the detail page, so set detail columns. If not, set list columns.
+        var set_promise;
+        if (_.isEmpty($scope.building)) {
+            set_promise = user_service.set_default_columns(columns, $scope.user.show_shared_buildings)
+        } else {
+            set_promise = user_service.set_default_building_detail_columns(columns)
+        }
+        set_promise.then(function (data) {
             //resolve promise
             $scope.settings_updated = true;
             $uibModalInstance.close(columns);

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -453,10 +453,6 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                 'all_columns': ['building_services', function(building_services) {
                     return building_services.get_columns(false);
                 }],
-                'audit_payload': ['audit_service', '$route', function(audit_service, $route){
-                    var building_id = $route.current.params.building_id;
-                    return audit_service.get_building_logs(building_id);
-                }],
                 'default_columns': ['user_service', function(user_service){
                     return user_service.get_default_building_detail_columns();
                 }],

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -270,6 +270,9 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                 'audit_payload': ['audit_service', '$route', function(audit_service, $route){
                     var building_id = $route.current.params.building_id;
                     return audit_service.get_building_logs(building_id);
+                }],
+                'default_columns': ['user_service', function(user_service){
+                    return user_service.get_default_building_detail_columns();
                 }]
             },
             templateUrl: static_url + 'seed/partials/building_detail_section.html'
@@ -391,6 +394,9 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                 'audit_payload': ['audit_service', '$route', function(audit_service, $route){
                     var building_id = $route.current.params.building_id;
                     return audit_service.get_building_logs(building_id);
+                }],
+                'default_columns': ['user_service', function(user_service){
+                    return user_service.get_default_building_detail_columns();
                 }]
             }
         })
@@ -410,6 +416,9 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                 'audit_payload': ['audit_service', '$route', function(audit_service, $route){
                     var building_id = $route.current.params.building_id;
                     return audit_service.get_building_logs(building_id);
+                }],
+                'default_columns': ['user_service', function(user_service){
+                    return user_service.get_default_building_detail_columns();
                 }]
             }
         })
@@ -429,6 +438,9 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                 'audit_payload': ['audit_service', '$route', function(audit_service, $route){
                     var building_id = $route.current.params.building_id;
                     return audit_service.get_building_logs(building_id);
+                }],
+                'default_columns': ['user_service', function(user_service){
+                    return user_service.get_default_building_detail_columns();
                 }]
             }
         })

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -251,7 +251,10 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                     var params = angular.copy($route.current.params);
                     var project_slug = params.project_id;
                     return project_service.get_project(project_slug);
-                }]
+                }],
+                'building_payload': function() {
+                    return {'building': {}};
+                }
             }
         })
         .when('/projects/:project_id/:building_id', {
@@ -335,6 +338,9 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                 },
                 'project_payload': function() {
                     return {'project': {}};
+                },
+                'building_payload': function() {
+                    return {'building': {}};
                 }
             }
 
@@ -363,6 +369,9 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                 'audit_payload': ['audit_service', '$route', function(audit_service, $route){
                     var building_id = $route.current.params.building_id;
                     return audit_service.get_building_logs(building_id);
+                }],
+                'default_columns': ['user_service', function(user_service){
+                    return user_service.get_default_building_detail_columns();
                 }]
             }
         })
@@ -421,6 +430,37 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                     var building_id = $route.current.params.building_id;
                     return audit_service.get_building_logs(building_id);
                 }]
+            }
+        })
+        .when('/buildings/:building_id/settings', {
+            controller: 'buildings_settings_controller',
+            templateUrl: static_url + 'seed/partials/building_settings_section.html',
+            resolve: {
+                'building_payload': ['building_services', '$route', function(building_services, $route){
+                    // load `get_building` before page is loaded to avoid
+                    // page flicker.
+                    var building_id = $route.current.params.building_id;
+                    return building_services.get_building(building_id);
+                }],
+                'all_columns': ['building_services', function(building_services) {
+                    return building_services.get_columns(false);
+                }],
+                'audit_payload': ['audit_service', '$route', function(audit_service, $route){
+                    var building_id = $route.current.params.building_id;
+                    return audit_service.get_building_logs(building_id);
+                }],
+                'default_columns': ['user_service', function(user_service){
+                    return user_service.get_default_building_detail_columns();
+                }],
+                'shared_fields_payload': ['user_service', '$route', function(user_service, $route) {
+                    return {'show_shared_buildings': false};
+                }],
+                '$uibModalInstance': function() {
+                    return {close: function () {}};
+                },
+                'project_payload': function() {
+                    return {'project': {}};
+                }
             }
         })
         .when('/data/mapping/:importfile_id', {

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -267,10 +267,9 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                 'all_columns': ['building_services', function(building_services) {
                     return building_services.get_columns(false);
                 }],
-                'audit_payload': ['audit_service', '$route', function(audit_service, $route){
-                    var building_id = $route.current.params.building_id;
-                    return audit_service.get_building_logs(building_id);
-                }],
+                'audit_payload': function(){
+                    return {'audit_logs': {}};
+                },
                 'default_columns': ['user_service', function(user_service){
                     return user_service.get_default_building_detail_columns();
                 }]
@@ -369,10 +368,9 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                 'all_columns': ['building_services', function(building_services) {
                     return building_services.get_columns(false);
                 }],
-                'audit_payload': ['audit_service', '$route', function(audit_service, $route){
-                    var building_id = $route.current.params.building_id;
-                    return audit_service.get_building_logs(building_id);
-                }],
+                'audit_payload': function(){
+                    return {'audit_logs': {}};
+                },
                 'default_columns': ['user_service', function(user_service){
                     return user_service.get_default_building_detail_columns();
                 }]
@@ -391,13 +389,12 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                 'all_columns': ['building_services', function(building_services) {
                     return building_services.get_columns(false);
                 }],
-                'audit_payload': ['audit_service', '$route', function(audit_service, $route){
-                    var building_id = $route.current.params.building_id;
-                    return audit_service.get_building_logs(building_id);
-                }],
-                'default_columns': ['user_service', function(user_service){
-                    return user_service.get_default_building_detail_columns();
-                }]
+                'audit_payload': function(){
+                    return {'audit_logs': {}};
+                },
+                'default_columns': function(){
+                    return {'columns': {}};
+                }
             }
         })
         .when('/buildings/:building_id/audit', {
@@ -417,9 +414,9 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                     var building_id = $route.current.params.building_id;
                     return audit_service.get_building_logs(building_id);
                 }],
-                'default_columns': ['user_service', function(user_service){
-                    return user_service.get_default_building_detail_columns();
-                }]
+                'default_columns': function(){
+                    return {'columns': {}};
+                }
             }
         })
         .when('/buildings/:building_id/energy', {
@@ -435,13 +432,12 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                 'all_columns': ['building_services', function(building_services) {
                     return building_services.get_columns(false);
                 }],
-                'audit_payload': ['audit_service', '$route', function(audit_service, $route){
-                    var building_id = $route.current.params.building_id;
-                    return audit_service.get_building_logs(building_id);
-                }],
-                'default_columns': ['user_service', function(user_service){
-                    return user_service.get_default_building_detail_columns();
-                }]
+                'audit_payload': function(){
+                    return {'audit_logs': {}};
+                },
+                'default_columns': function(){
+                    return {'columns': {}};
+                }
             }
         })
         .when('/buildings/:building_id/settings', {

--- a/seed/static/seed/js/services/user_service.js
+++ b/seed/static/seed/js/services/user_service.js
@@ -101,6 +101,19 @@ angular.module('BE.seed.service.user', []).factory('user_service', [
         return defer.promise;
     };
 
+    user_factory.get_default_building_detail_columns = function() {
+        var defer = $q.defer();
+        $http({
+            method: 'GET',
+            'url': urls.seed.get_default_building_detail_columns
+        }).success(function(data) {
+            defer.resolve(data);
+        }).error(function(data, status) {
+            defer.reject(data, status);
+        });
+        return defer.promise;
+    };
+
     user_factory.get_shared_buildings = function() {
         var defer = $q.defer();
         $http({
@@ -154,6 +167,20 @@ angular.module('BE.seed.service.user', []).factory('user_service', [
             method: 'POST',
             'url': urls.seed.set_default_columns,
             'data': {'columns': columns, 'show_shared_buildings': show_shared_buildings}
+        }).success(function(data) {
+            defer.resolve(data);
+        }).error(function(data, status) {
+            defer.reject(data, status);
+        });
+        return defer.promise;
+    };
+
+    user_factory.set_default_building_detail_columns = function(columns) {
+        var defer = $q.defer();
+        $http({
+            method: 'POST',
+            'url': urls.seed.set_default_building_detail_columns,
+            'data': {'columns': columns}
         }).success(function(data) {
             defer.resolve(data);
         }).error(function(data, status) {

--- a/seed/static/seed/partials/building_audit_log.html
+++ b/seed/static/seed/partials/building_audit_log.html
@@ -13,7 +13,7 @@
     <div class="section_nav">
         <a id="building" ng-href="#/buildings/{$ building.canonical_building $}">Building Info</a>
         <a id="projects" ng-href="#/buildings/{$ building.canonical_building $}/projects">Projects</a>
-        <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit" class="active">Log &amp Notes</a>
+        <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit" class="active">Log &amp; Notes</a>
         <a id="energy" ng-href="#/buildings/{$ building.canonical_building $}/energy">Energy</a>
         <a id="settings" ng-href="#/buildings/{$ building.canonical_building $}/settings">Settings</a>
     </div>

--- a/seed/static/seed/partials/building_audit_log.html
+++ b/seed/static/seed/partials/building_audit_log.html
@@ -15,6 +15,7 @@
         <a id="projects" ng-href="#/buildings/{$ building.canonical_building $}/projects">Projects</a>
         <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit" class="active">Log &amp Notes</a>
         <a id="energy" ng-href="#/buildings/{$ building.canonical_building $}/energy">Energy</a>
+        <a id="settings" ng-href="#/buildings/{$ building.canonical_building $}/settings">Settings</a>
     </div>
 </div>
 <div class="section">

--- a/seed/static/seed/partials/building_detail_section.html
+++ b/seed/static/seed/partials/building_detail_section.html
@@ -13,7 +13,7 @@
     <div class="section_nav">
         <a id="building" ng-href="#/buildings/{$ building.canonical_building $}" class="active">Building Info</a>
         <a id="projects" ng-href="#/buildings/{$ building.canonical_building $}/projects">Projects</a>
-        <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit">Log &amp Notes</a>
+        <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit">Log &amp; Notes</a>
         <a id="energy" ng-href="#/buildings/{$ building.canonical_building $}/energy">Energy</a>
         <a id="settings" ng-href="#/buildings/{$ building.canonical_building $}/settings">Settings</a>
     </div>

--- a/seed/static/seed/partials/building_detail_section.html
+++ b/seed/static/seed/partials/building_detail_section.html
@@ -15,6 +15,7 @@
         <a id="projects" ng-href="#/buildings/{$ building.canonical_building $}/projects">Projects</a>
         <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit">Log &amp Notes</a>
         <a id="energy" ng-href="#/buildings/{$ building.canonical_building $}/energy">Energy</a>
+        <a id="settings" ng-href="#/buildings/{$ building.canonical_building $}/settings">Settings</a>
     </div>
 </div>
 <div class="section">

--- a/seed/static/seed/partials/building_detail_section.html
+++ b/seed/static/seed/partials/building_detail_section.html
@@ -60,7 +60,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr ng-repeat="f in data_columns | orderBy:'key'">
+                        <tr ng-repeat="f in data_columns">
                             <td>{$ f.key | titleCase $}</td>
                             <td>
                                 <span ng-hide="building.edit_form_showing" ng-if="f.type === 'extra_data'">{$ building.extra_data[f.key] $}</span>

--- a/seed/static/seed/partials/building_energy_section.html
+++ b/seed/static/seed/partials/building_energy_section.html
@@ -13,7 +13,7 @@
     <div class="section_nav">
         <a id="building" ng-href="#/buildings/{$ building.canonical_building $}">Building Info</a>
         <a id="projects" ng-href="#/buildings/{$ building.canonical_building $}/projects">Projects</a>
-        <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit">Log &amp Notes</a>
+        <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit">Log &amp; Notes</a>
         <a id="energy" ng-href="#/buildings/{$ building.canonical_building $}/energy" class="active">Energy</a>
         <a id="settings" ng-href="#/buildings/{$ building.canonical_building $}/settings">Settings</a>
     </div>

--- a/seed/static/seed/partials/building_energy_section.html
+++ b/seed/static/seed/partials/building_energy_section.html
@@ -15,6 +15,7 @@
         <a id="projects" ng-href="#/buildings/{$ building.canonical_building $}/projects">Projects</a>
         <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit">Log &amp Notes</a>
         <a id="energy" ng-href="#/buildings/{$ building.canonical_building $}/energy" class="active">Energy</a>
+        <a id="settings" ng-href="#/buildings/{$ building.canonical_building $}/settings">Settings</a>
     </div>
 </div>
 <div class="section">

--- a/seed/static/seed/partials/building_projects_section.html
+++ b/seed/static/seed/partials/building_projects_section.html
@@ -13,7 +13,7 @@
     <div class="section_nav">
         <a id="building" ng-href="#/buildings/{$ building.canonical_building $}">Building Info</a>
         <a id="projects" ng-href="#/buildings/{$ building.canonical_building $}/projects" class="active">Projects</a>
-        <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit">Log &amp Notes</a>
+        <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit">Log &amp; Notes</a>
         <a id="energy" ng-href="#/buildings/{$ building.canonical_building $}/energy">Energy</a>
         <a id="settings" ng-href="#/buildings/{$ building.canonical_building $}/settings">Settings</a>
     </div>

--- a/seed/static/seed/partials/building_projects_section.html
+++ b/seed/static/seed/partials/building_projects_section.html
@@ -15,6 +15,7 @@
         <a id="projects" ng-href="#/buildings/{$ building.canonical_building $}/projects" class="active">Projects</a>
         <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit">Log &amp Notes</a>
         <a id="energy" ng-href="#/buildings/{$ building.canonical_building $}/energy">Energy</a>
+        <a id="settings" ng-href="#/buildings/{$ building.canonical_building $}/settings">Settings</a>
     </div>
 </div>
 <div class="section">

--- a/seed/static/seed/partials/building_settings_section.html
+++ b/seed/static/seed/partials/building_settings_section.html
@@ -1,0 +1,110 @@
+<div class="page_header_container" ng-cloak>
+    <div class="page_header">
+        <div class="left page_action_container">
+            <a href="#/buildings" class="page_action" ng-show="!is_project()"><i class="fa fa-chevron-left"></i> Buildings</a>
+            <a href="#/projects/{$ user.project_slug $}" class="page_action" ng-show="is_project()"><i class="fa fa-chevron-left"></i> Project: {$ project.name $}</a>
+        </div>
+        <div class="page_title">
+            <h1>{$ building.address_line_1 $}</h1>
+        </div>
+    </div>
+</div>
+<div class="section_nav_container">
+    <div class="section_nav">
+        <a id="building" ng-href="#/buildings/{$ building.canonical_building $}">Building Info</a>
+        <a id="projects" ng-href="#/buildings/{$ building.canonical_building $}/projects">Projects</a>
+        <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit">Log &amp Notes</a>
+        <a id="energy" ng-href="#/buildings/{$ building.canonical_building $}/energy">Energy</a>
+        <a id="settings" ng-href="#/buildings/{$ building.canonical_building $}/settings" class="active">Settings</a>
+    </div>
+</div>
+<div class="section">
+    <div class="section_header_container">
+        <div id="building-settings" class="section_header has_no_padding fixed_height_short">
+            <div class="section_action_container left_wide">
+                <h2><i class="fa fa-cogs"></i> Building Settings:
+                    <span ng-show="!is_show_reorder">Show/Hide Columns</span>
+                    <a href ng-click="is_show_reorder=false" ng-show="is_show_reorder">Show/Hide Columns</a>
+                    |
+                    <span ng-show="is_show_reorder">Reorder Columns</span>
+                    <a href ng-click="on_show_reorder_fields()" ng-show="!is_show_reorder">Reorder Columns</a>
+                </h2>
+            </div>
+            <div class="section_action_container right section_action_btn">
+                <button type="button" class="pull-right btn btn-primary" ng-click="save_settings()">Save Changes <i class="fa fa-check align_right" ng-show="settings_updated"></i></button>
+            </div>
+        </div>
+    </div>
+    <div class="section_content_container" ng-show="!is_show_reorder">
+        <div class="section_content with_padding">
+            <h3>There are {$ fields.length | number $} columns of data available to you.</h3>
+            <p>Select columns from the list below to make them appear in your Building Info table.</p>
+        </div>
+        <div class="section_content with_padding">
+            <div class="table_list_container has_borders">
+                <table class="table table-striped has_no_btm_margin table_highlight_first">
+                    <thead>
+                        <tr>
+                            <th class="check is_aligned_center"><input type="checkbox" ng-model="controls.select_all" ng-change="select_all_clicked()"></th>
+                            <th>Column Name</th>
+                        </tr>
+                        <tr class="sub_head">
+                            <th class="sub_head check_row"></th>
+                            <th class="sub_head">
+                                <input type="text" class="form-control input-sm" ng-model="filter_params.title" placeholder="Search column name" ng-class="{active: filter_params.title.length > 0}">
+                            </th>
+                        </tr>
+                    </thead>
+                </table>
+                <div class="vert_table_scroll_container">
+                    <table class="table has_no_btm_margin table-striped table_scroll">
+                        <tbody>
+                            <tr ng-repeat="field in fields | filter:filter_params:strict">
+                                <td class="check is_aligned_center" style="width: 5%; min-width: 30px;">
+                                    <input type="checkbox" ng-model="field.checked">
+                                </td>
+                                <td>
+                                    <span>{$ field.title $}</span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="section_content_container" ng-show="is_show_reorder">
+        <div class="section_content with_padding">
+            <h3>Drag the columns below to change the order that they appear in your Buildings List table.</h3>
+        </div>
+        <div class="section_content with_padding">
+            <div class="table_list_container has_borders">
+                <table class="table table-striped has_no_btm_margin table_highlight_first">
+                    <thead>
+                    <tr>
+                        <th>Column Name</th>
+                    </tr>
+                    </thead>
+                </table>
+                <div class="vert_table_scroll_container">
+                    <table id="sort" class="table has_no_btm_margin table-striped table_scroll">
+                        <tbody ui-sortable="sortable_options" ng-model="fields">
+                        <tr ng-repeat="field in fields | filter:{ checked: true }  | filter:filter_params:strict">
+                            <td>
+                                <span>{$ field.title $}</span>
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="section_content_container has_top_margin">
+        <div class="section_content with_padding">
+            <button type="button" class="btn btn-primary" ng-click="save_settings()">Save Changes <i class="fa fa-check align_right" ng-show="settings_updated"></i></button>
+        </div>
+    </div>
+</div>

--- a/seed/static/seed/partials/building_settings_section.html
+++ b/seed/static/seed/partials/building_settings_section.html
@@ -13,7 +13,7 @@
     <div class="section_nav">
         <a id="building" ng-href="#/buildings/{$ building.canonical_building $}">Building Info</a>
         <a id="projects" ng-href="#/buildings/{$ building.canonical_building $}/projects">Projects</a>
-        <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit">Log &amp Notes</a>
+        <a id="audit" ng-href="#/buildings/{$ building.canonical_building $}/audit">Log &amp; Notes</a>
         <a id="energy" ng-href="#/buildings/{$ building.canonical_building $}/energy">Energy</a>
         <a id="settings" ng-href="#/buildings/{$ building.canonical_building $}/settings" class="active">Settings</a>
     </div>

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -146,9 +146,8 @@ class DefaultColumnsViewTests(TestCase):
         json_string = response.content
         data = json.loads(json_string)
 
-        self.assertEqual(data['status'], 'success')
+        self.assertEqual(200, response.status_code)
         self.assertEqual(data['columns'], columns)
-        self.assertEqual(data['initial_columns'], False)
 
     def test_get_default_columns_initial_state(self):
         url = reverse_lazy("seed:get_default_columns")
@@ -156,9 +155,8 @@ class DefaultColumnsViewTests(TestCase):
         json_string = response.content
         data = json.loads(json_string)
 
-        self.assertEqual(data['status'], 'success')
+        self.assertEqual(200, response.status_code)
         self.assertEqual(data['columns'], DEFAULT_CUSTOM_COLUMNS)
-        self.assertEqual(data['initial_columns'], True)
 
     def test_set_default_columns(self):
         url = reverse_lazy("seed:set_default_columns")
@@ -175,7 +173,7 @@ class DefaultColumnsViewTests(TestCase):
         )
         json_string = response.content
         data = json.loads(json_string)
-        self.assertEqual(data['status'], 'success')
+        self.assertEqual(200, response.status_code)
 
         # get the columns
         url = reverse_lazy("seed:get_default_columns")
@@ -201,7 +199,7 @@ class DefaultColumnsViewTests(TestCase):
         )
         json_string = response.content
         data = json.loads(json_string)
-        self.assertEqual(data['status'], 'success')
+        self.assertEqual(200, response.status_code)
 
         # get show_shared_buildings
         url = reverse_lazy("accounts:get_shared_buildings")

--- a/seed/urls/main.py
+++ b/seed/urls/main.py
@@ -43,6 +43,16 @@ urlpatterns = patterns(
         'set_default_columns',
         name='set_default_columns'
     ),
+    url(
+        r'^get_default_building_detail_columns/$',
+        'get_default_building_detail_columns',
+        name='get_default_building_detail_columns'
+    ),
+    url(
+        r'^set_default_building_detail_columns/$',
+        'set_default_building_detail_columns',
+        name='set_default_building_detail_columns'
+    ),
     url(r'^get_columns/$', 'get_columns', name='get_columns'),
     url(r'^save_match/$', 'save_match', name='save_match'),
     url(r'^get_match_tree/$', 'get_match_tree', name='get_match_tree'),

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -759,7 +759,9 @@ def search_building_snapshots(request):
 @ajax_request
 @login_required
 def get_default_columns(request):
-    """front end is expecting a JSON object with an array of field names
+    """Get default columns for building list view.
+
+    front end is expecting a JSON object with an array of field names
         i.e.
         {
             "columns": ["project_id", "name", "gross_floor_area"]
@@ -780,16 +782,52 @@ def get_default_columns(request):
 
 @ajax_request
 @login_required
-def set_default_columns(request):
+def get_default_building_detail_columns(request):
+    """Get default columns for building detail view.
+
+    front end is expecting a JSON object with an array of field names
+        i.e.
+        {
+            "columns": ["project_id", "name", "gross_floor_area"]
+        }
+    """
+    columns = request.user.default_building_detail_custom_columns
+
+    if columns == '{}' or type(columns) == dict:
+        # Return empty result, telling the FE to show all.
+        columns = []
+    if type(columns) == unicode:
+        # postgres 9.1 stores JsonField as unicode
+        columns = json.loads(columns)
+
+    return {
+        'columns': columns,
+    }
+
+
+def _set_default_columns_by_request(body, user, field):
     """sets the default value for the user's default_custom_columns"""
-    body = json.loads(request.body)
     columns = body['columns']
     show_shared_buildings = body.get('show_shared_buildings')
-    request.user.default_custom_columns = columns
+    setattr(user, field, columns)
     if show_shared_buildings is not None:
-        request.user.show_shared_buildings = show_shared_buildings
-    request.user.save()
-    return {'status': 'success'}
+        user.show_shared_buildings = show_shared_buildings
+    user.save()
+    return {}
+
+
+@ajax_request
+@login_required
+def set_default_columns(request):
+    body = json.loads(request.body)
+    return _set_default_columns_by_request(body, request.user, 'default_custom_columns')
+
+
+@ajax_request
+@login_required
+def set_default_building_detail_columns(request):
+    body = json.loads(request.body)
+    return _set_default_columns_by_request(body, request.user, 'default_building_detail_custom_columns')
 
 
 @ajax_request

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -768,18 +768,13 @@ def get_default_columns(request):
     columns = request.user.default_custom_columns
 
     if columns == '{}' or type(columns) == dict:
-        initial_columns = True
         columns = DEFAULT_CUSTOM_COLUMNS
-    else:
-        initial_columns = False
     if type(columns) == unicode:
         # postgres 9.1 stores JsonField as unicode
         columns = json.loads(columns)
 
     return {
-        'status': 'success',
         'columns': columns,
-        'initial_columns': initial_columns,
     }
 
 


### PR DESCRIPTION
#### What's this PR do?
Adds column show/hide/reordering on the Building Details page. Implements this in the same way as the Building List page is done. A new "settings" tab is added to the detail page for this.

I was able to use the existing buildings_settings_controller to accomplish this, by making minor modifications to handle a single building.

On the BE, these preferences are stored in the same way as the buildings list page, in a new field on the user model. Building Detail column settings are global in this implementation. I used a new field so that we could easily make changes if we feel there's a need for a different solution.

#### How should this be manually tested?
Try it out on a Building Detail page.

#### What are the relevant tickets?
Refs #577 

#### Screenshots (if appropriate)

![animated](http://g.recordit.co/PhBNIVlvnk.gif)

![screen shot 2016-02-02 at 3 19 19 pm](https://cloud.githubusercontent.com/assets/512288/12764572/92201cda-c9c8-11e5-819a-b2e25727e71a.png)

![screen shot 2016-02-02 at 3 19 38 pm](https://cloud.githubusercontent.com/assets/512288/12764580/9ad9eeaa-c9c8-11e5-8b27-c1e83d2e75d7.png)
