### PR TITLE
Pairing - Show the left columns on the right for child rows

### DIFF
--- a/seed/static/seed/js/controllers/pairing_controller.js
+++ b/seed/static/seed/js/controllers/pairing_controller.js
@@ -291,7 +291,7 @@ angular.module('BE.seed.controller.pairing', []).controller('pairing_controller'
       for (var i = 0; i < $scope.leftColumns.length; i++) {
         if ($scope.leftColumns[i].searchText && value[$scope.leftColumns[i].name]) {
           var searchTextLower = $scope.leftColumns[i].searchText.toLowerCase();
-          var leftColLower = value[$scope.leftColumns[i].name].toLowerCase();
+          var leftColLower = (value[$scope.leftColumns[i].name] + '').toLowerCase();
           var isMatch = leftColLower.indexOf(searchTextLower) > -1;
           if (!isMatch) {
             return false;
@@ -308,7 +308,7 @@ angular.module('BE.seed.controller.pairing', []).controller('pairing_controller'
         // console.log("RC V: " + value[$scope.rightColumns[i].name]);
         if ($scope.rightColumns[i].searchText && value[$scope.rightColumns[i].name]) {
           var searchTextLower = $scope.rightColumns[i].searchText.toLowerCase();
-          var rightColLower = value[$scope.rightColumns[i].name].toLowerCase();
+          var rightColLower = (value[$scope.rightColumns[i].name] + '').toLowerCase();
           var isMatch = rightColLower.indexOf(searchTextLower) > -1;
           if (!isMatch) {
             return false;

--- a/seed/static/seed/partials/pairing.html
+++ b/seed/static/seed/partials/pairing.html
@@ -61,7 +61,7 @@
                 <div class="pairing-body left-scroll" dragula='"drag-pairing-row"'>
                     <div class="pairing-row grab-pairing-left" ng-repeat="row in newLeftData | orderBy : getLeftSortColumn() : leftReverseSort : naturalSortComparator | filter:leftSearch" title="Drag from here" ng-click="doubleClick('left',$event)">
                         <div leftParentId="{$ getLeftParentId(row) $}" ng-repeat="col in ::leftColumns track by $index">{$:: row[col.name] $}</div>
-                        <div class="paired-column">{$ leftPaired(row) $}</div>
+                        <div class="paired-column">{$ leftPaired(row) || '' $}</div>
                     </div>
                 </div>
             </div>
@@ -96,7 +96,7 @@
                                 </div>
                             </div>
                             <div ng-repeat="id in whichChildren(row) track by $index">
-                                <div viewId="{$ id $}" ng-repeat="col in ::rightColumns track by $index">
+                                <div viewId="{$ id $}" ng-repeat="col in ::leftColumns track by $index">
                                     <div class="pairing-cell">{$ whichChildData(id, col.name) $}</div>
                                 </div>
                                 <div class="unpair-child">


### PR DESCRIPTION
#### What's this PR do?
- Shows the selected left columns on the right half for the child rows
- Fixed filtering numeric columns on the pairing page

#### What are the relevant tickets?
#1432