### PR TITLE
upgrade tox to 2.3.1 and do not clobber local_untracked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,13 @@ env:
     - TOX_ENV=py27-dj17
     - TOX_ENV=flake8
 
-before_install:
-  - "sh -e /etc/init.d/xvfb start"
-
 install:
   - pip install --upgrade pip
-  - pip install tox==1.8.0
+  - pip install tox==2.3.1
 
 before_script:
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
   - psql -c "create database seeddb;" -U postgres
 
 script:

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,9 +1,9 @@
 # Local development dependencies go here
 -r base.txt
 Sphinx==1.3.4
-flake8==2.5.1
+flake8==2.5.2
 Werkzeug==0.10.4
-tox==1.8.0
+tox==2.3.1
 
 # Debug toolbar
 django-debug-toolbar==1.3.2

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps=
   coveralls
 passenv=
   DJANGO_SETTINGS_MODULE
+  DISPLAY
 whitelist_externals=
   cp
   env

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ skipsdist = True
 basepython=
   py27: python2.7
 commands=
+  - cp -n {toxinidir}/config/settings/local_untracked.py.dist {toxinidir}/config/settings/local_untracked.py
   {toxinidir}/bin/install_javascript_dependencies.sh
-  cp {toxinidir}/config/settings/local_untracked.py.dist {toxinidir}/config/settings/local_untracked.py
   dj17: pip install Django>=1.7,<1.8
   /usr/bin/env
   coverage run manage.py test


### PR DESCRIPTION
Require a newer version of tox with the '-' argument is available to suppress output errors.

