### PR TITLE
migrate_labels manage command now uses property.labels etc

### DIFF
--- a/seed/management/commands/migrate_labels.py
+++ b/seed/management/commands/migrate_labels.py
@@ -5,36 +5,53 @@ associates labels with PropertyViews and with TaxLotViews.
 
 from __future__ import unicode_literals
 
-from seed.models import CanonicalBuilding
-from seed.models import PropertyView
-from seed.models import TaxLotView
+from django.apps import apps
+from django.core.management.base import BaseCommand
+from django.core.exceptions import ObjectDoesNotExist
+
+from seed.models import (
+    CanonicalBuilding, Property, PropertyView, TaxLot, TaxLotView
+)
 
 from _localtools import get_core_organizations
 
-from django.core.management.base import BaseCommand
-from seed.lib.superperms.orgs.models import Organization
-from django.core.exceptions import ObjectDoesNotExist
+PropertyLabels = apps.get_model("seed", "Property_labels")
+TaxLotLabels = apps.get_model("seed", "TaxLot_labels")
 
 
 class Command(BaseCommand):
         def add_arguments(self, parser):
             parser.add_argument('--org', dest='organization', default=False)
 
-            parser.add_argument('--clear-bluesky-labels', dest='clear_bluesky_labels', default=False, action="store_true",
-                                help="Delete all labels associated with all View objects")
+            parser.add_argument(
+                '--clear-bluesky-labels', dest='clear_bluesky_labels',
+                default=False, action="store_true",
+                help="Delete all labels associated with all View objects"
+            )
 
-            parser.add_argument('--labels-add-property-labels', dest='add_property_labels', default=True, action="store_true",
-                                help="Create labels for PropertyView Objects")
-            parser.add_argument('--labels-no-add-property-labels', dest='add_property_labels', default=True, action="store_false",
-                                help="Do not create Labels to Property View Objects")
+            parser.add_argument(
+                '--labels-add-property-labels', dest='add_property_labels',
+                default=True, action="store_true",
+                help="Create labels for Property Objects"
+            )
+            parser.add_argument(
+                '--labels-no-add-property-labels', dest='add_property_labels',
+                default=True, action="store_false",
+                help="Do not create Labels to Property Objects"
+            )
 
-            parser.add_argument('--labels-add-taxlot-labels', dest='add_taxlot_labels', default=True, action="store_true",
-                                help="Create labels on TaxLotView objects")
+            parser.add_argument(
+                '--labels-add-taxlot-labels', dest='add_taxlot_labels',
+                default=True, action="store_true",
+                help="Create labels on TaxLot objects"
+            )
 
-            parser.add_argument('--labels-no-add-taxlot-labels', dest='add_taxlot_labels', default=True, action="store_false",
-                                help="Do not create labels on TaxLotView objects")
+            parser.add_argument(
+                '--labels-no-add-taxlot-labels', dest='add_taxlot_labels',
+                default=True, action="store_false",
+                help="Do not create labels on TaxLot objects"
+            )
             return
-
 
         def handle(self, *args, **options):
             # Process Arguments
@@ -51,30 +68,41 @@ class Command(BaseCommand):
             for org_id in organization_ids:
 
                 ##############################
-                # Handle the clear case.  This is a bit inelegant the
-                # way the loop on org_ids is setup.
+                # Handle the clear case.
                 if clear_bluesky_labels:
-                    print "Org={}: Clearing all labels on PropertyView and TaxLotView objects.".format(org_id)
-                    for pv in PropertyView.objects.filter(property__organization = org_id).all():
-                        pv.labels.clear()
-                    for tlv in TaxLotView.objects.filter(taxlot__organization = org_id).all():
-                        tlv.labels.clear()
+                    print "Org={}: Clearing all labels on Property and TaxLot objects.".format(org_id)
+                    property_ids = Property.objects.filter(
+                        organization_id=org_id
+                    ).values_list('id')
+                    PropertyLabels.objects.filter(
+                        property_id__in=property_ids
+                    ).delete()
+
+                    taxlot_ids = TaxLot.objects.filter(
+                        organization_id=org_id
+                    ).values_list('id')
+                    TaxLotLabels.objects.filter(
+                        taxlot_id__in=taxlot_ids
+                    ).delete()
+
                     continue
 
                 # End Clear Case
                 ##############################
 
-
-                print ("Org={}: Migrating Labels with settings add_property_labels={}"
-                       ", add_taxlot_labels={}").format(org_id, add_property_labels, add_taxlot_labels)
-
+                print (
+                    "Org={}: Migrating Labels with settings add_property_labels={}"
+                    ", add_taxlot_labels={}"
+                ).format(org_id, add_property_labels, add_taxlot_labels)
 
                 ##############################
                 # Copy Property
 
                 if add_property_labels:
-                    for pv in PropertyView.objects.filter(property__organization = org_id).select_related('state').all():
-                        if not "prop_cb_id" in pv.state.extra_data:
+                    for pv in PropertyView.objects.filter(
+                        property__organization=org_id
+                    ).select_related('state').all():
+                        if "prop_cb_id" not in pv.state.extra_data:
                             print "Warning: key 'prop_cb_id' was not found for PropertyView={}".format(pv)
                             continue
 
@@ -82,28 +110,24 @@ class Command(BaseCommand):
 
                         try:
                             cb = CanonicalBuilding.objects.get(pk=cb_id)
-                        except ObjectDoesNotExist, xcpt:
+                        except ObjectDoesNotExist:
                             print "Warning: Canonical Building={} was not found in the DB".format(cb_id)
                             continue
 
                         cb_labels = cb.labels.all()
-                        preexisting_pv_labels = set(map(lambda l: l.pk, pv.labels.all()))
 
                         for label in cb_labels:
-                            if label.pk not in preexisting_pv_labels:
-                                pv.labels.add(label)
-                        else:
-                            pv.save()
-                #
-                ##############################
-
+                            # note: won't add a label twice,
+                            pv.property.labels.add(label)
 
                 ##############################
                 # Copy Tax Lot labels
 
                 if add_taxlot_labels:
-                    for tlv in TaxLotView.objects.filter(taxlot__organization = org_id).select_related('state').all():
-                        if not "taxlot_cb_id" in tlv.state.extra_data:
+                    for tlv in TaxLotView.objects.filter(
+                            taxlot__organization=org_id
+                    ).select_related('state').all():
+                        if "taxlot_cb_id" not in tlv.state.extra_data:
                             print "Warning: key 'prop_cb_id' was not found for TaxLotView={}".format(tlv)
                             continue
 
@@ -111,19 +135,16 @@ class Command(BaseCommand):
 
                         try:
                             cb = CanonicalBuilding.objects.get(pk=cb_id)
-                        except ObjectDoesNotExist, xcpt:
+                        except ObjectDoesNotExist:
                             print "Warning: Canonical Building={} was not found in the DB".format(cb_id)
                             continue
 
                         cb_labels = cb.labels.all()
-                        preexisting_tlv_labels = set(map(lambda l: l.pk, tlv.labels.all()))
 
                         for label in cb_labels:
-                            if label.pk not in preexisting_tlv_labels:
-                                tlv.labels.add(label)
-                        else:
-                            tlv.save()
-                #
+                            # note: won't add a label twice,
+                            tlv.taxlot.labels.add(label)
+
                 ##############################
 
             return


### PR DESCRIPTION
#### What's this PR do?

Changes the migrate_labels manage.py command to use labels on Property & TaxLot 
