### PR TITLE
Don't reload the page after changing what columns are being viewed

### DIFF
--- a/seed/static/seed/js/controllers/buildings_settings_controller.js
+++ b/seed/static/seed/js/controllers/buildings_settings_controller.js
@@ -104,7 +104,6 @@ angular.module('BE.seed.controller.buildings_settings', [])
             //resolve promise
             $scope.settings_updated = true;
             $uibModalInstance.close(columns);
-            location.reload();
         });
     };
 


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/635

### What was wrong.

When using the Show/Hide columns feature during the 2nd step of mapping, the page refreshed upon closing the modal which reset the view back to step 1.

### How was it fixed.

Removed the call to `location.reload()` at the end of the code which executes when the modal closes.  As far as I can tell everything works fine without this statement.

#### Cute animal picture

![5567107626_6e39ecd9c1_z](https://cloud.githubusercontent.com/assets/824194/12796666/23dc47de-ca7d-11e5-997d-709e4b14e270.jpg)
