### PR TITLE
Override exception flag from access mixin in our derived class

### DIFF
--- a/seed/views/datasets.py
+++ b/seed/views/datasets.py
@@ -25,6 +25,8 @@ _log = logging.getLogger(__name__)
 
 
 class DatasetViewSet(LoginRequiredMixin, viewsets.ViewSet):
+    raise_exception = True
+
     @require_organization_id_class
     @api_endpoint_class
     @ajax_request_class
@@ -74,7 +76,6 @@ class DatasetViewSet(LoginRequiredMixin, viewsets.ViewSet):
                 description: The datasets
                 type: object
         """
-
         org_id = request.query_params.get('organization_id', None)
         from seed.models import obj_to_dict
         org = Organization.objects.get(pk=org_id)

--- a/seed/views/organizations.py
+++ b/seed/views/organizations.py
@@ -152,6 +152,7 @@ _log = logging.getLogger(__name__)
 
 
 class OrganizationViewSet(LoginRequiredMixin, viewsets.ViewSet):
+    raise_exception = True
 
     @api_endpoint_class
     @ajax_request_class


### PR DESCRIPTION
#### Any background context you want to provide?
The Swagger page wasn't behaving nicely when the user wasn't logged in.  It was trying to access a class member that didn't exist in our structure, so the exception was a Python exception traceback and not a nice response.  

#### What's this PR do?
This PR simply adds a class member variable that overrides a variable on the inherited class.  This variable tells the logged-out code to throw an exception that can be caught nicely and return a 403 instead of trying to access an invalid member.

#### How should this be manually tested?
Well, the existing response when you aren't logged in looks like this:

![image](https://cloud.githubusercontent.com/assets/849824/17236680/df86a906-5507-11e6-8d28-f82c787d2932.png)

Not great.  With this fix, it looks like this:

![image](https://cloud.githubusercontent.com/assets/849824/17236648/ce63287a-5507-11e6-818e-de485e536558.png)

Maybe it could be polished a little, but it's way better, and clear to the user that they don't have permission to access the underlying views, and should clue them in to logging in.

#### What are the relevant tickets?
#1039 

#### Definition of Done:
- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [ ] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [ ] Does this PR require a regression test? All fixes require a regression test.
- [ ] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?
… doesnt have a request member