### PR TITLE
Issue #723 - Refactor FE columns methods into single method.

### DIFF
--- a/seed/static/seed/js/controllers/matching_controller.js
+++ b/seed/static/seed/js/controllers/matching_controller.js
@@ -360,7 +360,7 @@ angular.module('BE.seed.controller.matching', [])
      *   in the matching list table, sets the table buildings from the building_payload
      */
     $scope.init = function() {
-        $scope.columns = building_services.create_column_array($scope.fields, $scope.default_columns);
+        $scope.columns = search_service.generate_columns($scope.fields, $scope.default_columns);
         update_start_end_paging();
         $scope.buildings = buildings_payload.buildings;
         $scope.number_matching_search = buildings_payload.number_matching_search;

--- a/seed/static/seed/js/services/building_service.js
+++ b/seed/static/seed/js/services/building_service.js
@@ -188,49 +188,6 @@ angular.module('BE.seed.service.building', ['BE.seed.services.label_helper'])
         return defer.promise;
     };
 
-    /*
-     * create_column_array: returns an array of columns used to set table
-     *   headers from an array of all possible columns and an array of 
-     *   keys 
-     * 
-     * @param {Array} all_columns an array of Objects with a default key of
-     *   `sort_column` to filter
-     * @param {Array} column_names an array of String names to filter the 
-     *   `all_columns` array 
-     * @param {String} key (optional) if provided will filter on `key`,
-     *   otherwise filters on `sort_column`
-     *
-     * Currently only used in matching controller. Very similar to
-     * search_service.generate_columns, could be combined. - nicholasserra
-     */
-    building_factory.create_column_array = function(all_columns, column_names, key) {
-        key = key || "sort_column";
-        var columns = all_columns.filter(function(f) {
-            return column_names.indexOf(f[key]) > -1;
-        });
-
-        // also apply the user sort order
-        columns.sort(function(a,b) {
-            // when viewing the list of projects, there is an extra "Status" column that is always first
-            if (a.sort_column === 'project_building_snapshots__status_label__name') {
-                return -1;
-            } else if (b.sort_column === 'project_building_snapshots__status_label__name') {
-                return 1;
-            }
-            // if no status, sort according to user's selected order
-            if (column_names.indexOf(a.sort_column) > -1 && column_names.indexOf(b.sort_column) > -1) {
-                return (column_names.indexOf(a.sort_column) - column_names.indexOf(b.sort_column));
-            } else if (column_names.indexOf(a.sort_column) > -1) {
-                return -1;
-            } else if (column_names.indexOf(b.sort_column) > -1) {
-                return 1;
-            } else { // preserve previous order
-                return (all_columns.indexOf(a) - all_columns.indexOf(b));
-            }
-        });
-        return columns;
-    };
-
     building_factory.get_PM_filter_by_counts = function(import_file_id) {
         var defer = $q.defer();
         $http({

--- a/seed/static/seed/js/services/search_service.js
+++ b/seed/static/seed/js/services/search_service.js
@@ -467,8 +467,10 @@ angular.module('BE.seed.service.search', [])
             }
         });
 
-        for (var i = 0; i < columns.length; i++) {
-            angular.extend(columns[i], column_prototype);
+        if (typeof column_prototype !== 'undefined') {
+            for (var i = 0; i < columns.length; i++) {
+                angular.extend(columns[i], column_prototype);
+            }
         }
         return columns;
     };


### PR DESCRIPTION
#### Any background context you want to provide?
`search_service.generate_columns` and `building_service.create_column_array` were very similar. `building_service.create_column_array` was only used during matching.

#### What's this PR do?
Combine these methods into one, using the `search_service.generate_columns` method. Call the search_service method on the matching page instead. Removes duplicate code.

#### What are the relevant tickets?
Refs #723 