### PR TITLE
Fix for #1031 cut against release 1.5.0

### DIFF
--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -1555,6 +1555,49 @@ class SearchBuildingSnapshotsViewTests(TestCase):
         )
         self.assertEqual(1, json.loads(response.content)['number_returned'])
 
+    def test_search_building_snapshots_extra_data_order_by(self):
+            """
+            Test to ensure search_building_snapshot correctly handles
+            order_by when it is an extra data field.
+            """
+            import_record = ImportRecord.objects.create(owner=self.user)
+            import_record.super_organization = self.org
+            import_record.save()
+            import_file = ImportFile.objects.create(
+                import_record=import_record
+            )
+            cb1 = CanonicalBuilding(active=True)
+            cb1.save()
+            b1 = SEEDFactory.building_snapshot(
+                canonical_building=cb1,
+                address_line_1="test",
+                import_file=import_file,
+                source_type=ASSESSED_BS,
+                extra_data= {'nearest_national_park': 'mt hood'}
+            )
+            cb1.canonical_snapshot = b1
+            cb1.save()
+            b1.super_organization = self.org
+            b1.save()
+            post_data = {
+                'filter_params': {},
+                'number_per_page': 10,
+                'order_by': 'nearest_national_park',
+                'page': 1,
+                'q': '',
+                'sort_reverse': False,
+                'project_id': None,
+                'import_file_id': import_file.pk
+            }
+
+            # act
+            response = self.client.post(
+                reverse_lazy("seed:search_building_snapshots"),
+                content_type='application/json',
+                data=json.dumps(post_data)
+            )
+            self.assertEqual(1, json.loads(response.content)['number_returned'])
+
 
 class GetDatasetsViewsTests(TestCase):
 

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -1573,7 +1573,7 @@ class SearchBuildingSnapshotsViewTests(TestCase):
                 address_line_1="test",
                 import_file=import_file,
                 source_type=ASSESSED_BS,
-                extra_data= {'nearest_national_park': 'mt hood'}
+                extra_data={'nearest_national_park': 'mt hood'}
             )
             cb1.canonical_snapshot = b1
             cb1.save()

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -79,7 +79,7 @@ DEFAULT_CUSTOM_COLUMNS = [
 ]
 
 BUILDING_SNAPSHOT_FIELDS = [
-        col.name for col in BuildingSnapshot._meta.get_fields()
+    col.name for col in BuildingSnapshot._meta.get_fields()
 ]
 
 _log = logging.getLogger(__name__)

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -20,6 +20,7 @@ from django.contrib.auth.decorators import login_required, permission_required
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import DefaultStorage
 from django.db.models import Q
+from django.db.models.expressions import RawSQL
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render_to_response
 from django.template.context import RequestContext
@@ -75,6 +76,10 @@ DEFAULT_CUSTOM_COLUMNS = [
     'address_line_1',
     'city',
     'state_province',
+]
+
+BUILDING_SNAPSHOT_FIELDS = [
+        col.name for col in BuildingSnapshot._meta.get_fields()
 ]
 
 _log = logging.getLogger(__name__)
@@ -773,10 +778,20 @@ def search_building_snapshots(request):
         order_by = "-%s" % order_by
 
     # only search in ASSESED_BS, PORTFOLIO_BS, GREEN_BUTTON_BS
-    building_snapshots = BuildingSnapshot.objects.order_by(order_by).filter(
-        import_file__pk=import_file_id,
-        source_type__in=[ASSESSED_BS, PORTFOLIO_BS, GREEN_BUTTON_BS],
-    )
+
+    if order_by not in BUILDING_SNAPSHOT_FIELDS:
+        # for Extra data fieles
+        building_snapshots = BuildingSnapshot.objects.order_by(
+            RawSQL("extra_data->>%s", (order_by,))
+        ).filter(
+            import_file__pk=import_file_id,
+            source_type__in=[ASSESSED_BS, PORTFOLIO_BS, GREEN_BUTTON_BS],
+        )
+    else:
+        building_snapshots = BuildingSnapshot.objects.order_by(order_by).filter(
+            import_file__pk=import_file_id,
+            source_type__in=[ASSESSED_BS, PORTFOLIO_BS, GREEN_BUTTON_BS],
+        )
 
     fieldnames = [
         'pm_property_id',


### PR DESCRIPTION
Cut against release 1.5.0  branch.
- error was caused when an extra data field was used in an order by query, as this is not supported by Django
- added a raw sql query for order_by when order_by is an extra data field.

#### What's this PR do?
Add an alternate means of resolving order_by query in search_building_snapshots when the field is an extra data field 
#### How should this be manually tested?
Upload data containing columns that will need to be stored as extra data. At the end of Step 1 - Map Your Data, click on an extra data column and verify the page loads correctly
#### What are the relevant tickets?
#1031
#### Screenshots (if appropriate)#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a regression test? All fixes require a regression test.
