### PR TITLE
Fixes startup warning on `seed.NonCanonicalProjectBuildings.projectbuilding`

### DIFF
--- a/seed/models/models.py
+++ b/seed/models/models.py
@@ -318,7 +318,7 @@ class Enum(models.Model):
 class NonCanonicalProjectBuildings(models.Model):
     """Holds a reference to all project buildings that do not point at a
     canonical building snapshot."""
-    projectbuilding = models.ForeignKey(ProjectBuilding, primary_key=True)
+    projectbuilding = models.OneToOneField(ProjectBuilding, primary_key=True)
 
 
 class AttributeOption(models.Model):


### PR DESCRIPTION
Doesn't look like this model is used anywhere anymore, but this startup warning courtesy of the Django system check was starting to bug me.

Starting the dev server without this patch was always giving me this notice:

```
September 08, 2017 - 20:19:45
Django version 1.9.13, using settings 'config.settings.dev'
Starting development server at http://0.0.0.0:8000/
Quit the server with CONTROL-C.
Performing system checks...

System check identified some issues:

WARNINGS:
seed.NonCanonicalProjectBuildings.projectbuilding: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
        HINT: ForeignKey(unique=True) is usually better served by a OneToOneField.

System check identified 1 issue (0 silenced).
```