### PR TITLE
Fix can't delete data in extra_data fields in Building Detail #1027

### DIFF
--- a/seed/mappings/mapper.py
+++ b/seed/mappings/mapper.py
@@ -77,7 +77,7 @@ def merge_extra_data(b1, b2, default=None, allow_delete=False):
     ..Note:
 
         If default is neither b1 or b2 b1 becomes the default and b2
-        is silently ignored. Thus you *cannot* supply a diferent default
+        is silently ignored. Thus you *cannot* supply a different default
         and merge b1 and b2 (with the default supplying default values for
         keys not present (or null) in b1 and b2.
 
@@ -92,12 +92,14 @@ def merge_extra_data(b1, b2, default=None, allow_delete=False):
     :type allow_delete: Bool.
 
     :returns tuple of dict:
+
     .. code-block::python
 
         # first dict contains values, second the source pks.
         ({'data': 'value'}, {'data': 23},)
 
     :Example:
+
     >>> b1.extra_data
     {'key1': 1, 'key2': '', 'key3': 3}
     >>> b2.extra_data

--- a/seed/mappings/mapper.py
+++ b/seed/mappings/mapper.py
@@ -57,18 +57,60 @@ def get_source_id(source_inst, attr):
     )
 
 
-def merge_extra_data(b1, b2, default=None):
-    """Merge extra_data field between two BuildingSnapshots, return result.
+def merge_extra_data(b1, b2, default=None, allow_delete=False):
+    """
+    Merge extra_data field between two BuildingSnapshots, return result.
+
+    If the 'default' parameter is not specified b1 will be set as the
+    default.
+
+    The merged result contains all keys from both sets. By default the
+    values from the default set will override the values from the
+    non-default set, unless the default values are null (e.g. an
+    empty string).
+
+    Setting allow_delete to True alters this behavior so that null/blank
+    values in the default set will propagate to the merged set if the key
+    is present in the default set. This allows for 'deleting' extra data
+    fields (or rather setting them to null).
+
+    ..Note:
+
+        If default is neither b1 or b2 b1 becomes the default and b2
+        is silently ignored. Thus you *cannot* supply a diferent default
+        and merge b1 and b2 (with the default supplying default values for
+        keys not present (or null) in b1 and b2.
 
     :param b1: BuildingSnapshot inst.
     :param b2: BuildingSnapshot inst.
     :param default: BuildingSnapshot inst.
-    :returns tuple of dict:
+    :param allow_delete: allow the new data to delete field contents.
 
+    :type b1: BuildingSnapshot inst.
+    :type b2: BuildingSnapshot inst.
+    :type default: BuildingSnapshot inst.
+    :type allow_delete: Bool.
+
+    :returns tuple of dict:
     .. code-block::python
 
         # first dict contains values, second the source pks.
         ({'data': 'value'}, {'data': 23},)
+
+    :Example:
+    >>> b1.extra_data
+    {'key1': 1, 'key2': '', 'key3': 3}
+    >>> b2.extra_data
+    {'key1': 0, 'key2': 2, 'key4': 4}
+    >>> extra_data, _ = merge_extra_data(b1, b2)
+    >>> extra_data
+    {'key1': 1, 'key2': 2, 'key3': 3, 'key4': 4}
+    >>> extra_data, _ = merge_extra_data(b1, b2, default=b2)
+    >>> extra_data
+    {'key1': 0, 'key2': 2, 'key3': 3, 'key4': 4}
+    >>> extra_data, _ = merge_extra_data(b1, b2, allow_delete=True)
+    >>> extra_data
+    {'key1': 1, 'key2': '', 'key3': 3, 'key4': 4}
 
     """
     default = default or b1
@@ -81,10 +123,18 @@ def merge_extra_data(b1, b2, default=None):
     non_default_extra_data = getattr(non_default, 'extra_data', {})
 
     all_keys = set(default_extra_data.keys() + non_default_extra_data.keys())
-    extra_data = {
-        k: default_extra_data.get(k) or non_default_extra_data.get(k)
-        for k in all_keys
-    }
+
+    if allow_delete:
+        extra_data = {
+            k: default_extra_data[k] if k in default_extra_data
+            else non_default_extra_data[k]
+            for k in all_keys
+        }
+    else:
+        extra_data = {
+            k: default_extra_data.get(k) or non_default_extra_data.get(k)
+            for k in all_keys
+        }
 
     for item in extra_data:
         if item in default_extra_data and default_extra_data[item]:

--- a/seed/models.py
+++ b/seed/models.py
@@ -517,7 +517,9 @@ def _get_diff_sources(mappable, old_snapshot):
     return results
 
 
-def update_building(old_snapshot, updated_values, user, *args, **kwargs):
+def update_building(old_snapshot, updated_values, user,
+                    allow_delete_extra_data=False,
+                    *args, **kwargs):                   # Why?
     """Creates a new snapshot with updated values."""
     from seed.mappings import seed_mappings, mapper as seed_mapper
 
@@ -565,7 +567,8 @@ def update_building(old_snapshot, updated_values, user, *args, **kwargs):
 
     # Update/override anything in extra data.
     extra, sources = seed_mapper.merge_extra_data(
-        new_snapshot, old_snapshot, default=new_snapshot
+        new_snapshot, old_snapshot, default=new_snapshot,
+        allow_delete=allow_delete_extra_data
     )
     new_snapshot.extra_data = extra
     new_snapshot.extra_data_sources = sources

--- a/seed/tests/test_models.py
+++ b/seed/tests/test_models.py
@@ -360,6 +360,40 @@ class TestBuildingSnapshot(TestCase):
         self.assertDictEqual(actual_extra, expected_extra)
         self.assertDictEqual(actual_sources, expected_sources)
 
+    def test_merge_extra_data_does_override_with_blank_data(self):
+        """Test that blank fields in extra data does override real data
+        if allow_delete is True.
+        """
+        self.bs1.extra_data = {
+            'field_a': 'data-1a',
+            'field_b': '',
+            'field_c': '',
+        }
+        self.bs1.save()
+
+        self.bs2.extra_data = {
+            'field_a': 'data-2a',
+            'field_b': 'data-2b',
+            'field_c': '',
+        }
+        self.bs2.save()
+
+        expected_extra = {
+            'field_a': 'data-1a',
+            'field_b': '',
+            'field_c': '',
+        }
+        expected_sources = {
+            'field_a': self.bs1.pk,
+            'field_b': self.bs2.pk,
+            'field_c': self.bs1.pk,
+        }
+
+        actual_extra, actual_sources = mapper.merge_extra_data(self.bs1, self.bs2)
+
+        self.assertDictEqual(actual_extra, expected_extra)
+        self.assertDictEqual(actual_sources, expected_sources)
+
     def test_update_building(self):
         """Good case for updating a building."""
         fake_building_extra = {

--- a/seed/tests/test_models.py
+++ b/seed/tests/test_models.py
@@ -389,7 +389,9 @@ class TestBuildingSnapshot(TestCase):
             'field_c': self.bs1.pk,
         }
 
-        actual_extra, actual_sources = mapper.merge_extra_data(self.bs1, self.bs2)
+        actual_extra, actual_sources = mapper.merge_extra_data(
+            self.bs1, self.bs2, allow_delete=True
+        )
 
         self.assertDictEqual(actual_extra, expected_extra)
         self.assertDictEqual(actual_sources, expected_sources)

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -2199,7 +2199,9 @@ def update_building(request):
     canon = CanonicalBuilding.objects.get(pk=building['canonical_building'])
     old_snapshot = canon.canonical_snapshot
 
-    new_building = models.update_building(old_snapshot, building, request.user)
+    new_building = models.update_building(
+        old_snapshot, building, request.user, allow_delete_extra_data=True
+    )
 
     resp = {'status': 'success',
             'child_id': new_building.pk}


### PR DESCRIPTION
 -  adds allow_delete parameter to seed.mappings.mapper.merge_extra_data        
        if allow_delete is True extra_data fields can be set to null.
 -  adds allow_delete_extra_data to seed.models.update_building
        value is passed to merge_extra_data
 -  sets allow_delete_extra_data=True in the call to update_buildings in
        seed.views.main.update_building view

#### What's this PR do?
Allows users to "delete" (set to null) extra data fields when updating buildings

#### How should this be manually tested?
Edit a building with extra data fields in the Building Details view, by blanking the relevant box and saving. Visit Buildings List view to ensure previous value is no longer there.

#### What are the relevant tickets?
#1027 
#### Definition of Done:
- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [ ] Does this PR require a regression test? All fixes require a regression test.

Note tests won't run if you have migrated to develop.