### PR TITLE
Added a mapping button to `Map SEED fields to imported file fields`

### DIFF
--- a/seed/static/seed/js/controllers/mapping_controller.js
+++ b/seed/static/seed/js/controllers/mapping_controller.js
@@ -461,6 +461,35 @@ angular.module('BE.seed.controller.mapping', [])
         return mappings;
       };
 
+      /**
+       * reset_mappings
+       * Ignore suggestions and set all seed data headers to the headers from the original import file
+       */
+      $scope.reset_mappings = function () {
+        _.forEach($scope.valids, function (tcm) {
+          var changed = false;
+          if (tcm.suggestion !== tcm.name) {
+            tcm.suggestion = tcm.name;
+            changed = true;
+          }
+          if (tcm.suggestion_table_name !== 'PropertyState') {
+            tcm.suggestion_table_name = 'PropertyState';
+            changed = true;
+          }
+          if (changed) $scope.change(tcm, true);
+        });
+      };
+
+      /**
+       * check_reset_mappings
+       * Return true if the mappings match the original import file
+       */
+      $scope.check_reset_mappings = function () {
+        return _.every($scope.valids, function (tcm) {
+          return tcm.suggestion === tcm.name && tcm.suggestion_table_name === 'PropertyState';
+        });
+      };
+
       // As far as I can tell, this is never used.
       // /**
       //  * show_mapping_progress: shows the progress bar and kicks off the mapping,

--- a/seed/static/seed/partials/mapping.html
+++ b/seed/static/seed/partials/mapping.html
@@ -65,7 +65,9 @@
 
     <div class="section_header_container has_no_border" ng-hide="review_mappings">
         <div class="section_header fixed_height">
-            <div class="left section_action_container"></div>
+            <div class="left section_action_container">
+                <button type="button" class="btn btn-primary" ng-hide="import_file.matching_done && isValidCycle" ng-disabled="check_reset_mappings()" ng-click="reset_mappings()">Map SEED fields to imported file fields</button>
+            </div>
             <div class="right section_action_container section_action_btn">
                 <button type="button" class="pull-right btn btn-primary mapping-button" ng-disabled="check_fields()" ng-click="remap_buildings()" ng-hide="import_file.matching_done">Map Your Data</button>
                 <button type="button" class="pull-right btn btn-default" ng-click="get_mapped_buildings()" ng-show="import_file.matching_done && isValidCycle">Review Mapped Data</button>


### PR DESCRIPTION
Added a  `Map SEED fields to imported file fields` button to the mapping page

#### How should this be manually tested?
Import a file, then press the button on the mapping page.  All seed header names should change to the original imported column names, and the type should be Property
#### What are the relevant tickets?
#1238 
#### Screenshots (if appropriate)
![2017-10-18_142854](https://user-images.githubusercontent.com/411466/31742357-89577fde-b414-11e7-9eb4-ce26eadfa40d.png)
