### PR TITLE
return json when invalid organization is passed, catch the error nicely

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 # Test dependencies go here. The local and test are the same at the moment.
 -r base.txt
 coverage==3.7.1
-django-nose==1.4.1
+django-nose==1.4.4
 flake8==2.5.2
 mock==1.0.1
 nose==1.3.7

--- a/seed/decorators.py
+++ b/seed/decorators.py
@@ -8,7 +8,7 @@ import json
 from functools import wraps
 
 from django.core.serializers.json import DjangoJSONEncoder
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import HttpResponse
 
 from seed.utils.cache import make_key, lock_cache, unlock_cache, get_lock
 

--- a/seed/decorators.py
+++ b/seed/decorators.py
@@ -136,9 +136,9 @@ def require_organization_id(func):
         if error:
             format_type = 'application/json'
             message = {
-                        'status': 'error',
-                        'message': 'Invalid organization_id: either blank or not an integer'
-                       }
+                'status': 'error',
+                'message': 'Invalid organization_id: either blank or not an integer'
+            }
 
             # NL: I think the error code should be 401: unauthorized, not 400: bad request.
             # Leaving as 400 for now in case this breaks something else.

--- a/seed/decorators.py
+++ b/seed/decorators.py
@@ -118,19 +118,34 @@ def ajax_request(func):
     return wrapper
 
 
-def require_organization_id(fn):
+def require_organization_id(func):
     """
     Validate that organization_id is in the GET params and it's an int.
     """
-    @wraps(fn)
+
+    @wraps(func)
     def _wrapped(request, *args, **kwargs):
 
+        error = False
         try:
             int(request.GET['organization_id'])
-        except (KeyError, ValueError):
-            return HttpResponseBadRequest('Valid organization ID is required.')
+        except (ValueError, KeyError):
+            error = True
+            pass
 
-        return fn(request, *args, **kwargs)
+        if error:
+            format_type = 'application/json'
+            message = {
+                        'status': 'error',
+                        'message': 'Invalid organization_id: either blank or not an integer'
+                       }
+
+            # NL: I think the error code should be 401: unauthorized, not 400: bad request.
+            # Leaving as 400 for now in case this breaks something else.
+            return HttpResponse(json.dumps(message), content_type=format_type, status=400)
+        else:
+            return func(request, *args, **kwargs)
+
     return _wrapped
 
 

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -1576,6 +1576,29 @@ class GetDatasetsViewsTests(TestCase):
         response = self.client.get(reverse("seed:get_datasets"), {'organization_id': self.org.pk})
         self.assertEqual(1, len(json.loads(response.content)['datasets']))
 
+    def test_get_datasets_count(self):
+        import_record = ImportRecord.objects.create(owner=self.user)
+        import_record.super_organization = self.org
+        import_record.save()
+        response = self.client.get(reverse("seed:get_datasets_count"),
+                                   {'organization_id': self.org.pk})
+        self.assertEqual(200, response.status_code)
+        j = json.loads(response.content)
+        self.assertEqual(j['status'], 'success')
+        self.assertEqual(j['datasets_count'], 1)
+
+    def test_get_datasets_count_invalid(self):
+        import_record = ImportRecord.objects.create(owner=self.user)
+        import_record.super_organization = self.org
+        import_record.save()
+        response = self.client.get(reverse("seed:get_datasets_count"),
+                                   {'organization_id': 666})
+        self.assertEqual(400, response.status_code)
+        j = json.loads(response.content)
+        self.assertEqual(j['status'], 'error')
+        self.assertEqual(j['message'],
+                         'Could not find organization_id: 666')
+
     def test_get_dataset(self):
         import_record = ImportRecord.objects.create(owner=self.user)
         import_record.super_organization = self.org

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -627,7 +627,6 @@ def get_datasets_count(request):
                             status=400)
 
 
-
 @ajax_request
 def public_search(request):
     """the public API unauthenticated endpoint

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -20,7 +20,7 @@ from django.contrib.auth.decorators import login_required, permission_required
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import DefaultStorage
 from django.db.models import Q
-from django.http import HttpResponseBadRequest
+from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render_to_response
 from django.template.context import RequestContext
 
@@ -610,10 +610,22 @@ def get_datasets_count(request):
         }
 
     """
-    datasets_count = Organization.objects.get(
-        pk=request.GET['organization_id']).import_records.all().distinct().count()
+    org_id = request.GET['organization_id']
 
-    return {'status': 'success', 'datasets_count': datasets_count}
+    # first make sure that the organization id exists
+    if Organization.objects.filter(pk=request.GET['organization_id']).exists():
+        datasets_count = Organization.objects.get(pk=org_id).import_records.\
+            all().distinct().count()
+        return {'status': 'success', 'datasets_count': datasets_count}
+    else:
+        message = {
+            'status': 'error',
+            'message': 'Could not find organization_id: {}'.format(org_id)
+        }
+        return HttpResponse(json.dumps(message),
+                            content_type='application/json',
+                            status=400)
+
 
 
 @ajax_request


### PR DESCRIPTION
#### Any background context you want to provide?
See #1008.

There were many errors on sentry related to this bug. I have not determined what action on the front end is causing this, but this PR will allow for the app to continue.

#### What's this PR do?
Makes the error of org id not existing explicit and a JSON. Before it was a string result.

#### How should this be manually tested?
Normal monkey testing.

#### What are the relevant tickets?
#1008 

#### Definition of Done:
- [X] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.). Tests were added
- [X] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs). No
- [X] Does this PR require a regression test? All fixes require a regression test. No
- [X] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated? Yeah, I updated django-nose
