### PR TITLE
Tightens up check for whether celery's running in dev

### DIFF
--- a/bin/start-seed.sh
+++ b/bin/start-seed.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Start SEED in developer mode
 
+CELERY_PIDFILE="/tmp/celery-seed-dev.pid"
+
 # check if "$prog" is running
 running () {
     prog="$1"
@@ -24,10 +26,9 @@ else
 fi
 
 # Celery
-running celery
-if [ $? -eq 0 ]; then
+if [ ! -f $CELERY_PIDFILE ]; then
     printf "Starting Celery\n"
-    celery -A seed worker -l info -c 4 --maxtasksperchild 1000 --events > /tmp/celeryd.log 2>&1 &
+    celery -A seed worker -l info -c 4 --maxtasksperchild 1000 --events --pidfile=$CELERY_PIDFILE > /tmp/celeryd.log 2>&1 &
 else
     printf "Celery is already running\n"
 fi


### PR DESCRIPTION
The old implementation (count the # of times "celery" is greppable from
the process list) is vulnerable to skipping a needed start if I'm
tailing `/tmp/celeryd.log` in another terminal window. Here we let the
celery process write a pid file and check for the presence of that
instead.

#### How should this be manually tested?

1. Before merge, use `./bin/start-seed.sh` to start the dev environment
2. Open a second window and then tail `/tmp/celeryd.log`
3. Kill django and celery in the first window
4. Restart with `./bin/start-seed.sh`

Expected: celery should restart.
Observed: celery doesn't restart; we're told it's already running because the tail command is spoofing it.

After merge, repeat steps. Expected and observed should now match.

#### What are the relevant tickets?

n/a