### PR TITLE
Many taxlotids import field

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -21,8 +21,7 @@ api_v2_router.register(r'organizations', OrganizationViewSet, base_name="organiz
 api_v2_router.register(r'data_files', DataFileViewSet, base_name="data_files")
 api_v2_router.register(r'projects', ProjectsViewSet, base_name="projects")
 api_v2_router.register(r'users', UserViewSet, base_name="users")
-# api_v2_router.register(r'labels', LabelViewSet, base_name="labels")
-api_v2_router.register(r'reverse_test', TestReverseViewSet, base_name="reverse_test")
+# api_v2_router.register(r'reverse_and_test', TestReverseViewSet, base_name="reverse_and_test")
 
 urlpatterns = [
     # v2 api

--- a/api/views.py
+++ b/api/views.py
@@ -80,6 +80,21 @@ class TestReverseViewSet(viewsets.ViewSet):
         reversed_url = reverse(reverse_string, args = [argument])
         return HttpResponse(json.dumps({reverse_string: reversed_url}))
 
+    @list_route(methods=['GET'])
+    def show_file_type(self, request):
+        """
+        Show how to use a multipart file variable type
+        ---
+        parameters:
+            - name: file
+              type: file
+        consumes:
+            - application/json
+            - multipart/form-data
+        """
+        return HttpResponse("Hello, world")
+
+
 @api_endpoint
 @ajax_request
 def test_view_with_arg(request, pk=None):

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -205,7 +205,7 @@ def map_row_chunk(ids, file_pk, source_type, prog_key, increment, *args,
 
     # create a set of tables that are being mapped to.
     tables = set()
-    for k,v in mappings.iteritems():
+    for k, v in mappings.iteritems():
         tables.add(v[0])
 
     md = MappingData()
@@ -272,7 +272,12 @@ def map_row_chunk(ids, file_pk, source_type, prog_key, increment, *args,
                 map_model_obj.year_ending = None
             # --- END TEMP HACK ----
 
-            map_model_obj.save()
+            # There is a potential threadsafe issue here:
+            # This method is called in parallel on production systems, so we need to make
+            # sure that the object hasn't already been created.
+            # For example, in the test data the taxlot id is the same for many rows. Make sure
+            # to only create/save the object if it hasn't been created before.
+            print map_model_obj.save()
 
         if map_model_obj:
             # Make sure that we've saved all of the extra_data column names
@@ -395,7 +400,7 @@ def _cleanse_data(file_pk, record_type='property'):
     tasks = [
         cleanse_data_chunk.s(record_type, ids, file_pk, increment)
         for ids in id_chunks
-        ]
+    ]
 
     if tasks:
         # specify the chord as an immutable with .si
@@ -923,7 +928,7 @@ def _normalize_address_str(address_val):
                 addr['AddressNumber'])
 
         if 'StreetNamePreDirectional' in addr and addr[
-            'StreetNamePreDirectional'] is not None:
+                'StreetNamePreDirectional'] is not None:
             normalized_address = normalized_address + ' ' + _normalize_address_direction(
                 addr['StreetNamePreDirectional'])  # NOQA
 
@@ -931,13 +936,13 @@ def _normalize_address_str(address_val):
             normalized_address = normalized_address + ' ' + addr['StreetName']
 
         if 'StreetNamePostType' in addr and addr[
-            'StreetNamePostType'] is not None:
+                'StreetNamePostType'] is not None:
             # remove any periods from abbreviations
             normalized_address = normalized_address + ' ' + _normalize_address_post_type(
                 addr['StreetNamePostType'])  # NOQA
 
         if 'StreetNamePostDirectional' in addr and addr[
-            'StreetNamePostDirectional'] is not None:
+                'StreetNamePostDirectional'] is not None:
             normalized_address = normalized_address + ' ' + _normalize_address_direction(
                 addr['StreetNamePostDirectional'])  # NOQA
 
@@ -1014,7 +1019,7 @@ def _match_buildings(file_pk, user_pk):
     unmatched_normalized_addresses = [
         _normalize_address_str(unmatched[4]) for unmatched in
         unmatched_buildings
-        ]
+    ]
 
     # Here we want all the values not related to the BS id for doing comps.
     # dont do this now
@@ -1043,7 +1048,7 @@ def _match_buildings(file_pk, user_pk):
     can_rev_idx = {
         _normalize_address_str(value[4]): value[0] for value in
         canonical_buildings
-        }
+    }
     # (SD) This loads up an ngram object with all the canonical buildings. The
     # values are the lists of identifying data for each building
     #
@@ -1059,7 +1064,7 @@ def _match_buildings(file_pk, user_pk):
     # address_1 but different city
     canonical_buildings_addresses = [
         _normalize_address_str(values[4]) for values in canonical_buildings
-        ]
+    ]
     # For progress tracking
     # sd we now use the address
     #    num_unmatched = len(unmatched_ngrams) or 1

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -417,7 +417,7 @@ def _cleanse_data(file_pk, record_type='property'):
     tasks = [
         cleanse_data_chunk.s(record_type, ids, file_pk, increment)
         for ids in id_chunks
-        ]
+    ]
 
     if tasks:
         # specify the chord as an immutable with .si
@@ -946,7 +946,7 @@ def _normalize_address_str(address_val):
                 addr['AddressNumber'])
 
         if 'StreetNamePreDirectional' in addr and addr[
-            'StreetNamePreDirectional'] is not None:
+                'StreetNamePreDirectional'] is not None:
             normalized_address = normalized_address + ' ' + _normalize_address_direction(
                 addr['StreetNamePreDirectional'])  # NOQA
 
@@ -954,13 +954,13 @@ def _normalize_address_str(address_val):
             normalized_address = normalized_address + ' ' + addr['StreetName']
 
         if 'StreetNamePostType' in addr and addr[
-            'StreetNamePostType'] is not None:
+                'StreetNamePostType'] is not None:
             # remove any periods from abbreviations
             normalized_address = normalized_address + ' ' + _normalize_address_post_type(
                 addr['StreetNamePostType'])  # NOQA
 
         if 'StreetNamePostDirectional' in addr and addr[
-            'StreetNamePostDirectional'] is not None:
+                'StreetNamePostDirectional'] is not None:
             normalized_address = normalized_address + ' ' + _normalize_address_direction(
                 addr['StreetNamePostDirectional'])  # NOQA
 
@@ -1037,7 +1037,7 @@ def _match_buildings(file_pk, user_pk):
     unmatched_normalized_addresses = [
         _normalize_address_str(unmatched[4]) for unmatched in
         unmatched_buildings
-        ]
+    ]
 
     # Here we want all the values not related to the BS id for doing comps.
     # dont do this now
@@ -1066,7 +1066,7 @@ def _match_buildings(file_pk, user_pk):
     can_rev_idx = {
         _normalize_address_str(value[4]): value[0] for value in
         canonical_buildings
-        }
+    }
     # (SD) This loads up an ngram object with all the canonical buildings. The
     # values are the lists of identifying data for each building
     #
@@ -1082,7 +1082,7 @@ def _match_buildings(file_pk, user_pk):
     # address_1 but different city
     canonical_buildings_addresses = [
         _normalize_address_str(values[4]) for values in canonical_buildings
-        ]
+    ]
     # For progress tracking
     # sd we now use the address
     #    num_unmatched = len(unmatched_ngrams) or 1

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -44,6 +44,7 @@ from seed.lib.mappings.mapping_data import MappingData
 from seed.lib.mcm import cleaners, mapper, reader
 from seed.lib.mcm.data.ESPM import espm as espm_schema
 from seed.lib.mcm.data.SEED import seed as seed_schema
+from seed.lib.mcm.mapper import expand_rows
 from seed.lib.mcm.utils import batch
 from seed.lib.superperms.orgs.models import Organization
 from seed.models import (
@@ -84,6 +85,8 @@ PORTFOLIO_CLEANER = cleaners.Cleaner(espm_schema.schema)
 PUNCT_REGEX = re.compile('[{0}]'.format(
     re.escape(string.punctuation)
 ))
+
+STR_TO_CLASS = {"TaxLotState": TaxLotState, "PropertyState": PropertyState}
 
 
 def get_cache_increment_value(chunk):
@@ -175,18 +178,16 @@ def _normalize_tax_lot_id(value):
 
 
 @shared_task
-def map_row_chunk(ids, file_pk, source_type, prog_key, increment, *args,
-                  **kwargs):
+def map_row_chunk(ids, file_pk, source_type, prog_key, increment, *args, **kwargs):
     """Does the work of matching a mapping to a source type and saving
 
     :param ids: list of PropertyState IDs to map.
     :param file_pk: int, the PK for an ImportFile obj.
-    :param source_type: int, represented by either ASSESSED_RAW, or
-        PORTFOLIO_RAW.
+    :param source_type: int, represented by either ASSESSED_RAW or PORTFOLIO_RAW.
     :param prog_key: string, key of the progress key
     :param increment: double, value by which to increment progress key
-    :param cleaner: (optional), the cleaner class you want to send
-    to mapper.map_row. (e.g. turn numbers into floats.).
+    :param cleaner: (optional), the cleaner class you want to send to mapper.map_row.
+                    (e.g. turn numbers into floats.).
     :param raw_ids: (optional kwarg), the list of ids in chunk order.
 
     """
@@ -199,88 +200,104 @@ def map_row_chunk(ids, file_pk, source_type, prog_key, increment, *args,
 
     org = Organization.objects.get(pk=import_file.import_record.super_organization.pk)
 
-    mappings, _ = ColumnMapping.get_column_mappings(org)
-    logger.debug("Mappings are %s" % mappings)
+    table_mappings = ColumnMapping.get_column_mappings_by_table_name(org)
+    logger.debug("Mappings are %s" % table_mappings)
     map_cleaner = _build_cleaner(org)
 
-    # create a set of tables that are being mapped to.
-    tables = set()
-    for k, v in mappings.iteritems():
-        tables.add(v[0])
-
+    # yes, there are three cascading for loops here. sorry :(
     md = MappingData()
-    for table in tables:
-        # apply_columns are extra_data columns (the raw column names)
+    for table, mappings in table_mappings.iteritems():
+        # This may be historic, but we need to pull out the extra_data_fields here to pass into
+        # mapper.map_row. apply_columns are extra_data columns (the raw column names)
         extra_data_fields = []
         for k, v in mappings.iteritems():
             if not md.find_column(v[0], v[1]):
                 extra_data_fields.append(k)
         logger.debug("extra data fields: {}".format(extra_data_fields))
+        logger.debug("table {} has the maps: {}".format(table, mappings))
+        # All the data live in the PropertyState.extra_data field when the data are imported
+        data = PropertyState.objects.filter(id__in=ids).only('extra_data').iterator()
 
-        # All the data live in the extra_data field when the data are imported
-        if table == 'PropertyState':
-            model_obj = PropertyState
-            data = PropertyState.objects.filter(id__in=ids).only('extra_data').iterator()
-        elif table == 'TaxLotState':
-            model_obj = TaxLotState
-            # Data are still in the PropertyState object because it was imported into that table
-            data = PropertyState.objects.filter(id__in=ids).only('extra_data').iterator()
+        # figure out which import field is defined as the unique field that may have a delimiter of
+        # individual values (e.g. tax lot ids). The definition of the delimited field is currently
+        # hard coded
+        try:
+            delimited_field = mappings.keys()[
+                mappings.values().index(('TaxLotState', 'jurisdiction_tax_lot_id'))]
+        except ValueError:
+            delimited_field = None
+            # field does not exist in mapping list, so ignoring
+
+        logger.debug("my delimited_field is {}".format(delimited_field))
+
+        # TODO: we probably need a way to allow for certain fields to be imported into all tables.
+        # for example the jurisdiction_tax_lot_id is useful on propertystate.extra_data too.
 
         # Since we are importing CSV, then each extra_data field will have the same fields. So
         # save the map_model_obj outside of for loop to pass into the `save_column_names` methods
         map_model_obj = None
-        for row in data:
-            # TODO: during the mapping the data are saved back in the database
-            # If the user decided to not use the mapped data and go back and remap
-            # then the data will forever be in the property state table for
-            # no reason. FIX THIS!
-            map_model_obj = mapper.map_row(
-                row.extra_data,
-                mappings,
-                model_obj,
-                extra_data_fields,
-                cleaner=map_cleaner,
-                *args,
-                **kwargs
-            )
 
-            # Assign some other arguments here
-            map_model_obj.import_file = import_file
-            map_model_obj.source_type = save_type
-            if hasattr(map_model_obj, 'data_state'):
-                map_model_obj.data_state = DATA_STATE_MAPPING
-            if hasattr(map_model_obj, 'organization'):
-                map_model_obj.organization = import_file.import_record.super_organization
-            if hasattr(map_model_obj, 'clean'):
-                map_model_obj.clean()
+        # Loop over all the rows
+        for original_row in data:
 
-            # --- BEGIN TEMP HACK ----
-            # TODO: fix these in the cleaner, but for now just get things to work, yuck.
-            # It appears that the cleaner pulls from some schema somewhere that defines the
-            # data types... stay tuned.
-            if hasattr(map_model_obj, 'recent_sale_date') and map_model_obj.recent_sale_date == '':
-                logger.debug("recent_sale_date was an empty string, setting to None")
-                map_model_obj.recent_sale_date = None
-            if hasattr(map_model_obj, 'generation_date') and map_model_obj.generation_date == '':
-                logger.debug("generation_date was an empty string, setting to None")
-                map_model_obj.generation_date = None
-            if hasattr(map_model_obj, 'release_date') and map_model_obj.release_date == '':
-                logger.debug("release_date was an empty string, setting to None")
-                map_model_obj.release_date = None
-            if hasattr(map_model_obj, 'year_ending') and map_model_obj.year_ending == '':
-                logger.debug("year_ending was an empty string, setting to None")
-                map_model_obj.year_ending = None
-            # --- END TEMP HACK ----
+            # expand the row into multiple rows if needed with the delimited_field replaced with a
+            # single value. This minimizes the need to rewrite the downstream code.
+            # Weeee... the data are in the extra_data column.
+            for row in expand_rows(original_row.extra_data, delimited_field):
 
-            # There is a potential threadsafe issue here:
-            # This method is called in parallel on production systems, so we need to make
-            # sure that the object hasn't already been created.
-            # For example, in the test data the taxlot id is the same for many rows. Make sure
-            # to only create/save the object if it hasn't been created before.
-            print map_model_obj.save()
+                # TODO: during the mapping the data are saved back in the database
+                # If the user decided to not use the mapped data and go back and remap
+                # then the data will forever be in the property state table for
+                # no reason. FIX THIS!
+                map_model_obj = mapper.map_row(
+                    row,
+                    mappings,
+                    STR_TO_CLASS[table],
+                    extra_data_fields,
+                    cleaner=map_cleaner,
+                    *args,
+                    **kwargs
+                )
 
+                # Assign some other arguments here
+                map_model_obj.import_file = import_file
+                map_model_obj.source_type = save_type
+                if hasattr(map_model_obj, 'data_state'):
+                    map_model_obj.data_state = DATA_STATE_MAPPING
+                if hasattr(map_model_obj, 'organization'):
+                    map_model_obj.organization = import_file.import_record.super_organization
+                if hasattr(map_model_obj, 'clean'):
+                    map_model_obj.clean()
+
+                # --- BEGIN TEMP HACK ----
+                # TODO: fix these in the cleaner, but for now just get things to work, yuck.
+                # It appears that the cleaner pulls from some schema somewhere that defines the
+                # data types... stay tuned.
+                if hasattr(map_model_obj,
+                           'recent_sale_date') and map_model_obj.recent_sale_date == '':
+                    logger.debug("recent_sale_date was an empty string, setting to None")
+                    map_model_obj.recent_sale_date = None
+                if hasattr(map_model_obj,
+                           'generation_date') and map_model_obj.generation_date == '':
+                    logger.debug("generation_date was an empty string, setting to None")
+                    map_model_obj.generation_date = None
+                if hasattr(map_model_obj, 'release_date') and map_model_obj.release_date == '':
+                    logger.debug("release_date was an empty string, setting to None")
+                    map_model_obj.release_date = None
+                if hasattr(map_model_obj, 'year_ending') and map_model_obj.year_ending == '':
+                    logger.debug("year_ending was an empty string, setting to None")
+                    map_model_obj.year_ending = None
+                # --- END TEMP HACK ----
+
+                # There is a potential thread safe issue here:
+                # This method is called in parallel on production systems, so we need to make
+                # sure that the object hasn't already been created.
+                # For example, in the test data the tax lot id is the same for many rows. Make sure
+                # to only create/save the object if it hasn't been created before.
+                map_model_obj.save()
+
+                # Make sure that we've saved all of the extra_data column names from the first item in list
         if map_model_obj:
-            # Make sure that we've saved all of the extra_data column names
             Column.save_column_names(map_model_obj)
 
     increment_cache(prog_key, increment)
@@ -400,7 +417,7 @@ def _cleanse_data(file_pk, record_type='property'):
     tasks = [
         cleanse_data_chunk.s(record_type, ids, file_pk, increment)
         for ids in id_chunks
-    ]
+        ]
 
     if tasks:
         # specify the chord as an immutable with .si
@@ -778,7 +795,8 @@ def handle_id_matches(unmatched_bs, test_property, import_file, user_pk):
             match.pk,
             unmatched_bs.pk,
             confidence=0.9,
-            match_type=SYSTEM_MATCH,  # TODO: we should and probably can remove this field, please :D
+            match_type=SYSTEM_MATCH,
+            # TODO: we should and probably can remove this field, please :D
             user=import_file.import_record.owner,
             default_pk=unmatched_bs.pk
         )
@@ -928,7 +946,7 @@ def _normalize_address_str(address_val):
                 addr['AddressNumber'])
 
         if 'StreetNamePreDirectional' in addr and addr[
-                'StreetNamePreDirectional'] is not None:
+            'StreetNamePreDirectional'] is not None:
             normalized_address = normalized_address + ' ' + _normalize_address_direction(
                 addr['StreetNamePreDirectional'])  # NOQA
 
@@ -936,13 +954,13 @@ def _normalize_address_str(address_val):
             normalized_address = normalized_address + ' ' + addr['StreetName']
 
         if 'StreetNamePostType' in addr and addr[
-                'StreetNamePostType'] is not None:
+            'StreetNamePostType'] is not None:
             # remove any periods from abbreviations
             normalized_address = normalized_address + ' ' + _normalize_address_post_type(
                 addr['StreetNamePostType'])  # NOQA
 
         if 'StreetNamePostDirectional' in addr and addr[
-                'StreetNamePostDirectional'] is not None:
+            'StreetNamePostDirectional'] is not None:
             normalized_address = normalized_address + ' ' + _normalize_address_direction(
                 addr['StreetNamePostDirectional'])  # NOQA
 
@@ -1019,7 +1037,7 @@ def _match_buildings(file_pk, user_pk):
     unmatched_normalized_addresses = [
         _normalize_address_str(unmatched[4]) for unmatched in
         unmatched_buildings
-    ]
+        ]
 
     # Here we want all the values not related to the BS id for doing comps.
     # dont do this now
@@ -1048,7 +1066,7 @@ def _match_buildings(file_pk, user_pk):
     can_rev_idx = {
         _normalize_address_str(value[4]): value[0] for value in
         canonical_buildings
-    }
+        }
     # (SD) This loads up an ngram object with all the canonical buildings. The
     # values are the lists of identifying data for each building
     #
@@ -1064,7 +1082,7 @@ def _match_buildings(file_pk, user_pk):
     # address_1 but different city
     canonical_buildings_addresses = [
         _normalize_address_str(values[4]) for values in canonical_buildings
-    ]
+        ]
     # For progress tracking
     # sd we now use the address
     #    num_unmatched = len(unmatched_ngrams) or 1

--- a/seed/data_importer/tests/test_case_a.py
+++ b/seed/data_importer/tests/test_case_a.py
@@ -71,7 +71,7 @@ class TestCaseA(DataMappingBaseTestCase):
             organization=self.org,
             import_file=self.import_file,
         )
-        self.assertEqual(len(ts), 10) # 10 unique taxlots after duplicates and delimeters
+        self.assertEqual(len(ts), 10)  # 10 unique taxlots after duplicates and delimeters
 
         # Check a single case of the taxlotstate
         ts = TaxLotState.objects.filter(jurisdiction_tax_lot_id='1552813').first()

--- a/seed/data_importer/tests/test_case_a.py
+++ b/seed/data_importer/tests/test_case_a.py
@@ -71,7 +71,7 @@ class TestCaseA(DataMappingBaseTestCase):
             organization=self.org,
             import_file=self.import_file,
         )
-        self.assertEqual(len(ts), 12)
+        self.assertEqual(len(ts), 10) # 10 unique taxlots after duplicates and delimeters
 
         # Check a single case of the taxlotstate
         ts = TaxLotState.objects.filter(jurisdiction_tax_lot_id='1552813').first()

--- a/seed/data_importer/tests/test_case_a.py
+++ b/seed/data_importer/tests/test_case_a.py
@@ -20,8 +20,10 @@ from seed.models import (
 from seed.models import (
     Column,
     PropertyState,
+    PropertyView,
     DATA_STATE_MAPPING,
     TaxLotState,
+    TaxLotProperty,
 )
 from seed.utils.generic import pp
 
@@ -78,7 +80,6 @@ class TestCaseA(DataMappingBaseTestCase):
         self.assertEqual(ts.jurisdiction_tax_lot_id, '1552813')
         self.assertEqual(ts.address_line_1, None)
         self.assertEqual(ts.extra_data["extra_data_2"], 1)
-        pp(ts)
 
         # Check a single case of the propertystate
         ps = PropertyState.objects.filter(pm_property_id='2264')
@@ -88,12 +89,11 @@ class TestCaseA(DataMappingBaseTestCase):
         self.assertEqual(ps.address_line_1, '50 Willow Ave SE')
         self.assertEqual(ps.extra_data["extra_data_1"], 'a')
         self.assertEqual('extra_data_2' in ps.extra_data.keys(), False)
-        pp(ps)
 
         # Promote case A (one property <-> one tax lot) for testing
         # Typically this method should not be called here, rather in the matching code.
-        ps.promote(self.cycle)
-        ts.promote(self.cycle)
+        pv = ps.promote(self.cycle)
+        tlv = ts.promote(self.cycle)
 
         # Now try to match the properties and tax lots
         from django.db.models.query import QuerySet
@@ -101,43 +101,18 @@ class TestCaseA(DataMappingBaseTestCase):
         self.assertTrue(isinstance(ps, QuerySet))
         self.assertEqual(len(ps), 1)
 
-        for p in ps:
-            pp(p)
+        # tasks.match_buildings(self.import_file.id, self.user.id)
+        # tasks.pair_buildings(self.import_file.id, self.user.id)
 
-        tasks.match_buildings(self.import_file.id, self.user.id)
+        # Manually pair up the ts and ps until the match/pair properties works
+        tlp = TaxLotProperty.objects.create(cycle=self.cycle, property_view=pv, taxlot_view=tlv)
 
-        # M2M Matching
+        # make sure the the property only has one tax lot and vice versa
+        # ps = PropertyState.objects.filter(pm_property_id='2264').first()
 
-        # # Promote 5 of these to views to test the remaining code
-        # promote_mes = PropertyState.objects.filter(
-        #     data_state=DATA_STATE_MAPPING,
-        #     super_organization=self.fake_org)[:5]
-        # for promote_me in promote_mes:
-        #     promote_me.promote(cycle)
-        #
-        # ps = tasks.list_canonical_property_states(self.fake_org)
-        # from django.db.models.query import QuerySet
-        # self.assertTrue(isinstance(ps, QuerySet))
-        # logger.debug("There are %s properties" % len(ps))
-        # for p in ps:
-        #     print p
-        #
-        # self.assertEqual(len(ps), 5)
-        # self.assertEqual(ps[0].address_line_1, '1211 Bryant Street')
-        # self.assertEqual(ps[4].address_line_1, '1031 Ellis Lane')
+        pv = PropertyView.objects.filter(state__pm_property_id='2264', cycle=self.cycle).first()
 
-        # tasks.match_buildings(self.import_file.pk, self.fake_user.pk)
+        self.assertEqual(len(pv.tax_lots()), 1)
 
-        # self.assertEqual(result.property_name, snapshot.property_name)
-        # self.assertEqual(result.property_name, new_snapshot.property_name)
-        # # Since these two buildings share a common ID, we match that way.
-        # # self.assertEqual(result.confidence, 0.9)
-        # self.assertEqual(
-        #     sorted([r.pk for r in result.parents.all()]),
-        #     sorted([new_snapshot.pk, snapshot.pk])
-        # )
-        # self.assertGreater(AuditLog.objects.count(), 0)
-        # self.assertEqual(
-        #     AuditLog.objects.first().action_note,
-        #     'System matched building ID.'
-        # )
+        for tl in pv.tax_lots():
+            pp(tl)

--- a/seed/data_importer/tests/test_case_b.py
+++ b/seed/data_importer/tests/test_case_b.py
@@ -62,7 +62,7 @@ class TestCaseB(DataMappingBaseTestCase):
             organization=self.org,
             import_file=self.import_file,
         )
-        self.assertEqual(len(ts), 6)  # there are only 6 unique tax lots in the test file
+        self.assertEqual(len(ts), 10)  # there are only 10 unique tax lots in the test file once splitting on delimiters # noqa
 
         # tasks.match_buildings(self.import_file.id, self.user.id)
         # tasks.pair_buildings(self.import_file.id, self.user.id)

--- a/seed/data_importer/tests/test_data_import.py
+++ b/seed/data_importer/tests/test_data_import.py
@@ -214,13 +214,17 @@ class TestMappingExampleData(DataMappingBaseTestCase):
         Column.create_mappings(self.fake_mappings, self.org, self.user)
         tasks.map_data(self.import_file.pk)
 
-        # make sure that no taxlot objects were created
+        # make sure that no taxlot objects were created. the 12 here are the import extra_data.
         ps = PropertyState.objects.all()
         self.assertEqual(len(ps), 12)
 
         # make sure that the new data was loaded correctly
-        ts = TaxLotState.objects.filter(address_line_1='2700 Welstone Ave NE')[0]
-        self.assertEqual(ts.extra_data['site_eui'], 1202)
+        ts = TaxLotState.objects.filter(address_line_1='50 Willow Ave SE').first()
+        self.assertEqual(ts.extra_data['site_eui'], 125)
+
+        # note that this used to be 2700 Welstone Ave NE but needed to change the check because
+        # this has the same jurisdiction_tax_lot_id as others so it was never imported. So assigning
+        # the address was never happening because the tax_lot_id was already in use.
 
     @skip('fix this soon')
     def test_promote_properties(self):

--- a/seed/data_importer/tests/test_data_import.py
+++ b/seed/data_importer/tests/test_data_import.py
@@ -254,6 +254,7 @@ class TestMappingExampleData(DataMappingBaseTestCase):
 
 
 class TestPromotingProperties(DataMappingBaseTestCase):
+
     def setUp(self):
         filename = getattr(self, 'filename', 'example-data-properties.xlsx')
         import_file_source_type = ASSESSED_RAW

--- a/seed/data_importer/tests/test_data_import.py
+++ b/seed/data_importer/tests/test_data_import.py
@@ -171,6 +171,7 @@ class TestMappingPortfolioData(DataMappingBaseTestCase):
 
 
 class TestMappingExampleData(DataMappingBaseTestCase):
+
     def setUp(self):
         filename = getattr(self, 'filename', 'example-data-properties.xlsx')
         import_file_source_type = ASSESSED_RAW
@@ -344,13 +345,10 @@ class TestPromotingProperties(DataMappingBaseTestCase):
         # call the mapping function from the tasks file
         map_data(self.import_file.id)
 
-
-
         # TODO: figure out why this isn't working here
         # self.assertRaises(tasks.DuplicateDataError, tasks.handle_id_matches,
         #                   new_snapshot, duplicate_import_file,
         #                   self.user.pk)
-
 
         # @skip("Fix for new data model")
         # class TestOldMatching(TestCase):

--- a/seed/data_importer/tests/test_matching.py
+++ b/seed/data_importer/tests/test_matching.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 class TestMatching(DataMappingBaseTestCase):
+
     def setUp(self):
         filename = getattr(self, 'filename', 'example-data-properties.xlsx')
         import_file_source_type = ASSESSED_RAW
@@ -164,8 +165,6 @@ class TestMatching(DataMappingBaseTestCase):
         for p in unmatched_properties_2:
             pp(p)
         print len(unmatched_properties_2)
-
-
 
         # TODO: figure out why this isn't working here
         # self.assertRaises(tasks.DuplicateDataError, tasks.handle_id_matches,

--- a/seed/lib/mcm/mapper.py
+++ b/seed/lib/mcm/mapper.py
@@ -5,7 +5,9 @@
 :author
 """
 
+import copy
 import logging
+import re
 
 import matchers
 from cleaners import default_cleaner
@@ -93,7 +95,7 @@ def _concat_values(concat_columns, column_values, delimiter):
     # Use the order of values that we got from concat_columns def.
     values = [
         column_values[item] for item in concat_columns if item in column_values
-    ]
+        ]
     return delimiter.join(values) or None
 
 
@@ -104,18 +106,11 @@ def apply_column_value(raw_field, value, model, mapping, is_extra_data, cleaner)
     :param value: dict, the value of that column for a given row.
     :param model: inst, the object we're mapping data to.
     :param mapping: dict, the mapping of row data to attribute data.
-    :param cleaner: runnable, something to clean data values.
     :param is_extra_data: bool, is the column supposed to be extra_data
-    :param apply: (optional), function to apply value to our model.
+    :param cleaner: runnable, something to clean data values.
+
     :rtype: model inst
-
     """
-    # _log.debug("item is %s" % item)
-    # _log.debug("value is %s" % value)
-    # _log.debug("model is %s" % model)
-    # _log.debug("mapping is %s" % mapping)
-    # _log.debug("is_extra_data is %s" % is_extra_data)
-
     cleaned_value = None
     tmp_field = raw_field
 
@@ -126,8 +121,12 @@ def apply_column_value(raw_field, value, model, mapping, is_extra_data, cleaner)
             tmp_field = mapping.get(raw_field)
             if tmp_field:
                 tmp_field = tmp_field[1]
-            else:
-                _log.warn("Could not find the field to clean: %s" % raw_field)
+
+            # TODO: there are a lot of warnings right now because we iterate over the header
+            # of the file instead of iterating over the fields that we want to map.
+                
+            # else:
+                # _log.warn("Could not find the field to clean: %s" % raw_field)
 
         cleaned_value = cleaner.clean_value(value, tmp_field)
     else:
@@ -136,30 +135,30 @@ def apply_column_value(raw_field, value, model, mapping, is_extra_data, cleaner)
     # If the item is the extra_data column, then make sure to save it to the
     # extra_data field of the database
     if raw_field in mapping:
-        table_name = mapping.get(raw_field)[0]
-        field_name = mapping.get(raw_field)[1]
+        table_name, field_name = mapping.get(raw_field)
         # _log.debug("item is in the mapping: %s -- %s" % (table_name, field_name))
 
+        # NL: 9/29/16 turn off all the debug logging because it was too verbose.
         if is_extra_data:
             if hasattr(model, 'extra_data'):
                 # only save it if the model and the mapping are the same
                 if model.__class__.__name__ == table_name:
                     model.extra_data[raw_field] = cleaned_value
-                else:
-                    _log.debug(
-                        "model name '%s' is not the same as the mapped table name '%s' -- skipping field '%s'" % (
-                        model.__class__.__name__, table_name, field_name))  # noqa
-            else:
-                _log.debug(
-                    "model object does not have extra_data field, skipping mapping for %s" % raw_field)  # noqa
+                    # else:
+                    #     _log.debug(
+                    #         "model name '%s' is not the same as the mapped table name '%s' -- skipping field '%s'" % (
+                    #         model.__class__.__name__, table_name, field_name))  # noqa
+                    # else:
+                    #     _log.debug(
+                    #         "model object does not have extra_data field, skipping mapping for %s" % raw_field)  # noqa
         else:
             # Simply set the field to the cleaned value if it is the correct model
             if model.__class__.__name__ == table_name:
                 setattr(model, field_name, cleaned_value)
-            else:
-                _log.debug(
-                    "model name '%s' is not the same as the mapped table name '%s' -- skipping field '%s'" % (
-                        model.__class__.__name__, table_name, field_name))  # noqa
+                # else:
+                #     _log.debug(
+                #         "model name '%s' is not the same as the mapped table name '%s' -- skipping field '%s'" % (
+                #             model.__class__.__name__, table_name, field_name))  # noqa
 
     return model
 
@@ -178,17 +177,57 @@ def _set_default_concat_config(concat):
     return concat
 
 
+def expand_field(field):
+    """
+    take a field from the csv and expand/split on a delimiter and return a list of individual values
+
+    :param field: str, value to parse
+
+    :return: list of individual values after after delimiting
+    """
+
+    if isinstance(field, str) or isinstance(field, unicode):
+        return re.split(",|;|:", field)
+    else:
+        return [field]
+
+
+def expand_rows(row, delimited_field):
+    """
+    Take a row and a field which may have delimited values and convert into a list of new rows
+    with the same data expect for the replaced delimited value.
+
+    :param row: dict, original row to split out
+    :param delimited_field: string - column to try and split
+
+    :return: list
+    """
+
+    # does the chosen delimited field even exist in the row dict?
+    if delimited_field not in row:
+        return [row]
+    else:
+        new_values = expand_field(row[delimited_field])
+        new_rows = []
+        for v in new_values:
+            new_row = copy.deepcopy(row)
+            new_row[delimited_field] = v
+            new_rows.append(new_row)
+
+        return new_rows
+
+
 def map_row(row, mapping, model_class, extra_data_fields=[], cleaner=None, concat=None, **kwargs):
     """Apply mapping of row data to model.
 
-    :param row: dict, parsed row data from csv.
+    :param original_row: dict, parsed row data from csv.
     :param mapping: dict, keys map row columns to model_class attrs.
     :param model_class: class, reference to model class we map against.
     :param extra_data_fields: list, list of raw columns that are considered extra data (per mapping)
     :param cleaner: (optional) inst, cleaner instance for row values.
-    :param concat: (optional) list of dict,
-        config for concatenating rows into an attr.
-    :rtype: model_inst, with mapped data attributes; ready to save.
+    :param concat: (optional) list of dict, config for concatenating rows into an attr.
+
+    :rtype: list of model instances that were created
 
     """
     initial_data = kwargs.get('initial_data', None)

--- a/seed/lib/mcm/mapper.py
+++ b/seed/lib/mcm/mapper.py
@@ -95,7 +95,7 @@ def _concat_values(concat_columns, column_values, delimiter):
     # Use the order of values that we got from concat_columns def.
     values = [
         column_values[item] for item in concat_columns if item in column_values
-        ]
+    ]
     return delimiter.join(values) or None
 
 

--- a/seed/lib/mcm/mapper.py
+++ b/seed/lib/mcm/mapper.py
@@ -124,7 +124,7 @@ def apply_column_value(raw_field, value, model, mapping, is_extra_data, cleaner)
 
             # TODO: there are a lot of warnings right now because we iterate over the header
             # of the file instead of iterating over the fields that we want to map.
-                
+
             # else:
                 # _log.warn("Could not find the field to clean: %s" % raw_field)
 
@@ -241,6 +241,9 @@ def map_row(row, mapping, model_class, extra_data_fields=[], cleaner=None, conca
     # concat = _set_default_concat_config(concat)
 
     # In case we need to look up cleaner by dynamic field mapping.
+    # TODO: we should flip this around and iterate over the mappings because there is a lot
+    # of extra work being done (sometimes) when the columns are being split across two
+    # different data base objects (i.e. taxlotstate and propertystate)
     for raw_field, value in row.items():
         # Look through any of our concatenation configs to see if this row
         # needs to be set aside for merging with others at the end of the map.

--- a/seed/lib/mcm/tests/test_mapper.py
+++ b/seed/lib/mcm/tests/test_mapper.py
@@ -412,3 +412,46 @@ class TestMapper(TestCase):
         sale_expected = u'01/23/2012'
         self.assertEqual(modified_model.address1, st_expected)
         self.assertEqual(modified_model.sale_date, sale_expected)
+
+    def test_expand_field(self):
+        r = mapper.expand_field(10000)
+        self.assertEqual(r, [10000])
+        r = mapper.expand_field('1,2,3')
+        self.assertEqual(r, ['1', '2', '3'])
+        r = mapper.expand_field("123,15543;32132:321321;1231;")
+        self.assertEqual(r, ['123', '15543', '32132', '321321', '1231', ''])
+        r = mapper.expand_field("123,15543;32132:321321;1231;987")
+        self.assertEqual(r, ['123', '15543', '32132', '321321', '1231', '987'])
+        r = mapper.expand_field(u"123,15543;32132:321321;1231;987")
+        self.assertEqual(r, ['123', '15543', '32132', '321321', '1231', '987'])
+        r = mapper.expand_field(u"4815162342")
+        self.assertEqual(r, ['4815162342'])
+
+    def test_expand_rows(self):
+        data = {
+            u'city': u'Meereen',
+            u'country': u'Westeros',
+            u'jurisdiction_tax_lot_id': 1552813
+        }
+
+        r = mapper.expand_rows(data, 'jurisdiction_tax_lot_id')
+        self.assertEqual(r, [data])
+
+        data = {
+            u'city': u'Meereen',
+            u'country': u'Westeros',
+            u'jurisdiction_tax_lot_id': "1,2,3,4,5"
+        }
+        expected_0 = {
+            u'city': u'Meereen',
+            u'country': u'Westeros',
+            u'jurisdiction_tax_lot_id': "1"
+        }
+
+        r = mapper.expand_rows(data, 'jurisdiction_tax_lot_id')
+        self.assertEqual(len(r), 5)
+        self.assertEqual(r[0], expected_0)
+        self.assertEqual(r[2]['jurisdiction_tax_lot_id'], '3')
+        self.assertEqual(r[4]['jurisdiction_tax_lot_id'], '5')
+
+

--- a/seed/lib/mcm/tests/test_mapper.py
+++ b/seed/lib/mcm/tests/test_mapper.py
@@ -453,5 +453,3 @@ class TestMapper(TestCase):
         self.assertEqual(r[0], expected_0)
         self.assertEqual(r[2]['jurisdiction_tax_lot_id'], '3')
         self.assertEqual(r[4]['jurisdiction_tax_lot_id'], '5')
-
-

--- a/seed/models/__init__.py
+++ b/seed/models/__init__.py
@@ -12,9 +12,9 @@
 
 from .cycles import *  # noqa
 from .models import *  # noqa
+from .joins import *  # noqa
 from .properties import *  # noqa
 from .tax_lots import *  # noqa
 from .columns import *  # noqa
-from .joins import *  # noqa
 from .auditlog import *  # noqa
 from .deprecate import *  # noqa

--- a/seed/models/columns.py
+++ b/seed/models/columns.py
@@ -423,3 +423,49 @@ class ColumnMapping(models.Model):
             mapping[key[1]] = value
 
         return mapping, []
+
+    @staticmethod
+    def get_column_mappings_by_table_name(organization):
+        """
+        Breaks up the get_column_mappings into another layer to provide access by the table
+        name as a key.
+
+        :param organization: instance, Organization
+        :return: dict
+
+        expected = {
+            u'PropertyState': {
+                u'Wookiee': (u'PropertyState', u'Dothraki'),
+                u'eui': (u'PropertyState', u'site_eui'),
+            },
+            u'TaxLotState': {
+                u'address': (u'TaxLotState', u'address'),
+                u'Ewok': (u'TaxLotState', u'Hattin'),
+            }
+        }
+
+        """
+
+        data, _ = ColumnMapping.get_column_mappings(organization)
+        # data will be in format
+        # {
+        #     u'Wookiee': (u'PropertyState', u'Dothraki'),
+        #     u'Ewok': (u'TaxLotState', u'Hattin'),
+        #     u'eui': (u'PropertyState', u'site_eui'),
+        #     u'address': (u'TaxLotState', u'address')
+        # }
+
+        tables = set()
+        for k, v in data.iteritems():
+            tables.add(v[0])
+
+        # initialize the new container to store the results
+        # (there has to be a better way of doing this... not enough time)
+        container = {}
+        for t in tables:
+            container[t] = {}
+
+        for k, v in data.iteritems():
+            container[v[0]][k] = v
+
+        return container

--- a/seed/models/joins.py
+++ b/seed/models/joins.py
@@ -10,19 +10,13 @@ import logging
 
 from django.db import models
 
-from seed.models import (
-    Cycle,
-    PropertyView,
-    TaxLotView,
-)
-
 logger = logging.getLogger(__name__)
 
 
 class TaxLotProperty(models.Model):
-    property_view = models.ForeignKey(PropertyView)
-    taxlot_view = models.ForeignKey(TaxLotView)
-    cycle = models.ForeignKey(Cycle)
+    property_view = models.ForeignKey('PropertyView')
+    taxlot_view = models.ForeignKey('TaxLotView')
+    cycle = models.ForeignKey('Cycle')
 
     # If there is a complex TaxLot/Property association, this field
     # lists the "main" tax lot that Properties should be reported under.

--- a/seed/models/properties.py
+++ b/seed/models/properties.py
@@ -210,10 +210,10 @@ class PropertyState(models.Model):
 
             result = {
                 field: getattr(self, field) for field in model_fields
-                }
+            }
             result['extra_data'] = {
                 field: extra_data[field] for field in ed_fields
-                }
+            }
 
             # always return id's and canonical_building id's
             result['id'] = result['pk'] = self.pk
@@ -315,7 +315,6 @@ class PropertyView(models.Model):
             )
 
     def tax_lot_views(self):
-
         """
         Return a list of TaxLotViews that are associated with this PropertyView and Cycle
 

--- a/seed/models/properties.py
+++ b/seed/models/properties.py
@@ -24,7 +24,9 @@ from seed.models import (
     DATA_STATE_UNKNOWN,
     DATA_STATE_MATCHING,
     ASSESSED_BS,
+    TaxLotProperty,
 )
+
 from auditlog import AUDIT_IMPORT
 from auditlog import DATA_UPDATE_TYPE
 from seed.utils.time import convert_datestr
@@ -208,10 +210,10 @@ class PropertyState(models.Model):
 
             result = {
                 field: getattr(self, field) for field in model_fields
-            }
+                }
             result['extra_data'] = {
                 field: extra_data[field] for field in ed_fields
-            }
+                }
 
             # always return id's and canonical_building id's
             result['id'] = result['pk'] = self.pk
@@ -241,8 +243,8 @@ class PropertyState(models.Model):
 
 
 class PropertyView(models.Model):
-    """Similar to the old world of canonical building"""
-    # different property views can be associated with each other (2012, 2013.
+    """Similar to the old world of canonical building."""
+    # different property views can be associated with each other (2012, 2013)
     property = models.ForeignKey(Property, related_name='views')
     cycle = models.ForeignKey(Cycle)
     state = models.ForeignKey(PropertyState)
@@ -300,6 +302,17 @@ class PropertyView(models.Model):
                 record_type=AUDIT_IMPORT,
                 import_filename=import_filename
             )
+
+    def tax_lots(self):
+        """
+        Return a list of tax lot objects that are associated with this object
+
+        :return: list of tax lot views
+        """
+
+        return list(
+            TaxLotProperty.objects.filter(cycle=self.cycle, property_view=self).select_related(
+                'taxlot_view'))
 
     @property_decorator
     def import_filename(self):

--- a/seed/pagination.py
+++ b/seed/pagination.py
@@ -27,6 +27,7 @@ class FakePagination(pagination.PageNumberPagination):
 
 
 class NoPagination(pagination.PageNumberPagination):
+
     def get_paginated_response(self, data):
         return response.Response(data)
 

--- a/seed/tests/test_columns.py
+++ b/seed/tests/test_columns.py
@@ -182,6 +182,20 @@ class TestColumns(TestCase):
         self.assertEqual(column.table_name, "PropertyState")
         self.assertEqual(column.column_name, "Dothraki")
 
+        # test by table name sorting
+        test_mapping = ColumnMapping.get_column_mappings_by_table_name(self.fake_org)
+        expected = {
+            u'PropertyState': {
+                u'Wookiee': (u'PropertyState', u'Dothraki'),
+                u'eui': (u'PropertyState', u'site_eui'),
+            },
+            u'TaxLotState': {
+                u'address': (u'TaxLotState', u'address'),
+                u'Ewok': (u'TaxLotState', u'Hattin'),
+            }
+        }
+        self.assertDictEqual(test_mapping, expected)
+
     def test_save_columns(self):
         # create
 

--- a/seed/views/datasets.py
+++ b/seed/views/datasets.py
@@ -36,48 +36,23 @@ class DatasetViewSet(viewsets.ViewSet):
     def list(self, request):
         """
         Retrieves all datasets for the user's organization.
-
-        Until we can get the nested JSON response working, here's what we're sending back as a response:
-
-           {
-                'status': 'success',
-                'datasets':  [
-                    {
-                        'name': Name of ImportRecord,
-                        'number_of_buildings': Total number of buildings in all ImportFiles,
-                        'id': ID of ImportRecord,
-                        'updated_at': Timestamp of when ImportRecord was last modified,
-                        'last_modified_by': Email address of user making last change,
-                        'importfiles': [
-                            {
-                                'name': Name of associated ImportFile, e.g. 'buildings.csv',
-                                'number_of_buildings': Count of buildings in this file,
-                                'number_of_mappings': Number of mapped headers to fields,
-                                'number_of_cleanings': Number of fields cleaned,
-                                'source_type': Type of file (see source_types),
-                                'id': ID of ImportFile (needed for most operations)
-                            }
-                        ],
-                        ...
-                    },
-                    ...
-                ]
-            }
         ---
+        type:
+            status:
+                required: true
+                type: string
+                description: Either success or error
+            datasets:
+                required: true
+                type: array[dataset]
+                description: Returns an array where each item is a full dataset structure, including
+                             keys ''name'', ''number_of_buildings'', ''id'', ''updated_at'',
+                             ''last_modified_by'', ''importfiles'', ...
         parameters:
             - name: organization_id
               description: The organization_id for this user's organization
               required: true
               paramType: query
-        type:
-            status:
-                required: true
-                type: string
-                description: "'success' if the call succeeds"
-            datasets:
-                required: true
-                description: The datasets
-                type: object
         """
 
         org_id = request.query_params.get('organization_id', None)
@@ -165,38 +140,28 @@ class DatasetViewSet(viewsets.ViewSet):
     def retrieve(self, request, pk=None):
         """
             Retrieves a dataset (ImportRecord).
-
-            Until we can get the nested JSON response working, here's what we're sending back as a response:
-
-            {
-                'status': 'success',
-                'dataset': {
-                    'name': Name of ImportRecord,
-                    'number_of_buildings': Total number of buildings in all ImportFiles for this dataset,
-                    'id': ID of ImportRecord,
-                    'updated_at': Timestamp of when ImportRecord was last modified,
-                    'last_modified_by': Email address of user making last change,
-                    'importfiles': [
-                        {
-                           'name': Name of associated ImportFile, e.g. 'buildings.csv',
-                           'number_of_buildings': Count of buildings in this file,
-                           'number_of_mappings': Number of mapped headers to fields,
-                           'number_of_cleanings': Number of fields cleaned,
-                           'source_type': Type of file (see source_types),
-                           'id': ID of ImportFile (needed for most operations)
-                        }
-                     ],
-                     ...
-                },
-                    ...
-            }
             ---
+            type:
+                status:
+                    required: true
+                    type: string
+                    description: Either success or error
+                dataset:
+                    required: true
+                    type: dictionary
+                    description: A dictionary of a full dataset structure, including
+                                 keys ''name'', ''number_of_buildings'', ''id'', ''updated_at'',
+                                 ''last_modified_by'', ''importfiles'', ...
             parameter_strategy: replace
             parameters:
                 - name: pk
                   description: "Primary Key"
                   required: true
                   paramType: path
+                - name: organization_id
+                  description: The organization_id for this user's organization
+                  required: true
+                  paramType: query
         """
 
         organization_id = request.query_params.get('organization_id', None)

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -1355,18 +1355,25 @@ class DataFileViewSet(viewsets.ViewSet):
         """
         Returns suggested mappings from an uploaded file's headers to known
         data fields.
-
-        Returns::
-            {
-                'status': 'success',
-                'suggested_column_mappings': {
-                    column header from file: [ (destination_column, score) ...]
-                    ...
-                },
-                'building_columns': [ a list of all possible columns ],
-                'building_column_types': [a list of column types corresponding to building_columns],
-            }
         ---
+        type:
+            status:
+                required: true
+                type: string
+                description: Either success or error
+            suggested_column_mappings:
+                required: true
+                type: dictionary
+                description: Dictionary where (key, value) = (the column header from the file,
+                      array of tuples (destination column, score))
+            building_columns:
+                required: true
+                type: array
+                description: A list of all possible columns
+            building_column_types:
+                required: true
+                type: array
+                description: A list of column types corresponding to the building_columns array
         parameter_strategy: replace
         parameters:
             - name: pk

--- a/seed/views/organizations.py
+++ b/seed/views/organizations.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.http import JsonResponse
 from django.utils.decorators import method_decorator
 from rest_framework import status
-from rest_framework import viewsets
+from rest_framework import viewsets, serializers
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import detail_route
 
@@ -195,6 +195,79 @@ def _save_fields(org, new_fields, old_fields, is_public=False):
 _log = logging.getLogger(__name__)
 
 
+class RulesSubSerializer(serializers.Serializer):
+    field = serializers.CharField(max_length=100)
+    severity = serializers.CharField(max_length=100)
+
+
+class RulesSubSerializerB(serializers.Serializer):
+    field = serializers.CharField(max_length=100)
+    enabled = serializers.BooleanField()
+    type = serializers.CharField(max_length=100)
+    min = serializers.FloatField()
+    max = serializers.FloatField()
+    severity = serializers.CharField(max_length=100)
+    units = serializers.CharField(max_length=100)
+
+
+class RulesIntermediateSerializer(serializers.Serializer):
+    missing_matching_field = RulesSubSerializer(many=True)
+    missing_values = RulesSubSerializer(many=True)
+    in_range_checking = RulesSubSerializerB(many=True)
+
+
+class RulesSerializer(serializers.Serializer):
+    cleansing_rules = RulesIntermediateSerializer()
+
+
+class SaveSettingsOrgFieldSerializer(serializers.Serializer):
+    sort_column = serializers.CharField()
+
+
+class SaveSettingsOrganizationSerializer(serializers.Serializer):
+    query_threshold = serializers.IntegerField()
+    name = serializers.CharField(max_length=100)
+    fields = SaveSettingsOrgFieldSerializer(many=True)
+    public_fields = SaveSettingsOrgFieldSerializer(many=True)
+
+
+class SaveSettingsSerializer(serializers.Serializer):
+    organization = SaveSettingsOrganizationSerializer()
+
+
+class SharedFieldSerializer(serializers.Serializer):
+    title = serializers.CharField(max_length=100)
+    sort_column = serializers.CharField(max_length=100)
+    field_class = serializers.CharField(max_length=100)
+    title_class = serializers.CharField(max_length=100)
+    type = serializers.CharField(max_length=100)
+    field_type = serializers.CharField(max_length=100)
+    sortable = serializers.CharField(max_length=100)
+
+
+class SharedFieldsReturnSerializer(serializers.Serializer):
+    status = serializers.CharField(max_length=100)
+    shared_fields = SharedFieldSerializer(many=True)
+    public_fields = SharedFieldSerializer(many=True)
+
+
+class SharedFieldsActualReturnSerializer(serializers.Serializer):
+    shared_fields = SharedFieldsReturnSerializer(many=True)
+
+
+class OrganizationUserSerializer(serializers.Serializer):
+    email = serializers.CharField(max_length=100)
+    first_name = serializers.CharField(max_length=100)
+    last_name = serializers.CharField(max_length=100)
+    user_id = serializers.IntegerField()
+    role = serializers.CharField(max_length=100)
+
+
+class OrganizationUsersSerializer(serializers.Serializer):
+    status = serializers.CharField(max_length=100)
+    users = OrganizationUserSerializer(many=True)
+
+
 class OrganizationViewSet(viewsets.ViewSet):
     raise_exception = True
     authentication_classes = (SessionAuthentication, SEEDAuthentication)
@@ -204,32 +277,14 @@ class OrganizationViewSet(viewsets.ViewSet):
     def list(self, request):
         """
         Retrieves all orgs the user has access to.
-
-        Returns::
-
-            {'organizations': [
-                {'name': org name,
-                 'org_id': org's identifier (used with Authorization header),
-                 'id': org's identifier,
-                 'number_of_users': count of members of org,
-                 'user_is_owner': True if the user is owner of this org,
-                 'user_role': The role of user in this org (owner, viewer, member),
-                 'owners': [
-                             {
-                              'first_name': the owner's first name,
-                              'last_name': the owner's last name,
-                              'email': the owner's email address,
-                              'id': the owner's identifier (int)
-                             }
-                           ]
-                 'sub_orgs': [ a list of orgs having this org as parent, in
-                            the same format...],
-                 'is_parent': True if this org contains suborgs,
-                 'parent_id': id of this orgs parent (self.id if it is a parent)
-                 'num_buildings': Count of buildings belonging to this org
-                }...
-               ]
-            }
+        ---
+        type:
+            organizations:
+                required: true
+                type: array[organizations]
+                description: Returns an array where each item is a full organization structure, including
+                             keys ''name'', ''org_id'', ''number_of_users'', ''user_is_owner'',
+                             ''user_role'', ''sub_orgs'', ...
         """
         if request.user.is_superuser:
             qs = Organization.objects.all()
@@ -281,31 +336,17 @@ class OrganizationViewSet(viewsets.ViewSet):
         """
         Retrieves a single organization by id.
         ---
-
-        Returns::
-
-            {'status': 'success or error', 'message': 'error message, if any',
-             'organization':
-                {'name': org name,
-                 'org_id': org's identifier (used with Authorization header),
-                 'id': org's identifier,
-                 'number_of_users': count of members of org,
-                 'user_is_owner': True if the user is owner of this org,
-                 'user_role': The role of user in this org (owner, viewer, member),
-                 'owners': [
-                     {
-                      'first_name': the owner's first name,
-                      'last_name': the owner's last name,
-                      'email': the owner's email address,
-                      'id': the owner's identifier (int)
-                      }
-                     ]
-                  'sub_orgs': [ a list of orgs having this org as parent, in
-                                the same format...],
-                  'is_parent': True if this org contains suborgs,
-                  'num_buildings': Count of buildings belonging to this org
-                }
-            }
+        type:
+            status:
+                required: true
+                type: string
+                description: success, or error
+            organization:
+                required: true
+                type: array[organizations]
+                description: Returns an array where each item is a full organization structure, including
+                             keys ''name'', ''org_id'', ''number_of_users'', ''user_is_owner'',
+                             ''user_role'', ''sub_orgs'', ...
         """
         org_id = pk
 
@@ -348,25 +389,17 @@ class OrganizationViewSet(viewsets.ViewSet):
     def users(self, request, pk=None):
         """
         Retrieve all users belonging to an org.
-
-        Payload::
-
-            {'organization_id': org_id}
-
-        Returns::
-
-            {'status': 'success',
-             'users': [
-                {
-                 'first_name': the user's first name,
-                 'last_name': the user's last name,
-                 'email': the user's email address,
-                 'id': the user's identifier (int),
-                 'role': the user's role ('owner', 'member', 'viewer')
-                }
-              ]
-            }
-
+        ---
+        response_serializer: OrganizationUsersSerializer
+        parameter_strategy: replace
+        parameters:
+            - name: pk
+              type: integer
+              description: Organization ID (primary key)
+              required: true
+              paramType: path
+        """
+        """
         .. todo::
 
             check permissions that request.user is owner or admin
@@ -564,35 +597,28 @@ class OrganizationViewSet(viewsets.ViewSet):
     def save_settings(self, request, pk=None):
         """
         Saves an organization's settings: name, query threshold, shared fields
-
-        Payload::
-
-            {
-                'organization_id: 2,
-                'organization': {
-                    'query_threshold': 2,
-                    'name': 'demo org',
-                    'fields': [  # All internal sibling org shared fields
-                        {
-                            'sort_column': database/search field name,
-                                e.g. 'pm_property_id',
-                        }
-                    ],
-                    'public_fields': [  # All publicly shared fields
-                        {
-                            'sort_column': database/search field name,
-                                e.g. 'pm_property_id',
-                        }
-                    ],
-                }
-            }
-
-        Returns::
-
-            {
-                'status': 'success or error',
-                'message': 'error message, if any'
-            }
+        ---
+        type:
+            status:
+                description: success or error
+                type: string
+                required: true
+            message:
+                description: Error message, if any
+                type: string
+                required: false
+        parameter_strategy: replace
+        parameters:
+            - name: pk
+              description: Organization ID (Primary key)
+              type: integer
+              required: true
+              paramType: path
+            - name: body
+              description: JSON body containing organization settings information
+              paramType: body
+              pytype: SaveSettingsSerializer
+              required: true
         """
         body = request.data
         org = Organization.objects.get(pk=pk)
@@ -662,12 +688,14 @@ class OrganizationViewSet(viewsets.ViewSet):
             'query_threshold': org.query_threshold
         })
 
+    # TODO: Shared fields structure has a "class" attribute that won't serialize
     @api_endpoint_class
     @ajax_request_class
     @detail_route(methods=['GET'])
     def shared_fields(self, request, pk=None):
         """
         Retrieves all fields marked as shared for this org tree.
+        DANGER!  Currently broken due to class attribute name in the body, do not use!
         ---
         parameter_strategy: replace
         parameters:
@@ -676,43 +704,7 @@ class OrganizationViewSet(viewsets.ViewSet):
               type: integer
               required: true
               paramType: path
-        type: object
-        """
-        """
-            {
-             'status': 'success',
-             'shared_fields': [
-                 {
-                  "title": Display name of field,
-                  "sort_column": database/search name of field,
-                  "class": css used for field,
-                  "title_class": css used for title,
-                  "type": data type of field,
-                      (One of: 'date', 'floor_area', 'link', 'string', 'number')
-                  "field_type": classification of field.  One of:
-                      'contact_information', 'building_information',
-                      'assessor', 'pm',
-                  "sortable": True if buildings can be sorted on this field,
-                 }
-                 ...
-               ],
-               'public_fields': [
-                   {
-                      "title": Display name of field,
-                      "sort_column": database/search name of field,
-                      "class": css used for field,
-                      "title_class": css used for title,
-                      "type": data type of field,
-                        (One of: 'date', 'floor_area', 'link', 'string', 'number')
-                      "field_type": classification of field.  One of:
-                          'contact_information', 'building_information',
-                          'assessor', 'pm',
-                      "sortable": True if buildings can be sorted on this field,
-                     }
-                     ...
-               ]
-            }
-
+        response_serializer: SharedFieldsActualReturnSerializer
         """
         org_id = pk
         org = Organization.objects.get(pk=org_id)
@@ -860,34 +852,6 @@ class OrganizationViewSet(viewsets.ViewSet):
     def save_cleansing_rules(self, request, pk=None):
         """
         Saves an organization's settings: name, query threshold, shared fields
-        Body type is:
-        {
-            'cleansing_rules': {
-                'missing_matching_field': [
-                    {
-                        'field': 'address_line_1',
-                        'severity': 'error'
-                    }
-                ],
-                'missing_values': [
-                    {
-                        'field': 'address_line_1',
-                        'severity': 'error'
-                    }
-                ],
-                'in_range_checking': [
-                    {
-                        'field': 'conditioned_floor_area',
-                        'enabled': true,
-                        'type': 'number',
-                        'min': null,
-                        'max': 7000000,
-                        'severity': 'error',
-                        'units': 'square feet'
-                    },
-                ]
-            }
-        }
         ---
         parameter_strategy: replace
         parameters:
@@ -897,9 +861,9 @@ class OrganizationViewSet(viewsets.ViewSet):
               required: true
               paramType: path
             - name: body
-              description: body containing all the things
-              type: object
+              description: JSON body containing organization rules information
               paramType: body
+              pytype: RulesSerializer
               required: true
         type:
             status:

--- a/seed/views/users.py
+++ b/seed/views/users.py
@@ -11,7 +11,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
 from django.http import JsonResponse
-from rest_framework import viewsets, status
+from rest_framework import viewsets, status, serializers
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import list_route, detail_route
 
@@ -104,6 +104,15 @@ def _get_severity_from_js(severity):
     """
     d = {v: k for k, v in dict(CLEANSING_SEVERITY).items()}
     return d.get(severity)
+
+
+class EmailAndIDSerializer(serializers.Serializer):
+    email = serializers.CharField(max_length=100)
+    user_id = serializers.IntegerField()
+
+
+class ListUsersResponseSerializer(serializers.Serializer):
+    users = EmailAndIDSerializer(many=True)
 
 
 class UserViewSet(viewsets.ViewSet):
@@ -237,14 +246,7 @@ class UserViewSet(viewsets.ViewSet):
         Retrieves all users' email addresses and IDs.
         Only usable by superusers.
         ---
-        type:
-            users:
-                many: true
-                description: an array of email/user_id objects
-                email:
-                    description: email address
-                user_id:
-                    description: user_id
+        response_serializer: ListUsersResponseSerializer
         """
         users = []
         for u in User.objects.all():


### PR DESCRIPTION
#### Any background context you want to provide?
A user can put a delimited list of tax lot ids in a field. 

#### What's this PR do?
Handles delimited values in jurisdiction_tax_lot_id field. For example, 33366555; 33366125; 33366148 will be broken up into 3 separate tax lots.

#### How should this be manually tested?
There are some test.

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/1907354/18974099/5349846c-865e-11e6-9921-1d537f477f00.png)

#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.) Yes
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs) No
- [x] Does this PR require a regression test? All fixes require a regression test. No
- [ ] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated? No