### PR TITLE
Added column pinning

### DIFF
--- a/seed/bluesky/views.py
+++ b/seed/bluesky/views.py
@@ -330,6 +330,7 @@ def get_property_columns(request):
         {
             'name': 'building_portfolio_manager_identifier',
             'displayName': 'PM Property ID',
+            'pinnedLeft': True,
             'type': 'number',
             'related': False,
             'extra_data': False
@@ -585,6 +586,7 @@ def get_taxlot_columns(request):
         {
             'name': 'jurisdiction_taxlot_identifier',
             'displayName': 'Tax Lot ID',
+            'pinnedLeft': True,
             'type': 'number',
             'related': False
         }, {

--- a/seed/static/seed/js/controllers/bluesky_properties_controller.js
+++ b/seed/static/seed/js/controllers/bluesky_properties_controller.js
@@ -132,7 +132,6 @@ angular.module('BE.seed.controller.bluesky_properties_controller', [])
         saveFocus: false,
         saveGrouping: false,
         saveGroupingExpandedStates: false,
-        savePinning: false,
         saveScroll: false,
         saveSelection: false,
         saveTreeView: false,

--- a/seed/static/seed/js/controllers/bluesky_properties_controller.js
+++ b/seed/static/seed/js/controllers/bluesky_properties_controller.js
@@ -148,6 +148,7 @@ angular.module('BE.seed.controller.bluesky_properties_controller', [])
           gridApi.core.on.columnVisibilityChanged($scope, saveState);
           gridApi.core.on.filterChanged($scope, saveState);
           gridApi.core.on.sortChanged($scope, saveState);
+          gridApi.pinning.on.columnPinned($scope, saveState);
 
           _.defer(function () {
             $scope.defaultState = $scope.gridApi.saveState.save();

--- a/seed/static/seed/js/controllers/bluesky_taxlots_controller.js
+++ b/seed/static/seed/js/controllers/bluesky_taxlots_controller.js
@@ -148,6 +148,7 @@ angular.module('BE.seed.controller.bluesky_taxlots_controller', [])
           gridApi.core.on.columnVisibilityChanged($scope, saveState);
           gridApi.core.on.filterChanged($scope, saveState);
           gridApi.core.on.sortChanged($scope, saveState);
+          gridApi.pinning.on.columnPinned($scope, saveState);
 
           _.defer(function () {
             $scope.defaultState = $scope.gridApi.saveState.save();

--- a/seed/static/seed/js/controllers/bluesky_taxlots_controller.js
+++ b/seed/static/seed/js/controllers/bluesky_taxlots_controller.js
@@ -132,7 +132,6 @@ angular.module('BE.seed.controller.bluesky_taxlots_controller', [])
         saveFocus: false,
         saveGrouping: false,
         saveGroupingExpandedStates: false,
-        savePinning: false,
         saveScroll: false,
         saveSelection: false,
         saveTreeView: false,

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -16,6 +16,7 @@ angular.module('BE.seed.vendor_dependencies', [
     'ui.grid.exporter',
     'ui.grid.grouping',
     'ui.grid.moveColumns',
+    'ui.grid.pinning',
     'ui.grid.resizeColumns',
     'ui.grid.saveState',
     'ui.grid.treeView',

--- a/seed/static/seed/partials/bluesky/table.html
+++ b/seed/static/seed/partials/bluesky/table.html
@@ -1,3 +1,3 @@
 <div id="grid-container">
-    <div ui-grid="gridOptions" ui-grid-exporter ui-grid-move-columns ui-grid-resize-columns ui-grid-save-state ui-grid-tree-view></div>
+    <div ui-grid="gridOptions" ui-grid-exporter ui-grid-move-columns ui-grid-pinning ui-grid-resize-columns ui-grid-save-state ui-grid-tree-view></div>
 </div>


### PR DESCRIPTION
The bluesky grids now allow any columns to be pinned to the left or right, and for your settings to be saved.  By default, the first column in each grid is pinned.

IMPORTANT: You won't see the first column pinned unless you pin it yourself or reset the grid settings.  This is because you have already "saved" your grid state with no columns pinned since this wasn't a feature until now.  In the top-right grid menu, hit `Reset Settings`