### PR TITLE
Remove djorm-ext-expressions package

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -50,7 +50,6 @@ csvkit==0.6.1
 dbf==0.95.004
 dj-database-url==0.2.1
 djorm-ext-core==0.7
-djorm-ext-expressions==0.6
 django-pgjson==0.3.1
 django-storages==1.4
 -e git+https://github.com/wellfire/django-organizations.git@f9da9778c212b253ebda49453cc57fe199020f51#egg=django_organizations

--- a/seed/audit_logs/models.py
+++ b/seed/audit_logs/models.py
@@ -12,10 +12,10 @@ from django.contrib.contenttypes import generic
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.db import models
+from django.db.models.query import QuerySet
 
 # vendor imports
 from django_extensions.db.models import TimeStampedModel
-from djorm_expressions.models import ExpressionManager, ExpressionQuerySet
 from django_pgjson.fields import JsonField
 from seed.lib.superperms.orgs.models import Organization
 
@@ -35,7 +35,7 @@ ACTION_OPTIONS = {
 }
 
 
-class AuditLogQuerySet(ExpressionQuerySet):
+class AuditLogQuerySet(QuerySet):
 
     def update(self, *args, **kwargs):
         """only notes should be updated, so filter out non-notes"""
@@ -43,7 +43,7 @@ class AuditLogQuerySet(ExpressionQuerySet):
         return super(AuditLogQuerySet, self).update(*args, **kwargs)
 
 
-class AuditLogManager(ExpressionManager):
+class AuditLogManager(models.Manager):
     """ExpressionManager with ``update`` preventing the update of non-notes"""
     use_for_related_fields = True
 
@@ -96,8 +96,6 @@ class AuditLog(TimeStampedModel):
     class Meta:
         ordering = ('-created', )
 
-    # extends djorm_expressions.models.ExpressionManager to prevent update of
-    # non-notes
     objects = AuditLogManager()
 
     def __unicode__(self):


### PR DESCRIPTION
This package is unnecessary. It is also unmaintained and not compatible with Django 1.8. 