### PR TITLE
display analysis state string instead of int

### DIFF
--- a/seed/api/v2_1/views.py
+++ b/seed/api/v2_1/views.py
@@ -48,8 +48,7 @@ class PropertyViewFilterSet(FilterSet):
 
     class Meta:
         model = PropertyView
-        fields = ['identifier', 'address_line_1', 'cycle', 'property', 'cycle_start', 'cycle_end',
-                  'analysis_state']
+        fields = ['identifier', 'address_line_1', 'cycle', 'property', 'cycle_start', 'cycle_end', 'analysis_state']
 
     def identifier_filter(self, queryset, name, value):
         address_line_1 = Q(state__address_line_1__icontains=value)

--- a/seed/models/tax_lot_properties.py
+++ b/seed/models/tax_lot_properties.py
@@ -117,6 +117,8 @@ class TaxLotProperty(models.Model):
                 # Do not make these timestamps naive. They persist correctly.
                 related_dict['updated'] = related_view.property.updated
                 related_dict['created'] = related_view.property.created
+                # Replace the enumerations
+                related_dict['analysis_state'] = related_view.state.get_analysis_state_display()
             elif lookups['obj_class'] == 'PropertyView':
                 # Do not make these timestamps naive. They persist correctly.
                 related_dict['updated'] = related_view.taxlot.updated
@@ -170,8 +172,6 @@ class TaxLotProperty(models.Model):
                 if none_in_jurisdiction_tax_lot_ids:
                     jurisdiction_tax_lot_ids.append('Missing')
 
-                    # jurisdiction_tax_lot_ids = [""]
-
                 join_dict = related_map[join.property_view_id].copy()
                 join_dict.update({
                     'primary': 'P' if join.primary else 'S',
@@ -197,12 +197,10 @@ class TaxLotProperty(models.Model):
                 join_dict['generation_date'] = make_naive(join_dict['generation_date']).isoformat()
 
             if join_dict.get('analysis_start_time'):
-                join_dict['analysis_start_time'] = make_naive(
-                    join_dict['analysis_start_time']).isoformat()
+                join_dict['analysis_start_time'] = make_naive(join_dict['analysis_start_time']).isoformat()
 
             if join_dict.get('analysis_end_time'):
-                join_dict['analysis_end_time'] = make_naive(
-                    join_dict['analysis_end_time']).isoformat()
+                join_dict['analysis_end_time'] = make_naive(join_dict['analysis_end_time']).isoformat()
 
             # remove the measures from this view for now
             if join_dict.get('measures'):
@@ -238,6 +236,7 @@ class TaxLotProperty(models.Model):
                 # Do not make these timestamps naive. They persist correctly.
                 obj_dict['created'] = obj.property.created
                 obj_dict['updated'] = obj.property.updated
+                obj_dict['analysis_state'] = obj.state.get_analysis_state_display()
             elif lookups['obj_class'] == 'TaxLotView':
                 # Do not make these timestamps naive. They persist correctly.
                 obj_dict['updated'] = obj.taxlot.updated
@@ -258,12 +257,10 @@ class TaxLotProperty(models.Model):
                 obj_dict['generation_date'] = make_naive(obj_dict['generation_date']).isoformat()
 
             if obj_dict.get('analysis_start_time'):
-                obj_dict['analysis_start_time'] = make_naive(
-                    obj_dict['analysis_start_time']).isoformat()
+                obj_dict['analysis_start_time'] = make_naive(obj_dict['analysis_start_time']).isoformat()
 
             if obj_dict.get('analysis_end_time'):
-                obj_dict['analysis_end_time'] = make_naive(
-                    obj_dict['analysis_end_time']).isoformat()
+                obj_dict['analysis_end_time'] = make_naive(obj_dict['analysis_end_time']).isoformat()
 
             # remove the measures from this view for now
             if obj_dict.get('measures'):

--- a/seed/test_helpers/fake.py
+++ b/seed/test_helpers/fake.py
@@ -193,9 +193,7 @@ class FakePropertyAuditLogFactory(BaseFake):
         }
         details.update(kw)
         if not details.get('state'):
-            details['state'] = self.state_factory.get_property_state(
-                organization=self.organization
-            )
+            details['state'] = self.state_factory.get_property_state(organization=self.organization)
         if not details.get('view'):
             details['view'] = self.view_factory.get_property_view()
         return PropertyAuditLog.objects.create(**details)
@@ -234,16 +232,20 @@ class FakePropertyStateFactory(BaseFake):
             'owner_postal_code': owner.postal_code,
         }
 
-    def get_property_state(self, organization, **kw):
+    def get_property_state(self, organization=None, **kw):
         """Return a property state populated with pseudo random data"""
         property_details = self.get_details()
         property_details.update(kw)
         ps = PropertyState.objects.create(
-            organization=organization, **property_details
+            organization=self._get_attr('organization', self.organization),
+            **property_details
         )
         # make sure to create an audit log so that we can test various methods (e.g. updating properties)
         PropertyAuditLog.objects.create(
-            organization=organization, state=ps, record_type=AUDIT_IMPORT, name='Import Creation'
+            organization=self._get_attr('organization', self.organization),
+            state=ps,
+            record_type=AUDIT_IMPORT,
+            name='Import Creation'
         )
         return ps
 
@@ -253,8 +255,7 @@ class FakePropertyViewFactory(BaseFake):
     Factory Class for producing PropertyView instances.
     """
 
-    def __init__(self, prprty=None, cycle=None,
-                 organization=None, user=None):
+    def __init__(self, prprty=None, cycle=None, organization=None, user=None):
         super(FakePropertyViewFactory, self).__init__()
         self.prprty = prprty
         self.cycle = cycle
@@ -269,8 +270,7 @@ class FakePropertyViewFactory(BaseFake):
         )
         self.state_factory = FakePropertyStateFactory(organization=organization)
 
-    def get_property_view(self, prprty=None, cycle=None, state=None,
-                          organization=None, user=None, **kw):
+    def get_property_view(self, prprty=None, cycle=None, state=None, organization=None, user=None, **kw):
         # pylint:disable=too-many-arguments
         """Get property view instance."""
         organization = organization if organization else self.organization
@@ -285,9 +285,7 @@ class FakePropertyViewFactory(BaseFake):
         property_view_details = {
             'property': prprty,
             'cycle': cycle,
-            'state': state if state else self.state_factory.get_property_state(
-                organization=organization, **kw
-            )
+            'state': state if state else self.state_factory.get_property_state(organization=organization, **kw)
         }
         return PropertyView.objects.create(**property_view_details)
 
@@ -297,7 +295,7 @@ class FakePropertyMeasureFactory(BaseFake):
         self.organization = organization
 
         if not property_state:
-            self.property_state = FakePropertyStateFactory().get_property_state(self.organization)
+            self.property_state = FakePropertyStateFactory(organization=self.organization).get_property_state()
         else:
             self.property_state = property_state
         super(FakePropertyMeasureFactory, self).__init__()
@@ -327,7 +325,7 @@ class FakePropertyMeasureFactory(BaseFake):
             }
             PropertyMeasure.objects.create(**property_measure_details)
 
-    def get_property_state(self, number_of_measures=5, **kw):
+    def get_property_state(self, number_of_measures=5):
         """Return a measure"""
         self.assign_random_measures(number_of_measures)
         return self.property_state
@@ -427,8 +425,7 @@ class FakeGreenAssessmentPropertyFactory(BaseFake):
             details['rating'] = rating
         return details
 
-    def get_green_assessment_property(self, assessment=None, property_view=None,
-                                      organization=None, user=None,
+    def get_green_assessment_property(self, assessment=None, property_view=None, organization=None, user=None,
                                       urls=None, with_url=None, **kw):
         """
         Get a GreenAssessmentProperty instance.
@@ -541,7 +538,7 @@ class FakeTaxLotStateFactory(BaseFake):
         super(FakeTaxLotStateFactory, self).__init__()
         self.organization = organization
 
-    def get_details(self, organization):
+    def get_details(self):
         """Get taxlot details."""
         taxlot_details = {
             'jurisdiction_tax_lot_id': self.fake.numerify(text='#####'),
@@ -557,7 +554,7 @@ class FakeTaxLotStateFactory(BaseFake):
     def get_taxlot_state(self, organization=None, **kw):
         """Return a taxlot state populated with pseudo random data"""
         org = self._get_attr('organization', organization)
-        taxlot_details = self.get_details(org)
+        taxlot_details = self.get_details()
         taxlot_details.update(kw)
         tls = TaxLotState.objects.create(organization=org, **taxlot_details)
         TaxLotAuditLog.objects.create(

--- a/seed/tests/test_project_views.py
+++ b/seed/tests/test_project_views.py
@@ -7,7 +7,6 @@
 import json
 
 from django.core.urlresolvers import reverse_lazy
-from django.test import TestCase
 from django.utils.text import slugify
 
 from seed.data_importer.models import ImportRecord
@@ -21,15 +20,15 @@ from seed.lib.superperms.orgs.models import (
 )
 from seed.models import (
     Project, ProjectPropertyView,
-    Property, PropertyState, PropertyView
+    PropertyView
 )
 from seed.test_helpers import fake
-from seed.tests.util import FakeRequest
+from seed.tests.util import FakeRequest, DeleteModelsTestCase
 
 DEFAULT_NAME = 'proj1'
 
 
-class ProjectViewTests(TestCase):
+class ProjectViewTests(DeleteModelsTestCase):
     """
     Tests of the SEED project views: get_project, get_projects, create_project,
     delete_project, update_project, add_buildings_to_project,
@@ -51,14 +50,14 @@ class ProjectViewTests(TestCase):
         self.fake_request = FakeRequest(user=self.user)
         self.maxDiff = None
 
-    def tearDown(self):
-        self.user.delete()
-        self.org.delete()
-        Property.objects.all().delete()
-        PropertyState.objects.all().delete()
-        PropertyView.objects.all().delete()
-        Project.objects.all().delete()
-        ProjectPropertyView.objects.all().delete()
+    # def tearDown(self):
+    #     Property.objects.all().delete()
+    #     PropertyState.objects.all().delete()
+    #     PropertyView.objects.all().delete()
+    #     Project.objects.all().delete()
+    #     ProjectPropertyView.objects.all().delete()
+    #     self.user.delete()
+    #     self.org.delete()
 
     def _create_project(self, name=DEFAULT_NAME, org_id=None, user=None,
                         via_http=False, **kwargs):
@@ -100,8 +99,8 @@ class ProjectViewTests(TestCase):
     def _create_property_view(self, project):
         property_factory = fake.FakePropertyFactory(organization=self.org)
         property = property_factory.get_property()
-        property_state_factory = fake.FakePropertyStateFactory()
-        state = property_state_factory.get_property_state(self.org)
+        property_state_factory = fake.FakePropertyStateFactory(organization=self.org)
+        state = property_state_factory.get_property_state()
         cycle_factory = fake.FakeCycleFactory()
         cycle = cycle_factory.get_cycle()
         property_view, _ = PropertyView.objects.get_or_create(

--- a/seed/tests/test_project_views.py
+++ b/seed/tests/test_project_views.py
@@ -50,15 +50,6 @@ class ProjectViewTests(DeleteModelsTestCase):
         self.fake_request = FakeRequest(user=self.user)
         self.maxDiff = None
 
-    # def tearDown(self):
-    #     Property.objects.all().delete()
-    #     PropertyState.objects.all().delete()
-    #     PropertyView.objects.all().delete()
-    #     Project.objects.all().delete()
-    #     ProjectPropertyView.objects.all().delete()
-    #     self.user.delete()
-    #     self.org.delete()
-
     def _create_project(self, name=DEFAULT_NAME, org_id=None, user=None,
                         via_http=False, **kwargs):
         """helper to create a project, returns the response"""

--- a/seed/tests/test_properties_serializers.py
+++ b/seed/tests/test_properties_serializers.py
@@ -285,7 +285,7 @@ class TestPropertyViewAsStateSerializers(TestCase):
         )
         self.assessment = self.ga_factory.get_green_assessment()
         self.cycle = self.cycle_factory.get_cycle()
-        self.property_state = self.property_state_factory.get_property_state(self.org)
+        self.property_state = self.property_state_factory.get_property_state()
         self.property_view = self.property_view_factory.get_property_view(
             state=self.property_state, cycle=self.cycle
         )

--- a/seed/tests/util.py
+++ b/seed/tests/util.py
@@ -31,13 +31,10 @@ from seed.models.data_quality import DataQualityCheck
 
 
 class DeleteModelsTestCase(TestCase):
-    def setUp(self):
-        User.objects.all().delete()
-        Organization.objects.all().delete()
-        OrganizationUser.objects.all().delete()
+    def _delete_models(self):
+        # Order matters here
         Column.objects.all().delete()
         ColumnMapping.objects.all().delete()
-        Cycle.objects.all().delete()
         DataQualityCheck.objects.all().delete()
         ImportFile.objects.all().delete()
         ImportRecord.objects.all().delete()
@@ -52,26 +49,19 @@ class DeleteModelsTestCase(TestCase):
         TaxLotAuditLog.objects.all().delete()
         TaxLotProperty.objects.all().delete()
 
-    def tearDown(self):
+        # Now delete the cycle after all the states and views have been removed
+        Cycle.objects.all().delete()
+
+        # Delete users last
         User.objects.all().delete()
         Organization.objects.all().delete()
         OrganizationUser.objects.all().delete()
-        Column.objects.all().delete()
-        ColumnMapping.objects.all().delete()
-        Cycle.objects.all().delete()
-        DataQualityCheck.objects.all().delete()
-        ImportFile.objects.all().delete()
-        ImportRecord.objects.all().delete()
-        Property.objects.all().delete()
-        PropertyState.objects.all().delete()
-        PropertyView.objects.all().delete()
-        PropertyAuditLog.objects.all().delete()
-        StatusLabel.objects.all().delete()
-        TaxLot.objects.all().delete()
-        TaxLotState.objects.all().delete()
-        TaxLotView.objects.all().delete()
-        TaxLotAuditLog.objects.all().delete()
-        TaxLotProperty.objects.all().delete()
+
+    def setUp(self):
+        self._delete_models()
+
+    def tearDown(self):
+        self._delete_models()
 
 
 class FakeRequest(object):


### PR DESCRIPTION
#### Any background context you want to provide?
The inventory list page did not show the analysis state as a string. 

#### What's this PR do?
Converts the analysis_state field to the enumeration string.

#### How should this be manually tested?
Load data, check inventory page for analysis_state as 'Not Started' instead of 0.

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/1907354/34860585-c15def40-f71b-11e7-9fa6-1f6d7565c52a.png)

#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?