### PR TITLE
Date filter

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -185,6 +185,7 @@ angular.module('BE.seed.controller.inventory_list', [])
       _.map($scope.columns, function (col) {
         var options = {};
         if (col.type === 'number') options.filter = inventory_service.numFilter();
+        else if (col.type === 'date') options.filter = inventory_service.dateFilter();
         else options.filter = inventory_service.textFilter();
         if (col.type == 'text' || col.type == 'numberStr') options.sortingAlgorithm = naturalSort;
         if (col.name == 'number_properties' && col.related) options.treeAggregationType = 'total';

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -536,18 +536,73 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
                 }
 
                 operator = filterData[3];
-                value = Date.parse(filterData[4] + 'T00:00:00');
                 switch (operator) {
                   case '<':
+                    value = Date.parse(filterData[4] + 'T00:00:00');
                     match = cellDate < value;
                     return match;
                   case '<=':
+                    value = filterData[4];
+                    var v = value.match(/^(\d{4})(?:-(\d{2})(?:-(\d{2}))?)?$/);
+                    var ymd = {
+                      y: _.parseInt(v[1]),
+                      m: _.parseInt(v[2]),
+                      d: _.parseInt(v[3])
+                    };
+
+                    // Add a day, subtract a millisecond
+                    if (filterData[4].length === 10) {
+                      value = Date.parse(filterData[4] + 'T00:00:00') + 86399999;
+                    }
+                    // Add a month, subtract a millisecond
+                    else if (filterData[4].length === 7) {
+                      var d;
+                      if (ymd.m === 12) {
+                        d = (ymd.y + 1) + '-01';
+                      } else {
+                        d = ymd.y + '-' + _.padStart(ymd.m + 1, 2, '0');
+                      }
+                      value = Date.parse(d + 'T00:00:00') - 1;
+                    }
+                    // Add a year, subtract a millisecond
+                    else if (filterData[4].length === 4) {
+                      value = Date.parse((ymd.y + 1) + 'T00:00:00') - 1;
+                    }
+
                     match = cellDate <= value;
                     return match;
                   case '>':
+                    value = filterData[4];
+                    var v = value.match(/^(\d{4})(?:-(\d{2})(?:-(\d{2}))?)?$/);
+                    var ymd = {
+                      y: _.parseInt(v[1]),
+                      m: _.parseInt(v[2]),
+                      d: _.parseInt(v[3])
+                    };
+
+                    // Add a day, subtract a millisecond
+                    if (filterData[4].length === 10) {
+                      value = Date.parse(filterData[4] + 'T00:00:00') + 86399999;
+                    }
+                    // Add a month, subtract a millisecond
+                    else if (filterData[4].length === 7) {
+                      var d;
+                      if (ymd.m === 12) {
+                        d = (ymd.y + 1) + '-01';
+                      } else {
+                        d = ymd.y + '-' + _.padStart(ymd.m + 1, 2, '0');
+                      }
+                      value = Date.parse(d + 'T00:00:00') - 1;
+                    }
+                    // Add a year, subtract a millisecond
+                    else if (filterData[4].length === 4) {
+                      value = Date.parse((ymd.y + 1) + 'T00:00:00') - 1;
+                    }
+
                     match = cellDate > value;
                     return match;
                   case '>=':
+                    value = Date.parse(filterData[4] + 'T00:00:00');
                     match = cellDate >= value;
                     return match;
                 }

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -431,7 +431,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
     };
 
 
-    var numRegex = /^(==?|!=?|<>)?\s*(null|-?\d+)|(<=?|>=?)\s*(-?\d+)$/;
+    var numRegex = /^(==?|!=?|<>)?\s*(null|-?\d+)$|^(<=?|>=?)\s*(-?\d+)$/;
     inventory_service.numFilter = function () {
       return {
         condition: function (searchTerm, cellValue) {
@@ -475,6 +475,80 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
                     return match;
                   case '>=':
                     match = cellValue >= value;
+                    return match;
+                }
+              }
+            } else {
+              match = false;
+              return match;
+            }
+          });
+          return match;
+        }
+      };
+    };
+
+    var dateRegex = /^(==?|!=?|<>)?\s*(null|\d{4}(?:-\d{2}(?:-\d{2})?)?)$|^(<=?|>=?)\s*(\d{4}(?:-\d{2}(?:-\d{2})?)?)$/;
+    inventory_service.dateFilter = function () {
+      return {
+        condition: function (searchTerm, cellValue) {
+          var match = true;
+          var cellDate = Date.parse(cellValue);
+          var d = new Date(cellValue);
+          var cellYMD = {
+            y: d.getFullYear(),
+            m: d.getMonth() + 1,
+            d: d.getDate()
+          };
+          var searchTerms = _.map(_.split(_.replace(searchTerm, /\\-/g, '-'), ','), _.trim);
+          _.forEach(searchTerms, function (search) {
+            var filterData = search.match(dateRegex);
+            if (filterData) {
+              var operator, value;
+              if (!_.isUndefined(filterData[2])) {
+                // Equality condition
+                operator = filterData[1];
+                value = filterData[2];
+                var v = value.match(/^(\d{4})(?:-(\d{2})(?:-(\d{2}))?)?$/);
+                var ymd = {
+                  y: _.parseInt(v[1]),
+                  m: _.parseInt(v[2]),
+                  d: _.parseInt(v[3])
+                };
+                if (_.isUndefined(operator) || _.startsWith(operator, '=')) {
+                  // Equal
+                  match = (value === 'null') ? (_.isNil(cellValue)) : (
+                    cellYMD.y === ymd.y && (_.isNaN(ymd.m) || cellYMD.m === ymd.m) && (_.isNaN(ymd.d) || cellYMD.d === ymd.d)
+                  );
+                  return match;
+                } else {
+                  // Not equal
+                  match = (value === 'null') ? (!_.isNil(cellValue)) : (
+                    cellYMD.y !== ymd.y || (!_.isNaN(ymd.m) && cellYMD.y === ymd.y && cellYMD.m !== ymd.m) || (!_.isNaN(ymd.m) && !_.isNaN(ymd.d) && cellYMD.y === ymd.y && cellYMD.m === ymd.m && cellYMD.d !== ymd.d)
+                  );
+                  return match;
+                }
+              } else {
+                // Range condition
+                if (_.isNil(cellValue)) {
+                  match = false;
+                  return match;
+                }
+
+                operator = filterData[3];
+                value = Date.parse(filterData[4] + 'T00:00:00');
+                switch (operator) {
+                  case '<':
+                    match = cellDate < value;
+                    return match;
+                  case '<=':
+                    match = cellDate <= value;
+                    return match;
+                  case '>':
+                    match = cellDate > value;
+                    return match;
+                  case '>=':
+                    match = cellDate >= value;
                     return match;
                 }
               }


### PR DESCRIPTION
#### What's this PR do?
#### How should this be manually tested?
On the inventory list page, the 3 datetime fields (`Recent Sale Date`, `PM Generation Date`, `PM Release Date`) can now be filtered similar to the number filter.

The filter supports multiple filters separated by commas, and the date string can be either a year (`2016`), a year and a month (`2016-05`), or a full date with no time (`2016-05-31`).

The filter syntax is as follows:
##### Equality
> 2016
> 2016-05
> 2016-05-31
> = 2016
> == 2016-05

##### Inequality
> != 2015
> ! 2015
> <> 2015-10

##### Range, Combination
> \>= 2016
> < 2016-05
> 2016, >= 2016-10-01
> \>= 2015, < 2017

#### What are the relevant tickets?
#1416