### PR TITLE
Issue #899 - Delete users without orgs on org delete.

### DIFF
--- a/seed/tests/test_tasks.py
+++ b/seed/tests/test_tasks.py
@@ -769,7 +769,7 @@ class TestTasks(TestCase):
 
     def test_delete_organization_doesnt_delete_user_if_multiple_memberships(self):
         """
-        Deleting an org shouldnt delete the orgs users if the user belongs to many orgs.
+        Deleting an org shouldn't delete the orgs users if the user belongs to many orgs.
         """
         org = Organization.objects.create()
         OrganizationUser.objects.create(organization=org, user=self.fake_user)


### PR DESCRIPTION
#### What's this PR do?
Deletes users without organization memberships when an organization is deleted.

#### How should this be manually tested?
Delete an org with one user, user should be deleted.

#### What are the relevant tickets?
Refs #899 

#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?
