### PR TITLE
do not create taxlot table if not mapping to it

### DIFF
--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -205,9 +205,15 @@ def map_row_chunk(ids, file_pk, source_type, prog_key, increment, *args,
 
     # For those column mapping which are not db columns, we
     # need to let MCM know that we apply our mapping function to those.
-    md = MappingData()
 
-    for table in ('PropertyState', 'TaxLotState'):
+    print mappings
+
+    tables = set()
+    for k,v in mappings.iteritems():
+        tables.add(v[0])
+
+    md = MappingData()
+    for table in tables:
         # apply_columns are extra_data columns (the raw column names)
         extra_data_fields = []
         for k, v in mappings.iteritems():

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -203,11 +203,7 @@ def map_row_chunk(ids, file_pk, source_type, prog_key, increment, *args,
     logger.debug("Mappings are %s" % mappings)
     map_cleaner = _build_cleaner(org)
 
-    # For those column mapping which are not db columns, we
-    # need to let MCM know that we apply our mapping function to those.
-
-    print mappings
-
+    # create a set of tables that are being mapped to.
     tables = set()
     for k,v in mappings.iteritems():
         tables.add(v[0])

--- a/seed/lib/mcm/data/SEED/seed.py
+++ b/seed/lib/mcm/data/SEED/seed.py
@@ -18,6 +18,7 @@ schema = {
         u'energy_score': u'float',
         u'generation_date': u'date',
         u'gross_floor_area': u'float',
+        u'jurisdiction_tax_lot_id': u'string',
         u'occupied_floor_area': u'float',
         u'owner': u'',
         u'owner_email': u'',


### PR DESCRIPTION
#### Any background context you want to provide?
Save to taxlot table only if the mapping says to use the taxlot table.

#### What's this PR do?
fixed bug where taxlotstate objects were being created for every import record.

#### How should this be manually tested?
run tests.

#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Definition of Done:
- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [ ] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [ ] Does this PR require a regression test? All fixes require a regression test.
- [ ] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?
