### PR TITLE
Audit History Order

### DIFF
--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -624,6 +624,14 @@ class PropertyViewSet(GenericViewSet):
                         if log.parent2.name in ['Import Creation', 'Manual Edit']:
                             record = record_dict(log.parent2)
                             history.append(record)
+                        elif log.parent2.name == 'System Match' and log.parent2.parent1.name == 'Import Creation' and \
+                                log.parent2.parent2.name == 'Import Creation':
+                            # Handle case where an import file matches within itself, and proceeds to match with
+                            # existing records
+                            record = record_dict(log.parent2.parent2)
+                            history.append(record)
+                            record = record_dict(log.parent2.parent1)
+                            history.append(record)
                         else:
                             tree = log.parent2
                     if log.parent1.name in ['Import Creation', 'Manual Edit']:

--- a/seed/views/taxlots.py
+++ b/seed/views/taxlots.py
@@ -499,6 +499,14 @@ class TaxLotViewSet(GenericViewSet):
                         if log.parent2.name in ['Import Creation', 'Manual Edit']:
                             record = record_dict(log.parent2)
                             history.append(record)
+                        elif log.parent2.name == 'System Match' and log.parent2.parent1.name == 'Import Creation' and \
+                                log.parent2.parent2.name == 'Import Creation':
+                            # Handle case where an import file matches within itself, and proceeds to match with
+                            # existing records
+                            record = record_dict(log.parent2.parent2)
+                            history.append(record)
+                            record = record_dict(log.parent2.parent1)
+                            history.append(record)
                         else:
                             tree = log.parent2
                     if log.parent1.name in ['Import Creation', 'Manual Edit']:


### PR DESCRIPTION
Correct cosmetic audit history order in the case where an import file matches within itself and then proceeds to match with existing data.

It's difficult to order a tree structure linearly, but this PR fixes a corner case where some import files with duplicates (or matches) need to match with existing data