### PR TITLE
add extra_data on coparent for PropertyStates

### DIFF
--- a/seed/models/properties.py
+++ b/seed/models/properties.py
@@ -324,6 +324,7 @@ class PropertyState(models.Model):
                     ps.energy_alerts,
                     ps.space_alerts,
                     ps.building_certification,
+                    ps.extra_data,
                     NULL
                 FROM seed_propertystate ps, audit_id aid
                 WHERE (ps.id = aid.parent_state1_id AND
@@ -344,7 +345,7 @@ class PropertyState(models.Model):
                        'owner_address', 'owner_postal_code', 'home_energy_score_id',
                        'generation_date', 'release_date', 'source_eui_weather_normalized',
                        'site_eui_weather_normalized', 'source_eui',
-                       'energy_alerts', 'space_alerts', 'building_certification', ]
+                       'energy_alerts', 'space_alerts', 'building_certification', 'extra_data', ]
         coparents = [{key: getattr(c, key) for key in keep_fields} for c in coparents]
 
         return coparents, len(coparents)


### PR DESCRIPTION
#### Any background context you want to provide?
Extra data was not showing up in the property coparent requests. 

#### What's this PR do?
Add extra_data to coparent. I don't expect this to slow down the requests significantly.

#### How should this be manually tested?
Import two sets of data that have matches. Look at the matching page and make sure that extra_data can be seen/selected.

#### What are the relevant tickets?
in PT

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?