### PR TITLE
Add Sentry to Frontend

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,8 @@
     "angular-translate": "^2.16.0",
     "angular-translate-loader-static-files": "^2.16.0",
     "angular-sanitize": "^1.6.6",
-    "angular-translate-interpolation-messageformat": "^2.16.0"
+    "angular-translate-interpolation-messageformat": "^2.16.0",
+    "raven-js": "^3.22.1"
   },
   "resolutions": {
     "angular": "~1.6.8",

--- a/config/settings/local_untracked.py.dist
+++ b/config/settings/local_untracked.py.dist
@@ -28,6 +28,17 @@ import os
 # email through SES (django-ses)
 #EMAIL_BACKEND = 'django_ses.SESBackend'
 
+# Optional Sentry Configuration
+# import raven
+
+# RAVEN_CONFIG = {
+#    'dsn': 'https://<user>:<key>@sentry.io/<job_id>',
+#    # If you are using git, you can also automatically configure the
+#    # release based on the git info.
+#    'release': raven.fetch_git_sha(os.path.abspath(os.curdir)),
+# }
+# SENTRY_JS_DSN = 'https://<key>@sentry.io/<job_id>'
+
 # postgres DB config
 DATABASES = {
     'default': {

--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -19,5 +19,20 @@ Monitoring
 Sentry
 ^^^^^^
 
-Sentry is used for development. The front end tests are run on Sentry for every commit through
-travis.
+Sentry can monitor your webservers for any issues. To enable sentry add the following to
+your local_untracked.py files after setting up your Sentry account on sentry.io.
+
+The RAVEN_CONFIG is used for the backend and the SENTRY_JS_DSN is used for the frontend. At the moment,
+it is recommended to setup two sentry projects, one for backend and one for frontend.
+
+.. code-block:: python
+
+    import raven
+
+    RAVEN_CONFIG = {
+       'dsn': 'https://<user>:<key>@sentry.io/<job_id>',
+       # If you are using git, you can also automatically configure the
+       # release based on the git info.
+       'release': raven.fetch_git_sha(os.path.abspath(os.curdir)),
+    }
+    SENTRY_JS_DSN = 'https://<key>@sentry.io/<job_id>'

--- a/seed/templates/seed/base.html
+++ b/seed/templates/seed/base.html
@@ -100,8 +100,11 @@
         <script src="/static/vendors/bower_components/angular-ui-router.stateHelper/statehelper.min.js"></script>
 
             {% if not debug and SENTRY_JS_DSN %}
-        <script src="https://cdn.ravenjs.com/2.1.0/angular/raven.min.js"></script>
-        <script>Raven.config('{{ SENTRY_JS_DSN }}').install();</script>
+        <script src="/static/vendors/bower_components/raven-js/dist/raven.js"></script>
+        <script src="/static/vendors/bower_components/raven-js/dist/plugins/angular.js"></script>
+        <script>
+            Raven.config('{{ SENTRY_JS_DSN }}').addPlugin(Raven.Plugins.Angular).install();
+        </script>
             {% endif %}
 
         <script src="/static/vendors/bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>


### PR DESCRIPTION
#### Any background context you want to provide?
Sentry has been disabled for quite some time... time to reenable.

#### What's this PR do?
Add dependencies for frontend sentry.

#### How should this be manually tested?
On production/staging machines, add your SENTRY_JS_DSN variable to your local_untracked.py file.
N/A

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?