### PR TITLE
Allow the mapping columns to be resizable

### DIFF
--- a/seed/static/seed/partials/mapping.html
+++ b/seed/static/seed/partials/mapping.html
@@ -137,16 +137,16 @@
                             <th class="sub_head is_aligned_center hide">Map
                                 <a uib-popover="{$ MAP_copy $}" popover-placement="right"><i class="fa fa-info-circle" style="cursor: pointer;"></i></a>
                             </th>
-                            <th class="mapping_field" translate>SEED Header</th>
+                            <th class="mapping_field ellipsis-resizable" sd-resizable><translate>SEED Header</translate></th>
                             <!--th class="sub_head is_aligned_center">Duplicate <a uib-popover="{$VALIDATE_copy$}" popover-placement="right"><i class="fa fa-info-circle" style="cursor: pointer;"></i></a></th-->
-                            <th class="import_column_name" translate>Data File Header</th>
-                            <th translate>Inventory Type</th>
-                            <th translate>Measurement Units</th>
-                            <th translate>Row 1</th>
-                            <th translate>Row 2</th>
-                            <th translate>Row 3</th>
-                            <th translate>Row 4</th>
-                            <th translate>Row 5</th>
+                            <th class="import_column_name ellipsis-resizable" sd-resizable><translate>Data File Header</translate></th>
+                            <th class="ellipsis-resizable" sd-resizable><translate>Inventory Type</translate></th>
+                            <th class="ellipsis-resizable" sd-resizable><translate>Measurement Units</translate></th>
+                            <th class="ellipsis-resizable" sd-resizable><translate>Row 1</translate></th>
+                            <th class="ellipsis-resizable" sd-resizable><translate>Row 2</translate></th>
+                            <th class="ellipsis-resizable" sd-resizable><translate>Row 3</translate></th>
+                            <th class="ellipsis-resizable" sd-resizable><translate>Row 4</translate></th>
+                            <th class="ellipsis-resizable" sd-resizable><translate>Row 5</translate></th>
                         </tr>
                     </thead>
                     <tbody id="mapped-table">


### PR DESCRIPTION
#### What's this PR do?
Allows the mapping columns to be resizable with drag handles
#### How should this be manually tested?
Upload a file, go to the mapping page, drag the column dividers to resize
#### What are the relevant tickets?
fixes #1337