### PR TITLE
Makes start-seed run a bit easier under Vagrant

### DIFF
--- a/bin/start-seed.sh
+++ b/bin/start-seed.sh
@@ -36,7 +36,7 @@ fi
 running "manage.py runserver"
 if [ $? -eq 0 ]; then
     printf "Starting Django standalone server\n"
-    ./manage.py runserver --settings=config.settings.dev
+    ./manage.py runserver 0.0.0.0:8000 --settings=config.settings.dev
 else
     printf "Django server is already running\n"
 fi


### PR DESCRIPTION
Sets the listening interfaces to "all" ie. 0.0.0.0, instead of
implicitly localhost. This makes setting up network forwarding under
Vagrant for dev instances a bit easier.