### PR TITLE
Issue #861 - Use a custom $http serializer to encode semicolons.

### DIFF
--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -87,7 +87,8 @@ angular.module('BE.seed.services', [
     'BE.seed.service.user',
     'mappingValidatorService',
     'BE.seed.service.search',
-    'BE.seed.service.simple_modal'
+    'BE.seed.service.simple_modal',
+    'BE.seed.service.httpParamSerializerSeed'
     ]);
 angular.module('BE.seed.utilities', [
     'BE.seed.utility.spinner'

--- a/seed/static/seed/js/services/http_serializer.js
+++ b/seed/static/seed/js/services/http_serializer.js
@@ -1,0 +1,54 @@
+/*
+ * :copyright (c) 2014 - 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.
+ * :author 'Nicholas Serra <nickserra@gmail.com>'
+ */
+/**
+ *
+ * Custom $http params serializer that url encodes semicolons.
+ * Temporary until a fix is landed in angular.
+ * - nicholasserra
+ */
+angular.module('BE.seed.service.httpParamSerializerSeed', []).factory('httpParamSerializerSeed', [
+  function () {
+
+    function serializeValue(v) {
+      if (angular.isObject(v)) {
+        return angular.isDate(v) ? v.toISOString() : angular.toJson(v);
+      }
+      return v;
+    }
+
+    function forEachSorted(obj, iterator, context) {
+      var keys = Object.keys(obj).sort();
+      for (var i = 0; i < keys.length; i++) {
+        iterator.call(context, obj[keys[i]], keys[i]);
+      }
+      return keys;
+    }
+
+    function encodeUriQuerySeed(val, pctEncodeSpaces) {
+      return encodeURIComponent(val).
+        replace(/%40/gi, '@').
+        replace(/%3A/gi, ':').
+        replace(/%24/g, '$').
+        replace(/%2C/gi, ',').
+        replace(/%20/g, (pctEncodeSpaces ? '%20' : '+'));
+    }
+
+    return function(params) {
+      if (!params) return '';
+      var parts = [];
+      forEachSorted(params, function(value, key) {
+        if (value === null || angular.isUndefined(value)) return;
+        if (angular.isArray(value)) {
+          angular.forEach(value, function(v) {
+            parts.push(encodeUriQuerySeed(key)  + '=' + encodeUriQuerySeed(serializeValue(v)));
+          });
+        } else {
+          parts.push(encodeUriQuerySeed(key) + '=' + encodeUriQuerySeed(serializeValue(value)));
+        }
+      });
+
+      return parts.join('&');
+    };
+}]);

--- a/seed/static/seed/js/services/label_service.js
+++ b/seed/static/seed/js/services/label_service.js
@@ -76,7 +76,8 @@ angular.module('BE.seed.service.label',
         $http({
             method: 'GET',
             url: window.BE.urls.label_list,
-            params: searchArgs
+            params: searchArgs,
+            paramSerializer: 'httpParamSerializerSeed'
         }).success(function(data, status, headers, config) {
             
             if (_.isEmpty(data.results)) {

--- a/seed/templates/seed/_scripts.html
+++ b/seed/templates/seed/_scripts.html
@@ -57,6 +57,7 @@
 <script src="{{STATIC_URL}}seed/js/services/cleansing_service.js"></script>
 <script src="{{STATIC_URL}}seed/js/services/dataset_service.js"></script>
 <script src="{{STATIC_URL}}seed/js/services/export_service.js"></script>
+<script src="{{STATIC_URL}}seed/js/services/http_serializer.js"></script>
 <script src="{{STATIC_URL}}seed/js/services/label_helper_service.js"></script>
 <script src="{{STATIC_URL}}seed/js/services/label_service.js"></script>
 <script src="{{STATIC_URL}}seed/js/services/mapping_service.js"></script>


### PR DESCRIPTION
#### Any background context you want to provide?
Semicolons inside of JSON inside of GET params were not being urlencoded by angular. Angular is doing this on purpose for some situations.

#### What's this PR do?
Adds a custom params encoder to use where necessary. This may be an issue in many places, so it's reusable. This is also temporary, as I plan on opening a PR on Angular to make this behavior less strict.

#### What are the relevant tickets?
Refs #861 

#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?
