### PR TITLE
Removes node_modules from fine-uploader after building

### DIFF
--- a/bin/install_javascript_dependencies.sh
+++ b/bin/install_javascript_dependencies.sh
@@ -16,6 +16,7 @@ then
     sed -i -e 's/compress: true/compress: \{\}/g' Gruntfile.coffee
     npm install
     $grunt build
+    rm -rf node_modules
     cd ../../../../../
 else
     echo -e "\n\n\nFineuploader already built"


### PR DESCRIPTION
#### Any background context you want to provide?
Running Django's `collectstatic` command has to copy and validate about 15,259 files and directories.  Cleaning up after fine-uploader reduces this total to 2,741

#### What's this PR do?
Deletes the `node_modules` directory from the fine-uploader directory after building

#### How should this be manually tested?
From the seed directory:
```bash
rm -rf seed/static/vendors/bower_components/fine-uploader
./bin/install_javascript_dependencies.sh
```