### PR TITLE
Fixed old column settings from showing invalid entries - #1320

### DIFF
--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -637,7 +637,6 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
 
       var localColumns = localStorage.getItem(key);
       if (!_.isNull(localColumns)) {
-        var existingColumnNames = _.map(columns, 'name');
         localColumns = JSON.parse(localColumns);
 
         // Remove deprecated columns missing 'related' field
@@ -650,7 +649,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
 
         // Remove nonexistent columns
         _.remove(localColumns, function (col) {
-          return !_.includes(existingColumnNames, col.name);
+          return !_.find(columns, {name: col.name, related: col.related});
         });
         // Use saved column settings with original data as defaults
         localColumns = _.map(localColumns, function (col) {


### PR DESCRIPTION
#### Any background context you want to provide?
Changes to column settings are saved to localStorage.  On loading the settings, they are compared to all existing columns and defunct ones are removed.  The issue was that only the column name was previously checked, and the column name could be identical for both Property and Tax Lot columns.

#### What's this PR do?
This PR checks both the column name and the table to make sure the column still exists before showing it.

#### What are the relevant tickets?
#1320