### PR TITLE
Switch to supported django-storanges pypi package

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -52,7 +52,7 @@ dj-database-url==0.2.1
 djorm-ext-core==0.7
 djorm-ext-expressions==0.6
 django-pgjson==0.3.1
--e hg+https://bitbucket.org/david/django-storages@e27c8b61ab57e5afaf21cccfee005c980d89480f#egg=django_storages
+django-storages==1.4
 -e git+https://github.com/wellfire/django-organizations.git@f9da9778c212b253ebda49453cc57fe199020f51#egg=django_organizations
 fuzzywuzzy>=0.3.1
 ipython==0.13.1


### PR DESCRIPTION
Switch to a pypi supported and current version of django-storages. The previous one was 3 years unmaintained and was installed via mercurial.