### PR TITLE
Timeseries testing update

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -87,8 +87,6 @@ INSTALLED_APPS = (
     'raven.contrib.django.raven_compat',
     'tos',
     'rest_framework',
-    
-    'django',
 )
 
 SEED_CORE_APPS = (

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -87,6 +87,8 @@ INSTALLED_APPS = (
     'raven.contrib.django.raven_compat',
     'tos',
     'rest_framework',
+    
+    'django',
 )
 
 SEED_CORE_APPS = (

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -224,15 +224,16 @@ CELERY_TASK_SERIALIZER = 'seed_json'
 CELERY_RESULT_SERIALIZER = 'seed_json'
 CELERY_TASK_RESULT_EXPIRES = 18000  # 5 hours
 
+CELERY_IMPORTS = ('seed.energy.meter_data_processor.tasks')
 CELERYBEAT_SCHEDULE = {
-    'Run daily': {
-        'task': 'seed.energy.tasks.aggregate_monthly_data',
-        'schedule': timedelta(seconds=2), # For Demo purpose, should be days=1 in product environment
+    'Run monthly': {
+        'task': 'seed.energy.meter_data_processor.tasks.aggregate_monthly_data',
+        'schedule': timedelta(weeks=4),
         'args': ()
     },
-    'Run monthly': {
-        'task': 'seed.energy.tasks.green_button_task_runner',
-        'schedule': timedelta(seconds=5), # For Demo purpose, should be months=1 in product environment
+    'Run daily': {
+        'task': 'seed.energy.meter_data_processor.tasks.green_button_task_runner',
+        'schedule': timedelta(days=1),
         'args': ()
     },
 }

--- a/config/settings/local_untracked.py.dist
+++ b/config/settings/local_untracked.py.dist
@@ -79,9 +79,10 @@ CELERY_QUEUES = (
 )
 
 # KairosDB Settings
+TSDB_SERVER_URL = 'http://127.0.0.1:8013'
 TSDB = {
-    'insert_url': 'http://127.0.0.1:8013/api/v1/datapoints',
-    'query_url': 'http://127.0.0.1:8013/api/v1/datapoints/query',
+    'insert_url': TSDB_SERVER_URL+'/api/v1/datapoints',
+    'query_url': TSDB_SERVER_URL+'/api/v1/datapoints/query',
     'measurement': 'your-time-series-db-name'
 }
 LOCAL_TIMEZONE = 'your-local-timezone'  #e.g. America/New_York'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -36,7 +36,7 @@ django-autoslug==1.8.0
 pytz==2012h
 
 # background process management
-# django-celery==3.1.16
+django-celery==3.1.16
 celery==3.1.18
 redis==2.10.3
 flower==0.8.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -36,7 +36,7 @@ django-autoslug==1.8.0
 pytz==2012h
 
 # background process management
-django-celery==3.1.16
+# django-celery==3.1.16
 celery==3.1.18
 redis==2.10.3
 flower==0.8.3

--- a/seed/energy/meter_data_processor/green_button_data_analyser.py
+++ b/seed/energy/meter_data_processor/green_button_data_analyser.py
@@ -2,7 +2,7 @@ import logging
 from datetime import date, datetime
 from time import sleep
 
-import tasks as aggregator
+import tasks
 from seed.energy.meter_data_processor import kairos_insert as tsdb
 from seed.models import (
     Meter,
@@ -109,5 +109,5 @@ def data_analyse(ts_data, name):
         # TODO: is there another way to check for the data to be inserted?
         sleep(5)  # wait for data inserted
         _log.info('Having back filling data, aggregate immediately')
-        aggregator.aggregate_monthly_data(ts_data[0]['canonical_id'])
+        tasks.aggregate_monthly_data(ts_data[0]['canonical_id'])
         _log.info('Immediate aggregation finished')

--- a/seed/energy/meter_data_processor/green_button_data_analyser.py
+++ b/seed/energy/meter_data_processor/green_button_data_analyser.py
@@ -3,7 +3,7 @@ from datetime import date, datetime
 from time import sleep
 
 from seed.energy.meter_data_processor import kairos_insert as tsdb
-from seed.energy.meter_data_processor import monthly_data_aggregator as aggregator
+import tasks as aggregator
 from seed.models import (
     Meter,
     CanonicalBuilding,
@@ -53,7 +53,7 @@ def data_analyse(ts_data, name):
             ts_cell['insert_date'] = today_str
 
             ts_dateObj = getMonthFromTS(ts_cell['start'])
-            if ts_dateObj['month'] != today_month and ts_dateObj['year'] != today_year:
+            if ts_dateObj['month'] != today_month or ts_dateObj['year'] != today_year:
                 # has back filling
                 immediate_aggregate = True
 
@@ -100,5 +100,5 @@ def data_analyse(ts_data, name):
     if insert_flag and immediate_aggregate:
         sleep(5)  # wait for data inserted
         _log.info('Having back filling data, aggregate immediately')
-        aggregator.aggregatemonthlysum(ts_data[0]['canonical_id'])
+        aggregator.aggregate_monthly_data(ts_data[0]['canonical_id'])
         _log.info('Immediate aggregation finished')

--- a/seed/energy/meter_data_processor/tasks.py
+++ b/seed/energy/meter_data_processor/tasks.py
@@ -1,4 +1,3 @@
-from django.db.models import Q
 from seed.models import (
     GreenButtonBatchRequestsInfo,
 )
@@ -14,7 +13,6 @@ from django.core.cache import cache
 from seed.energy.meter_data_processor.monthly_data_aggregator import aggr_sum_metric
 from seed.energy.meter_data_processor import green_button_driver as driver
 import green_button_data_analyser as analyser
-from seed.energy.meter_data_processor import kairos_insert as db_insert
 
 _log = logging.getLogger(__name__)
 
@@ -64,18 +62,18 @@ def process_green_button_batch_request(row_id, url, subscription_id, building_id
 
         yesterday_timestamp = str(calendar.timegm(time.strptime(yesterday_str, '%m/%d/%Y')))
 
-        url = url + settings.GREEN_BUTTON_BATCH_URL_SYNTAX + subscription_id + "&" + min_date_para + "=" + min_date + "&" + max_date_para + "=" + str(yesterday)
+        url = url + settings.GREEN_BUTTON_BATCH_URL_SYNTAX + subscription_id + "&" + min_date_para + "=" + min_date + "&" + max_date_para + "=" + yesterday_timestamp
 
-    _log.info('Fetching url '+url)
-    print url
+    _log.info('Fetching url ' + url)
+    
     ts_data = driver.get_gb_data(url, building_id)
 
     _log.info('data fetched')
 
-    if ts_data!=None:
+    if ts_data is not None:
         analyser.data_analyse(ts_data, 'GreenButton')
 
-        _log.info('update db record: last_date=\''+today_str+'\' for id='+str(row_id))
+        _log.info('update db record: last_date=\'' + today_str + '\' for id=' + str(row_id))
         record = GreenButtonBatchRequestsInfo.objects.get(id=row_id)
         record.last_date = today_str
         record.save()

--- a/seed/energy/meter_data_processor/tasks.py
+++ b/seed/energy/meter_data_processor/tasks.py
@@ -1,13 +1,20 @@
+from django.db.models import Q
+from seed.models import (
+    GreenButtonBatchRequestsInfo,
+)
+
 import logging
 import time
+import calendar
 from datetime import date, timedelta, datetime
 
-# from billiard import current_process # was used in green_button_task_runner
-# from celery import current_app # was used in green_button_task_runner
 from celery import shared_task
 from django.conf import settings
 from django.core.cache import cache
 from seed.energy.meter_data_processor.monthly_data_aggregator import aggr_sum_metric
+from seed.energy.meter_data_processor import green_button_driver as driver
+import green_button_data_analyser as analyser
+from seed.energy.meter_data_processor import kairos_insert as db_insert
 
 _log = logging.getLogger(__name__)
 
@@ -33,76 +40,74 @@ def increment_day(date_str):
 
 
 @shared_task
+def process_green_button_batch_request(row_id, url, subscription_id, building_id, time_type, date_pattern, min_date_para, min_date, max_date_para):
+    today_date = date.today()
+    today_str = today_date.strftime('%m/%d/%Y')
+
+    yesterday = date.today() - timedelta(1)
+    yesterday_str = yesterday.strftime('%m/%d/%Y')
+
+    if time_type == 'date':
+        last_datetime = datetime.strptime(min_date, date_pattern)
+        last_date = last_datetime.date()
+
+        if last_date > yesterday:
+            _log.info('Green Button last date is beyond yesterday')
+            return
+
+        url = url + settings.GREEN_BUTTON_BATCH_URL_SYNTAX + subscription_id + "&" + min_date_para + "=" + min_date + "&" + max_date_para + "=" + yesterday_str
+    elif time_type == 'timestamp':
+        last_date = long(min_date)
+        if last_date > yesterday:
+            _log.info('Green Button last date is beyond yesterday')
+            return
+
+        yesterday_timestamp = str(calendar.timegm(time.strptime(yesterday_str, '%m/%d/%Y')))
+
+        url = url + settings.GREEN_BUTTON_BATCH_URL_SYNTAX + subscription_id + "&" + min_date_para + "=" + min_date + "&" + max_date_para + "=" + str(yesterday)
+
+    _log.info('Fetching url '+url)
+    print url
+    ts_data = driver.get_gb_data(url, building_id)
+
+    _log.info('data fetched')
+
+    if ts_data!=None:
+        analyser.data_analyse(ts_data, 'GreenButton')
+
+        _log.info('update db record: last_date=\''+today_str+'\' for id='+str(row_id))
+        record = GreenButtonBatchRequestsInfo.objects.get(id=row_id)
+        record.last_date = today_str
+        record.save()
+
+
+@shared_task
 def green_button_task_runner():
-    # Get total number of processes and current process index, to set offset
-    # Tasks are distributed to all workers in Round-Robin style
-    # NL: This is supposedly deprecated. Commenting out for now
-    _log.debug("running green_button_task_runner")
-    # stats = current_app.control.inspect().stats()
-    # num_process = len(stats[stats.keys()[0]]['pool']['processes'])
-    # offset = current_process().index
-    #
-    # record = ts_parser_record.objects.filter(active='Y')
-    # if record:
-    #     today_date = date.today()
-    #     today_str = today_date.strftime('%m/%d/%Y')
-    #
-    #     yesterday = date.today() - timedelta(1)
-    #     yesterday_str = yesterday.strftime('%m/%d/%Y')
-    #
-    #     row_index = 0
-    #     for gb_info in record:
-    #         row_index = row_index + 1
-    #         if row_index - 1 < offset:
-    #             continue
-    #         else:
-    #             offset = offset + num_process
-    #
-    #         last_date_str = gb_info.last_date
-    #         row_id = gb_info.id
-    #         url = gb_info.url
-    #         subscription_id = gb_info.subscription_id
-    #         last_ts = gb_info.last_ts
-    #         min_date_parameter = gb_info.min_date_parameter
-    #         max_date_parameter = gb_info.max_date_parameter
-    #         building_id = gb_info.building_id
-    #
-    #         time_type = gb_info.time_type
-    #         if time_type == 'date':
-    #             date_pattern = gb_info.date_pattern
-    #
-    #             last_datetime = datetime.strptime(last_date_str, date_pattern)
-    #             last_date = last_datetime.date()
-    #
-    #             if last_date > yesterday:
-    #                 _log.info('Green Button last date is beyond yesterday')
-    #                 continue
-    #
-    #             url = url + settings.GREEN_BUTTON_BATCH_URL_SYNTAX + subscription_id + "&" + min_date_parameter + "=" + last_date_str + "&" + max_date_parameter + "=" + yesterday_str
-    #         elif time_type == 'timestamp':
-    #             last_date = long(last_date_str)
-    #             if last_date > yesterday:
-    #                 _log.info('Green Button last date is beyond yesterday')
-    #                 continue
-    #             yesterday_timestamp = str(calendar.timegm(time.strptime(yesterday_str, '%m/%d/%Y')))
-    #             url = url + settings.GREEN_BUTTON_BATCH_URL_SYNTAX + subscription_id + "&" + min_date_parameter + "=" + last_date_str + "&" + max_date_parameter + "=" + str(
-    #                 yesterday)
-    #
-    #         _log.info('Fetching url ' + url)
-    #
-    #         ts_data = driver.get_gb_data(url, building_id)
-    #
-    #         _log.info('data fetched')
-    #
-    #         if ts_data is not None:
-    #             analyser.data_analyse(ts_data, 'GreenButton')
-    #
-    #         _log.info('update db record: last_date=\'' + today_str + '\' for id=' + str(row_id))
-    #         record = GreenButtonBatchRequestsInfo.objects.get(id=row_id)
-    #         record.last_date = today_str
-    #         record.save()
-    # else:
-    #     _log.info('No GreenButton record info found')
+    lock_id = 'green_button_batch_request_scheduler_lock'
+    if not cache.add(lock_id, 'true', None):
+        _log.info('last green_button_task_runner is not finished')
+        print 'last green_button_task_runner is not finished'
+        return
+
+    record = GreenButtonBatchRequestsInfo.objects.filter(active='Y')
+    if record:
+        for gb_info in record:
+            last_date_str = gb_info.last_date
+            row_id = gb_info.id
+            url = gb_info.url
+            subscription_id = gb_info.subscription_id
+            min_date_parameter = gb_info.min_date_parameter
+            max_date_parameter = gb_info.max_date_parameter
+            building_id = gb_info.building_id
+
+            time_type = gb_info.time_type
+            date_pattern = gb_info.date_pattern
+
+            process_green_button_batch_request.delay(row_id, url, subscription_id, building_id, time_type, date_pattern, min_date_parameter, last_date_str, max_date_parameter)
+    else:
+        _log.info('No GreenButton record info found')
+
+    cache.delete(lock_id)
 
 
 @shared_task
@@ -134,17 +139,14 @@ def aggregate_monthly_data(building_id=-1):
     else:
         lastmonth = today.replace(month=(today.month - 1))
 
-    # first day of last month
-    # firstDayOfLastMonth = lastmonth.replace(day=1).replace(hour=0).replace(minute=0).replace(second=0).replace(
-    #    microsecond=0)  # Not used
-
     # last day of the month
     if lastmonth.month in monthlist:
         lastDayOfLastMonth = lastmonth.replace(day=31)
-    elif (lastmonth.month == 2) and (lastmonth.year % 4 != 0):
-        lastDayOfLastMonth = lastmonth.replace(day=28)
-    elif (lastmonth.month == 2) and (lastmonth.year % 4 == 0):
-        lastDayOfLastMonth = lastmonth.replace(day=29)
+    elif lastmonth.month == 2:
+        if calendar.isleap(lastmonth.year):
+            lastDayOfLastMonth = lastmonth.replace(day=29)
+        else:
+            lastDayOfLastMonth = lastmonth.replace(day=28)
     else:
         lastDayOfLastMonth = lastmonth.replace(day=30)
     lastDayOfLastMonth = lastDayOfLastMonth.replace(hour=23).replace(minute=59).replace(second=59).replace(

--- a/seed/energy/meter_data_processor/tasks.py
+++ b/seed/energy/meter_data_processor/tasks.py
@@ -65,7 +65,7 @@ def process_green_button_batch_request(row_id, url, subscription_id, building_id
         url = url + settings.GREEN_BUTTON_BATCH_URL_SYNTAX + subscription_id + "&" + min_date_para + "=" + min_date + "&" + max_date_para + "=" + yesterday_timestamp
 
     _log.info('Fetching url ' + url)
-    
+
     ts_data = driver.get_gb_data(url, building_id)
 
     _log.info('data fetched')

--- a/seed/energy/pm_energy_template/post_process.py
+++ b/seed/energy/pm_energy_template/post_process.py
@@ -41,9 +41,6 @@ def post_process(file_path):
                 else:
                     data['uom_int'] = '72'  # default Wh
 
-                if not data['custom_id']:
-                    data['custom_id'] = '1'  # default custom id is 1
-
                 for k, v in data.iteritems():
                     data[k] = re.sub('[^\w|\.|]', '_', str(v))
 

--- a/seed/energy/pm_energy_template/template_to_json.py
+++ b/seed/energy/pm_energy_template/template_to_json.py
@@ -22,23 +22,23 @@ def pm_to_json_single(excel, file_path):
     '''
 
     meter_con_df = pd.read_excel(excel, sheetname=0)
-    
+
     # Replace empty cell with NaN
     for c in meter_con_df.select_dtypes(include=["object"]).columns:
         meter_con_df[c] = meter_con_df[c].replace('', np.nan)
 
     # Remove rows missing critical data
-    meter_con_df = meter_con_df.dropna(axis=0, how='any', subset = ['Street Address', 
-                                                                    'Meter Type', 
-                                                                    'Start Date', 
-                                                                    'End Date', 
-                                                                    'Usage/Quantity', 
-                                                                    'Usage Units'])
+    meter_con_df = meter_con_df.dropna(axis=0, how='any', subset=['Street Address',
+                                                                  'Meter Type',
+                                                                  'Start Date',
+                                                                  'End Date',
+                                                                  'Usage/Quantity',
+                                                                  'Usage Units'])
 
     # Set default value if non-critical fields are missing
-    meter_con_df['Custom Meter ID'] = meter_con_df.apply(lambda row: row['Meter Type'] + '_Meter' if np.isnan(row['Custom Meter ID']) else row['Custom Meter ID'], axis=1) # axis=1, apply to each row
-    meter_con_df['Custom ID'] = meter_con_df.apply(lambda row:'1' if np.isnan(row['Custom ID']) else row['Custom ID'], axis=1)
-    meter_con_df['Cost ($)'] = meter_con_df.apply(lambda row:'NA' if np.isnan(row['Cost ($)']) else row['Cost ($)'], axis=1)
+    meter_con_df['Custom Meter ID'] = meter_con_df.apply(lambda row: row['Meter Type'] + '_Meter' if np.isnan(row['Custom Meter ID']) else row['Custom Meter ID'], axis=1)  # axis=1, apply to each row
+    meter_con_df['Custom ID'] = meter_con_df.apply(lambda row: '1' if np.isnan(row['Custom ID']) else row['Custom ID'], axis=1)
+    meter_con_df['Cost ($)'] = meter_con_df.apply(lambda row: 'NA' if np.isnan(row['Cost ($)']) else row['Cost ($)'], axis=1)
 
     _log.info('start query')
     address = meter_con_df['Street Address'].values

--- a/seed/static/seed/partials/building_energy_section.html
+++ b/seed/static/seed/partials/building_energy_section.html
@@ -1,3 +1,7 @@
+<script type="text/javascript">
+    var scope = angular.element(document.getElementById('finer_ts_chart')).scope();
+</script>
+<toast></toast>
 <div class="page_header_container" ng-cloak>
     <div class="page_header">
         <div class="left page_action_container">

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -2371,9 +2371,9 @@ def save_gb_request_info(request):
 
     loopback_flag = info['loopback']
 
-	# last_date is the last requested date of GreenButton XML data, next GreenButton request will start from the saved last_date and end at the preivous day of the date making the request
-	# If there is no need to backfill, the last_date is set to yesterday
-	# If backfill is needed, we hard coded a very first date as 3/1/2014 for now. Later we will backfill month by month till there is no data available and set the last_date to yesterday
+    # last_date is the last requested date of GreenButton XML data, next GreenButton request will start from the saved last_date and end at the preivous day of the date making the request
+    # If there is no need to backfill, the last_date is set to yesterday
+    # If backfill is needed, we hard coded a very first date as 3/1/2014 for now. Later we will backfill month by month till there is no data available and set the last_date to yesterday
     last_date = ''
     yesterday = date.today() - timedelta(1)
     if time_type == 'date':

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -2371,7 +2371,9 @@ def save_gb_request_info(request):
 
     loopback_flag = info['loopback']
 
-    # today_date = date.today() # unused
+	# last_date is the last requested date of GreenButton XML data, next GreenButton request will start from the saved last_date and end at the preivous day of the date making the request
+	# If there is no need to backfill, the last_date is set to yesterday
+	# If backfill is needed, we hard coded a very first date as 3/1/2014 for now. Later we will backfill month by month till there is no data available and set the last_date to yesterday
     last_date = ''
     yesterday = date.today() - timedelta(1)
     if time_type == 'date':

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -72,6 +72,7 @@ from django.http import HttpResponseBadRequest
 
 from seed.energy.pm_energy_template import pm_energy_processor, energy_template_process
 from seed.energy.meter_data_processor import green_button_data_analyser
+from seed.energy.meter_data_processor.tasks import process_green_button_batch_request
 from dateutil.parser import parse
 from collections import defaultdict
 
@@ -2385,6 +2386,8 @@ def save_gb_request_info(request):
     record = GreenButtonBatchRequestsInfo.objects.filter(building_id=building_id)
     if not record:
         record = GreenButtonBatchRequestsInfo(url=url, last_date=last_date, min_date_parameter=min_date_parameter, max_date_parameter=max_date_parameter, building_id=building_id, active=active, time_type=time_type, date_pattern=date_pattern, subscription_id=subscription_id)
+        record.save()
+        process_green_button_batch_request.delay(record.id, url, subscription_id, building_id, time_type, date_pattern, min_date_parameter, last_date, max_date_parameter)
     else:
         record = GreenButtonBatchRequestsInfo.objects.get(building_id=building_id)
         record.url = url
@@ -2394,8 +2397,8 @@ def save_gb_request_info(request):
         record.active = active
         record.time_type = time_type
         record.date_pattern = date_pattern
-
-    record.save()
+        record.save()
+        process_green_button_batch_request.delay(record.id, url, subscription_id, building_id, time_type, date_pattern, min_date_parameter, record.last_date, max_date_parameter)
 
 
 @api_endpoint

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -2377,12 +2377,12 @@ def save_gb_request_info(request):
     if time_type == 'date':
         last_date = yesterday.strftime(date_pattern)
         if loopback_flag == 'Y':
-            very_first_date = datetime.strptime('1/1/2014', '%m/%d/%Y').date()
+            very_first_date = datetime.strptime('3/1/2014', '%m/%d/%Y').date()
             last_date = very_first_date.strftime(date_pattern)
     else:
         last_date = str(calendar.timegm(time.strptime(yesterday.strftime('%m/%d/%Y'), '%m/%d/%Y')))
         if loopback_flag == 'Y':
-            last_date = str(1388534400)
+            last_date = str(1393632000)
 
     record = GreenButtonBatchRequestsInfo.objects.filter(building_id=building_id)
     if not record:


### PR DESCRIPTION
Update log:
- Fixed ngToast not shown bug.
- Add django-celery for `python manage.py celery` command to work.
- Move seed/energy/tasks.py to seed/energy/meter_data_processor folder to avoid circular import.
- Separate the code requesting GreenButton XML data as an independent task. Since schedulers will be set to run daily/monthly, when new GreenButton batch request info is saved by user, the new separated task will be called to request GreenButton XML file immediately instead of waiting for the scheduler to do it.
- Ignore rows missing critical data in uploaded energy template to avoid KairosDB insert exception.

Note:
- The backfill start date for GreenButton data is set to March 1, 2014, it is hard coded for the service provided by DC partner. I'm working on making it flexible.
- Processing Full PM exported spreadsheet data and energy template currently uses address_line_1 column to match building record in SEED, so the building records having PM or energy template data need to have the according address in address_line_1 column for now. I'm working on including building match module.
- Please don't modify the sheets and column structure of exported PM spreadsheet, the code parsing the report assuming the default structure.