### PR TITLE
Fixed cycle mismatch when the backend doesn't order the cycles by name

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -170,9 +170,8 @@ angular.module('BE.seed.controller.inventory_list', [])
         });
       };
 
-      var lastCycleId = inventory_service.get_last_cycle();
       $scope.cycle = {
-        selected_cycle: lastCycleId ? _.find(cycles.cycles, {id: lastCycleId}) : _.first(cycles.cycles),
+        selected_cycle: _.find(cycles.cycles, {id: inventory.cycle_id}),
         cycles: cycles.cycles
       };
 

--- a/seed/views/cycles.py
+++ b/seed/views/cycles.py
@@ -147,6 +147,11 @@ class CycleViewSet(SEEDOrgModelViewSet):
     data_name = 'cycles'
     filter_class = CycleFilterSet
 
+    def get_queryset(self):
+        org_id = self.get_organization(self.request)
+        # Order cycles by name because if the user hasn't specified then the front end WILL default to the first
+        return Cycle.objects.filter(organization_id=org_id).order_by('name')
+
     def perform_create(self, serializer):
         org_id = self.get_organization(self.request)
         user = self.request.user

--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -528,7 +528,7 @@ class PropertyViewSet(GenericViewSet):
         except PropertyView.DoesNotExist:
             result = {
                 'status': 'error',
-                'message': 'property view with id {} does not exist'.format(pk)
+                'message': 'property view with property id {} does not exist'.format(pk)
             }
         except PropertyView.MultipleObjectsReturned:
             result = {

--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -213,6 +213,7 @@ class PropertyViewSet(GenericViewSet):
                     'pagination': {
                         'total': 0
                     },
+                    'cycle_id': None,
                     'results': []
                 })
 
@@ -241,6 +242,7 @@ class PropertyViewSet(GenericViewSet):
                 'has_previous': paginator.page(page).has_previous(),
                 'total': paginator.count
             },
+            'cycle_id': cycle.id,
             'results': []
         }
 


### PR DESCRIPTION
#### How should this be manually tested?
Click the (i) button on the inventory list page (for multiple cycles) to make sure that the hyperlinks work as expected