### PR TITLE
Issue #792 - AttributeOption.value larger field

### DIFF
--- a/seed/migrations/0013_auto_20160225_1213.py
+++ b/seed/migrations/0013_auto_20160225_1213.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('seed', '0012_auto_20151222_1031'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='attributeoption',
+            name='value',
+            field=models.TextField(),
+            preserve_default=True,
+        ),
+    ]

--- a/seed/models.py
+++ b/seed/models.py
@@ -1554,7 +1554,7 @@ class NonCanonicalProjectBuildings(models.Model):
 
 class AttributeOption(models.Model):
     """Holds a single conflicting value for a BuildingSnapshot attribute."""
-    value = models.CharField(max_length=255)
+    value = models.TextField()
     value_source = models.IntegerField(choices=SEED_DATA_SOURCES)
     building_variant = models.ForeignKey(
         'BuildingAttributeVariant',


### PR DESCRIPTION
#### Any background context you want to provide?
If a merged building has differing values for a field, that difference is stored in the AttributeOption model.

#### What's this PR do?
Makes the AttributeOption.value field larger by changing it from CharField to TextField. This is necessary because some values are bigger than 255 characters.

#### What are the relevant tickets?
Refs #792