### PR TITLE
Added a label exclusion button #1401

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -76,7 +76,7 @@ angular.module('BE.seed.controller.inventory_list', [])
         var ids;
         if ($scope.labelLogic === 'and') {
           ids = _.intersection.apply(null, _.map($scope.selected_labels, 'is_applied'));
-        } else if ($scope.labelLogic === 'or') {
+        } else if (_.includes(['or', 'exclude'], $scope.labelLogic)) {
           ids = _.uniq(_.flatten(_.map($scope.selected_labels, 'is_applied')));
         }
 
@@ -84,8 +84,13 @@ angular.module('BE.seed.controller.inventory_list', [])
 
         if ($scope.selected_labels.length) {
           _.forEach($scope.gridApi.grid.rows, function (row) {
-            if ((!_.includes(ids, row.entity.id) && row.treeLevel === 0) || !_.has(row, 'treeLevel')) $scope.gridApi.core.setRowInvisible(row);
-            else $scope.gridApi.core.clearRowInvisible(row);
+            if ($scope.labelLogic === 'exclude') {
+              if ((_.includes(ids, row.entity.id) && row.treeLevel === 0) || !_.has(row, 'treeLevel')) $scope.gridApi.core.setRowInvisible(row);
+              else $scope.gridApi.core.clearRowInvisible(row);
+            } else {
+              if ((!_.includes(ids, row.entity.id) && row.treeLevel === 0) || !_.has(row, 'treeLevel')) $scope.gridApi.core.setRowInvisible(row);
+              else $scope.gridApi.core.clearRowInvisible(row);
+            }
           });
         } else {
           _.forEach($scope.gridApi.grid.rows, $scope.gridApi.core.clearRowInvisible);
@@ -94,7 +99,7 @@ angular.module('BE.seed.controller.inventory_list', [])
       };
 
       $scope.labelLogic = localStorage.getItem('labelLogic');
-      $scope.labelLogic = _.includes(['and', 'or'], $scope.labelLogic) ? $scope.labelLogic : 'and';
+      $scope.labelLogic = _.includes(['and', 'or', 'exclude'], $scope.labelLogic) ? $scope.labelLogic : 'and';
       $scope.labelLogicUpdated = function () {
         localStorage.setItem('labelLogic', $scope.labelLogic);
         filterUsingLabels();

--- a/seed/static/seed/partials/inventory_list.html
+++ b/seed/static/seed/partials/inventory_list.html
@@ -67,6 +67,7 @@
         <div class="form-group btn-group">
             <label class="btn btn-default btn-sm" style="width:50px;" ng-model="labelLogic" uib-btn-radio="'and'" ng-change="labelLogicUpdated()" ng-disabled="!labels.length">AND</label>
             <label class="btn btn-default btn-sm" style="width:50px;" ng-model="labelLogic" uib-btn-radio="'or'" ng-change="labelLogicUpdated()" ng-disabled="!labels.length">OR</label>
+            <label class="btn btn-default btn-sm" style="width:75px;" ng-model="labelLogic" uib-btn-radio="'exclude'" ng-change="labelLogicUpdated()" ng-disabled="!labels.length">EXCLUDE</label>
         </div>
         <div class="form-group btn-group building-list-filter-buttons">
             <button type="button" ng-click="clear_labels()" class="btn btn-default btn-sm" ng-disabled="!labels.length">Clear Labels</button>


### PR DESCRIPTION
#### What's this PR do?
Adds a label `EXCLUDE` button to the inventory list page
#### How should this be manually tested?
Add one or more labels to the label filter on the inventory list page and select the `EXCLUDE` button.  Any inventory records with any of those labels will be hidden.
#### What are the relevant tickets?
#1401 
#### Screenshots (if appropriate)
![2017-07-28_114356](https://user-images.githubusercontent.com/411466/28729579-277078a4-738a-11e7-8bbb-00a4d830b20c.png)
