### PR TITLE
Bluesky Cycle Saving

### DIFF
--- a/seed/static/seed/js/controllers/bluesky_properties_controller.js
+++ b/seed/static/seed/js/controllers/bluesky_properties_controller.js
@@ -5,14 +5,12 @@
 angular.module('BE.seed.controller.bluesky_properties_controller', [])
   .controller('bluesky_properties_controller', [
     '$scope',
-    '$routeParams',
     '$window',
     'bluesky_service',
     'properties',
     'cycles',
     'columns',
     function ($scope,
-              $routeParams,
               $window,
               bluesky_service,
               properties,
@@ -24,8 +22,9 @@ angular.module('BE.seed.controller.bluesky_properties_controller', [])
       $scope.number_per_page = 999999999;
       $scope.restoring = false;
 
+      var lastCycleId = bluesky_service.get_last_cycle();
       $scope.cycle = {
-        selected_cycle: cycles[0],
+        selected_cycle: lastCycleId ? _.find(cycles, {pk: lastCycleId}) : cycles[0],
         cycles: cycles
       };
 
@@ -68,6 +67,7 @@ angular.module('BE.seed.controller.bluesky_properties_controller', [])
       };
 
       $scope.update_cycle = function (cycle) {
+        bluesky_service.save_last_cycle(cycle.pk);
         $scope.cycle.selected_cycle = cycle;
         refresh_objects();
       };

--- a/seed/static/seed/js/controllers/bluesky_taxlots_controller.js
+++ b/seed/static/seed/js/controllers/bluesky_taxlots_controller.js
@@ -5,14 +5,12 @@
 angular.module('BE.seed.controller.bluesky_taxlots_controller', [])
   .controller('bluesky_taxlots_controller', [
     '$scope',
-    '$routeParams',
     '$window',
     'bluesky_service',
     'taxlots',
     'cycles',
     'columns',
     function ($scope,
-              $routeParams,
               $window,
               bluesky_service,
               taxlots,
@@ -24,8 +22,9 @@ angular.module('BE.seed.controller.bluesky_taxlots_controller', [])
       $scope.number_per_page = 999999999;
       $scope.restoring = false;
 
+      var lastCycleId = bluesky_service.get_last_cycle();
       $scope.cycle = {
-        selected_cycle: cycles[0],
+        selected_cycle: lastCycleId ? _.find(cycles, {pk: lastCycleId}) : cycles[0],
         cycles: cycles
       };
 
@@ -68,6 +67,7 @@ angular.module('BE.seed.controller.bluesky_taxlots_controller', [])
       };
 
       $scope.update_cycle = function (cycle) {
+        bluesky_service.save_last_cycle(cycle.pk);
         $scope.cycle.selected_cycle = cycle;
         refresh_objects();
       };

--- a/seed/static/seed/js/services/bluesky_service.js
+++ b/seed/static/seed/js/services/bluesky_service.js
@@ -18,8 +18,12 @@ angular.module('BE.seed.service.bluesky_service', []).factory('bluesky_service',
         per_page: per_page || 999999999
       };
 
+      var lastCycleId = bluesky_service.get_last_cycle();
       if (cycle) {
         params.cycle = cycle.pk;
+        bluesky_service.save_last_cycle(cycle.pk);
+      } else if (_.isInteger(lastCycleId)) {
+        params.cycle = lastCycleId;
       }
 
       var defer = $q.defer();
@@ -42,8 +46,12 @@ angular.module('BE.seed.service.bluesky_service', []).factory('bluesky_service',
         per_page: per_page || 999999999
       };
 
+      var lastCycleId = bluesky_service.get_last_cycle();
       if (cycle) {
         params.cycle = cycle.pk;
+        bluesky_service.save_last_cycle(cycle.pk);
+      } else if (_.isInteger(lastCycleId)) {
+        params.cycle = lastCycleId;
       }
 
       var defer = $q.defer();
@@ -73,6 +81,19 @@ angular.module('BE.seed.service.bluesky_service', []).factory('bluesky_service',
         defer.reject(data, status);
       });
       return defer.promise;
+    };
+
+    bluesky_service.get_last_cycle = function () {
+      var organization_id = user_service.get_organization().id,
+        pk = (JSON.parse(sessionStorage.getItem('cycles')) || {})[organization_id];
+      return pk;
+    };
+
+    bluesky_service.save_last_cycle = function (pk) {
+      var organization_id = user_service.get_organization().id,
+        cycles = JSON.parse(sessionStorage.getItem('cycles')) || {};
+      cycles[organization_id] = _.toInteger(pk);
+      sessionStorage.setItem('cycles', JSON.stringify(cycles));
     };
 
     bluesky_service.get_property_columns = function () {


### PR DESCRIPTION
Saves the chosen cycle between property/taxlot views for each organization.  The selected cycle will persist for the duration of the session, after which point it will default back to the first choice.