### PR TITLE
removing instruction to python setup.py install

### DIFF
--- a/docs/source/setup_osx.rst
+++ b/docs/source/setup_osx.rst
@@ -153,12 +153,6 @@ Install requirements with `pip`
 
     pip install -r requirements/local.txt
 
-Install library with `setup.py`
-
-.. code-block:: bash
-
-    python setup.py install
-
 NodeJS/npm
 ----------
 


### PR DESCRIPTION
It caused problems with finding the settings for celery in on mac. Also those instructions weren't there in the Ubuntu instructions.

@nllong @axelstudios 