### PR TITLE
Added column menus, grid menus, and saving/restoring state

### DIFF
--- a/seed/static/seed/js/controllers/bluesky_properties_controller.js
+++ b/seed/static/seed/js/controllers/bluesky_properties_controller.js
@@ -22,16 +22,48 @@ angular.module('BE.seed.controller.bluesky_properties_controller', [])
       $scope.objects = properties.results;
       $scope.pagination = properties.pagination;
       $scope.number_per_page = 999999999;
+      $scope.restoring = false;
 
       $scope.cycle = {
         selected_cycle: cycles[0],
         cycles: cycles
       };
 
+      var processData = function () {
+        var data = angular.copy($scope.objects);
+        var roots = data.length;
+        for (var i = 0, trueIndex = 0; i < roots; ++i) {
+          data[trueIndex].$$treeLevel = 0;
+          var related = data[trueIndex].related;
+          var relatedIndex = trueIndex;
+          for (var j = 0; j < related.length; ++j) {
+            // Rename nested keys
+            var map = {
+              city: 'tax_city',
+              state: 'tax_state',
+              postal_code: 'tax_postal_code'
+            };
+            var updated = _.reduce(related[j], function (result, value, key) {
+              key = map[key] || key;
+              result[key] = value;
+              return result;
+            }, {});
+
+            data.splice(++trueIndex, 0, updated);
+          }
+          // Remove unnecessary data
+          delete data[relatedIndex].collapsed;
+          delete data[relatedIndex].related;
+          ++trueIndex;
+        }
+        $scope.data = data;
+      };
+
       var refresh_objects = function () {
         bluesky_service.get_properties($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle).then(function (properties) {
           $scope.objects = properties.results;
           $scope.pagination = properties.pagination;
+          processData();
         });
       };
 
@@ -39,6 +71,8 @@ angular.module('BE.seed.controller.bluesky_properties_controller', [])
         $scope.cycle.selected_cycle = cycle;
         refresh_objects();
       };
+
+      processData();
 
       var defaults = {
         minWidth: 150
@@ -51,34 +85,7 @@ angular.module('BE.seed.controller.bluesky_properties_controller', [])
         return _.defaults(col, filter, defaults);
       });
 
-      var data = angular.copy($scope.objects);
-      var roots = data.length;
-      for (var i = 0, trueIndex = 0; i < roots; ++i) {
-        data[trueIndex].$$treeLevel = 0;
-        var related = data[trueIndex].related;
-        var relatedIndex = trueIndex;
-        for (var j = 0; j < related.length; ++j) {
-          // Rename nested keys
-          var map = {
-            city: 'tax_city',
-            state: 'tax_state',
-            postal_code: 'tax_postal_code'
-          };
-          var updated = _.reduce(related[j], function (result, value, key) {
-            key = map[key] || key;
-            result[key] = value;
-            return result;
-          }, {});
-
-          data.splice(++trueIndex, 0, updated);
-        }
-        // Remove unnecessary data
-        delete data[relatedIndex].collapsed;
-        delete data[relatedIndex].related;
-        ++trueIndex;
-      }
-
-      $scope.updateHeight = function () {
+      var updateHeight = function () {
         var height = 0;
         _.forEach(['.header', '.page_header_container', '.buildingListControls', 'ul.nav'], function (selector) {
           height += angular.element(selector)[0].offsetHeight;
@@ -87,20 +94,66 @@ angular.module('BE.seed.controller.bluesky_properties_controller', [])
         angular.element('#grid-container > div').css('height', 'calc(100vh - ' + (height + 4) + 'px)');
       };
 
+      var saveState = function () {
+        if (!$scope.restoring) {
+          localStorage.setItem('grid.properties', JSON.stringify($scope.gridApi.saveState.save()));
+        }
+      };
+
+      var restoreState = function () {
+        $scope.restoring = true;
+        var state = localStorage.getItem('grid.properties');
+        if (!_.isNull(state)) {
+          state = JSON.parse(state);
+          $scope.gridApi.saveState.restore($scope, state);
+        }
+        _.defer(function () {
+          $scope.restoring = false;
+        });
+      };
+
+      var restoreDefaultState = function () {
+        $scope.gridApi.saveState.restore($scope, $scope.defaultState);
+      };
+
       $scope.gridOptions = {
-        data: data,
-        enableColumnMenus: false,
+        data: 'data',
         enableFiltering: true,
+        enableGridMenu: true,
         enableSorting: true,
+        exporterCsvFilename: 'Property Data.csv',
+        exporterMenuPdf: false,
         fastWatch: true,
         flatEntityAccess: true,
+        gridMenuCustomItems: [{
+          title: 'Reset settings',
+          action: restoreDefaultState
+        }],
+        saveFocus: false,
+        saveGrouping: false,
+        saveGroupingExpandedStates: false,
+        savePinning: false,
+        saveScroll: false,
+        saveSelection: false,
+        saveTreeView: false,
         showTreeExpandNoChildren: false,
         columnDefs: columns,
         treeCustomAggregations: bluesky_service.aggregations(),
         onRegisterApi: function (gridApi) {
           $scope.gridApi = gridApi;
-          $scope.updateHeight();
-          angular.element($window).on('resize', _.debounce($scope.updateHeight, 150));
+          updateHeight();
+          angular.element($window).on('resize', _.debounce(updateHeight, 150));
+
+          gridApi.colMovable.on.columnPositionChanged($scope, saveState);
+          gridApi.colResizable.on.columnSizeChanged($scope, saveState);
+          gridApi.core.on.columnVisibilityChanged($scope, saveState);
+          gridApi.core.on.filterChanged($scope, saveState);
+          gridApi.core.on.sortChanged($scope, saveState);
+
+          _.defer(function () {
+            $scope.defaultState = $scope.gridApi.saveState.save();
+            restoreState();
+          });
         }
       }
     }]);

--- a/seed/static/seed/js/controllers/bluesky_taxlots_controller.js
+++ b/seed/static/seed/js/controllers/bluesky_taxlots_controller.js
@@ -22,16 +22,48 @@ angular.module('BE.seed.controller.bluesky_taxlots_controller', [])
       $scope.objects = taxlots.results;
       $scope.pagination = taxlots.pagination;
       $scope.number_per_page = 999999999;
+      $scope.restoring = false;
 
       $scope.cycle = {
         selected_cycle: cycles[0],
         cycles: cycles
       };
 
+      var processData = function () {
+        var data = angular.copy($scope.objects);
+        var roots = data.length;
+        for (var i = 0, trueIndex = 0; i < roots; ++i) {
+          data[trueIndex].$$treeLevel = 0;
+          var related = data[trueIndex].related;
+          var relatedIndex = trueIndex;
+          for (var j = 0; j < related.length; ++j) {
+            // Rename nested keys
+            var map = {
+              city: 'property_city',
+              state: 'property_state',
+              postal_code: 'property_postal_code'
+            };
+            var updated = _.reduce(related[j], function (result, value, key) {
+              key = map[key] || key;
+              result[key] = value;
+              return result;
+            }, {});
+
+            data.splice(++trueIndex, 0, updated);
+          }
+          // Remove unnecessary data
+          delete data[relatedIndex].collapsed;
+          delete data[relatedIndex].related;
+          ++trueIndex;
+        }
+        $scope.data = data;
+      };
+
       var refresh_objects = function () {
         bluesky_service.get_taxlots($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle).then(function (taxlots) {
           $scope.objects = taxlots.results;
           $scope.pagination = taxlots.pagination;
+          processData();
         });
       };
 
@@ -39,6 +71,8 @@ angular.module('BE.seed.controller.bluesky_taxlots_controller', [])
         $scope.cycle.selected_cycle = cycle;
         refresh_objects();
       };
+
+      processData();
 
       var defaults = {
         minWidth: 150
@@ -51,34 +85,7 @@ angular.module('BE.seed.controller.bluesky_taxlots_controller', [])
         return _.defaults(col, filter, defaults);
       });
 
-      var data = angular.copy($scope.objects);
-      var roots = data.length;
-      for (var i = 0, trueIndex = 0; i < roots; ++i) {
-        data[trueIndex].$$treeLevel = 0;
-        var related = data[trueIndex].related;
-        var relatedIndex = trueIndex;
-        for (var j = 0; j < related.length; ++j) {
-          // Rename nested keys
-          var map = {
-            city: 'property_city',
-            state: 'property_state',
-            postal_code: 'property_postal_code'
-          };
-          var updated = _.reduce(related[j], function (result, value, key) {
-            key = map[key] || key;
-            result[key] = value;
-            return result;
-          }, {});
-
-          data.splice(++trueIndex, 0, updated);
-        }
-        // Remove unnecessary data
-        delete data[relatedIndex].collapsed;
-        delete data[relatedIndex].related;
-        ++trueIndex;
-      }
-
-      $scope.updateHeight = function () {
+      var updateHeight = function () {
         var height = 0;
         _.forEach(['.header', '.page_header_container', '.buildingListControls', 'ul.nav'], function (selector) {
           height += angular.element(selector)[0].offsetHeight;
@@ -87,20 +94,66 @@ angular.module('BE.seed.controller.bluesky_taxlots_controller', [])
         angular.element('#grid-container > div').css('height', 'calc(100vh - ' + (height + 4) + 'px)');
       };
 
+      var saveState = function () {
+        if (!$scope.restoring) {
+          localStorage.setItem('grid.taxlots', JSON.stringify($scope.gridApi.saveState.save()));
+        }
+      };
+
+      var restoreState = function () {
+        $scope.restoring = true;
+        var state = localStorage.getItem('grid.taxlots');
+        if (!_.isNull(state)) {
+          state = JSON.parse(state);
+          $scope.gridApi.saveState.restore($scope, state);
+        }
+        _.defer(function () {
+          $scope.restoring = false;
+        });
+      };
+
+      var restoreDefaultState = function () {
+        $scope.gridApi.saveState.restore($scope, $scope.defaultState);
+      };
+
       $scope.gridOptions = {
-        data: data,
-        enableColumnMenus: false,
+        data: 'data',
         enableFiltering: true,
+        enableGridMenu: true,
         enableSorting: true,
+        exporterCsvFilename: 'Taxlot Data.csv',
+        exporterMenuPdf: false,
         fastWatch: true,
         flatEntityAccess: true,
+        gridMenuCustomItems: [{
+          title: 'Reset settings',
+          action: restoreDefaultState
+        }],
+        saveFocus: false,
+        saveGrouping: false,
+        saveGroupingExpandedStates: false,
+        savePinning: false,
+        saveScroll: false,
+        saveSelection: false,
+        saveTreeView: false,
         showTreeExpandNoChildren: false,
         columnDefs: columns,
         treeCustomAggregations: bluesky_service.aggregations(),
         onRegisterApi: function (gridApi) {
           $scope.gridApi = gridApi;
-          $scope.updateHeight();
-          angular.element($window).on('resize', _.debounce($scope.updateHeight, 150));
+          updateHeight();
+          angular.element($window).on('resize', _.debounce(updateHeight, 150));
+
+          gridApi.colMovable.on.columnPositionChanged($scope, saveState);
+          gridApi.colResizable.on.columnSizeChanged($scope, saveState);
+          gridApi.core.on.columnVisibilityChanged($scope, saveState);
+          gridApi.core.on.filterChanged($scope, saveState);
+          gridApi.core.on.sortChanged($scope, saveState);
+
+          _.defer(function () {
+            $scope.defaultState = $scope.gridApi.saveState.save();
+            restoreState();
+          });
         }
       }
     }]);

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -13,9 +13,11 @@ angular.module('BE.seed.angular_dependencies', [
 angular.module('BE.seed.vendor_dependencies', [
     'ui.bootstrap',
     'ui.grid',
+    'ui.grid.exporter',
     'ui.grid.grouping',
     'ui.grid.moveColumns',
     'ui.grid.resizeColumns',
+    'ui.grid.saveState',
     'ui.grid.treeView',
     'ui.sortable',
     'ui.tree',

--- a/seed/static/seed/partials/bluesky/table.html
+++ b/seed/static/seed/partials/bluesky/table.html
@@ -1,3 +1,3 @@
 <div id="grid-container">
-    <div ui-grid="gridOptions" ui-grid-move-columns ui-grid-resize-columns ui-grid-tree-view></div>
+    <div ui-grid="gridOptions" ui-grid-exporter ui-grid-move-columns ui-grid-resize-columns ui-grid-save-state ui-grid-tree-view></div>
 </div>


### PR DESCRIPTION
(See title) More UI Grid additions to the bluesky property and taxlot grids.  The individual grid settings are saved separately, and there's a custom option under the grid menu at the top right to completely reset any saved grid changes (filters, sorting, column order, column width, column visibility).

Please deploy to seeddev at your convenience.