### PR TITLE
Hides `*_pint` columns in Property List Settings view

### DIFF
--- a/seed/static/seed/js/controllers/inventory_settings_controller.js
+++ b/seed/static/seed/js/controllers/inventory_settings_controller.js
@@ -12,7 +12,8 @@ angular.module('BE.seed.controller.inventory_settings', [])
     'user_service',
     'all_columns',
     'shared_fields_payload',
-    function ($scope, $window, $uibModalInstance, $stateParams, inventory_service, user_service, all_columns, shared_fields_payload) {
+    'flippers',
+    function ($scope, $window, $uibModalInstance, $stateParams, inventory_service, user_service, all_columns, shared_fields_payload, flippers) {
       $scope.inventory_type = $stateParams.inventory_type;
       $scope.inventory = {
         id: $stateParams.inventory_id
@@ -76,6 +77,15 @@ angular.module('BE.seed.controller.inventory_settings', [])
       };
 
       $scope.data = inventory_service.loadSettings(localStorageKey, all_columns);
+
+      var is_pint_column = function (obj) {
+        return /_pint$/.test(obj.name);
+      };
+
+      if (!flippers.is_active('release:use_pint')) {
+        // db may return _pint columns; don't put them in the list settings
+        _.remove($scope.data, is_pint_column);
+      }
 
       $scope.gridOptions = {
         data: 'data',


### PR DESCRIPTION
Follow-on work to #1457. Hides the `*_pint` columns until the main body
of the UI work for differentiating metric and imperial units is ready.

#### Any background context you want to provide?

There are now database columns ready to receive tagged Quantity units for the EUIs and Areas. The UI is not yet ready, so these columns should not be displayed to users. They have a `(Pint)` suffix in the UI, just in case they display, to avoid mistakenly stuffing production data into them.

#### What's this PR do?

Fixes one missed case where the Quantity-related columns (eg. `Site EUI (pint)`) show in the Property List Settings.

#### How should this be manually tested?

See "Definition of Done" below.

#### What are the relevant tickets?

#1457 

#### Definition of Done:

Given a migrated 2.2 database, the page `/app/#/properties/settings` should not show any columns with the suffix `(pint)` available for toggling display.