### PR TITLE
add objects to create responses

### DIFF
--- a/seed/data_importer/tests/test_mergeduplicaterows.py
+++ b/seed/data_importer/tests/test_mergeduplicaterows.py
@@ -96,7 +96,7 @@ class TestCaseMultipleDuplicateMatching(DataMappingBaseTestCase):
 
         self.assertEqual(TaxLot.objects.count(), 0)
 
-        self.assertEqual(self.import_file.find_unmatched_property_states().count(), 7)
+        self.assertEqual(self.import_file.find_unmatched_property_states().count(), 2)
         self.assertEqual(self.import_file.find_unmatched_tax_lot_states().count(), 0)
 
         return

--- a/seed/tests/api/test_modules.py
+++ b/seed/tests/api/test_modules.py
@@ -101,7 +101,7 @@ def upload_match_sort(header, main_url, organization_id, dataset_id, cycle_id, f
         json=payload
     )
     result = check_progress(main_url, header, result.json()['progress_key'])
-    check_status(result, partmsg, log)
+    check_status(result, partmsg, c)
 
     # Check number of matched and unmatched BuildingSnapshots
     print ('API Function: matching_results\n'),
@@ -250,9 +250,9 @@ def account(header, main_url, username, log):
                           headers=header)
     check_status(result, partmsg, log, piid_flag='organizations')
 
-    # # Get the organization id to be used.
-    # # NOTE: Loop through the organizations and get the org_id
-    # # where the organization owner is 'username' else get the first organization.
+    # Get the organization id to be used.
+    # NOTE: Loop through the organizations and get the org_id
+    # where the organization owner is 'username' else get the first organization.
     orgs_result = result.json()
 
     for org in orgs_result['organizations']:
@@ -268,17 +268,18 @@ def account(header, main_url, username, log):
     # Get the organization details
     partmsg = 'get_organization (2)'
     mod_url = main_url + '/api/v2/organizations/%s' % str(organization_id)
-    result = requests.get(mod_url,
-                          headers=header)
+    result = requests.get(mod_url, headers=header)
     check_status(result, partmsg, log)
 
     # Change user profile
     # NOTE: Make sure these credentials are ok.
     print ('API Function: update_user\n'),
     partmsg = 'update_user'
-    user_payload = {'first_name': 'Sherlock',
-                    'last_name': 'Holmes',
-                    'email': username}
+    user_payload = {
+        'first_name': 'Sherlock',
+        'last_name': 'Holmes',
+        'email': username
+    }
     result = requests.put(main_url + '/api/v2/users/%s/' % user_pk,
                           headers=header,
                           data=user_payload)

--- a/seed/views/cycles.py
+++ b/seed/views/cycles.py
@@ -92,6 +92,20 @@ class CycleView(GenericViewSet):
               description: The organization_id
               required: true
               paramType: query
+        type:
+            status:
+                required: true
+                type: string
+                description: either success or error
+            message:
+                type: string
+                description: error message, if any
+            name:
+                type: string
+                description: Name of the cycle that was created
+            cycle:
+                type dict
+                description: cycle that was created as JSON
         """
 
         body = request.data
@@ -109,7 +123,15 @@ class CycleView(GenericViewSet):
             end=body['end'],
             created=timezone.now()
         )
-        return JsonResponse({'status': 'success', 'id': record.pk, 'name': record.name})
+        return JsonResponse(
+            {
+                'status': 'success',
+                'id': record.pk,
+                'name': record.name,
+                'cycle': model_to_dict(record),
+            }
+            # TODO: this should return 201
+        )
 
     @api_endpoint_class
     @ajax_request_class

--- a/seed/views/cycles.py
+++ b/seed/views/cycles.py
@@ -104,7 +104,7 @@ class CycleView(GenericViewSet):
                 type: string
                 description: Name of the cycle that was created
             cycle:
-                type dict
+                type: dict
                 description: cycle that was created as JSON
         """
 


### PR DESCRIPTION
#### Any background context you want to provide?
Working on the Ruby Client to talk to SEED and realized that the SEED API could be improved a bit.

#### What's this PR do?
Add the created objects to the JSON response for Organizations and Cycles.

#### How should this be manually tested?
Monkey Test

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
#### Definition of Done:
- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [ ] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [ ] Does this PR require a regression test? All fixes require a regression test.
- [ ] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?