### PR TITLE
upon org creation, create a default cycle

### DIFF
--- a/config/management/commands/create_default_user.py
+++ b/config/management/commands/create_default_user.py
@@ -4,7 +4,6 @@
 :author
 """
 # stdlib
-from datetime import date, datetime, timedelta
 from optparse import make_option
 
 # Django
@@ -14,7 +13,6 @@ from django.core.management.base import BaseCommand
 from seed.utils.organizations import create_organization
 from seed.landing.models import SEEDUser as User
 from seed.lib.superperms.orgs.models import Organization
-from seed.models import Cycle
 
 
 class Command(BaseCommand):
@@ -72,24 +70,4 @@ class Command(BaseCommand):
                 ending=' '
             )
             org, _, user_added = create_organization(u, options['organization'])
-            self.stdout.write('Created!', ending='\n')
-
-        year = date.today().year - 1
-        cycle_name = str(year) + ' Calendar Year'
-        if Cycle.objects.filter(name=cycle_name, organization=org).exists():
-            self.stdout.write(
-                'Cycle <%s> already exists' % cycle_name,
-                ending='\n'
-            )
-            c = Cycle.objects.get(name=cycle_name, organization=org)
-        else:
-            self.stdout.write(
-                'Creating cycle <%s> ...' % cycle_name,
-                ending=' '
-            )
-            c = Cycle.objects.create(name=cycle_name,
-                                     organization=org,
-                                     start=datetime(year, 1, 1),
-                                     end=datetime(year + 1, 1, 1) - timedelta(seconds=1)
-                                     )
             self.stdout.write('Created!', ending='\n')

--- a/seed/tests/test_api.py
+++ b/seed/tests/test_api.py
@@ -208,7 +208,9 @@ class TestApi(TestCase):
         self.assertEqual(r['organizations'][0]['number_of_users'], 1)
         self.assertEqual(r['organizations'][0]['user_role'], 'owner')
         self.assertEqual(r['organizations'][0]['owners'][0]['first_name'], 'Jaqen')
-        self.assertEqual(r['organizations'][0]['cycles'], [{u'name': u'Test Hack Cycle 2015', u'num_properties': 0, u'num_taxlots': 0}])
+        self.assertEqual(r['organizations'][0]['cycles'], [
+            {u'name': u'Default 2016 Calendar Year', u'num_properties': 0, u'num_taxlots': 0},
+            {u'name': u'Test Hack Cycle 2015', u'num_properties': 0, u'num_taxlots': 0}])
 
     def test_organization_details(self):
         r = self.client.get('/api/v2/organizations/', follow=True, **self.headers)

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -3547,7 +3547,7 @@ class InventoryViewTests(TestCase):
         results = json.loads(response.content)
         self.assertEqual(results['status'], 'success')
 
-        self.assertEqual(len(results['cycles']), 1)
+        self.assertEqual(len(results['cycles']), 2)
         cycle = results['cycles'][0]
         self.assertEqual(cycle['id'], self.cycle.pk)
         self.assertEqual(cycle['name'], self.cycle.name)


### PR DESCRIPTION
#### Any background context you want to provide?
There was an error when new organizations were created that data sets could not be added. This was because there was not a cycle available. 

#### What's this PR do?
When an organization gets created a Default {year-1} Calendar Year cycle will be generated automatically.

#### How should this be manually tested?
Create org, then create a data set. Make sure that no error is thrown.

#### What are the relevant tickets?
#1182 

#### Screenshots (if appropriate)

#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?