### PR TITLE
Issue #686 - Send a working status if s3 file isn't ready.

### DIFF
--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -413,7 +413,13 @@ def export_buildings_download(request):
     else:
         keys = list(DefaultStorage().bucket.list(export_subdir))
 
-        if not keys or len(keys) > 1:
+        if not keys:
+            return {
+                'success': False,
+                'status': 'working'
+            }
+
+        if len(keys) > 1:
             return {
                 "success": False,
                 "status": "error",


### PR DESCRIPTION
#### What's this PR do?
Implement retries when exporting buildings. This was previously implemented for file system storage, but the servers use s3 storage. Now both cases should work.

#### What are the relevant tickets?
Refs #686 
