### PR TITLE
Fixes js error in getAggChartData

### DIFF
--- a/seed/static/seed/js/controllers/buildings_reports_controller.js
+++ b/seed/static/seed/js/controllers/buildings_reports_controller.js
@@ -326,7 +326,7 @@ angular.module('BE.seed.controller.buildings_reports', [])
             chartData: data.chart_data,
             xAxisTitle: $scope.xAxisSelectedItem.axisLabel,
             yAxisTitle: $scope.yAxisSelectedItem.axisLabel,
-            yAxisType: Category,
+            yAxisType: 'Category',
             colors: colorsArr
           };
           if($scope.aggChartData.chartData && $scope.aggChartData.chartData.length > 0) {


### PR DESCRIPTION
Fixes js error in getAggChartData
    - yAxisType: Category, missing quotes causing Undefined error
    - added quotes : produces bar chart

#### Any background context you want to provide?
Chart wasn't loading due to js error
#### What's this PR do?
Adds quotes to fix js error
#### How should this be manually tested?
Go to reports page and generate charts
#### What are the relevant tickets?
#965
#### Screenshots (if appropriate)
![selection_130](https://cloud.githubusercontent.com/assets/347498/16062351/67b2fde0-3247-11e6-926a-53cc4ba65d75.png)

#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.) 
- [x] Does this PR require a regression test? All fixes require a regression test.
Existing test at seed/static/seed/tests/buildings_reports_controller.spec.js was failing, now passes