### PR TITLE
1297 data quality typeerror

### DIFF
--- a/seed/models/data_quality.py
+++ b/seed/models/data_quality.py
@@ -241,8 +241,10 @@ DEFAULT_RULES = [
 class ComparisonError(Exception):
     pass
 
+
 class DataQualityTypeCastError(Exception):
     pass
+
 
 def format_pint_violation(rule, source_value):
     """
@@ -640,7 +642,7 @@ class DataQualityCheck(models.Model):
                     value = row.extra_data[rule.field]
                     try:
                         value = rule.str_to_data_type(value)
-                    except DataQualityTypeCastError as e:
+                    except DataQualityTypeCastError:
                         self.add_result_type_error(row.id, rule, display_name, value)
                         continue
 

--- a/seed/models/data_quality.py
+++ b/seed/models/data_quality.py
@@ -15,7 +15,6 @@ from django.apps import apps
 from django.db import models
 from django.utils.timezone import get_current_timezone, make_aware, make_naive
 from quantityfield import ureg
-from seed.serializers.pint import pretty_units
 
 from seed.lib.superperms.orgs.models import Organization
 from seed.models import (
@@ -23,6 +22,7 @@ from seed.models import (
     StatusLabel,
     PropertyView, TaxLotView)
 from seed.models import obj_to_dict
+from seed.serializers.pint import pretty_units
 from seed.utils.cache import (
     set_cache_raw, get_cache_raw
 )
@@ -241,6 +241,8 @@ DEFAULT_RULES = [
 class ComparisonError(Exception):
     pass
 
+class DataQualityTypeCastError(Exception):
+    pass
 
 def format_pint_violation(rule, source_value):
     """
@@ -419,7 +421,7 @@ class Rule(models.Model):
                             if dt is not None:
                                 return dt.date()
             except ValueError as e:
-                raise TypeError("Error converting {} with {}".format(value, e))
+                raise DataQualityTypeCastError("Error converting {} with {}".format(value, e))
         else:
             return value
 
@@ -630,14 +632,18 @@ class DataQualityCheck(models.Model):
             if hasattr(row, rule.field) or rule.field in row.extra_data:
                 value = None
                 label_applied = False
+                display_name = rule.field
 
                 if hasattr(row, rule.field):
                     value = getattr(row, rule.field)
                 elif rule.field in row.extra_data:
                     value = row.extra_data[rule.field]
-                    value = rule.str_to_data_type(value)
+                    try:
+                        value = rule.str_to_data_type(value)
+                    except DataQualityTypeCastError as e:
+                        self.add_result_type_error(row.id, rule, display_name, value)
+                        continue
 
-                display_name = rule.field
                 if (rule.table_name, rule.field) in self.column_lookup:
                     display_name = self.column_lookup[(rule.table_name, rule.field)]
 
@@ -811,6 +817,19 @@ class DataQualityCheck(models.Model):
                 'table_name': rule.table_name,
                 'message': display_name + ' could not be compared numerically',
                 'detailed_message': display_name + ' [' + value + '] <> ' + rule_check,
+                'severity': rule.get_severity_display(),
+            }
+        )
+
+    def add_result_type_error(self, row_id, rule, display_name, value):
+        self.results[row_id]['data_quality_results'].append(
+            {
+                'field': rule.field,
+                'formatted_field': display_name,
+                'value': value,
+                'table_name': rule.table_name,
+                'message': display_name + ' could not be converted to numerical value',
+                'detailed_message': 'Value [' + value + '] could not be converted to number',
                 'severity': rule.get_severity_display(),
             }
         )

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ skipsdist=True
 deps=
     -r{toxinidir}/requirements/test.txt
 commands=
+    ./manage.py flush --noinput
     ./manage.py test seed
 passenv=
     DJANGO_LOG_LEVEL
@@ -46,6 +47,7 @@ whitelist_externals=
 
 [testenv:functional]
 commands=
+    ./manage.py flush --noinput
     coverage run manage.py test seed
     {toxinidir}/bin/install_javascript_dependencies.sh
     {toxinidir}/bin/protractor_start_server.sh


### PR DESCRIPTION
#### Any background context you want to provide?
If there is a data quality rule that checks for numbers and the data is a string, then the data quality checking would error out and stop the mapping progress.

#### What's this PR do?
Check if the data are convertible to a number, if not, then log then error as a data quality rule error.

#### How should this be manually tested?
* Go to organization settings
* Create a data quality rule on a normally string field but set the type to number (e.g. city)
* Import some data that and verify that the data quality rules are now reporting that it is unable to convert city to number (or whatever field you are testing).

#### What are the relevant tickets?
#1297 

#### Screenshots (if appropriate)

#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?