### PR TITLE
Combined text/numeric filtering

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -221,9 +221,8 @@ angular.module('BE.seed.controller.inventory_list', [])
       };
       _.map($scope.columns, function (col) {
         var options = {};
-        if (col.type === 'number') options.filter = inventory_service.numFilter();
-        else if (col.type === 'date') options.filter = inventory_service.dateFilter();
-        else options.filter = inventory_service.textFilter();
+        if (col.type === 'date') options.filter = inventory_service.dateFilter();
+        else options.filter = inventory_service.combinedFilter();
         if (col.type === 'text' || _.isUndefined(col.type)) options.sortingAlgorithm = naturalSort;
         if (col.name === 'number_properties' && col.related) options.treeAggregationType = 'total';
         else if (col.related || col.extraData) options.treeAggregationType = 'uniqueList';

--- a/seed/static/seed/js/controllers/mapping_controller.js
+++ b/seed/static/seed/js/controllers/mapping_controller.js
@@ -384,10 +384,11 @@ angular.module('BE.seed.controller.mapping', [])
           var existing_extra_taxlot_keys = existing_taxlot_keys.length ? _.keys(data.tax_lots[0].extra_data) : [];
           _.map($scope.property_columns, function (col) {
             var options = {};
-            if (!_.includes(existing_property_keys, col.name) && !_.includes(existing_extra_property_keys, col.name)) col.visible = false;
-            else {
-              if (col.type === 'number') options.filter = inventory_service.numFilter();
-              else options.filter = inventory_service.textFilter();
+            if (!_.includes(existing_property_keys, col.name) && !_.includes(existing_extra_property_keys, col.name)) {
+              col.visible = false;
+            } else {
+              if (col.type === 'date') options.filter = inventory_service.dateFilter();
+              else options.filter = inventory_service.combinedFilter();
             }
             return _.defaults(col, options, defaults);
           });
@@ -396,8 +397,8 @@ angular.module('BE.seed.controller.mapping', [])
             if (!_.includes(existing_taxlot_keys, col.name) && !_.includes(existing_extra_taxlot_keys, col.name)) {
               col.visible = false;
             } else {
-              if (col.type === 'number') options.filter = inventory_service.numFilter();
-              else options.filter = inventory_service.textFilter();
+              if (col.type === 'date') options.filter = inventory_service.dateFilter();
+              else options.filter = inventory_service.combinedFilter();
             }
             return _.defaults(col, options, defaults);
           });


### PR DESCRIPTION
#### What's this PR do?
Previously, columns with `type: "number"` would be assigned the numeric filtering syntax, date columns would be assigned date filtering syntax, and all other columns would be assigned text filtering syntax documented [here](https://docs.google.com/a/lbl.gov/viewer?a=v&pid=sites&srcid=bGJsLmdvdnxzZWVkfGd4OjNmNjI4ZmYxOTg3MTM4ZTE).
This PR combines text and numeric filtering for all non-date columns, which is very helpful for extra_data columns which are always assumed to be "text".

#### How should this be manually tested?
On the inventory list page try filtering any column with the syntax below.

- The filter supports multiple filters separated by commas.
- Date strings can be either a year (`2016`), a year and a month (`2016-05`), or a full date with no time (`2016-05-31`).

The filter syntax is as follows:
##### Text/Numeric Case-Insensitive Contains
> abc
> 5

##### Text/Numeric Exact Match
> ""
> "abc"
> = 5

##### Text/Numeric Not Exact Match
> != ""
> != "abc"
> != 5

##### Numeric Range
> \> 5
> \>= 5
> < 5
> <= 5

##### Text/Numeric Combination
> 123, street

##### Date Equality
> 2016
> 2016-05
> 2016-05-31
> = 2016
> = 2016-05

##### Date Inequality
> != 2015
> != 2016-10-01

##### Date Range
> \>= 2016
> < 2016-05

##### Date Combination
> 2016, >= 2016-10-01
> \>= 2015, < 2017

#### What are the relevant tickets?
#1328 