### PR TITLE
Issue #902 - Use Django built in password validation

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -252,14 +252,36 @@ MATCH_MIN_THRESHOLD = 0.3
 MATCH_MED_THRESHOLD = 0.4
 
 
-# django-passwords settings: passwords should requre alphnumberic and 8
-# character minimum, with a minimum of 1 upper and 1 lower case character
-PASSWORD_MIN_LENGTH = 8
-PASSWORD_COMPLEXITY = {
-    "UPPER": 1,  # at least 1 Uppercase
-    "LOWER": 1,  # at least 1 Lowercase
-    "DIGITS": 1,  # at least 1 Digit
-}
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {
+            'min_length': 8,
+        }
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'seed.validators.PasswordUppercaseCharacterValidator',
+        'OPTIONS': {
+            'quantity': 1,
+        }
+    },
+    {
+        'NAME': 'seed.validators.PasswordLowercaseCharacterValidator',
+        'OPTIONS': {
+            'quantity': 1,
+        }
+    },
+    {
+        'NAME': 'seed.validators.PasswordDigitValidator',
+        'OPTIONS': {
+            'quantity': 1,
+        }
+    },
+]
+
 
 # Django Rest Framework
 REST_FRAMEWORK = {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,6 @@ Django==1.9.5
 # Forms
 django_compressor==1.5
 django-extensions==1.6.1
-django-passwords==0.2.0
 django-redis-cache==1.6.0
 django-ses==0.4.1
 django-sslify==0.2

--- a/seed/landing/forms.py
+++ b/seed/landing/forms.py
@@ -6,9 +6,6 @@
 """
 from django import forms
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.auth.forms import SetPasswordForm
-
-from passwords.fields import PasswordField
 
 
 class LoginForm(forms.Form):
@@ -25,14 +22,4 @@ class LoginForm(forms.Form):
             attrs={'class': 'field', 'placeholder': 'Password'}
         ),
         required=True
-    )
-
-
-class SetStrongPasswordForm(SetPasswordForm):
-    """
-    The Django SetPasswordForm with django-passwords PasswordField
-    """
-    new_password2 = PasswordField(
-        label=_("New password confirmation"),
-        widget=forms.PasswordInput
     )

--- a/seed/landing/views.py
+++ b/seed/landing/views.py
@@ -8,6 +8,7 @@ import logging
 
 from django.contrib import auth
 from django.contrib.auth import authenticate, login
+from django.contrib.auth.forms import SetPasswordForm
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.forms.utils import ErrorList
@@ -18,7 +19,7 @@ from django.shortcuts import render_to_response
 from tos.models import (
     has_user_agreed_latest_tos, TermsOfService, NoActiveTermsOfService
 )
-from forms import LoginForm, SetStrongPasswordForm
+from forms import LoginForm
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +123,7 @@ def password_reset_confirm(request, uidb64=None, token=None):
         uidb64=uidb64,
         token=token,
         template_name='landing/password_reset_confirm.html',
-        set_password_form=SetStrongPasswordForm,
+        set_password_form=SetPasswordForm,
         post_reset_redirect=reverse('landing:password_reset_complete')
     )
 
@@ -141,6 +142,6 @@ def signup(request, uidb64=None, token=None):
         uidb64=uidb64,
         token=token,
         template_name='landing/signup.html',
-        set_password_form=SetStrongPasswordForm,
+        set_password_form=SetPasswordForm,
         post_reset_redirect=reverse('landing:landing_page') + "?setup_complete"
     )

--- a/seed/tests/test_account_views.py
+++ b/seed/tests/test_account_views.py
@@ -850,7 +850,7 @@ class AccountsViewTests(TestCase):
             json.loads(resp.content),
             {
                 'status': 'error',
-                'message': 'Invalid Length (Must be 8 characters or more)',
+                'message': 'This password is too short. It must contain at least 8 characters.',
             })
         # check new password is has uppercase letters
         password_payload = {
@@ -871,8 +871,7 @@ class AccountsViewTests(TestCase):
             {
                 'status': 'error',
                 'message': (
-                    'Must be more complex (Must contain 1 or more uppercase '
-                    'characters)'
+                    'This password must contain at least 1 uppercase characters.'
                 ),
             })
         # check new password is has lowercase letters
@@ -894,8 +893,7 @@ class AccountsViewTests(TestCase):
             {
                 'status': 'error',
                 'message': (
-                    'Must be more complex (Must contain 1 or more lowercase '
-                    'characters)'
+                    'This password must contain at least 1 lowercase characters.'
                 ),
             })
         # check new password is has alphanumeric letters
@@ -917,7 +915,7 @@ class AccountsViewTests(TestCase):
             {
                 'status': 'error',
                 'message': (
-                    'Must be more complex (Must contain 1 or more digits)'
+                    'This password must contain at least 1 numeric characters.'
                 ),
             })
         password_payload = {
@@ -937,7 +935,7 @@ class AccountsViewTests(TestCase):
             json.loads(resp.content),
             {
                 'status': 'error',
-                'message': 'Based on a common sequence of characters',
+                'message': 'This password is too common.',
             })
 
     def test_create_sub_org(self):

--- a/seed/validators.py
+++ b/seed/validators.py
@@ -1,0 +1,41 @@
+import re
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext as _
+
+
+class PasswordBaseCharacterQuantityValidator(object):
+    TYPE = None
+    RE = re.compile(r'')
+
+    def __init__(self, quantity=1):
+        self.quantity = quantity
+
+    def validate(self, password, user=None):
+        if len(self.RE.findall(password)) < self.quantity:
+            raise ValidationError(
+                _("This password must contain at least %(quantity)d %(type)s characters."),
+                code='password_not_enough_%s' % self.TYPE,
+                params={'quantity': self.quantity, 'type': self.TYPE},
+            )
+
+    def get_help_text(self):
+        return _(
+            "Your password must contain at least %(quantity)d %(type)s characters."
+            % {'quantity': self.quantity, 'type': self.TYPE}
+        )
+
+
+class PasswordUppercaseCharacterValidator(PasswordBaseCharacterQuantityValidator):
+    TYPE = 'uppercase'
+    RE = re.compile(r'[A-Z]')
+
+
+class PasswordLowercaseCharacterValidator(PasswordBaseCharacterQuantityValidator):
+    TYPE = 'lowercase'
+    RE = re.compile(r'[a-z]')
+
+
+class PasswordDigitValidator(PasswordBaseCharacterQuantityValidator):
+    TYPE = 'numeric'
+    RE = re.compile(r'[0-9]')


### PR DESCRIPTION
#### Any background context you want to provide?
Django 1.9 comes with password validation built in.

#### What's this PR do?
Remove the django-passwords package and use Django's password validation.

#### What are the relevant tickets?
Refs #902 

#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?