### PR TITLE
Fix typo, remove spurious 301 redirect.

### DIFF
--- a/seed/static/seed/js/services/data_quality_service.js
+++ b/seed/static/seed/js/services/data_quality_service.js
@@ -17,7 +17,7 @@ angular.module('BE.seed.service.data_quality', []).factory('data_quality_service
      * @param import_file_id: int, represents file import id.
      */
     data_quality_factory.get_data_quality_results = function (import_file_id) {
-      return $http.get('/api/v2/import_files/' + import_file_id + '/data_quality_results').then(function (response) {
+      return $http.get('/api/v2/import_files/' + import_file_id + '/data_quality_results/').then(function (response) {
         return response.data.data;
       });
     };


### PR DESCRIPTION
Seems djangorestframework will fill in a 301 redirect to add a trailing slash. No need for two AJAX requests here.