### PR TITLE
normalize the jurisdiction tax lot id

### DIFF
--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -171,18 +171,6 @@ def _build_cleaner(org):
     return cleaners.Cleaner(units)
 
 
-def _normalize_tax_lot_id(value):
-    return value.strip().lstrip('0').upper().replace(
-        '-', ''
-    ).replace(
-        ' ', ''
-    ).replace(
-        '/', ''
-    ).replace(
-        '\\', ''
-    )
-
-
 @shared_task
 def map_row_chunk(ids, file_pk, source_type, prog_key, increment, *args, **kwargs):
     """Does the work of matching a mapping to a source type and saving
@@ -238,7 +226,7 @@ def map_row_chunk(ids, file_pk, source_type, prog_key, increment, *args, **kwarg
         # field does not exist in mapping list, so ignoring
 
     # _log.debug("my table mappings are {}".format(table_mappings))
-    # _log.debug("my delimited_field is {}".format(delimited_field))
+    _log.debug("delimited_field that will be expanded and normalized: {}".format(delimited_field))
 
     # Add custom mappings for cross-related data. Right now these are hard coded, but could
     # be a setting if so desired.
@@ -359,7 +347,7 @@ def map_row_chunk(ids, file_pk, source_type, prog_key, increment, *args, **kwarg
                                              import_filename=import_file,
                                              record_type=AUDIT_IMPORT)
 
-                # Make sure that we've saved all of the extra_data column names from the first item in list
+        # Make sure that we've saved all of the extra_data column names from the first item in list
         if map_model_obj:
             Column.save_column_names(map_model_obj)
 

--- a/seed/lib/mcm/mapper.py
+++ b/seed/lib/mcm/mapper.py
@@ -77,7 +77,7 @@ def _concat_values(concat_columns, column_values, delimiter):
     # Use the order of values that we got from concat_columns def.
     values = [
         column_values[item] for item in concat_columns if item in column_values
-        ]
+    ]
     return delimiter.join(values) or None
 
 

--- a/seed/lib/mcm/mapper.py
+++ b/seed/lib/mcm/mapper.py
@@ -77,7 +77,7 @@ def _concat_values(concat_columns, column_values, delimiter):
     # Use the order of values that we got from concat_columns def.
     values = [
         column_values[item] for item in concat_columns if item in column_values
-    ]
+        ]
     return delimiter.join(values) or None
 
 
@@ -159,6 +159,27 @@ def _set_default_concat_config(concat):
     return concat
 
 
+def _normalize_expanded_field(value):
+    """
+    Fields that are expanded (typically tax lot id) are also in need of normalization to remove
+    characters that prevent easy matching.
+
+    This method will remove unwanted characters from the jurisdiction tax lot id.
+
+    :param value: string
+    :return: string
+    """
+    return value.strip().upper().replace(
+        '-', ''
+    ).replace(
+        ' ', ''
+    ).replace(
+        '/', ''
+    ).replace(
+        '\\', ''
+    )
+
+
 def expand_field(field):
     """
     take a field from the csv and expand/split on a delimiter and return a list of individual values
@@ -169,7 +190,7 @@ def expand_field(field):
     """
 
     if isinstance(field, str) or isinstance(field, unicode):
-        return [r.strip() for r in re.split(",|;|:", field)]
+        return [_normalize_expanded_field(r) for r in re.split(",|;|:", field)]
     else:
         return [field]
 

--- a/seed/lib/mcm/mapper.py
+++ b/seed/lib/mcm/mapper.py
@@ -169,15 +169,7 @@ def _normalize_expanded_field(value):
     :param value: string
     :return: string
     """
-    return value.strip().upper().replace(
-        '-', ''
-    ).replace(
-        ' ', ''
-    ).replace(
-        '/', ''
-    ).replace(
-        '\\', ''
-    )
+    return re.sub(r'[-\s/\\]', '', value).upper()
 
 
 def expand_field(field):

--- a/seed/lib/mcm/tests/test_mapper.py
+++ b/seed/lib/mcm/tests/test_mapper.py
@@ -444,6 +444,8 @@ class TestMapper(TestCase):
         self.assertEqual(r, ['4815162342'])
         r = mapper.expand_field("33366555; 33366125; 33366148")
         self.assertEqual(r, ["33366555", "33366125", "33366148"])
+        r = mapper.expand_field("000064545; 0000--34-23492-0; 00///1234: //12  34\\1234")
+        self.assertEqual(r, ['000064545', '000034234920', '001234', '12341234'])
 
     def test_expand_rows(self):
         data = {


### PR DESCRIPTION
#### Any background context you want to provide?
The taxlot id needs to be normalized in order for matching code to work properly.

#### What's this PR do?
Removes -, spaces, /, \ from taxlot ids. Also trims white space and upcases.

#### How should this be manually tested?
import test files with characters above in tax lot id. Make sure to map the jurisdiction tax lot id to the tax lot field in the file.

#### What are the relevant tickets?
https://www.pivotaltracker.com/n/projects/1865423

#### Screenshots (if appropriate)
N/A

#### Definition of Done:
- [X] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [X] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [X] Does this PR require a regression test? All fixes require a regression test.
- [X] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?
