### PR TITLE
Improved Column Saving

### DIFF
--- a/seed/static/seed/js/controllers/inventory_settings_controller.js
+++ b/seed/static/seed/js/controllers/inventory_settings_controller.js
@@ -12,8 +12,7 @@ angular.module('BE.seed.controller.inventory_settings', [])
     'user_service',
     'all_columns',
     'shared_fields_payload',
-    'flippers',
-    function ($scope, $window, $uibModalInstance, $stateParams, inventory_service, user_service, all_columns, shared_fields_payload, flippers) {
+    function ($scope, $window, $uibModalInstance, $stateParams, inventory_service, user_service, all_columns, shared_fields_payload) {
       $scope.inventory_type = $stateParams.inventory_type;
       $scope.inventory = {
         id: $stateParams.inventory_id
@@ -77,15 +76,6 @@ angular.module('BE.seed.controller.inventory_settings', [])
       };
 
       $scope.data = inventory_service.loadSettings(localStorageKey, all_columns);
-
-      var is_pint_column = function (obj) {
-        return /_pint$/.test(obj.name);
-      };
-
-      if (!flippers.is_active('release:use_pint')) {
-        // db may return _pint columns; don't put them in the list settings
-        _.remove($scope.data, is_pint_column);
-      }
 
       $scope.gridOptions = {
         data: 'data',

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -313,18 +313,14 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           columns: ['$stateParams', 'inventory_service', function ($stateParams, inventory_service) {
             if ($stateParams.inventory_type === 'properties') {
               return inventory_service.get_property_columns().then(function (columns) {
-                _.remove(columns, function (col) {
-                  return col.related === true;
-                });
+                _.remove(columns, 'related');
                 return _.map(columns, function (col) {
                   return _.omit(col, ['pinnedLeft', 'related']);
                 });
               });
             } else if ($stateParams.inventory_type === 'taxlots') {
               return inventory_service.get_taxlot_columns().then(function (columns) {
-                _.remove(columns, function (col) {
-                  return col.related === true;
-                });
+                _.remove(columns, 'related');
                 return _.map(columns, function (col) {
                   return _.omit(col, ['pinnedLeft', 'related']);
                 });
@@ -405,18 +401,14 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           columns: ['$stateParams', 'inventory_service', function ($stateParams, inventory_service) {
             if ($stateParams.inventory_type === 'properties') {
               return inventory_service.get_property_columns().then(function (columns) {
-                _.remove(columns, function (col) {
-                  return col.related === true;
-                });
+                _.remove(columns, 'related');
                 return _.map(columns, function (col) {
                   return _.omit(col, ['pinnedLeft', 'related']);
                 });
               });
             } else if ($stateParams.inventory_type === 'taxlots') {
               return inventory_service.get_taxlot_columns().then(function (columns) {
-                _.remove(columns, function (col) {
-                  return col.related === true;
-                });
+                _.remove(columns, 'related');
                 return _.map(columns, function (col) {
                   return _.omit(col, ['pinnedLeft', 'related']);
                 });

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -10,7 +10,8 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
   'user_service',
   'cycle_service',
   'spinner_utility',
-  function ($http, $log, urls, user_service, cycle_service, spinner_utility) {
+  'flippers',
+  function ($http, $log, urls, user_service, cycle_service, spinner_utility, flippers) {
 
     var inventory_service = {
       total_properties_for_user: 0,
@@ -390,9 +391,18 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         }
       }).then(function (response) {
         // Remove empty columns
-        return _.filter(response.data.columns, function (col) {
+        var columns = _.filter(response.data.columns, function (col) {
           return !_.isEmpty(col.name);
         });
+
+        // Remove _pint columns
+        if (!flippers.is_active('release:use_pint')) {
+          _.remove(columns, function (col) {
+            return /_pint$/.test(col.name);
+          });
+        }
+
+        return columns;
       });
     };
 
@@ -404,9 +414,18 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         }
       }).then(function (response) {
         // Remove empty columns
-        return _.filter(response.data.columns, function (col) {
+        var columns = _.filter(response.data.columns, function (col) {
           return !_.isEmpty(col.name);
         });
+
+        // Remove _pint columns
+        if (!flippers.is_active('release:use_pint')) {
+          _.remove(columns, function (col) {
+            return /_pint$/.test(col.name);
+          });
+        }
+
+        return columns;
       });
     };
 
@@ -615,7 +634,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
     inventory_service.saveSettings = function (key, columns) {
       key += '.' + user_service.get_organization().id;
       var toSave = inventory_service.reorderSettings(_.map(columns, function (col) {
-        return _.pick(col, ['name', 'pinnedLeft', 'related', 'visible']);
+        return _.pick(col, ['name', 'table', 'visible', 'pinnedLeft']);
       }));
       localStorage.setItem(key, JSON.stringify(toSave));
     };
@@ -623,8 +642,6 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
     inventory_service.loadSettings = function (key, columns) {
       key += '.' + user_service.get_organization().id;
       columns = angular.copy(columns);
-
-      var isDetailSetting = key.match(/\.(properties|taxlots)\.detail\.\d+$/);
 
       // Hide extra data columns by default
       _.forEach(columns, function (col) {
@@ -635,22 +652,13 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       if (!_.isNull(localColumns)) {
         localColumns = JSON.parse(localColumns);
 
-        // Remove deprecated columns missing 'related' field
-        // NOT FOR DETAIL SETTINGS
-        if (!isDetailSetting) {
-          _.remove(localColumns, function (col) {
-            return !_.has(col, 'related');
-          });
-        }
-
         // Remove nonexistent columns
         _.remove(localColumns, function (col) {
-          return !_.find(columns, {name: col.name, related: col.related});
+          return !_.find(columns, {name: col.name, table: col.table});
         });
         // Use saved column settings with original data as defaults
         localColumns = _.map(localColumns, function (col) {
-          if (isDetailSetting) return _.defaults(col, _.remove(columns, {name: col.name})[0]);
-          else return _.defaults(col, _.remove(columns, {name: col.name, related: col.related})[0]);
+          return _.defaults(col, _.remove(columns, {name: col.name, table: col.table})[0]);
         });
         // If no columns are visible, reset visibility only
         if (!_.find(localColumns, 'visible')) {

--- a/seed/static/seed/js/services/matching_service.js
+++ b/seed/static/seed/js/services/matching_service.js
@@ -112,7 +112,7 @@ angular.module('BE.seed.service.matching', []).factory('matching_service', [
     matching_service.saveLeftColumns = function (key, columns) {
       key += '.left.' + user_service.get_organization().id;
       var toSave = matching_service.reorderSettings(_.map(columns, function (col) {
-        return _.pick(col, ['name', 'visible']);
+        return _.pick(col, ['name', 'table', 'visible']);
       }));
       localStorage.setItem(key, JSON.stringify(toSave));
     };
@@ -135,11 +135,11 @@ angular.module('BE.seed.service.matching', []).factory('matching_service', [
 
         // Remove nonexistent columns
         _.remove(localColumns, function (col) {
-          return !_.find(columns, {name: col.name});
+          return !_.find(columns, {name: col.name, table: col.table});
         });
         // Use saved column settings with original data as defaults
         localColumns = _.map(localColumns, function (col) {
-          return _.defaults(col, _.remove(columns, {name: col.name})[0]);
+          return _.defaults(col, _.remove(columns, {name: col.name, table: col.table})[0]);
         });
         // If no columns are visible, reset visibility only
         if (!_.find(localColumns, 'visible')) {
@@ -156,7 +156,7 @@ angular.module('BE.seed.service.matching', []).factory('matching_service', [
     matching_service.saveRightColumns = function (key, columns) {
       key += '.right.' + user_service.get_organization().id;
       var toSave = matching_service.reorderSettings(_.map(columns, function (col) {
-        return _.pick(col, ['name', 'visible']);
+        return _.pick(col, ['name', 'table', 'visible']);
       }));
       localStorage.setItem(key, JSON.stringify(toSave));
     };
@@ -176,11 +176,11 @@ angular.module('BE.seed.service.matching', []).factory('matching_service', [
 
         // Remove nonexistent columns
         _.remove(localColumns, function (col) {
-          return !_.find(columns, {name: col.name});
+          return !_.find(columns, {name: col.name, table: col.table});
         });
         // Use saved column settings with original data as defaults
         localColumns = _.map(localColumns, function (col) {
-          return _.defaults(col, _.remove(columns, {name: col.name})[0]);
+          return _.defaults(col, _.remove(columns, {name: col.name, table: col.table})[0]);
         });
         // If no columns are visible, reset visibility only
         if (!_.find(localColumns, 'visible')) {
@@ -197,7 +197,7 @@ angular.module('BE.seed.service.matching', []).factory('matching_service', [
     matching_service.saveDetailColumns = function (key, columns) {
       key += '.' + user_service.get_organization().id;
       var toSave = matching_service.reorderSettings(_.map(columns, function (col) {
-        return _.pick(col, ['name', 'visible']);
+        return _.pick(col, ['name', 'table', 'visible']);
       }));
       localStorage.setItem(key, JSON.stringify(toSave));
     };
@@ -217,11 +217,11 @@ angular.module('BE.seed.service.matching', []).factory('matching_service', [
 
         // Remove nonexistent columns
         _.remove(localColumns, function (col) {
-          return !_.find(columns, {name: col.name});
+          return !_.find(columns, {name: col.name, table: col.table});
         });
         // Use saved column settings with original data as defaults
         localColumns = _.map(localColumns, function (col) {
-          return _.defaults(col, _.remove(columns, {name: col.name})[0]);
+          return _.defaults(col, _.remove(columns, {name: col.name, table: col.table})[0]);
         });
         // If no columns are visible, reset visibility only
         if (!_.find(localColumns, 'visible')) {


### PR DESCRIPTION
- Use `table` instead of `related` in settings for checking saved columns against all existing columns
- Ensure that *_pint columns are hidden more broadly

#### What's this PR do?
Improves column saving/loading broadly, but primarily to fix the saving of settings for the inventory detail page.
This will also delete any previously saved column settings
#### How should this be manually tested?
Change column settings (inventory, inventory detail, matching, matching detail), refresh the page to see that the settings have persisted, and return to the primary view to see that the selected columns are being used as expected