### PR TITLE
allow null cycles in views of properties and taxlots

### DIFF
--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -63,7 +63,8 @@ def get_properties(request):
         cycle = Cycle.objects.get(organization_id=request.GET['organization_id'], pk=cycle_id)
     else:
         cycle = Cycle.objects.filter(organization_id=request.GET['organization_id'])
-        cycle = cycle.lastest() if cycle else None
+        print cycle.__class__
+        cycle = cycle.latest() if cycle else None
         # TODO: Need to catch if the cycle does not exist and return nice error
 
     property_views_list = PropertyView.objects.select_related('property', 'state', 'cycle') \
@@ -189,7 +190,7 @@ def get_taxlots(request):
         cycle = Cycle.objects.get(organization_id=request.GET['organization_id'], pk=cycle_id)
     else:
         cycle = Cycle.objects.filter(organization_id=request.GET['organization_id'])
-        cycle = cycle.lastest() if cycle else None
+        cycle = cycle.latest() if cycle else None
         # TODO: Need to catch if the cycle does not exist and return nice error
 
     taxlot_views_list = TaxLotView.objects.select_related('taxlot', 'state', 'cycle') \

--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -58,12 +58,13 @@ def get_properties(request):
     page = request.GET.get('page', 1)
     per_page = request.GET.get('per_page', 1)
 
-    # TODO: Need to catch if the cycle does not exist and return nice error
     cycle_id = request.GET.get('cycle')
     if cycle_id:
         cycle = Cycle.objects.get(organization_id=request.GET['organization_id'], pk=cycle_id)
     else:
-        cycle = Cycle.objects.filter(organization_id=request.GET['organization_id']).latest()
+        cycle = Cycle.objects.filter(organization_id=request.GET['organization_id'])
+        cycle = cycle.lastest() if cycle else None
+        # TODO: Need to catch if the cycle does not exist and return nice error
 
     property_views_list = PropertyView.objects.select_related('property', 'state', 'cycle') \
         .filter(property__organization_id=request.GET['organization_id'], cycle=cycle)
@@ -187,7 +188,9 @@ def get_taxlots(request):
     if cycle_id:
         cycle = Cycle.objects.get(organization_id=request.GET['organization_id'], pk=cycle_id)
     else:
-        cycle = Cycle.objects.filter(organization_id=request.GET['organization_id']).latest()
+        cycle = Cycle.objects.filter(organization_id=request.GET['organization_id'])
+        cycle = cycle.lastest() if cycle else None
+        # TODO: Need to catch if the cycle does not exist and return nice error
 
     taxlot_views_list = TaxLotView.objects.select_related('taxlot', 'state', 'cycle') \
         .filter(taxlot__organization_id=request.GET['organization_id'], cycle=cycle)


### PR DESCRIPTION
#### Any background context you want to provide?
Views of tax lots and properties were crashing when the cycle was not found. 

#### What's this PR do?
Added a simple guard to prevent .latest() from being called on None.

#### How should this be manually tested?
View properties

#### What are the relevant tickets?
None

#### Screenshots (if appropriate)

#### Definition of Done:
- [X] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [X] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [X] Does this PR require a regression test? All fixes require a regression test.
- [X] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?
