### PR TITLE
1488 data quality results

### DIFF
--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -17,7 +17,6 @@ from _csv import Error
 from collections import namedtuple
 from functools import reduce
 from itertools import chain
-from random import randint
 
 from celery import chord
 from celery import shared_task
@@ -124,8 +123,7 @@ def finish_checking(identifier):
 
 @shared_task
 def do_checks(propertystate_ids, taxlotstate_ids):
-    identifier = randint(100, 100000)
-    DataQualityCheck.initialize_cache(identifier)
+    identifier = DataQualityCheck.initialize_cache()
     prog_key = get_prog_key('check_data', identifier)
     trigger_data_quality_checks.delay(propertystate_ids, taxlotstate_ids, identifier)
     return {'status': 'success', 'progress_key': prog_key}
@@ -183,14 +181,19 @@ def finish_mapping(import_file_id, mark_as_done):
     }
     set_cache(prog_key, result['status'], result)
 
-    property_state_ids = list(PropertyState.objects.filter(import_file=import_file)
-                              .exclude(data_state__in=[DATA_STATE_UNKNOWN, DATA_STATE_IMPORT, DATA_STATE_DELETE])
-                              .values_list('id', flat=True))
-    taxlot_state_ids = list(TaxLotState.objects.filter(import_file=import_file)
-                            .exclude(data_state__in=[DATA_STATE_UNKNOWN, DATA_STATE_IMPORT, DATA_STATE_DELETE])
-                            .values_list('id', flat=True))
+    property_state_ids = list(
+        PropertyState.objects.filter(import_file=import_file).exclude(
+            data_state__in=[DATA_STATE_UNKNOWN, DATA_STATE_IMPORT, DATA_STATE_DELETE]).values_list(
+            'id', flat=True)
+    )
+    taxlot_state_ids = list(
+        TaxLotState.objects.filter(import_file=import_file).exclude(
+            data_state__in=[DATA_STATE_UNKNOWN, DATA_STATE_IMPORT, DATA_STATE_DELETE]).values_list(
+            'id', flat=True)
+    )
 
-    # now call data_quality
+    # now call data_quality - this uses the import_file_id which can cause issues if
+    # the result cache is not flushed out. Flushing happens on the initialize_cache call.
     _data_quality_check(property_state_ids, taxlot_state_ids, import_file_id)
 
 
@@ -424,8 +427,8 @@ def map_row_chunk(ids, file_pk, source_type, prog_key, increment, **kwargs):
 
                     # Create an audit log record for the new map_model_obj that was created.
 
-                    AuditLogClass = PropertyAuditLog if isinstance(map_model_obj,
-                                                                   PropertyState) else TaxLotAuditLog
+                    AuditLogClass = PropertyAuditLog if isinstance(
+                        map_model_obj, PropertyState) else TaxLotAuditLog
                     AuditLogClass.objects.create(organization=org,
                                                  state=map_model_obj,
                                                  name='Import Creation',
@@ -547,7 +550,6 @@ def map_data(import_file_id, remap=False, mark_as_done=True):
     :return: JSON
     """
     DataQualityCheck.initialize_cache(import_file_id)
-    prog_key = get_prog_key('check_data', import_file_id)
     import_file = ImportFile.objects.get(pk=import_file_id)
     if remap:
         # Check to ensure that import files has not already been matched/merged.
@@ -874,11 +876,13 @@ def _finish_matching(import_file, progress_key, data):
         'data': data
     }
     property_state_ids = list(PropertyState.objects.filter(import_file=import_file)
-                              .exclude(data_state__in=[DATA_STATE_UNKNOWN, DATA_STATE_IMPORT, DATA_STATE_DELETE])
-                              .only('id').values_list('id', flat=True))
+                              .exclude(
+        data_state__in=[DATA_STATE_UNKNOWN, DATA_STATE_IMPORT, DATA_STATE_DELETE])
+        .only('id').values_list('id', flat=True))
     taxlot_state_ids = list(TaxLotState.objects.filter(import_file=import_file)
-                            .exclude(data_state__in=[DATA_STATE_UNKNOWN, DATA_STATE_IMPORT, DATA_STATE_DELETE])
-                            .only('id').values_list('id', flat=True))
+                            .exclude(
+        data_state__in=[DATA_STATE_UNKNOWN, DATA_STATE_IMPORT, DATA_STATE_DELETE])
+        .only('id').values_list('id', flat=True))
     _data_quality_check(property_state_ids, taxlot_state_ids, import_file.id)
     set_cache(progress_key, result['status'], result)
     return result
@@ -899,8 +903,8 @@ def _find_matches(un_m_address, canonical_buildings_addresses):
 # TODO: CLEANUP - What are we doing here?
 md = MappingData()
 ALL_COMPARISON_FIELDS = sorted(list(set([field['name'] for field in md.data])))
-# Make sure that the import_file isn't part of the hash, as the import_file filename always has random characters
-# appended to it in the uploads directory
+# Make sure that the import_file isn't part of the hash, as the import_file filename always has
+# random characters appended to it in the uploads directory
 try:
     ALL_COMPARISON_FIELDS.remove('import_file')
 except ValueError:
@@ -1284,7 +1288,8 @@ def merge_unmatched_into_views(unmatched_states, partitioner, org, import_file):
                 if partitioner.calculate_key_equivalence(key, equiv_cmp_key):
                     if current_match_cycle in existing_view_states[key]:
                         # There is an existing View for the current cycle that matches us.
-                        # Merge the new state in with the existing one and update the view, audit log.
+                        # Merge the new state in with the existing one and update the view,
+                        # audit log.
                         current_view = existing_view_states[key][current_match_cycle]
                         current_state = current_view.state
 

--- a/seed/models/data_quality.py
+++ b/seed/models/data_quality.py
@@ -8,11 +8,13 @@ import json
 import logging
 import re
 from datetime import date, datetime
+from random import randint
 
 import pytz
 from django.apps import apps
 from django.db import models
 from django.utils.timezone import get_current_timezone, make_aware, make_naive
+from quantityfield import ureg
 
 from seed.lib.superperms.orgs.models import Organization
 from seed.models import (
@@ -24,8 +26,6 @@ from seed.utils.cache import (
     set_cache_raw, get_cache_raw
 )
 from seed.utils.time import convert_datestr
-
-from quantityfield import ureg
 
 _log = logging.getLogger(__name__)
 
@@ -527,18 +527,19 @@ class DataQualityCheck(models.Model):
         super(DataQualityCheck, self).__init__(*args, **kwargs)
 
     @staticmethod
-    def initialize_cache(identifier):
+    def initialize_cache(identifier=None):
         """
         Initialize the cache for storing the results. This is called before the
         celery tasks are chunked up.
 
-        :param identifier: Import file primary key
+        :param identifier: Identifier for cache, if None, then creates a random one
         :return: string, cache key
         """
-
-        k = DataQualityCheck.cache_key(identifier)
-        set_cache_raw(k, [])
-        return k
+        if identifier is None:
+            identifier = randint(100, 100000)
+        cache_key = DataQualityCheck.cache_key(identifier)
+        set_cache_raw(cache_key, [])
+        return cache_key
 
     @staticmethod
     def cache_key(identifier):

--- a/seed/static/seed/js/controllers/mapping_controller.js
+++ b/seed/static/seed/js/controllers/mapping_controller.js
@@ -47,7 +47,7 @@ angular.module('BE.seed.controller.mapping', [])
       var db_field_columns = suggested_mappings_payload.column_names;
       var columns = suggested_mappings_payload.columns;
       var extra_data_columns = _.filter(columns, 'extra_data');
-      var original_columns = _.map(columns, function f (n) {
+      var original_columns = _.map(columns, function f(n) {
         return n.name;
       });
       // var original_columns = angular.copy(db_field_columns.concat(extra_data_columns));
@@ -529,6 +529,14 @@ angular.module('BE.seed.controller.mapping', [])
         return mappings;
       };
 
+      /** wait for the result of the data quality results before presenting the mapped data **/
+      $scope.data_quality_checks = function () {
+        data_quality_service.data_quality_checks_status(':1:SEED:check_data:PROG:' + $scope.import_file.id).then(function (result) {
+          $scope.get_mapped_buildings();
+        });
+      };
+
+
       /**
        * remap_buildings: shows the progress bar and kicks off the re-mapping,
        *   after saving column mappings, deletes unmatched buildings
@@ -541,19 +549,18 @@ angular.module('BE.seed.controller.mapping', [])
         mapping_service.save_mappings(
           $scope.import_file.id,
           get_untitle_cased_mappings()
-        )
-          .then(function () {
-            // start re-mapping
-            mapping_service.remap_buildings($scope.import_file.id).then(function (data) {
-              if (data.status === 'error' || data.status === 'warning') {
-                $scope.$emit('app_error', data);
-                $scope.get_mapped_buildings();
-              } else {
-                // save maps start mapping data
-                check_mapping(data.progress_key);
-              }
-            });
+        ).then(function () {
+          // start re-mapping
+          mapping_service.remap_buildings($scope.import_file.id).then(function (data) {
+            if (data.status === 'error' || data.status === 'warning') {
+              $scope.$emit('app_error', data);
+              $scope.data_quality_checks();
+            } else {
+              // save maps start mapping data
+              check_mapping(data.progress_key);
+            }
           });
+        });
       };
 
       /**
@@ -565,7 +572,7 @@ angular.module('BE.seed.controller.mapping', [])
           0, //starting prog bar percentage
           1.0,  // progress multiplier
           function () {
-            $scope.get_mapped_buildings();
+            $scope.data_quality_checks();
           }, function () {
             // Do nothing
           },
@@ -609,7 +616,7 @@ angular.module('BE.seed.controller.mapping', [])
           {header: 'Address Line 1', inventory_type: 'TaxLotState'}
         ];
 
-        function compare_fields (x, y) {
+        function compare_fields(x, y) {
           return x.header == y.suggestion && x.inventory_type == y.suggestion_table_name;
         }
 


### PR DESCRIPTION
#### Any background context you want to provide?
If the user clicks back to mappings during the mapping review process and before the data quality checks were complete, then there was a chance that the results weren't cleared out.

#### What's this PR do?
Add in an explicit check that verifies that the data quality checks are complete before displaying the mapped results.

#### How should this be manually tested?
Load data with a lot of errors. Click Back to Mapping immediately once it appears and try remapping the data. The number of errors/warnings should not change.

#### What are the relevant tickets?
#1488 

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?