### PR TITLE
Issue #749 - Use fast password hasher during tests.

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -25,6 +25,10 @@ LOGGING = {
     },
 }
 
+PASSWORD_HASHERS = (
+    'django.contrib.auth.hashers.MD5PasswordHasher',
+)
+
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 SESSION_COOKIE_SECURE = False


### PR DESCRIPTION
Use faster hasher so tests run quicker.

Refs #749 