### PR TITLE
Piper/issue 687 dont allow organizations to end up empty

### DIFF
--- a/seed/static/seed/js/controllers/members_controller.js
+++ b/seed/static/seed/js/controllers/members_controller.js
@@ -10,6 +10,7 @@ angular.module('BE.seed.controller.members', [])
     'organization_payload',
     'auth_payload',
     'organization_service',
+    'user_profile_payload',
     'urls',
     function (
       $scope,
@@ -18,6 +19,7 @@ angular.module('BE.seed.controller.members', [])
       organization_payload,
       auth_payload,
       organization_service,
+      user_profile_payload,
       urls
     ) {
     $scope.roles = [
@@ -27,6 +29,8 @@ angular.module('BE.seed.controller.members', [])
     $scope.org = organization_payload.organization;
     $scope.filter_params = {};
     $scope.auth = auth_payload.auth;
+    $scope.user_profile = user_profile_payload.user;
+    console.log(user_profile_payload.user);
 
     /**
      * remove_member: removes a user from the org, an owner can only be removed

--- a/seed/static/seed/js/controllers/members_controller.js
+++ b/seed/static/seed/js/controllers/members_controller.js
@@ -30,7 +30,11 @@ angular.module('BE.seed.controller.members', [])
     $scope.filter_params = {};
     $scope.auth = auth_payload.auth;
     $scope.user_profile = user_profile_payload.user;
-    console.log(user_profile_payload.user);
+
+    $scope.is_last_owner = (_.chain($scope.users)
+        .filter(function(u) { return u.role === "owner"; })
+        .size()
+        .value() === 1);
 
     /**
      * remove_member: removes a user from the org, an owner can only be removed

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -731,6 +731,9 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                     }, function (data) {
                         return $q.reject(data.message);
                     });
+                }],
+                'user_profile_payload': ['user_service', function (user_service) {
+                    return user_service.get_user_profile();
                 }]
             }
         })

--- a/seed/static/seed/partials/members.html
+++ b/seed/static/seed/partials/members.html
@@ -59,7 +59,7 @@
                                 <div class="row">
                                     <div class="form-group">
                                         <div class="col-sm-12">
-                                            <select class="form-control input-sm" ng-model="u.role" ng-options="role for role in roles" ng-change="update_role(u)" ng-if="auth.requires_owner && u.email != user_profile.email">
+                                            <select class="form-control input-sm" ng-model="u.role" ng-options="role for role in roles" ng-change="update_role(u)" ng-if="!is_last_owner || auth.requires_owner && u.email != user_profile.email">
                                             </select>
                                             <span ng-if="!auth.requires_owner">{$ u.role $}</span>
                                         </div>
@@ -67,7 +67,7 @@
                                 </div>
                             </td>
                             <td ng-if="auth.can_remove_member">
-                                <a ng-if="u.email != user_profile.email" ng-click="remove_member(u)">Remove</a>
+                                <a ng-if="!is_last_owner || u.email != user_profile.email" ng-click="remove_member(u)">Remove</a>
                             </td>
                         </tr>
                     </tbody>

--- a/seed/static/seed/partials/members.html
+++ b/seed/static/seed/partials/members.html
@@ -59,7 +59,7 @@
                                 <div class="row">
                                     <div class="form-group">
                                         <div class="col-sm-12">
-                                            <select class="form-control input-sm" ng-model="u.role" ng-options="role for role in roles" ng-change="update_role(u)" ng-if="auth.requires_owner">
+                                            <select class="form-control input-sm" ng-model="u.role" ng-options="role for role in roles" ng-change="update_role(u)" ng-if="auth.requires_owner && u.email != user_profile.email">
                                             </select>
                                             <span ng-if="!auth.requires_owner">{$ u.role $}</span>
                                         </div>
@@ -67,7 +67,7 @@
                                 </div>
                             </td>
                             <td ng-if="auth.can_remove_member">
-                                <a ng-click="remove_member(u)">Remove</a>
+                                <a ng-if="u.email != user_profile.email" ng-click="remove_member(u)">Remove</a>
                             </td>
                         </tr>
                     </tbody>

--- a/seed/views/accounts.py
+++ b/seed/views/accounts.py
@@ -313,12 +313,29 @@ def remove_user_from_org(request):
             'status': 'error',
             'message': 'user does not exist'
         }
+    else:
+        if user == request.user:
+            return {
+                'status': 'error',
+                'message': 'cannot modify your own membership'
+            }
     if not OrganizationUser.objects.filter(
         user=request.user, organization=org, role_level=ROLE_OWNER
     ).exists():
         return {
             'status': 'error',
             'message': 'only the organization owner can remove a member'
+        }
+
+    is_last_owner = not OrganizationUser.objects.filter(
+        organization=org,
+        role_level=ROLE_OWNER,
+    ).exclude(user=user).exists()
+
+    if is_last_owner:
+        return {
+            'status': 'error',
+            'message': 'an organization must have at least one owner level member'
         }
 
     ou = OrganizationUser.objects.get(user=user, organization=org)
@@ -532,8 +549,13 @@ def update_role(request):
     body = json.loads(request.body)
     role = _get_role_from_js(body['role'])
 
+    user_id = body['user_id']
+
+    if str(user_id) == str(request.user.pk):
+        return {'status': 'error', 'message': 'you cannot modify your own role'}
+
     OrganizationUser.objects.filter(
-        user_id=body['user_id'],
+        user_id=user_id,
         organization_id=body['organization_id']
     ).update(role_level=role)
 


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/687

### What was wrong.

When managing organization members you could perform actions that would leave organizations having either no owners, or no users at all.

### How was it fixed.

Restrict the ability to edit your own role or remove yourself from a group if doing so would leave the group with no owners or empty.

#### Cute animal picture

![kitten_cheezburger](https://cloud.githubusercontent.com/assets/824194/12831488/7a14a458-cb49-11e5-8aae-b2bb5b4921c2.jpg)
