### PR TITLE
Filter out bazillions of markdown package import debug log statements

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -52,12 +52,18 @@ LOGGING = {
             'format': "%(pathname)s:%(lineno)d - %(message)s"
         }
     },
+    'filters': {
+        'mute_markdown_import': {
+            '()': 'seed.utils.generic.MarkdownPackageDebugFilter'
+        }
+    },
     # set up some log message handlers to choose from
     'handlers': {
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'file_line_number',
+            'filters': ['mute_markdown_import']
         }
     },
     'loggers': {

--- a/seed/utils/generic.py
+++ b/seed/utils/generic.py
@@ -5,11 +5,19 @@
 :author
 """
 import json
+import logging
 import math
 from datetime import datetime
 
 from django.core import serializers
 from django.contrib.postgres.fields import JSONField
+
+
+class MarkdownPackageDebugFilter(logging.Filter):
+    def filter(self, record):
+        if 'markdown.extensions.headerid' in record.msg:
+            return False
+        return True
 
 
 def split_model_fields(obj, fields):


### PR DESCRIPTION
#### Any background context you want to provide?
The Swagger page imports the markdown package, and upon import, it issues many, many debug lines to the console.  This only occurs in dev mode when the log is set to debug.  But it makes it hard to develop when all those lines mask actual messages.

#### What's this PR do?
Adds a log filter that will simply filter out the markdown import messages.

#### How should this be manually tested?
On the develop branch, run SEED in dev mode and load the swagger page.  The console should be littered with messages:

![image](https://user-images.githubusercontent.com/849824/29977104-de8b0a6c-8f01-11e7-8c61-acd0289135ea.png)

Then on this branch, run SEED in dev mode and those particular messages should be gone, leaving only relevant messages.

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
Above.

#### Definition of Done:
- [ ] Is there appropriate test coverage? N/A - I think.
- [ ] Does this PR require a Selenium test? No
- [ ] Does this PR require a regression test? No
- [ ] Does this add new dependencies? No