### PR TITLE
allow 255 items in label list

### DIFF
--- a/seed/static/seed/partials/buildings.html
+++ b/seed/static/seed/partials/buildings.html
@@ -80,7 +80,7 @@
                             replace-spaces-with-dashes="false"
                             add-from-autocomplete-only="true">
                     <auto-complete  source="loadLabelsForFilter($query)"
-                                    max-results-to-show="25"
+                                    max-results-to-show="255"
                                     min-length="0"
                                     load-on-empty="true"
                                     load-on-focus="true"


### PR DESCRIPTION
#### Any background context you want to provide?
List of labels to filter were limited to only 25 items

#### What's this PR do?
Expands the filter list to 255 items

#### How should this be manually tested?
add more than 25 labels and make sure that they show up in the building list filter by label box

#### What are the relevant tickets?
#989 

#### Screenshots (if appropriate)

#### Definition of Done:
- [X] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.) No
- [X] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [X] Does this PR require a regression test? All fixes require a regression test. No
- [X] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated? NO
