### PR TITLE
Fix faker dependency

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,7 +13,7 @@ selenium==2.53.6
 Sphinx==1.4.5
 tox==2.3.1
 unittest2
-fake-factory
+faker
 
 # For documentation, spelling, and code checking
 pep8


### PR DESCRIPTION
#### Any background context you want to provide?
The `fake-factory` pip package was deprecated and now fails to install.  It is now `faker`.

#### What's this PR do?
Fixes the dependency.

#### How should this be manually tested?
Travis tests should pass.

#### What are the relevant tickets?
n/a