### PR TITLE
Remove DOMAIN_URLCONFS setting.

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -90,10 +90,6 @@ if "COMPRESS_ENABLED" not in locals() or not COMPRESS_ENABLED:
 
 ALLOWED_HOSTS = ['*']
 
-# ReadTheDocs won't have a local_untracked, so even here in dev, there needs to be a few initializations
-DOMAIN_URLCONFS = {}
-DOMAIN_URLCONFS['default'] = 'config.urls'
-
 
 # use imp module to find the local_untracked file rather than a hard-coded path
 # TODO: There seems to be a bunch of loading of other files in these settings. First this loads the common, then this, then anything in the untracked file

--- a/config/settings/local_untracked.py.dist
+++ b/config/settings/local_untracked.py.dist
@@ -47,9 +47,6 @@ DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 
 STATICFILES_STORAGE = DEFAULT_FILE_STORAGE
 
-DOMAIN_URLCONFS = {}
-DOMAIN_URLCONFS['default'] = 'config.urls'
-
 # redis cache config
 # with AWS ElastiCache redis, the LOCATION setting looks something like:
 # 'xx-yy-zzrr0aax9a.ntmprk.0001.usw2.cache.amazonaws.com:6379'

--- a/config/settings/local_untracked_docker.py
+++ b/config/settings/local_untracked_docker.py
@@ -61,9 +61,6 @@ DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
 STATICFILES_STORAGE = DEFAULT_FILE_STORAGE
 
-DOMAIN_URLCONFS = {}
-DOMAIN_URLCONFS['default'] = 'config.urls'
-
 # redis cache config
 # with AWS ElastiCache redis, the LOCATION setting looks something like:
 # 'xx-yy-zzrr0aax9a.ntmprk.0001.usw2.cache.amazonaws.com:6379'

--- a/config/settings/main.py
+++ b/config/settings/main.py
@@ -24,8 +24,6 @@ ENV = STACK_OUTPUTS.get('StackFlavor', 'dev')
 
 DEBUG = os.environ.get('DEBUG', 'False') == 'True'
 TEMPLATE_DEBUG = DEBUG
-DOMAIN_URLCONFS = {}
-DOMAIN_URLCONFS[STACK_OUTPUTS.get('HostName')] = 'config.urls'
 
 # Handle SSL with django-sslify
 ONLY_HTTPS = os.environ.get('ONLY_HTTPS', 'True') == 'True'

--- a/config/settings/travis.py
+++ b/config/settings/travis.py
@@ -29,6 +29,3 @@ CACHES = {
 
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 STATICFILES_STORAGE = DEFAULT_FILE_STORAGE
-
-DOMAIN_URLCONFS = {}
-DOMAIN_URLCONFS['default'] = 'urls.main'

--- a/config/utils.py
+++ b/config/utils.py
@@ -9,11 +9,6 @@ from django.conf import settings
 logger = logging.getLogger(__name__)
 
 
-SITE_PREFIX_MAPPING = {}
-for k, v in settings.DOMAIN_URLCONFS.items():
-    SITE_PREFIX_MAPPING[k] = v.split(".")[1]
-
-
 def de_camel_case(name):
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1 \2', name)
     return re.sub('([a-z0-9])([A-Z])', r'\1 \2', s1)


### PR DESCRIPTION
#### Any background context you want to provide?
DOMAIN_URLCONFS is defined in all the settings files, but I can't find a reason for it to exist.

#### What's this PR do?
Remove the setting.

#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?
