### PR TITLE
Fixes Python build failures in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update \
         swig \
         python-pip \
         python-dev \
+        enchant \
+        python-numpy \
+        python-scipy \
         libssl-dev \
         liblzma-dev \
         libevent1-dev \

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -3,6 +3,4 @@
 django-debug-toolbar==1.4
 
 # required for migration scripts (for new data model) at the moment
-numpy
-scipy
 ipython

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,6 +10,9 @@ pytest
 pytest-django
 requests==2.10.0
 selenium==2.53.6
+enum34
+configparser
+imagesize
 Sphinx==1.4.5
 tox==2.3.1
 unittest2


### PR DESCRIPTION
#### Any background context you want to provide?

Building out the Docker dev instance fails with some unmet dependencies
in the Python build phase.

- Having some trouble building scipy/numpy with a `no lapack/blas
  resources found` error. Solution here is just to throw in pre-built
  versions with apt-get instead, since I understand these to be
  transitional dependencies from comments.

- Building sphinx for test fails with a missing dependency on C
  `enchant`, and missing Python modules on `enum`, `configparser`, and
  `imagesize`.  Added `enchant` to apt phase, missing python modules to
  `pip`'s test requirements file.

#### What's this PR do?

Repairs the docker build.

#### How should this be manually tested?

Expect to see no errors with `docker-compose up` on a machine with a fresh Docker environment.

#### What are the relevant tickets?

n/a

#### Screenshots (if appropriate)

n/a

#### Definition of Done:
- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [ ] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [ ] Does this PR require a regression test? All fixes require a regression test.
- [ ] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?