### PR TITLE
make the normalize tax lot code less stringent

### DIFF
--- a/seed/data_importer/tests/test_case_b.py
+++ b/seed/data_importer/tests/test_case_b.py
@@ -70,7 +70,7 @@ class TestCaseB(DataMappingBaseTestCase):
             data_state=DATA_STATE_MAPPING,
             import_file=self.import_file,
         ).first()
-        self.assertEqual(p_test.lot_number, "33366555;33366125;33366148")
+        self.assertEqual(p_test.lot_number, "333/66555;333/66125;333/66148")
 
         tasks.match_buildings(self.import_file.id)
 

--- a/seed/data_importer/tests/test_data_import.py
+++ b/seed/data_importer/tests/test_data_import.py
@@ -167,7 +167,7 @@ class TestMappingExampleData(DataMappingBaseTestCase):
         ps = PropertyState.objects.filter(address_line_1='521 Elm Street')[0]
         self.assertEqual(ps.site_eui, 1358)
         # The lot_number should also have the normalized code run, then re-delimited
-        self.assertEqual(ps.lot_number, '33366555;33366125;33366148')
+        self.assertEqual(ps.lot_number, '333/66555;333/66125;333/66148')
 
     def test_promote_properties(self):
         """Test if the promoting of a property works as expected"""

--- a/seed/lib/mcm/mapper.py
+++ b/seed/lib/mcm/mapper.py
@@ -143,14 +143,38 @@ def _set_default_concat_config(concat):
 def _normalize_expanded_field(value):
     """
     Fields that are expanded (typically tax lot id) are also in need of normalization to remove
-    characters that prevent easy matching.
+    characters that prevent easy matching. This method will remove unwanted characters from the
+    jurisdiction tax lot id.
 
-    This method will remove unwanted characters from the jurisdiction tax lot id.
+    Here are some examples of what actual city taxlots can look like
+        13153123902
+        069180102923*
+        14A6-12
+        123.4-123
+        PANL1593005
+        0.000099
+        00012312
+        12-123-12-12-12-1-34-567
+        12 0123 TT0612
+
+    Method does the following:
+        Removes leading/trailing spaces
+        Removes duplicate characters next to each other when it is a space, \, /, -, *, .
+        Does not remove compbinations of duplicates, so 1./*5 will still be valid
 
     :param value: string
     :return: string
     """
-    return re.sub(r'[-\s/\\]', '', value).upper()
+
+    value = value.strip()
+    value = re.sub(r'\s{2,}', ' ', value)
+    value = re.sub(r'/{2,}', '/', value)
+    value = re.sub(r'\\{2,}', '\\\\', value)
+    value = re.sub(r'-{2,}', '-', value)
+    value = re.sub(r'\*{2,}', '*', value)
+    value = re.sub(r'\.{2,}', '.', value)
+
+    return value
 
 
 def expand_and_normalize_field(field, return_list=False):

--- a/seed/lib/mcm/mapper.py
+++ b/seed/lib/mcm/mapper.py
@@ -173,6 +173,7 @@ def _normalize_expanded_field(value):
     value = re.sub(r'-{2,}', '-', value)
     value = re.sub(r'\*{2,}', '*', value)
     value = re.sub(r'\.{2,}', '.', value)
+    value = value.upper()
 
     return value
 

--- a/seed/lib/mcm/mapper.py
+++ b/seed/lib/mcm/mapper.py
@@ -160,7 +160,7 @@ def _normalize_expanded_field(value):
     Method does the following:
         Removes leading/trailing spaces
         Removes duplicate characters next to each other when it is a space, \, /, -, *, .
-        Does not remove compbinations of duplicates, so 1./*5 will still be valid
+        Does not remove combinations of duplicates, so 1./*5 will still be valid
 
     :param value: string
     :return: string

--- a/seed/lib/mcm/tests/test_mapper.py
+++ b/seed/lib/mcm/tests/test_mapper.py
@@ -290,6 +290,7 @@ class TestMapper(TestCase):
         self.assertEqual(mapper._normalize_expanded_field('L123-45'), 'L123-45')
         self.assertEqual(mapper._normalize_expanded_field('0.000099'), '0.000099')
         self.assertEqual(mapper._normalize_expanded_field('12-123-12-12-12-1-34-567'), '12-123-12-12-12-1-34-567')
+        self.assertEqual(mapper._normalize_expanded_field('ab-123-cd-12-12-1-34-567'), 'AB-123-CD-12-12-1-34-567')
 
     def test_expand_field(self):
         r = mapper.expand_and_normalize_field(None)


### PR DESCRIPTION
#### Any background context you want to provide?
SEED was removing too many characters when performing Jurisdiction Tax Lot ID normalization.

#### What's this PR do?
The normalization will only remove characters when they are repeated. It will also strip spaces from the beginning and ending.

#### How should this be manually tested?
Import test files. Test matching.

#### What are the relevant tickets?
#1329 

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?