### PR TITLE
Allow short labels to be filtered on the inventory list page

### DIFF
--- a/seed/static/seed/partials/inventory_list.html
+++ b/seed/static/seed/partials/inventory_list.html
@@ -50,6 +50,7 @@
             <div class="btn-group">
                 <tags-input id="tagsInput"
                             ng-model="selected_labels"
+                            min-length="1"
                             placeholder="Add a label"
                             replace-spaces-with-dashes="false"
                             add-from-autocomplete-only="true"


### PR DESCRIPTION
#### What's this PR do?
Short label names (less than 3 characters) were unselectable when filtering by label on the inventory list view.

#### How should this be manually tested?
Create (or rename) a label to be only one or two characters, apply that label to a record, and attempt to filter by that label on the inventory list view.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/411466/29795606-2492a79a-8c0a-11e7-8988-f1b4ef11d0e3.png)
