### PR TITLE
Issue #719 - Sentry logging on BE

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -86,7 +86,7 @@ INSTALLED_APPS = (
     'compressor',
     'django_extensions',
     'organizations',
-    'raven.contrib.django',
+    'raven.contrib.django.raven_compat',
     'tos',
     'rest_framework',
 )

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -59,7 +59,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'raven.contrib.django.middleware.Sentry404CatchMiddleware',
     'pagination.middleware.PaginationMiddleware',
 
 )

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -21,8 +21,6 @@ SEED_DATADIR = join(SITE_ROOT, 'seed', 'data')
 SESSION_COOKIE_DOMAIN = None
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
-# sentry
-SENTRY_DSN = os.environ.get('SENTRY_DSN', None)
 
 ADMINS = (
     # ('Your Name', 'your_email@domain.com'),
@@ -169,11 +167,6 @@ LOGGING = {
         },
     },
     'handlers': {
-        'sentry': {
-            'level': 'ERROR',
-            'class': 'raven.contrib.django.handlers.SentryHandler',
-            'formatter': 'verbose'
-        },
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
@@ -197,13 +190,8 @@ LOGGING = {
     },
     'loggers': {
         '': {
-            'level': 'WARNING',
-            'handlers': ['sentry'],
-        },
-        'sentry.errors': {
             'level': 'DEBUG',
             'handlers': ['console'],
-            'propagate': False,
         },
     }
 }

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -53,10 +53,6 @@ else:
         'disable_existing_loggers': True,
         # set up some log message handlers to choose from
         'handlers': {
-            'sentry': {
-                'level': 'ERROR',
-                'class': 'raven.contrib.django.handlers.SentryHandler',
-            },
             'console': {
                 'level': 'INFO',
                 'class': 'logging.StreamHandler'
@@ -67,14 +63,7 @@ else:
             '': {
                 'level': 'INFO',
                 'handlers': ['console'],
-            },
-            # sentry.errors are any error messages associated with failed
-            # connections to sentry
-            'sentry.errors': {
-                'level': 'DEBUG',
-                'handlers': ['console'],
-                'propagate': False,
-            },
+            }
         },
     }
 

--- a/config/settings/main.py
+++ b/config/settings/main.py
@@ -106,10 +106,14 @@ CACHES = {
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': True,
+    'root': {
+        'level': 'WARNING',
+        'handlers': ['sentry']
+    },
     'handlers': {
         'sentry': {
             'level': 'ERROR',
-            'class': 'raven.contrib.django.handlers.SentryHandler',
+            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
         },
         'console': {
             'level': 'ERROR',
@@ -117,12 +121,13 @@ LOGGING = {
         }
     },
     'loggers': {
-        '': {
-            'level': 'ERROR',
-            'handlers': ['sentry'],
+        'raven': {
+            'level': 'DEBUG',
+            'handlers': ['console'],
+            'propagate': False,
         },
         'sentry.errors': {
-            'level': 'ERROR',
+            'level': 'DEBUG',
             'handlers': ['console'],
             'propagate': False,
         },

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -66,7 +66,7 @@ openpyxl==1.7.0
 python-dateutil>=2.4
 python-memcached==1.53
 PyYAML==3.10
-raven==4.0.4
+raven==5.9.0
 regex==2014.01.10
 requests==1.1.0
 simplejson==3.3.0


### PR DESCRIPTION
#### What's this PR do?
Add sentry logging to servers. This is only for backend logging.

@mmclark I have a setting that needs to go into the server local settings for this to work. It's no-op without it.

#### What are the relevant tickets?
Refs #719
