### PR TITLE
Remove a test view from the get_api_schema function call

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -95,7 +95,6 @@ class TestReverseViewSet(viewsets.ViewSet):
         return HttpResponse("Hello, world")
 
 
-@api_endpoint
 @ajax_request
 def test_view_with_arg(request, pk=None):
     return {'value of pk': pk}


### PR DESCRIPTION
#### Any background context you want to provide?
The get_api_schema would return this "testing" function.

#### What's this PR do?
This removes the endpoint from the api_schema return.

#### How should this be manually tested?
Browse to /app/api/get_api_schema.  On develop, the `test_view_with_arg` function is listed.  With this fix it is no longer listed.

#### What are the relevant tickets?
#133876097

