### PR TITLE
Add co_parent to list of invalid keys to show on building detail page.

### DIFF
--- a/seed/static/seed/js/controllers/building_detail_controller.js
+++ b/seed/static/seed/js/controllers/building_detail_controller.js
@@ -162,7 +162,8 @@ angular.module('BE.seed.controller.building_detail', [])
             'pk',
             'super_organization',
             'source_type',
-            'duplicate'
+            'duplicate',
+            'co_parent'
         ];
         var no_invalid_key = known_invalid_keys.indexOf(key) === -1;
 


### PR DESCRIPTION
#### What's this PR do?
Tiny fix to hide `co_parent` field from building detail page.

#### What are the relevant tickets?
Refs #690 