### PR TITLE
Separate quantity and pluralized label

### DIFF
--- a/seed/static/seed/partials/buildings.html
+++ b/seed/static/seed/partials/buildings.html
@@ -4,8 +4,11 @@
            
         </div>
         <div class="page_title">
-            <h1><i class="fa fa-building-o"></i>
-                <ng-pluralize count="search.number_matching_search | number:0" when="{'one': '1 Building','other': '{} Buildings'}"></ng-pluralize>
+            <h1>
+                <i class="fa fa-building-o"></i>
+                {$ search.number_matching_search | number:0 $}
+                <ng-pluralize count="search.number_matching_search"
+                              when="{'one': 'Building','other': 'Buildings'}"></ng-pluralize>
             </h1>
         </div>
         <div class="right page_action_container page_action_btn">

--- a/seed/static/seed/partials/dataset_list.html
+++ b/seed/static/seed/partials/dataset_list.html
@@ -6,7 +6,10 @@
         </div>
         <div class="page_title">
             <h1><i class="fa fa-sitemap"></i>
-                <ng-pluralize count="datasets.length | number:0" when="{'one': '1 Data Set','other': '{} Data Sets'}"></ng-pluralize>
+                {$ datasets.length | number:0 $}
+                <ng-pluralize count="datasets.length"
+                              when="{'one': 'Data Set','other': 'Data Sets'}">
+                </ng-pluralize>
             </h1>
         </div>
         <div class="right page_action_container">

--- a/seed/static/seed/partials/project_detail.html
+++ b/seed/static/seed/partials/project_detail.html
@@ -5,7 +5,7 @@
         </div>
         <div class="page_title">
             <h1><i class="fa fa-folder-o"></i>
-                {$ project.name $} (<ng-pluralize count="search.number_matching_search | number:0" when="{'one': '1 Building','other': '{} Buildings'}"></ng-pluralize>)</h1>
+                {$ project.name $} ({$ search.number_matching_search | number:0 $} <ng-pluralize count="search.number_matching_search" when="{'one': 'Building','other': 'Buildings'}"></ng-pluralize>)</h1>
         </div>
         <div class="right page_action_container">
         </div>

--- a/seed/static/seed/partials/projects.html
+++ b/seed/static/seed/partials/projects.html
@@ -5,7 +5,10 @@
         </div>
         <div class="page_title">
             <h1><i class="fa fa-folder-o"></i>
-                <ng-pluralize count="projects_count | number:0" when="{'one': '1 Project','other': '{} Projects'}"></ng-pluralize>
+                {$ projects_count | number:0 $}
+                <ng-pluralize count="projects_count"
+                              when="{'one': 'Project','other': 'Projects'}">
+                </ng-pluralize>
             </h1>
         </div>
         <div class="right page_action_container">


### PR DESCRIPTION
#### Any background context you want to provide?
We introduced ng-pluralize as part of a bigger FE update, but this directive didn't respond well to the existing code's use of the  "number" formatter for the relevant value. 

I tried fixing via a documented strategy of formatting the value within the "when" attribute, but that didn't work in this situation (perhaps because of the scope.object.value nature of the value). So in the interest of time I just pulled out the number from the ng-pluralize, which now just updates the noun in the label.

#### What's this PR do?
Separates noun being pluralized from formatting of actual number.

#### How should this be manually tested?
Make sure "Buildings" header properly shows number of buildings, including when buildings > 1000.

#### What are the relevant tickets?
#914 

#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/119496/14692474/c727dc64-079a-11e6-9495-ee0af4c9aaa1.png)


#### Definition of Done:
- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [ ] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [ ] Does this PR require a regression test? All fixes require a regression test.
- [ ] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?
