### PR TITLE
Disable all client-side caching when the dev profile is used

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -26,6 +26,8 @@ DATABASES = {
     },
 }
 
+MIDDLEWARE_CLASSES = ('seed.utils.nocache.DisableClientSideCachingMiddleware',) + MIDDLEWARE_CLASSES
+
 CACHES = {
     'default': {
         'BACKEND': 'redis_cache.cache.RedisCache',

--- a/seed/utils/nocache.py
+++ b/seed/utils/nocache.py
@@ -1,0 +1,14 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2017, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+
+from django.utils.cache import add_never_cache_headers
+
+
+class DisableClientSideCachingMiddleware(object):
+    def process_response(self, request, response):
+        add_never_cache_headers(response)
+        return response


### PR DESCRIPTION
#### What's this PR do?
Completely disables client-side caching when the dev settings profile is used, without the browser Developer Tools being open with `Disable cache` checked.

This works by setting the response header `Cache-Control: no-cache, no-store, must-revalidate, max-age=0`, along with equal `Date` `Expires` and `Last-Modified` headers