### PR TITLE
Issue #942 - Be strict about requiring organization_id

### DIFF
--- a/seed/audit_logs/views.py
+++ b/seed/audit_logs/views.py
@@ -11,13 +11,14 @@ import json
 from django.contrib.auth.decorators import login_required
 
 # app imports
-from seed.decorators import ajax_request
+from seed.decorators import ajax_request, require_organization_id
 from seed.lib.superperms.orgs.decorators import has_perm
 from seed.utils.api import api_endpoint
 from seed.models import CanonicalBuilding
 from seed.audit_logs.models import AuditLog, NOTE
 
 
+@require_organization_id
 @api_endpoint
 @ajax_request
 @login_required
@@ -60,7 +61,7 @@ def get_building_logs(request):
     cb = CanonicalBuilding.objects.get(
         pk=request.GET.get('building_id')
     )
-    org_id = request.GET.get('organization_id', '')
+    org_id = request.GET['organization_id']
     log_qs = cb.audit_logs.filter(organization=org_id)
 
     audit_logs = [log.to_dict() for log in log_qs]

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -1650,6 +1650,7 @@ class ReportViewsTests(TestCase):
         params = {
             'start_date': (datetime.now() - timedelta(days=30)).strftime('%Y-%m-%d'),
             'end_date': datetime.now().strftime('%Y-%m-%d'),
+            'organization_id': self.org.pk
         }
 
         response = self.client.get(reverse("seed:get_building_summary_report_data"), params)

--- a/seed/views/accounts.py
+++ b/seed/views/accounts.py
@@ -12,7 +12,7 @@ from django.contrib.auth.password_validation import validate_password
 from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
 
-from seed.decorators import ajax_request
+from seed.decorators import ajax_request, require_organization_id
 from seed.lib.superperms.orgs.decorators import has_perm, PERMS
 from seed.lib.superperms.orgs.exceptions import TooManyNestedOrgs
 from seed.lib.superperms.orgs.models import (
@@ -742,6 +742,7 @@ def save_org_settings(request):
     return {'status': 'success'}
 
 
+@require_organization_id
 @api_endpoint
 @ajax_request
 @login_required
@@ -762,14 +763,14 @@ def get_query_threshold(request):
              returned from a search to avoid squelching non-member-org results.
         }
     """
-    org_id = request.GET.get('organization_id')
-    org = Organization.objects.get(pk=org_id)
+    org = Organization.objects.get(pk=request.GET['organization_id'])
     return {
         'status': 'success',
         'query_threshold': org.query_threshold
     }
 
 
+@require_organization_id
 @api_endpoint
 @ajax_request
 @login_required
@@ -816,7 +817,7 @@ def get_shared_fields(request):
         }
 
     """
-    org_id = request.GET.get('organization_id')
+    org_id = request.GET['organization_id']
     org = Organization.objects.get(pk=org_id)
 
     result = {'status': 'success',
@@ -843,6 +844,7 @@ def get_shared_fields(request):
     return result
 
 
+@require_organization_id
 @api_endpoint
 @ajax_request
 @login_required
@@ -863,8 +865,7 @@ def get_cleansing_rules(request):
          'missing_values': An array of fields to ignore missing values
         }
     """
-    org_id = request.GET.get('organization_id')
-    org = Organization.objects.get(pk=org_id)
+    org = Organization.objects.get(pk=request.GET['organization_id'])
 
     result = {
         'status': 'success',
@@ -907,6 +908,7 @@ def get_cleansing_rules(request):
     return result
 
 
+@require_organization_id
 @api_endpoint
 @ajax_request
 @login_required
@@ -927,8 +929,7 @@ def reset_cleansing_rules(request):
          'missing_values': An array of fields to ignore missing values
         }
     """
-    org_id = request.GET.get('organization_id')
-    org = Organization.objects.get(pk=org_id)
+    org = Organization.objects.get(pk=request.GET['organization_id'])
 
     Rules.restore_defaults(org)
     return get_cleansing_rules(request)

--- a/seed/views/projects.py
+++ b/seed/views/projects.py
@@ -22,7 +22,7 @@ from seed.tasks import (
     remove_buildings,
 )
 
-from seed.decorators import ajax_request
+from seed.decorators import ajax_request, require_organization_id
 from seed.lib.superperms.orgs.decorators import has_perm
 from seed.models import (
     Compliance,
@@ -43,6 +43,7 @@ DEFAULT_CUSTOM_COLUMNS = [
 ]
 
 
+@require_organization_id
 @api_endpoint
 @ajax_request
 @login_required
@@ -77,7 +78,7 @@ def get_projects(request):
             ]
         }
     """
-    organization_id = request.GET.get('organization_id', '')
+    organization_id = request.GET['organization_id']
     projects = []
 
     for p in Project.objects.filter(
@@ -117,6 +118,7 @@ def get_projects(request):
     return {'status': 'success', 'projects': projects}
 
 
+@require_organization_id
 @api_endpoint
 @ajax_request
 @login_required
@@ -151,9 +153,8 @@ def get_project(request):
 
     """
     project_slug = request.GET.get('project_slug', '')
-    organization_id = request.GET.get('organization_id', '')
     project = Project.objects.get(slug=project_slug)
-    if project.super_organization_id != int(organization_id):
+    if project.super_organization_id != int(request.GET['organization_id']):
         return {'status': 'error', 'message': 'Permission denied'}
     project_dict = project.__dict__
     project_dict['is_compliance'] = project.has_compliance
@@ -463,6 +464,7 @@ def get_adding_buildings_to_project_status_percentage(request):
     }
 
 
+@require_organization_id
 @api_endpoint
 @ajax_request
 @login_required
@@ -482,9 +484,8 @@ def get_projects_count(request):
         }
 
     """
-    organization_id = request.GET.get('organization_id', '')
     projects_count = Project.objects.filter(
-        super_organization_id=organization_id
+        super_organization_id=request.GET['organization_id']
     ).distinct().count()
 
     return {'status': 'success', 'projects_count': projects_count}


### PR DESCRIPTION
#### Any background context you want to provide?
Buncha errors in sentry around org id missing. I'd like to surface these as informative messages to the browser.

#### What's this PR do?
Make a decorator for views requiring organization_id passed via GET. Throw a bad request with an error message if not. Unsure how these are happening but this is a start.

#### What are the relevant tickets?
Refs #942 

#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?