### PR TITLE
Export DQ from Inventory

### DIFF
--- a/seed/data_importer/views.py
+++ b/seed/data_importer/views.py
@@ -5,7 +5,6 @@
 :author
 """
 import base64
-import csv
 import hashlib
 import hmac
 import json
@@ -1319,59 +1318,6 @@ class ImportFileViewSet(viewsets.ViewSet):
         prog_key = get_prog_key('get_progress', import_file_id)
         cache = get_cache(prog_key)
         return HttpResponse(cache['progress'])
-
-    @api_endpoint_class
-    @ajax_request_class
-    @detail_route(methods=['GET'], url_path='data_quality_results_csv')
-    def get_csv(self, request, pk=None):
-        """
-        Download a csv of the results.
-        ---
-        type:
-            status:
-                required: true
-                type: string
-                description: either success or error
-            progress_key:
-                type: integer
-                description: ID of background job, for retrieving job progress
-        parameter_strategy: replace
-        parameters:
-            - name: pk
-              description: Import file ID
-              required: true
-              paramType: path
-        """
-
-        import_file_id = pk
-        data_quality_results = get_cache_raw(DataQualityCheck.cache_key(import_file_id))
-        response = HttpResponse(content_type='text/csv')
-        response['Content-Disposition'] = 'attachment; filename="Data Quality Check Results.csv"'
-
-        writer = csv.writer(response)
-        if data_quality_results is None:
-            writer.writerow(['Error'])
-            writer.writerow(['data quality results not found'])
-            return response
-
-        writer.writerow(
-            ['Table', 'Address Line 1', 'PM Property ID', 'Tax Lot ID', 'Custom ID', 'Field',
-             'Error Message', 'Severity'])
-
-        for row in data_quality_results:
-            for result in row['data_quality_results']:
-                writer.writerow([
-                    row['data_quality_results'][0]['table_name'],
-                    row['address_line_1'],
-                    row['pm_property_id'] if 'pm_property_id' in row else None,
-                    row['jurisdiction_tax_lot_id'] if 'jurisdiction_tax_lot_id' in row else None,
-                    row['custom_id_1'],
-                    result['formatted_field'],
-                    result['detailed_message'],
-                    result['severity']
-                ])
-
-        return response
 
     @api_endpoint_class
     @ajax_request_class

--- a/seed/static/seed/js/controllers/data_quality_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_modal_controller.js
@@ -3,172 +3,171 @@
  * :author
  */
 angular.module('BE.seed.controller.data_quality_modal', [])
-.controller('data_quality_modal_controller', [
-  '$scope',
-  '$uibModalInstance',
-  'search_service',
-  'naturalSort',
-  'dataQualityResults',
-  'name',
-  'uploaded',
-  'importFileId',
-  function (
-    $scope,
-    $uibModalInstance,
-    search_service,
-    naturalSort,
-    dataQualityResults,
-    name,
-    uploaded,
-    importFileId
-  ) {
-    $scope.name = name;
-    $scope.uploaded = moment.utc(uploaded).local().format('MMMM Do YYYY, h:mm:ss A Z');
-    var originalDataQualityResults = dataQualityResults || [];
-    $scope.dataQualityResults = originalDataQualityResults;
-    $scope.importFileId = importFileId;
+  .controller('data_quality_modal_controller', [
+    '$scope',
+    '$uibModalInstance',
+    'search_service',
+    'naturalSort',
+    'dataQualityResults',
+    'name',
+    'uploaded',
+    'importFileId',
+    function ($scope,
+              $uibModalInstance,
+              search_service,
+              naturalSort,
+              dataQualityResults,
+              name,
+              uploaded,
+              importFileId) {
+      $scope.name = name;
+      $scope.uploaded = moment.utc(uploaded).local().format('MMMM Do YYYY, h:mm:ss A Z');
+      var originalDataQualityResults = dataQualityResults || [];
+      $scope.dataQualityResults = originalDataQualityResults;
+      $scope.importFileId = importFileId;
 
-    $scope.close = function () {
-      $uibModalInstance.close();
-    };
+      $scope.close = function () {
+        $uibModalInstance.close();
+      };
 
-    var fields = [{
-      sort_column: 'table_name',
-      sortable: false,
-      title: 'Table'
-    }, {
-      sort_column: 'address_line_1',
-      sortable: true,
-      title: 'Address Line 1'
-    }, {
-      sort_column: 'jurisdiction_tax_lot_id',
-      sortable: true,
-      title: 'Jurisdiction Tax Lot ID'
-    }, {
-      sort_column: 'pm_property_id',
-      sortable: true,
-      title: 'PM Property ID'
-    }, {
-      sort_column: 'custom_id_1',
-      sortable: true,
-      title: 'Custom ID'
-    }, {
-      sort_column: 'formatted_field',
-      sortable: false,
-      title: 'Field'
-    }, {
-      sort_column: 'detailed_message',
-      sortable: false,
-      title: 'Error Message'
-    }];
-    var columns = _.map(fields, 'sort_column');
-    _.forEach(fields, function (field) {
-      field.checked = false;
-      field.class = 'is_aligned_right';
-      field.field_type = null;
-      field.link = false;
-      field.static = false;
-      field.type = 'string';
-    });
-
-    $scope.sortData = function () {
-      var result = originalDataQualityResults.slice().sort(function (a, b) {
-        return naturalSort(a[$scope.search.sort_column], b[$scope.search.sort_column]);
+      var fields = [{
+        sort_column: 'table_name',
+        sortable: false,
+        title: 'Table'
+      }, {
+        sort_column: 'address_line_1',
+        sortable: true,
+        title: 'Address Line 1'
+      }, {
+        sort_column: 'jurisdiction_tax_lot_id',
+        sortable: true,
+        title: 'Jurisdiction Tax Lot ID'
+      }, {
+        sort_column: 'pm_property_id',
+        sortable: true,
+        title: 'PM Property ID'
+      }, {
+        sort_column: 'custom_id_1',
+        sortable: true,
+        title: 'Custom ID'
+      }, {
+        sort_column: 'formatted_field',
+        sortable: false,
+        title: 'Field'
+      }, {
+        sort_column: 'detailed_message',
+        sortable: false,
+        title: 'Error Message'
+      }];
+      var columns = _.map(fields, 'sort_column');
+      _.forEach(fields, function (field) {
+        field.checked = false;
+        field.class = 'is_aligned_right';
+        field.field_type = null;
+        field.link = false;
+        field.static = false;
+        field.type = 'string';
       });
-      if ($scope.search.sort_reverse) result.reverse();
-      $scope.dataQualityResults = result;
-    };
 
-    $scope.search = angular.copy(search_service);
+      $scope.sortData = function () {
+        var result = originalDataQualityResults.slice().sort(function (a, b) {
+          return naturalSort(a[$scope.search.sort_column], b[$scope.search.sort_column]);
+        });
+        if ($scope.search.sort_reverse) result.reverse();
+        $scope.dataQualityResults = result;
+      };
 
-    // Override storage, search, and filter functions
-    $scope.search.init_storage = function (prefix) {
-      // Check session storage for order and sort values.
-      if (!_.isUndefined(Storage)) {
-        $scope.search.prefix = prefix;
+      $scope.search = angular.copy(search_service);
 
-        // order_by & sort_column
-        if (sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy') !== null) {
-          $scope.search.order_by = sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy');
-          $scope.search.sort_column = sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy');
-        }
-
-        // sort_reverse
-        if (sessionStorage.getItem(prefix + ':' + 'seedBuildingSortReverse') !== null) {
-          $scope.search.sort_reverse = JSON.parse(sessionStorage.getItem(prefix + ':' + 'seedBuildingSortReverse'));
-        }
-
-        // filter_params
-        if (sessionStorage.getItem(prefix + ':' + 'seedBuildingFilterParams') !== null) {
-          $scope.search.filter_params = JSON.parse(sessionStorage.getItem(prefix + ':' + 'seedBuildingFilterParams'));
-        }
-      }
-    };
-    $scope.search.column_prototype.toggle_sort = function () {
-      if (this.sortable) {
-        if ($scope.search.sort_column === this.sort_column) {
-          $scope.search.sort_reverse = !$scope.search.sort_reverse;
-        } else {
-          $scope.search.sort_reverse = true;
-          $scope.search.sort_column = this.sort_column;
-        }
-
+      // Override storage, search, and filter functions
+      $scope.search.init_storage = function (prefix) {
+        // Check session storage for order and sort values.
         if (!_.isUndefined(Storage)) {
-          sessionStorage.setItem($scope.search.prefix + ':' + 'seedBuildingOrderBy', $scope.search.sort_column);
-          sessionStorage.setItem($scope.search.prefix + ':' + 'seedBuildingSortReverse', $scope.search.sort_reverse);
-        }
+          $scope.search.prefix = prefix;
 
-        $scope.search.order_by = this.sort_column;
-        $scope.sortData();
-      }
-    };
-    $scope.search.column_prototype.sorted_class = function () {
-      if ($scope.search.sort_column === this.sort_column) {
-        if ($scope.search.sort_reverse) {
-          return 'sorted sort_asc';
-        } else {
-          return 'sorted sort_desc';
-        }
-      } else {
-        return '';
-      }
-    };
-    $scope.search.filter_search = function () {
-      $scope.search.sanitize_params();
-      _.forEach($scope.dataQualityResults, function (result) {
-        if (!result.visible) result.visible = true;
-        _.forEach(result.data_quality_results, function (row) {
-          if (!row.visible) row.visible = true;
-        });
-      });
-      _.forEach(this.filter_params, function (value, column) {
-        value = value.toLowerCase();
-        _.forEach($scope.dataQualityResults, function (result) {
-          if (result.visible) {
-            if (_.includes(['detailed_message', 'formatted_field', 'table_name'], column)) {
-              _.forEach(result.data_quality_results, function (row) {
-                if (!_.includes(row[column].toLowerCase(), value)) row.visible = false;
-              });
-            } else {
-              if (_.isNull(result[column]) || !_.includes(result[column].toLowerCase(), value)) result.visible = false;
-            }
+          // order_by & sort_column
+          if (sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy') !== null) {
+            $scope.search.order_by = sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy');
+            $scope.search.sort_column = sessionStorage.getItem(prefix + ':' + 'seedBuildingOrderBy');
           }
-        });
-      });
-      if (!_.isUndefined(Storage)) {
-        sessionStorage.setItem(this.prefix + ':' + 'seedBuildingFilterParams', JSON.stringify(this.filter_params));
-      }
-    };
-    $scope.search.num_pages = 1;
-    $scope.search.number_per_page = $scope.dataQualityResults.length;
-    $scope.search.sort_column = null;
-    $scope.search.init_storage('data_quality');
-    if ($scope.search.sort_column !== null) $scope.sortData();
-    $scope.search.filter_search();
 
-    $scope.columns = $scope.search.generate_columns(
-      fields,
-      columns,
-      $scope.search.column_prototype
-    );
-  }]);
+          // sort_reverse
+          if (sessionStorage.getItem(prefix + ':' + 'seedBuildingSortReverse') !== null) {
+            $scope.search.sort_reverse = JSON.parse(sessionStorage.getItem(prefix + ':' + 'seedBuildingSortReverse'));
+          }
+
+          // filter_params
+          if (sessionStorage.getItem(prefix + ':' + 'seedBuildingFilterParams') !== null) {
+            $scope.search.filter_params = JSON.parse(sessionStorage.getItem(prefix + ':' + 'seedBuildingFilterParams'));
+          }
+        }
+      };
+      $scope.search.column_prototype.toggle_sort = function () {
+        if (this.sortable) {
+          if ($scope.search.sort_column === this.sort_column) {
+            $scope.search.sort_reverse = !$scope.search.sort_reverse;
+          } else {
+            $scope.search.sort_reverse = true;
+            $scope.search.sort_column = this.sort_column;
+          }
+
+          if (!_.isUndefined(Storage)) {
+            sessionStorage.setItem($scope.search.prefix + ':' + 'seedBuildingOrderBy', $scope.search.sort_column);
+            sessionStorage.setItem($scope.search.prefix + ':' + 'seedBuildingSortReverse', $scope.search.sort_reverse);
+          }
+
+          $scope.search.order_by = this.sort_column;
+          $scope.sortData();
+        }
+      };
+      $scope.search.column_prototype.sorted_class = function () {
+        if ($scope.search.sort_column === this.sort_column) {
+          if ($scope.search.sort_reverse) {
+            return 'sorted sort_asc';
+          } else {
+            return 'sorted sort_desc';
+          }
+        } else {
+          return '';
+        }
+      };
+      $scope.search.filter_search = function () {
+        $scope.search.sanitize_params();
+        _.forEach($scope.dataQualityResults, function (result) {
+          if (!result.visible) result.visible = true;
+          _.forEach(result.data_quality_results, function (row) {
+            if (!row.visible) row.visible = true;
+          });
+        });
+        _.forEach(this.filter_params, function (value, column) {
+          value = value.toLowerCase();
+          _.forEach($scope.dataQualityResults, function (result) {
+            if (result.visible) {
+              if (_.includes(['detailed_message', 'formatted_field', 'table_name'], column)) {
+                _.forEach(result.data_quality_results, function (row) {
+                  if (!_.includes(row[column].toLowerCase(), value)) row.visible = false;
+                });
+              } else {
+                if (_.isNull(result[column]) || !_.includes(result[column].toLowerCase(), value)) result.visible = false;
+              }
+            }
+          });
+        });
+        if (!_.isUndefined(Storage)) {
+          sessionStorage.setItem(this.prefix + ':' + 'seedBuildingFilterParams', JSON.stringify(this.filter_params));
+        }
+      };
+
+      $scope.search.num_pages = 1;
+      $scope.search.number_per_page = $scope.dataQualityResults.length;
+      $scope.search.sort_column = null;
+      $scope.search.init_storage('data_quality');
+      if ($scope.search.sort_column !== null) $scope.sortData();
+      $scope.search.filter_search();
+
+      $scope.columns = $scope.search.generate_columns(
+        fields,
+        columns,
+        $scope.search.column_prototype
+      );
+    }]);

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -175,7 +175,7 @@ angular.module('BE.seed.controller.inventory_list', [])
                 },
                 name: _.constant(null),
                 uploaded: _.constant(null),
-                importFileId: _.constant(null)
+                importFileId: _.constant(response.progress_key.split(':').pop())
               }
             });
             modalInstance.result.then(function () {

--- a/seed/static/seed/partials/data_quality_modal.html
+++ b/seed/static/seed/partials/data_quality_modal.html
@@ -53,5 +53,5 @@
     </div>
 </div>
 <div class="modal-footer">
-    <a ng-href="/api/v2/import_files/{$:: importFileId $}/data_quality_results_csv/" download><button type="button" class="btn btn-default" ng-show="::importFileId">Export</button></a> <button type="button" class="btn btn-default" ng-click="close()">Close</button>
+    <a ng-href="/api/v2/data_quality_checks/{$ ::importFileId $}/csv/" download><button type="button" class="btn btn-default" ng-show="::importFileId">Export</button></a> <button type="button" class="btn btn-default" ng-click="close()">Close</button>
 </div>

--- a/seed/tests/data_quality/test_views.py
+++ b/seed/tests/data_quality/test_views.py
@@ -52,5 +52,5 @@ class DataQualityViewTests(TestCase):
             }]
         }]
         cache.set('data_quality_results__1', data)
-        response = self.client.get(reverse('api:v2:import_files-data-quality-results-csv', args=[1]))
+        response = self.client.get(reverse('api:v2:data_quality_checks-csv', args=[1]))
         self.assertEqual(200, response.status_code)


### PR DESCRIPTION
#### Any background context you want to provide?
Data quality results that were presented in the modal were only exportable from the mapping results.

#### What's this PR do?
Add the export capability to the DQ results from the inventory list

#### How should this be manually tested?

- Go to inventory page
- Select a few records (that will have DQ issues)
- Run DQ
- From modal, make sure export exists
- Try to download results and inspect file.

#### What are the relevant tickets?
#1363 

#### Screenshots (if appropriate)
#### Definition of Done:
- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [ ] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [ ] Does this PR require a regression test? All fixes require a regression test.
- [ ] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?