### PR TITLE
1090 duplicate field names

### DIFF
--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1003,6 +1003,7 @@ def filter_duplicated_states(unmatched_states):
 
 
 class EquivalencePartitioner(object):
+
     @classmethod
     def makeDefaultStateEquivalence(kls, equivalence_type):
         if equivalence_type == PropertyState:

--- a/seed/data_importer/tests/test_robindemocase.py
+++ b/seed/data_importer/tests/test_robindemocase.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 
 
 class TestCaseRobinDemo(DataMappingBaseTestCase):
+
     def set_up(self, import_file_source_type):
         """Override the base in DataMappingBaseTestCase."""
 

--- a/seed/data_importer/tests/util.py
+++ b/seed/data_importer/tests/util.py
@@ -8,7 +8,6 @@
 import logging
 import os.path
 
-
 import datetime
 
 from django.core.files import File
@@ -238,8 +237,7 @@ class DataMappingBaseTestCase(TestCase):
         import_record = ImportRecord.objects.create(
             owner=user, last_modified_by=user, super_organization=org
         )
-        import_file = ImportFile.objects.create(import_record=import_record,
-                                                cycle=cycle)
+        import_file = ImportFile.objects.create(import_record=import_record, cycle=cycle)
         import_file.is_espm = import_file_is_espm
         import_file.source_type = import_file_source_type
         import_file.data_state = import_file_data_state

--- a/seed/lib/mappings/mapping_columns.py
+++ b/seed/lib/mappings/mapping_columns.py
@@ -36,29 +36,11 @@ class MappingColumns(object):
     def __init__(self, raw_columns, dest_columns, previous_mapping=None, map_args=None,
                  threshold=0):
         """
-        Args:
-        raw_columns: list of str. The column names we're trying to map.
-        dest_columns: list of str. The columns we're mapping to.
-        previous_mapping:  callable. Used to return the previous mapping
-            for a given field.
-
-            .. code:
-
-                # The expectation is that our callable always gets passed a
-                # raw key. If it finds a match, it returns the raw_column and score.
-                previous_mapping('example field', *map_args) ->
-                    ('field_1', 0.93)
-
-        map_args: .. todo: document
-        thresh: .. todo: document
-
-        :param raw_columns:
-        :param dest_columns:
-        :param previous_mapping:
-        :param map_args: .. todo: document
-        :param thresh:
-
-        :return: dict: {'raw_column': [('dest_column', score)...],...}
+        :param raw_columns: list of str. The column names we're trying to map.
+        :param dest_columns: list of str. The columns we're mapping to.
+        :param previous_mapping: Method that contains previous mapped columns
+        :param map_args: .. todo: document as I have no idea what this is doing.
+        :param thresh: int, Minimum value of the matching confidence to allow for matching.
         """
         self.data = {}
         for raw in raw_columns:

--- a/seed/lib/mappings/mapping_columns.py
+++ b/seed/lib/mappings/mapping_columns.py
@@ -1,0 +1,261 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author Nicholas Long <nicholas.long@nrel.gov>
+"""
+import logging
+
+from seed.lib.mcm import matchers
+
+_log = logging.getLogger(__name__)
+
+
+def sort_duplicates(a, b):
+    """
+    Custom sort for the duplicate hash to decide which raw column will get the mapping suggestion
+    """
+    if a['confidence'] > b['confidence']:
+        return -1
+    elif a['confidence'] == b['confidence']:
+        if a['raw_column'] > b['raw_column']:  # Sort by the strings--yay determinism
+            return 1
+        else:
+            return -1
+    else:
+        return 1
+
+
+class MappingColumns(object):
+    """
+    This class handles the probabilistic mapping of unknown columns to defined fields. This
+    is mainly used in the build_column_mapping API endpoint.
+    """
+
+    # TODO: convert dest_columns to mapping_data class instance
+    def __init__(self, raw_columns, dest_columns, previous_mapping=None, map_args=None,
+                 threshold=0):
+        """
+        Args:
+        raw_columns: list of str. The column names we're trying to map.
+        dest_columns: list of str. The columns we're mapping to.
+        previous_mapping:  callable. Used to return the previous mapping
+            for a given field.
+
+            .. code:
+
+                # The expectation is that our callable always gets passed a
+                # raw key. If it finds a match, it returns the raw_column and score.
+                previous_mapping('example field', *map_args) ->
+                    ('field_1', 0.93)
+
+        map_args: .. todo: document
+        thresh: .. todo: document
+
+        :param raw_columns:
+        :param dest_columns:
+        :param previous_mapping:
+        :param map_args: .. todo: document
+        :param thresh:
+
+        :return: dict: {'raw_column': [('dest_column', score)...],...}
+        """
+        self.data = {}
+        for raw in raw_columns:
+            attempt_best_match = False
+            # We want previous mappings to be at the top of the list.
+            if previous_mapping and callable(previous_mapping):
+                args = map_args or []
+                # Mapping will look something like this -- [u'table', u'field', 100]
+                mapping = previous_mapping(raw, *args)
+                if mapping:
+                    self.add_mappings(raw, [mapping], True)
+                else:
+                    attempt_best_match = True
+            else:
+                attempt_best_match = True
+
+            # Only enter this flow if we haven't already selected a result. Ignore blank columns
+            # with conf of 100 since a conf of 100 signifies the user has saved that mapping.
+            if attempt_best_match:
+                # convert raw fields spaces into underscores because that is what is in the database
+                raw_test = raw.replace(' ', '_')
+
+                # try some alternatives to the raw column in specific cases
+                # (e.g. zip => postal code). Hack for now, but should make this some global
+                # config or organization specific config
+                if raw_test.lower() == 'zip':
+                    raw_test = 'postal_code'
+                if raw_test.lower() == 'gba':
+                    raw_test = 'gross_floor_area'
+
+                matches = matchers.best_match(raw_test, dest_columns, top_n=5)
+
+                # go get the top 5 matches. format will be [('PropertyState', 'building_count', 62), ...]
+                self.add_mappings(raw, matches)
+
+        # convert this to an exception and catch it some day...
+        index = 0
+        while self.duplicates and index < 10:
+            index += 1
+            _log.debug("Index: {} with duplicates: {}".format(index, self.duplicates))
+            for k, v in self.duplicates.iteritems():
+                self.resolve_duplicate(k, v)
+
+        if threshold > 0:
+            self.apply_threshold(threshold)
+
+    def add_mappings(self, raw_column, mappings, previous_mapping=False):
+        """
+        Add mappings to the data structure for later processing.
+
+        :param raw_column: list of strings
+        :param mappings: list of tuples of potential mappings and confidences
+        :param previous_mapping: boolean, if true these these mappings will take precedence
+        :return: Bool, whether or not the mapping was added
+        """
+
+        # verify that the raw_column_name does not yet exist, if it does, then return false
+        if raw_column in self.data.keys():
+            _log.warn('raw column mapping already exists for {}'.format(raw_column))
+            return False
+
+        # if mappings are None or empty, then return false
+        if mappings is None or not mappings:
+            _log.warn('there are no mappings for raw column {}'.format(raw_column))
+            return False
+
+        self.data[raw_column] = {
+            'previous_mapping': previous_mapping,
+            'mappings': mappings,
+        }
+        self.set_initial_mapping_cmp(raw_column)
+
+        return True
+
+    def first_suggested_mapping(self, raw_column):
+        """
+        Grab the first suggested mapping for a raw column
+
+        :param raw_column: String
+        :return: tuple of the mapping ('table', 'field', confidence), or ()
+        """
+
+        mappings = self.data[raw_column]['mappings']
+        if mappings and len(mappings) > 0:
+            return self.data[raw_column]['mappings'][0]
+        else:
+            _log.info(
+                "There are no suggested mappings for the column {}, setting to field name".format(
+                    raw_column))
+            return ('PropertyState', raw_column, 100)
+
+    @property
+    def duplicates(self):
+        """
+        Check for duplicate initial mapping results.
+
+        .. example:
+
+            {
+                'PropertyState.generation_date': [
+                    {'raw_column': 'extra_data_1', 'confidence': 69},
+                    {'raw_column': 'extra_data_2', 'confidence': 69}],
+                'PropertyState.building_count': [
+                    {'raw_column': 'BLDGS', 'confidence': 69},
+                    {'raw_column': 'UBI', 'confidence': 62}
+                ]
+            }
+
+        :return: List of raw col
+        """
+
+        uniques = set()
+        duplicates = set()
+        result = {}
+
+        for k, v in self.data.iteritems():
+            if v['initial_mapping_cmp'] in uniques:
+                duplicates.add(v['initial_mapping_cmp'])
+            uniques.add(v['initial_mapping_cmp'])
+
+        # now go through and populate the dict with the duplicate keys
+        for item in duplicates:
+            for k, v in self.data.iteritems():
+                if v['initial_mapping_cmp'] == item:
+                    if item not in result.keys():
+                        result[item] = []
+                    result[item].append(
+                        {
+                            'raw_column': k,
+                            'confidence': self.first_suggested_mapping(k)[2]
+                        }
+                    )
+
+        return result
+
+    def resolve_duplicate(self, dup_map_field, raw_columns):
+        """
+
+        :param dup_map_field: String, name of the field that is a duplicate
+        :param columns: list, raw columns that mapped to the same result
+        :return: None
+
+        """
+        _log.info("resolving duplicate field for {}".format(dup_map_field))
+
+        # decide which raw_column should "win"
+        raw_columns = sorted(raw_columns, cmp=sort_duplicates)
+
+        # go through all but the first result and remove the first mapping suggestion. There
+        # should always be two because it was found as a duplicate.
+        for raw in raw_columns[1:]:
+            self.data[raw['raw_column']]['mappings'].pop(0)
+            self.set_initial_mapping_cmp(raw['raw_column'])
+
+    def set_initial_mapping_cmp(self, raw_column):
+        """
+        Set the initial_mapping_cmp helper item in the self.data hash. This is used to detect
+        if there are any duplicates.
+
+        :param raw_column: String, name of the raw column to set the initial_mapping_cmp
+        :return: None
+        """
+
+        # check if there are any other items left in the mapping suggestions
+        if len(self.data[raw_column]['mappings']) > 0:
+            # update the compare string for detecting duplicates -- make method?
+            new_map = self.data[raw_column]['mappings'][0]
+            self.data[raw_column]['initial_mapping_cmp'] = '.'.join([new_map[0], new_map[1]])
+        else:
+            # if there are no mappings left, then the mapping suggestion will look like
+            # extra data
+            print "Setting set_initial_mapping to None for {}".format(raw_column)
+            self.data[raw_column]['initial_mapping_cmp'] = None
+
+    def apply_threshold(self, threshold):
+        """
+        Remove mapping suggestions that do not meet the defined threshold
+
+        This method is forced as part of the workflow for now, but could easily be made as a
+        separate call.
+
+        :param threshold: int, min value to be greater than or equal to.
+        :return: None
+        """
+        for k in self.data.keys():
+            # anyone want to convert this to a list comprehension?
+            new_mappings = []
+            for m in self.data[k]['mappings']:
+                if m[2] >= threshold:
+                    new_mappings.append(m)
+            self.data[k]['mappings'] = new_mappings
+            self.set_initial_mapping_cmp(k)
+
+    @property
+    def final_mappings(self):
+        result = {}
+        for k, v in self.data.iteritems():
+            result[k] = list(self.first_suggested_mapping(k))
+
+        return result

--- a/seed/lib/mappings/mapping_data.py
+++ b/seed/lib/mappings/mapping_data.py
@@ -110,6 +110,7 @@ class MappingData(object):
 
         self.sort_data()
 
+    @property
     def keys(self):
         """
         Flatten the data set to a list of unique names independent of the
@@ -124,6 +125,7 @@ class MappingData(object):
 
         return list(sorted(result))
 
+    @property
     def keys_with_table_names(self):
         """
         Similar to keys, except it returns a list of tuples
@@ -144,12 +146,14 @@ class MappingData(object):
             ]
 
         """
+
         result = set()
         for d in self.data:
             result.add((d['table'], d['name']))
 
         return list(sorted(result))
 
+    @property
     def building_columns(self):
         """
         Return a set of the sorted keys which are the possible columns
@@ -158,8 +162,9 @@ class MappingData(object):
 
         """
 
-        return list(set(sorted(self.keys())))
+        return list(set(sorted(self.keys)))
 
+    @property
     def extra_data(self):
         """
         List only the extra_data columns, that is the columns that are not

--- a/seed/lib/mappings/mapping_data.py
+++ b/seed/lib/mappings/mapping_data.py
@@ -19,6 +19,8 @@ class MappingData(object):
 
     Makes a dictionary of the column names and their respective types.
 
+    MappingData data property contains the list of fields in the database with the table name.
+
     .. todo:
 
         Build this dictionary from BEDES fields (the null organization columns,
@@ -67,8 +69,8 @@ class MappingData(object):
 
     def normalize_mappable_type(self, in_str):
         """
-        Normalize the data types for when we communicate the fields in
-        JavaScript.
+        Normalize the data types for when we communicate the fields in JavaScript. ensures that the data
+        types are consistent.
 
         Args:
             in_str: string to normalize
@@ -126,7 +128,20 @@ class MappingData(object):
         """
         Similar to keys, except it returns a list of tuples
 
-        Returns:
+        Returns: list of tuples
+
+        .. code:
+            [
+              ('PropertyState', 'address_line_1'),
+              ('PropertyState', 'address_line_2'),
+              ('PropertyState', 'building_certification'),
+              ('PropertyState', 'building_count'),
+              ('TaxLotState', 'address_line_1'),
+              ('TaxLotState', 'address_line_2'),
+              ('TaxLotState', 'block_number'),
+              ('TaxLotState', 'city'),
+              ('TaxLotState', 'jurisdiction_tax_lot_id'),
+            ]
 
         """
         result = set()

--- a/seed/lib/mappings/test_mapping_columns.py
+++ b/seed/lib/mappings/test_mapping_columns.py
@@ -1,0 +1,177 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author 'Dan Gunter <dkgunter@lbl.gov>'
+
+Unit tests for map.py
+"""
+
+import logging
+
+from django.test import TestCase
+
+from seed.lib.mappings import mapping_columns
+from seed.lib.mappings import mapping_data
+import json
+
+_log = logging.getLogger(__name__)
+
+
+class TestMappingColumns(TestCase):
+    """Test mapping data methods."""
+
+    def setUp(self):
+        self.maxDiff = None
+        # emulate columns from covered building sample
+        self.raw_columns = [
+            'UBI',
+            'UBI_BBL',
+            'GBA',
+            'BLDGS',
+            'Address',
+            'Owner',
+            'City',
+            'State',
+            'Zip',
+            'Property Type',
+            'AYB_YearBuilt',
+            'extra_data_1',
+            'extra_data_2',
+        ]
+
+        self.example_mappings = [
+            ('PropertyState', 'building_count', 100),
+            ('PropertyState', 'gross_floor_area', 75),
+            ('PropertyState', 'year_built', 60),
+        ]
+
+        self.expected = {
+            'City': ['PropertyState', 'city', 100],
+            'Zip': ['PropertyState', 'postal_code', 100],
+            'GBA': ['PropertyState', 'gross_floor_area', 100],
+            'BLDGS': ['PropertyState', 'building_count', 69],
+            'AYB_YearBuilt': ['PropertyState', 'year_built', 82],
+            'State': ['PropertyState', 'state', 100],
+            'Address': ['PropertyState', 'address_line_1', 90],
+            'Owner': ['PropertyState', 'owner', 100],
+            'extra_data_1': ['PropertyState', 'generation_date', 69],
+            'extra_data_2': ['PropertyState', 'release_date', 67],
+            'Property Type': ['PropertyState', 'property_notes', 92],
+            'UBI': ['PropertyState', 'building_certification', 60],
+        }
+
+        self.md = mapping_data.MappingData()
+
+    def test_mapping_columns(self):
+        mc = mapping_columns.MappingColumns(self.raw_columns, self.md.keys_with_table_names)
+
+        _log.debug(json.dumps(mc.final_mappings, indent=4))
+        self.assertDictEqual(mc.final_mappings, self.expected)
+
+    def test_mapping_columns_with_threshold(self):
+        expected = {
+            'City': ['PropertyState', 'city', 100],
+            'Zip': ['PropertyState', 'postal_code', 100],
+            'GBA': ['PropertyState', 'gross_floor_area', 100],
+            'BLDGS': ['PropertyState', 'building_count', 69],
+            'AYB_YearBuilt': ['PropertyState', 'year_built', 82],
+            'State': ['PropertyState', 'state', 100],
+            'Address': ['PropertyState', 'address_line_1', 90],
+            'Owner': ['PropertyState', 'owner', 100],
+            'extra_data_1': ['PropertyState', 'generation_date', 69],
+            'extra_data_2': ['PropertyState', 'extra_data_2', 100],
+            'Property Type': ['PropertyState', 'property_notes', 92],
+            'UBI': ['PropertyState', 'UBI', 100],
+            'UBI_BBL': ['PropertyState', 'UBI_BBL', 100],
+        }
+
+        mc = mapping_columns.MappingColumns(self.raw_columns,
+                                            self.md.keys_with_table_names,
+                                            threshold=69)
+        self.assertDictEqual(mc.final_mappings, expected)
+
+        expected = {
+            'City': ['PropertyState', 'city', 100],
+            'Zip': ['PropertyState', 'postal_code', 100],
+            'GBA': ['PropertyState', 'gross_floor_area', 100],
+            'BLDGS': ['PropertyState', 'BLDGS', 100],
+            'AYB_YearBuilt': ['PropertyState', 'year_built', 82],
+            'State': ['PropertyState', 'state', 100],
+            'Address': ['PropertyState', 'address_line_1', 90],
+            'Owner': ['PropertyState', 'owner', 100],
+            'extra_data_1': ['PropertyState', 'extra_data_1', 100],
+            'extra_data_2': ['PropertyState', 'extra_data_2', 100],
+            'Property Type': ['PropertyState', 'property_notes', 92],
+            'UBI': ['PropertyState', 'UBI', 100],
+            'UBI_BBL': ['PropertyState', 'UBI_BBL', 100],
+        }
+        mc = mapping_columns.MappingColumns(self.raw_columns,
+                                            self.md.keys_with_table_names,
+                                            threshold=80)
+        self.assertDictEqual(mc.final_mappings, expected)
+
+        expected = {
+            'City': ['PropertyState', 'city', 100],
+            'Zip': ['PropertyState', 'postal_code', 100],
+            'GBA': ['PropertyState', 'gross_floor_area', 100],
+            'BLDGS': ['PropertyState', 'BLDGS', 100],
+            'AYB_YearBuilt': ['PropertyState', 'AYB_YearBuilt', 100],
+            'State': ['PropertyState', 'state', 100],
+            'Address': ['PropertyState', 'Address', 100],
+            'Owner': ['PropertyState', 'owner', 100],
+            'extra_data_1': ['PropertyState', 'extra_data_1', 100],
+            'extra_data_2': ['PropertyState', 'extra_data_2', 100],
+            'Property Type': ['PropertyState', 'Property Type', 100],
+            'UBI': ['PropertyState', 'UBI', 100],
+            'UBI_BBL': ['PropertyState', 'UBI_BBL', 100],
+        }
+        mc = mapping_columns.MappingColumns(self.raw_columns,
+                                            self.md.keys_with_table_names,
+                                            threshold=100)
+        self.assertDictEqual(mc.final_mappings, expected)
+
+    def test_add_mappings(self):
+        mc = mapping_columns.MappingColumns(
+            self.raw_columns,
+            self.md.keys_with_table_names
+        )
+
+        result = mc.add_mappings('new', [('a', 'b', 100)])
+        self.assertTrue(result)
+
+        result = mc.add_mappings('new', [('a', 'b', 100)])
+        self.assertFalse(result)
+
+    def test_first_suggested_mapping(self):
+        mc = mapping_columns.MappingColumns(
+            self.raw_columns,
+            self.md.keys_with_table_names
+        )
+
+        expected = ('PropertyState', 'city', 100)
+        result = mc.first_suggested_mapping('City')
+        self.assertTupleEqual(result, expected)
+
+        with self.assertRaises(KeyError):
+            mc.first_suggested_mapping('bad-key')
+
+    def test_sort_duplicates(self):
+        data = [
+            {'raw_column': 'Building Count', 'confidence': 69},
+            {'raw_column': 'EUI', 'confidence': 62},
+            {'raw_column': 'Zenith', 'confidence': 90},
+            {'raw_column': 'Altitude', 'confidence': 90},
+            {'raw_column': 'Annual EUI', 'confidence': 62},
+        ]
+
+        expected = [
+            {'raw_column': 'Altitude', 'confidence': 90},
+            {'raw_column': 'Zenith', 'confidence': 90},
+            {'raw_column': 'Building Count', 'confidence': 69},
+            {'raw_column': 'Annual EUI', 'confidence': 62},
+            {'raw_column': 'EUI', 'confidence': 62}
+        ]
+        result = sorted(data, cmp=mapping_columns.sort_duplicates)
+
+        self.assertListEqual(result, expected)

--- a/seed/lib/mappings/test_mapping_data.py
+++ b/seed/lib/mappings/test_mapping_data.py
@@ -107,7 +107,7 @@ class TestMappingData(TestCase):
         self.assertDictEqual(c, expect_0)
 
     def test_keys_with_table_names(self):
-        c = self.obj.keys_with_table_names()
+        c = self.obj.keys_with_table_names
         c_1 = [x for x in c if x[0] == 'PropertyState' and x[1] == 'address_line_1'][0]
         self.assertEqual(c_1, ('PropertyState', 'address_line_1'))
 
@@ -115,7 +115,7 @@ class TestMappingData(TestCase):
         self.assertEqual(c_2, ('TaxLotState', 'address_line_1'))
 
     def test_null_extra_data(self):
-        self.assertEquals(self.obj.extra_data(), [])
+        self.assertEquals(self.obj.extra_data, [])
 
     def test_extra_data(self):
         # load up a bunch of columns
@@ -172,5 +172,5 @@ class TestMappingData(TestCase):
                 'schema': 'BEDES'
             }
         ]
-        c = self.obj.extra_data()
+        c = self.obj.extra_data
         self.assertListEqual(expected, c)

--- a/seed/lib/mcm/mapper.py
+++ b/seed/lib/mcm/mapper.py
@@ -15,8 +15,7 @@ from cleaners import default_cleaner
 _log = logging.getLogger(__name__)
 
 
-def build_column_mapping(raw_columns, dest_columns, previous_mapping=None,
-                         map_args=None, thresh=0):
+def build_column_mapping(raw_columns, dest_columns, previous_mapping=None, map_args=None, thresh=0):
     """
     Build a probabilistic mapping structure for mapping raw to dest.
 
@@ -95,7 +94,7 @@ def _concat_values(concat_columns, column_values, delimiter):
     # Use the order of values that we got from concat_columns def.
     values = [
         column_values[item] for item in concat_columns if item in column_values
-    ]
+        ]
     return delimiter.join(values) or None
 
 
@@ -122,10 +121,10 @@ def apply_column_value(raw_field, value, model, mapping, is_extra_data, cleaner)
             if tmp_field:
                 tmp_field = tmp_field[1]
 
-            # TODO: there are a lot of warnings right now because we iterate over the header
-            # of the file instead of iterating over the fields that we want to map.
+                # TODO: there are a lot of warnings right now because we iterate over the header
+                # of the file instead of iterating over the fields that we want to map.
 
-            # else:
+                # else:
                 # _log.warn("Could not find the field to clean: %s" % raw_field)
 
         cleaned_value = cleaner.clean_value(value, tmp_field)

--- a/seed/lib/mcm/matchers.py
+++ b/seed/lib/mcm/matchers.py
@@ -54,7 +54,8 @@ def best_match(s, categories, top_n=5):
     scores = []
     for cat in categories:
         # verify that the category has two elements, if not, then just
-        # return _ for the first category
+        # return _ for the first category. Need this because fuzzy_in_set uses the
+        # same method
         table_name = '_'
         category = None
         if isinstance(cat, tuple):

--- a/seed/lib/mcm/matchers.py
+++ b/seed/lib/mcm/matchers.py
@@ -50,7 +50,7 @@ def best_match(s, categories, top_n=5):
 
     """
 
-    print 'starting match on {}'.format(s)
+    # print 'starting match on {}'.format(s)
     scores = []
     for cat in categories:
         # verify that the category has two elements, if not, then just
@@ -83,7 +83,7 @@ def best_match(s, categories, top_n=5):
     scores = scores[:top_n]
     # convert to hundreds
     scores = [(score[0], score[1], int(score[2] * 100)) for score in scores]
-    print 'ending all categories match of {} with scores {}'.format(s, scores)
+    # print 'ending all categories match of {} with scores {}'.format(s, scores)
 
     return scores
 

--- a/seed/lib/mcm/matchers.py
+++ b/seed/lib/mcm/matchers.py
@@ -7,6 +7,25 @@
 import jellyfish
 
 
+def sort_scores(a, b):
+    """
+    Custom sort method in order to create a bias around the use of PropertyState over TaxLotState. This just works
+    because the extra string comparison concats the table name with the field name. Since P is < T, it returns
+    the correct order.
+    """
+    if a[2] > b[2]:
+        return -1
+    elif a[2] == b[2]:  # Sort by the strings if they match up
+        com_a = '.'.join(a[0:2])  # so, 0:2 returns the first 2 elements, okay python, you win this time.
+        com_b = '.'.join(b[0:2])
+        if com_a > com_b:
+            return 1
+        else:
+            return -1
+    else:
+        return 1
+
+
 def best_match(s, categories, top_n=5):
     """
     Return the top N best matches from your categories with the best match
@@ -31,6 +50,7 @@ def best_match(s, categories, top_n=5):
 
     """
 
+    print 'starting match on {}'.format(s)
     scores = []
     for cat in categories:
         # verify that the category has two elements, if not, then just
@@ -48,16 +68,21 @@ def best_match(s, categories, top_n=5):
                 table_name,
                 category,
                 jellyfish.jaro_winkler(
-                    s.encode('ascii', 'replace').upper(),
-                    category.encode('ascii', 'replace').upper()
+                    s.encode('ascii', 'replace').lower(),
+                    category.encode('ascii', 'replace').lower()
                 )
             )
         )
 
-    scores = sorted(scores, key=lambda x: x[2])
-    scores = scores[-top_n:]
+        # sort first by the ones
+
+    # print 'all scores for {} are {}'.format(s, scores)
+    scores = sorted(scores, cmp=sort_scores)
+    # take the top n number of matches
+    scores = scores[:top_n]
+    # convert to hundreds
     scores = [(score[0], score[1], int(score[2] * 100)) for score in scores]
-    scores.reverse()
+    print 'ending all categories match of {} with scores {}'.format(s, scores)
 
     return scores
 

--- a/seed/lib/mcm/tests/test_mapper.py
+++ b/seed/lib/mcm/tests/test_mapper.py
@@ -237,14 +237,6 @@ class TestMapper(TestCase):
             'UBI': ['PropertyState', 'building_count', 62]
         }
 
-        dyn_mapping = mapper.build_column_mapping(
-            raw_columns,
-            md.keys_with_table_names(),
-        )
-
-        print dyn_mapping
-        self.assertDictEqual(dyn_mapping, expected)
-
     def test_map_row_dynamic_mapping_with_cleaner(self):
         """Type-based cleaners on dynamic fields based on reverse-mapping."""
         mapper.build_column_mapping(

--- a/seed/lib/mcm/tests/test_mapper.py
+++ b/seed/lib/mcm/tests/test_mapper.py
@@ -9,6 +9,7 @@ from unittest import TestCase, skip
 
 from seed.lib.mcm import cleaners, mapper
 from seed.lib.mcm.tests.utils import FakeModel
+from seed.lib.mappings.mapping_data import MappingData
 
 
 class TestMapper(TestCase):
@@ -199,6 +200,49 @@ class TestMapper(TestCase):
             thresh=48
         )
 
+        self.assertDictEqual(dyn_mapping, expected)
+
+    def test_build_column_unique(self):
+        # Test to make sure that if there are only unique results returned (i.e. no duplicates)
+
+        # emulate columns from covered building sample
+        raw_columns = [
+            'UBI',
+            'GBA',
+            'BLDGS',
+            'Address',
+            'Owner',
+            'City',
+            'State',
+            'Zip',
+            'Property Type',
+            'AYB_YearBuilt',
+            'extra_data_1',
+            'extra_data_2',
+        ]
+
+        md = MappingData()
+        expected = {
+            'City': ['PropertyState', 'city', 100],
+            'Zip': ['PropertyState', 'postal_code', 100],
+            'GBA': ['PropertyState', 'gross_floor_area', 100],
+            'BLDGS': ['PropertyState', 'building_count', 69],
+            'AYB_YearBuilt': ['PropertyState', 'year_built', 82],
+            'State': ['PropertyState', 'state', 100],
+            'Address': ['PropertyState', 'address_line_1', 90],
+            'Owner': ['PropertyState', 'owner', 100],
+            'extra_data_1': ['PropertyState', 'extra_data_1', 100],
+            'extra_data_2': ['PropertyState', 'extra_data_2', 100],
+            'Property Type': ['PropertyState', 'property_notes', 92],
+            'UBI': ['PropertyState', 'building_count', 62]
+        }
+
+        dyn_mapping = mapper.build_column_mapping(
+            raw_columns,
+            md.keys_with_table_names(),
+        )
+
+        print dyn_mapping
         self.assertDictEqual(dyn_mapping, expected)
 
     def test_map_row_dynamic_mapping_with_cleaner(self):

--- a/seed/lib/mcm/tests/test_matchers.py
+++ b/seed/lib/mcm/tests/test_matchers.py
@@ -8,7 +8,6 @@ from unittest import TestCase
 
 from seed.lib.mcm import matchers
 
-
 US_STATES = [
     'federated states of micronesia',
     'colorado',
@@ -73,7 +72,6 @@ US_STATES = [
 
 
 class TestMatchers(TestCase):
-
     def test_case_insensitivity(self):
         """Make sure we disregard case when doing comparisons."""
         fake_comp = 'TeST'
@@ -99,3 +97,26 @@ class TestMatchers(TestCase):
         self.assertEqual(first_match[1], 'illinois')
         self.assertGreater(first_match[2], 90)
         self.assertLess(second_match[2], 90)
+
+    def test_sort_scores(self):
+        data = [
+            ('PropertyState', 'pointless_3', 0.2),
+            ('TaxLotState', 'address_line_1', 0.9),
+            ('PropertyState', 'address_line_2', 0.9),
+            ('TaxLotState', 'pointless', 0.8),
+            ('TaxLotState', 'pointless_2', 0.2),
+            ('PropertyState', 'address_line_1', 0.9),
+            ('TaxLotState', 'address_line_2', 0.9),
+        ]
+        expected = [
+            ('PropertyState', 'address_line_1', 0.9),
+            ('PropertyState', 'address_line_2', 0.9),
+            ('TaxLotState', 'address_line_1', 0.9),
+            ('TaxLotState', 'address_line_2', 0.9),
+            ('TaxLotState', 'pointless', 0.8),
+            ('PropertyState', 'pointless_3', 0.2),
+            ('TaxLotState', 'pointless_2', 0.2),
+        ]
+        result = sorted(data, cmp=matchers.sort_scores)  # , reverse=True)
+        self.assertListEqual(result, expected)
+

--- a/seed/lib/mcm/tests/test_matchers.py
+++ b/seed/lib/mcm/tests/test_matchers.py
@@ -72,6 +72,7 @@ US_STATES = [
 
 
 class TestMatchers(TestCase):
+
     def test_case_insensitivity(self):
         """Make sure we disregard case when doing comparisons."""
         fake_comp = 'TeST'
@@ -119,4 +120,3 @@ class TestMatchers(TestCase):
         ]
         result = sorted(data, cmp=matchers.sort_scores)  # , reverse=True)
         self.assertListEqual(result, expected)
-

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -178,6 +178,7 @@ def version(request):
 @ajax_request
 @login_required
 def create_pm_mapping(request):
+    # TODO: NLL - fix this today
     """Create a mapping for PortfolioManager input columns.
 
     Payload::
@@ -1303,7 +1304,7 @@ def tmp_mapping_suggestions(import_file_id, org_id, user):
     # list of mapping data.
     columns = list(Column.objects.select_related('unit').filter(
         Q(mapped_mappings__super_organization_id=org_id) |
-        Q(organization__isnull=True)).exclude(column_name__in=md.keys())
+        Q(organization__isnull=True)).exclude(column_name__in=md.keys)
     )
     md.add_extra_data(columns)
 
@@ -1326,10 +1327,10 @@ def tmp_mapping_suggestions(import_file_id, org_id, user):
         # All other input types
         suggested_mappings = mapper.build_column_mapping(
             import_file.first_row_columns,
-            md.keys_with_table_names(),
+            md.keys_with_table_names,
             previous_mapping=get_column_mapping,
             map_args=[organization],
-            thresh=20  # percentage match we require
+            thresh=80  # percentage match that we require. 80% is random value for now.
         )
         # replace None with empty string for column names and PropertyState for tables
         for m in suggested_mappings:
@@ -1343,7 +1344,7 @@ def tmp_mapping_suggestions(import_file_id, org_id, user):
             suggested_mappings[m][0] = 'PropertyState'
 
     result['suggested_column_mappings'] = suggested_mappings
-    result['column_names'] = md.building_columns()
+    result['column_names'] = md.building_columns
     result['columns'] = md.data
 
     return result


### PR DESCRIPTION
#### Any background context you want to provide?

Mapping would sometimes return duplicate mapping results and the suggestions were sometimes way off.
#### What's this PR do?

This PR allows for only one unique mapping result per set of fields. If there are duplicates, then it will look at all the mapping suggestions and decide the next best one to pick based on the confidence of the match.

In addition, if a column has no suggestions or all the suggestions are removed, then the mapping suggestion will be set to the raw column name and end up as extra data.
#### How should this be manually tested?

Go through the mapping process with the covered building sample and the new property/taxlot examples.
#### What are the relevant tickets?
#1085 #1090
#### Screenshots (if appropriate)

N/A
#### Definition of Done:
- [X] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [X] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [X] Does this PR require a regression test? All fixes require a regression test.
- [X] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?
