### PR TITLE
1005 number of pages

### DIFF
--- a/config/settings/local_untracked.py.dist
+++ b/config/settings/local_untracked.py.dist
@@ -44,3 +44,20 @@ CACHES = {
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
 INTERNAL_IPS = ('127.0.0.1',)
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'level': 'ERROR',
+            'class': 'logging.StreamHandler'
+        }
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'DEBUG'),
+        },
+    },
+}

--- a/config/settings/local_untracked_docker.py
+++ b/config/settings/local_untracked_docker.py
@@ -88,3 +88,20 @@ CELERY_QUEUES = (
         routing_key=CELERY_DEFAULT_QUEUE
     ),
 )
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'level': 'ERROR',
+            'class': 'logging.StreamHandler'
+        }
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'DEBUG'),
+        },
+    },
+}

--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -196,7 +196,7 @@ angular.module('BE.seed.controller.building_list', [])
         label_service.get_labels().then(function(data) {
             // resolve promise
             $scope.labels = data.results;
- 
+
             // Load filtered labels from session storage and put them in selected_labels.
             if (!_.isUndefined(Storage) && sessionStorage.getItem($location.$$path + ':' + 'seedBuildingFilterParams') !== null) {
                 var filter_params = JSON.parse(sessionStorage.getItem($location.$$path + ':' + 'seedBuildingFilterParams'));
@@ -525,11 +525,13 @@ angular.module('BE.seed.controller.building_list', [])
             }
         });
 
-        $scope.search.init_storage($location.$$path);
+        // console.log("Storage " + $location.$$path)
+        // hardcoding the name of the storage and removing the preceding / to follow pattern of cleansing.
+        $scope.search.init_storage('buildings');
         get_columns();
         get_labels();
         init_matching_dropdown();
-
+        // console.log("number of pages " + $scope.search.num_pages())
     };
     init();
 }]);

--- a/seed/static/seed/js/controllers/building_list_controller.js
+++ b/seed/static/seed/js/controllers/building_list_controller.js
@@ -525,9 +525,8 @@ angular.module('BE.seed.controller.building_list', [])
             }
         });
 
-        // console.log("Storage " + $location.$$path)
-        // hardcoding the name of the storage and removing the preceding / to follow pattern of cleansing.
-        $scope.search.init_storage('buildings');
+        // console.log("Storage " + $location.$$path);
+        $scope.search.init_storage($location.$$path);
         get_columns();
         get_labels();
         init_matching_dropdown();

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -216,13 +216,38 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
             templateUrl: static_url + 'seed/partials/project_detail.html',
             resolve: {
                 search_payload: ['building_services', '$route', function(building_services, $route){
+                    var orderBy = '';
+                    var sortReverse = false;
                     var params = angular.copy($route.current.params);
+                    var q = params.q || '';
+                    var numberPerPage = 10;
                     var project_slug = params.project_id;
+                    var pageNumber = 1;
                     delete(params.project_id);
                     params.project__slug = project_slug;
-                    var q = params.q || '';
-                    // params: (query, number_per_page, page_number, order_by, sort_reverse, other_params, project_id, project_slug)
-                    return building_services.search_buildings(q, 10, 1, '', false, params, null, project_slug);
+
+                    // Check session storage for order, sort, and filter values.
+                    if (!_.isUndefined(Storage)) {
+
+                        var prefix = 'buildings';
+                        if (sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy') !== null) {
+                            orderBy = sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy');
+                        }
+                        if (sessionStorage.getItem(prefix + ':' + 'seedBuildingSortReverse') !== null) {
+                            sortReverse = JSON.parse(sessionStorage.getItem(prefix + ':' + 'seedBuildingSortReverse'));
+                        }
+                        if (sessionStorage.getItem(prefix + ':' + 'seedBuildingFilterParams') !== null) {
+                            params = JSON.parse(sessionStorage.getItem(prefix + ':' + 'seedBuildingFilterParams'));
+                        }
+                        if (sessionStorage.getItem(prefix + ':' + 'seedBuildingNumberPerPage') !== null) {
+                            numberPerPage = JSON.parse(sessionStorage.getItem(prefix + ':' + 'seedBuildingNumberPerPage'));
+                        }
+                        if (sessionStorage.getItem(prefix + ':' + 'seedBuildingPageNumber') !== null) {
+                            pageNumber = JSON.parse(sessionStorage.getItem(prefix + ':' + 'seedBuildingPageNumber'));
+                        }
+                    }
+                    // params: (query, number_per_page, page_number, order_by, sort_reverse, filter_params, project_id)
+                    return building_services.search_buildings(q, numberPerPage, pageNumber, orderBy, sortReverse, params, null);
                 }],
                 default_columns: ['user_service', function(user_service){
                     return user_service.get_default_columns();
@@ -300,7 +325,7 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                     // Check session storage for order, sort, and filter values.
                     if (!_.isUndefined(Storage)) {
 
-                        var prefix = $route.current.$$route.originalPath;
+                        var prefix = 'buildings';
                         if (sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy') !== null) {
                             orderBy = sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy');
                         }

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -229,7 +229,9 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                     // Check session storage for order, sort, and filter values.
                     if (!_.isUndefined(Storage)) {
 
-                        var prefix = 'buildings';
+                        // set the prefix to the specific project. This fixes
+                        // the issue where the filter was not persisting.
+                        var prefix = _.replace($route.current.$$route.originalPath, ':project_id', project_slug);
                         if (sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy') !== null) {
                             orderBy = sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy');
                         }
@@ -246,8 +248,8 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                             pageNumber = JSON.parse(sessionStorage.getItem(prefix + ':' + 'seedBuildingPageNumber'));
                         }
                     }
-                    // params: (query, number_per_page, page_number, order_by, sort_reverse, filter_params, project_id)
-                    return building_services.search_buildings(q, numberPerPage, pageNumber, orderBy, sortReverse, params, null);
+                    // params: (query_string, number_per_page, page_number, order_by, sort_reverse, filter_params, project_id, project_slug)
+                    return building_services.search_buildings(q, numberPerPage, pageNumber, orderBy, sortReverse, params, null, project_slug);
                 }],
                 default_columns: ['user_service', function(user_service){
                     return user_service.get_default_columns();
@@ -325,7 +327,8 @@ SEED_app.config(['$routeProvider', function ($routeProvider) {
                     // Check session storage for order, sort, and filter values.
                     if (!_.isUndefined(Storage)) {
 
-                        var prefix = 'buildings';
+                        var prefix = $route.current.$$route.originalPath;
+
                         if (sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy') !== null) {
                             orderBy = sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy');
                         }

--- a/seed/static/seed/js/services/building_service.js
+++ b/seed/static/seed/js/services/building_service.js
@@ -55,6 +55,18 @@ angular.module('BE.seed.service.building', ['BE.seed.services.label_helper'])
         return defer.promise;
     };
 
+      /**
+       *
+       * @param query_string
+       * @param number_per_page
+       * @param page_number
+       * @param order_by
+       * @param sort_reverse
+       * @param filter_params: If filter_params are provided, then project_slug will be ignored.
+       * @param project_id
+       * @param project_slug: Name of the project to constrain the query.
+       * @returns {Promise}
+       */
     building_factory.search_buildings = function(query_string, number_per_page, page_number, order_by, sort_reverse, filter_params, project_id, project_slug) {
         spinner_utility.show();
         var defer = $q.defer();

--- a/seed/static/seed/js/services/search_service.js
+++ b/seed/static/seed/js/services/search_service.js
@@ -209,10 +209,9 @@ angular.module('BE.seed.service.search', [])
         this.number_matching_search = data.number_matching_search || 0;
         this.alert = false;
         this.error_message = '';
-        // This is not right, the number per page is not being updated when it is changed
+        // Num Pages is now a method to allow for it to be up to date.
         // console.log("Number per page: " + this.number_per_page);
-        console.log("Number per page: " + this.number_per_page);
-        console.log("Number of pages: " + this.num_pages());
+        // console.log("Number of pages: " + this.num_pages());
 
         this.update_start_end_paging();
         this.update_buttons();

--- a/seed/static/seed/js/services/search_service.js
+++ b/seed/static/seed/js/services/search_service.js
@@ -39,7 +39,11 @@ angular.module('BE.seed.service.search', [])
   '$http',
   '$q',
   'spinner_utility',
-  function ($http, $q, spinner_utility) {
+  function(
+      $http,
+      $q,
+      spinner_utility
+  ) {
     /************
      * variables
      */
@@ -59,7 +63,6 @@ angular.module('BE.seed.service.search', [])
         order_by: '',
         sort_reverse: false,
         is_loading: false,
-        num_pages: 0,
         query: '',
         number_per_page_options: [10, 25, 50, 100],
         number_per_page_options_model: 10,
@@ -200,14 +203,17 @@ angular.module('BE.seed.service.search', [])
     search_service.update_results = function(data) {
         // safely handle no data back
         saas = this;
+
         data = data || {};
         this.buildings = data.buildings || [];
         this.number_matching_search = data.number_matching_search || 0;
         this.alert = false;
         this.error_message = '';
-        this.num_pages = Math.ceil(
-            this.number_matching_search / this.number_per_page
-        );
+        // This is not right, the number per page is not being updated when it is changed
+        // console.log("Number per page: " + this.number_per_page);
+        console.log("Number per page: " + this.number_per_page);
+        console.log("Number of pages: " + this.num_pages());
+
         this.update_start_end_paging();
         this.update_buttons();
         this.select_or_deselect_all_buildings();
@@ -225,7 +231,6 @@ angular.module('BE.seed.service.search', [])
             sessionStorage.setItem(this.prefix + ':' + 'seedBuildingFilterParams', JSON.stringify(this.filter_params));
         }
     };
-
 
 
     /**
@@ -252,7 +257,7 @@ angular.module('BE.seed.service.search', [])
      *   1,000 buildings` and is called after a successful search
      */
     search_service.update_start_end_paging = function() {
-        if (this.current_page === this.num_pages) {
+        if (this.current_page === this.num_pages()) {
             this.showing.end = this.number_matching_search;
         } else {
             this.showing.end = this.current_page * this.number_per_page;
@@ -271,11 +276,21 @@ angular.module('BE.seed.service.search', [])
     };
 
     /**
+    * num_pages: return the number of pages that are expected based on the
+    * total matches and the number_per_page setting
+    */
+    search_service.num_pages = function() {
+        return Math.ceil(
+            this.number_matching_search / this.number_per_page
+        );
+    };
+
+      /**
     * last_page: triggered when the `last` paging button is clicked, it
     *   sets the page to the last in the results, and fetches that page
     */
     search_service.last_page = function() {
-      this.current_page = this.num_pages;
+      this.current_page = this.num_pages();
       this.search_buildings();
     };
 
@@ -285,8 +300,8 @@ angular.module('BE.seed.service.search', [])
      */
     search_service.next_page = function() {
         this.current_page += 1;
-        if (this.current_page > this.num_pages) {
-            this.current_page = this.num_pages;
+        if (this.current_page > this.num_pages()) {
+            this.current_page = this.num_pages();
         }
         if (!_.isUndefined(Storage)) {
             sessionStorage.setItem(saas.prefix + ':' + 'seedBuildingPageNumber', this.current_page);
@@ -315,7 +330,7 @@ angular.module('BE.seed.service.search', [])
     search_service.update_buttons = function() {
         // body goes here
         this.prev_page_disabled = this.current_page === 1;
-        this.next_page_disabled = this.current_page === this.num_pages;
+        this.next_page_disabled = this.current_page === this.num_pages();
     };
     /**
      * end pagination code


### PR DESCRIPTION
#### Any background context you want to provide?
There were many errors in Sentry where the user tried to access a page in the building list that wasn't allowed. This addresses the issue by making the number of pages a method that is called.

Also, the building view of project buildings did not have the number of items, filters, etc in the local storage. This was updated.

Note that the filters for a project and all buildings are now the same. If you go from one to the other, the filters/settings persist.

#### What's this PR do?
Fixes the most prevalent sentry error.

#### How should this be manually tested?
List all the buildings and change from 10 -> 100. Go out, then come back to the view and click `last record`. It should return the results immediately (before it just hung).

Open up a project (list the buildings), and make sure the number of items and filters stick when clicking around.

#### What are the relevant tickets?
#1005 

#### Screenshots (if appropriate)
#### Definition of Done:
- [X] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.) None.
- [X] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs). It should, but I don't think this is setup yet.
- [X] Does this PR require a regression test? All fixes require a regression test. No
- [X] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated? No