### PR TITLE
fix swagger access

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -277,12 +277,14 @@ REST_FRAMEWORK = {
     'DATETIME_INPUT_FORMATS': (
         '%Y:%m:%d', 'iso-8601', '%Y-%m-%d'
     ),
-    'EXCEPTION_HANDLER': 'seed.exception_handler.custom_exception_handler'
+    'EXCEPTION_HANDLER': 'seed.exception_handler.custom_exception_handler',
+
 }
 
 SWAGGER_SETTINGS = {
     "exclude_namespaces": ["app"],  # List URL namespaces to ignore
-    'APIS_SORTER': 'alpha'
+    'APIS_SORTER': 'alpha',
+    'LOGOUT_URL': '/accounts/logout',
 }
 
 # Certification

--- a/seed/utils/api.py
+++ b/seed/utils/api.py
@@ -236,6 +236,9 @@ class OrgMixin(object):
         :return: int representing a valid organization pk or
             organization object.
         """
+        if not request.user:
+            return None
+
         if not getattr(self, '_organization', None):
             org_id = get_org_id(request)
             org = None


### PR DESCRIPTION
#### Any background context you want to provide?
* Swagger was not accessible to non-auth users causing sentry errors.
* Swagger logout was not working

#### What's this PR do?
* Fixes the swagger page to show the API endpoints that are available as an unauthenticated user. This is a shift from before where an unauthenticated user was able to see all endpoints.
* Fixes the Django Logout button on the swagger page.

#### How should this be manually tested?
* Log out of your seed instance
* Go to http://seed-instance.somewhere/api/swagger
* Verify that you can see /v2/schema
* Log in (via button on top)
* Verify that you can see the entire API
* Click Django Logout (via button on top) 
* Verify that you are now logged out.

#### What are the relevant tickets?
Fixes #1603 

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?