### PR TITLE
added taxlot_view_id to related property returned in getProperties, u…

### DIFF
--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -198,7 +198,8 @@ class PropertyViewSet(GenericViewSet):
         for join in joins:
             join_dict = taxlot_map[join.taxlot_view_id].copy()
             join_dict.update({
-                'primary': 'P' if join.primary else 'S'
+                'primary': 'P' if join.primary else 'S',
+                'taxlot_view_id': join.taxlot_view_id
             })
             try:
                 join_map[join.property_view_id].append(join_dict)


### PR DESCRIPTION
#### Any background context you want to provide?
Now that BE is done and API can pair, it pairs with view ids and not state ids.
#### What's this PR do?
Change FE to send view ids to API for pairing. Also get_properties now returns taxlot_view_id in related.
#### How should this be manually tested?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Definition of Done:
- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [ ] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [ ] Does this PR require a regression test? All fixes require a regression test.
- [ ] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?