### PR TITLE
Issue #916 - Slow building filtering

### DIFF
--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -34,6 +34,7 @@ concat
 cond
 config
 coparents
+coparent
 csv
 dataset
 datasets

--- a/seed/models.py
+++ b/seed/models.py
@@ -203,8 +203,9 @@ def obj_to_dict(obj, include_m2m=True):
     if include_m2m:
         data = serializers.serialize('json', [obj, ])
     else:
-        data = serializers.serialize('json', [obj, ],
-           fields=tuple([f.name for f in obj.__class__._meta.local_fields]))
+        data = serializers.serialize('json', [obj, ], fields=tuple(
+            [f.name for f in obj.__class__._meta.local_fields]
+        ))
 
     struct = json.loads(data)[0]
     response = struct['fields']

--- a/seed/models.py
+++ b/seed/models.py
@@ -1426,7 +1426,7 @@ class BuildingSnapshot(TimeStampedModel):
             if value and isinstance(value, basestring):
                 setattr(self, field, convert_datestr(value))
 
-    def to_dict(self, fields=None, include_co_parent=True, include_parents=True):
+    def to_dict(self, fields=None, include_related_data=True):
         """
         Returns a dict version of this building, either with all fields
         or masked to just those requested.
@@ -1459,12 +1459,10 @@ class BuildingSnapshot(TimeStampedModel):
 
             return result
 
-        d = obj_to_dict(self, include_m2m=False)
+        d = obj_to_dict(self, include_m2m=include_related_data)
 
-        if include_parents:
+        if include_related_data:
             d['parents'] = list(self.parents.values_list('id', flat=True))
-
-        if include_co_parent:
             d['co_parent'] = self.co_parent.pk if self.co_parent else None
 
         return d

--- a/seed/models.py
+++ b/seed/models.py
@@ -194,12 +194,18 @@ def find_canonical_building_values(org):
     ).distinct().values_list(*BS_VALUES_LIST)
 
 
-def obj_to_dict(obj):
+def obj_to_dict(obj, include_m2m=True):
     """serializes obj for a JSON friendly version
         tries to serialize JsonField
 
     """
-    data = serializers.serialize('json', [obj, ])
+
+    if include_m2m:
+        data = serializers.serialize('json', [obj, ])
+    else:
+        data = serializers.serialize('json', [obj, ],
+           fields=tuple([f.name for f in obj.__class__._meta.local_fields]))
+
     struct = json.loads(data)[0]
     response = struct['fields']
     response[u'id'] = response[u'pk'] = struct['pk']
@@ -1420,7 +1426,7 @@ class BuildingSnapshot(TimeStampedModel):
             if value and isinstance(value, basestring):
                 setattr(self, field, convert_datestr(value))
 
-    def to_dict(self, fields=None):
+    def to_dict(self, fields=None, include_co_parent=True, include_parents=True):
         """
         Returns a dict version of this building, either with all fields
         or masked to just those requested.
@@ -1453,9 +1459,14 @@ class BuildingSnapshot(TimeStampedModel):
 
             return result
 
-        d = obj_to_dict(self)
-        d['parents'] = list(self.parents.values_list('id', flat=True))
-        d['co_parent'] = self.co_parent.pk if self.co_parent else None
+        d = obj_to_dict(self, include_m2m=False)
+
+        if include_parents:
+            d['parents'] = list(self.parents.values_list('id', flat=True))
+
+        if include_co_parent:
+            d['co_parent'] = self.co_parent.pk if self.co_parent else None
+
         return d
 
     def __unicode__(self):

--- a/seed/search.py
+++ b/seed/search.py
@@ -64,7 +64,7 @@ def search_buildings(q, fieldnames=None, queryset=None):
 
 
 def generate_paginated_results(queryset, number_per_page=25, page=1,
-                               whitelist_orgs=None, below_threshold=False, 
+                               whitelist_orgs=None, below_threshold=False,
                                matching=True):
     """
     Return a page of results as a list from the queryset for the given fields
@@ -79,7 +79,7 @@ def generate_paginated_results(queryset, number_per_page=25, page=1,
     :param below_threshold: True if less than the parent org's query threshold \
         is greater than the number of queryset results. If True, only return \
         buildings within whitelist_orgs.
-    :param matching: Toggle expanded parent and children data, including 
+    :param matching: Toggle expanded parent and children data, including
         coparent and confidence
     Usage::
 
@@ -131,8 +131,10 @@ def generate_paginated_results(queryset, number_per_page=25, page=1,
     for b in buildings_from_query:
         # check and process buildings from other orgs
         if is_not_whitelist_building(parent_org, b, whitelist_orgs):
-            building_dict = b.to_dict(exportable_field_names,
-                include_related_data=matching)
+            building_dict = b.to_dict(
+                exportable_field_names,
+                include_related_data=matching
+            )
         else:
             building_dict = b.to_dict(include_related_data=matching)
         # see if a building is matched

--- a/seed/search.py
+++ b/seed/search.py
@@ -131,11 +131,10 @@ def generate_paginated_results(queryset, number_per_page=25, page=1,
     for b in buildings_from_query:
         # check and process buildings from other orgs
         if is_not_whitelist_building(parent_org, b, whitelist_orgs):
-            building_dict = b.to_dict(exportable_field_names, include_co_parent=matching,
-                include_parents=matching)
+            building_dict = b.to_dict(exportable_field_names,
+                include_related_data=matching)
         else:
-            building_dict = b.to_dict(include_co_parent=matching,
-                include_parents=matching)
+            building_dict = b.to_dict(include_related_data=matching)
         # see if a building is matched
 
         # This data is only needed on mapping/matching steps, not general filtering

--- a/seed/search.py
+++ b/seed/search.py
@@ -64,7 +64,8 @@ def search_buildings(q, fieldnames=None, queryset=None):
 
 
 def generate_paginated_results(queryset, number_per_page=25, page=1,
-                               whitelist_orgs=None, below_threshold=False):
+                               whitelist_orgs=None, below_threshold=False, 
+                               matching=True):
     """
     Return a page of results as a list from the queryset for the given fields
 
@@ -78,7 +79,8 @@ def generate_paginated_results(queryset, number_per_page=25, page=1,
     :param below_threshold: True if less than the parent org's query threshold \
         is greater than the number of queryset results. If True, only return \
         buildings within whitelist_orgs.
-
+    :param matching: Toggle expanded parent and children data, including 
+        coparent and confidence
     Usage::
 
         generate_paginated_results(q, 1)
@@ -129,19 +131,24 @@ def generate_paginated_results(queryset, number_per_page=25, page=1,
     for b in buildings_from_query:
         # check and process buildings from other orgs
         if is_not_whitelist_building(parent_org, b, whitelist_orgs):
-            building_dict = b.to_dict(exportable_field_names)
+            building_dict = b.to_dict(exportable_field_names, include_co_parent=matching,
+                include_parents=matching)
         else:
-            building_dict = b.to_dict()
+            building_dict = b.to_dict(include_co_parent=matching,
+                include_parents=matching)
         # see if a building is matched
-        co_parent = b.co_parent
-        if co_parent:
-            building_dict['matched'] = True
-            building_dict['coparent'] = co_parent.to_dict()
-            child = b.children.first()
-            if child:
-                building_dict['confidence'] = child.confidence
-        else:
-            building_dict['matched'] = False
+
+        # This data is only needed on mapping/matching steps, not general filtering
+        if matching:
+            co_parent = b.co_parent
+            if co_parent:
+                building_dict['matched'] = True
+                building_dict['coparent'] = co_parent.to_dict()
+                child = b.children.first()
+                if child:
+                    building_dict['confidence'] = child.confidence
+            else:
+                building_dict['matched'] = False
 
         # only add the buildings if it is in an org the user belongs or the
         # query count exceeds the query threshold


### PR DESCRIPTION
#### Any background context you want to provide?
Building list page is slow with a ton of records. 

#### What's this PR do?
This PR is a performance tweak for searching. The building list page calls `search_buildings`. The mapping/matching/other pages call `search_building_snapshots`. 

Both of these endpoints hit the same search methods that return children, parents, and coparent info. Building list does not need this information. So this PR passes along some info so that these related queries are not ran, speeding up the building list search.

#### How should this be manually tested?
@RDmitchell This needs solid testing, as it involves filtering in general. I ran through the normal flow with sample files and it looks good. But you may want to run your full test once this is merged.

#### What are the relevant tickets?
Refs #916

#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?