### PR TITLE
Fix updated building count

### DIFF
--- a/seed/views/labels.py
+++ b/seed/views/labels.py
@@ -121,8 +121,13 @@ class UpdateBuildingLabelsAPIView(generics.GenericAPIView):
         )
         serializer.is_valid(raise_exception=True)
 
+        # This needs to happen before `save()` so that we get an accurate
+        # number.  Otherwise, if the save changes the underlying queryset the
+        # call to `count()` will re-evaluate and return a different number.
+        num_updated = building_snapshots.count()
+
         serializer.save()
 
         return response.Response({
-            "num_buildings_updated": building_snapshots.count(),
+            "num_buildings_updated": num_updated,
         })


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/592

### What was wrong.

When removing a label via a bulk update where the current filters include filtering by that label the application informs you that 0 buildings were updated when in fact all of the selected buildings are updated.  

This was due to using a `queryset.count()` to return the number of updated buildings which re-evaluates the queryset.  Since the label had already been removed, the queryset evaluated to having zero items.

### How was it fixed?

Prior to calling `save()` which updates all of the buildings, the value of `count()` is stored.  This allows returning an accurate number of updated buildings.

#### Cute animal picture

![bnclvca](https://cloud.githubusercontent.com/assets/824194/12766844/057fdc70-c9c3-11e5-9756-8faa17f16661.jpg)
