### PR TITLE
Extra error handing for PM template list

### DIFF
--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -64,6 +64,7 @@ angular.module('BE.seed.controller.data_upload_modal', [])
       };
       $scope.pm_buttons_enabled = true;
       $scope.pm_error_alert = false;
+      $scope.pm_warning_message = false;
       /**
        * dataset: holds the state of the data set
        * name: string - the data set name
@@ -366,12 +367,16 @@ angular.module('BE.seed.controller.data_upload_modal', [])
       $scope.get_pm_report_template_names = function (pm_username, pm_password) {
         spinner_utility.show();
         $scope.pm_buttons_enabled = false;
+        $scope.pm_warning_message = false;
         $http.post('/api/v2_1/portfolio_manager/template_list/', {
           username: pm_username,
           password: pm_password
         }).then(function (response) {
           $scope.pm_error_alert = false;
-          $scope.pm_templates = response.data.templates;
+          if (response.data.any_errors) {
+            $scope.pm_warning_message = 'Issues encountered getting templates, but I will keep trying!';
+          }
+          $scope.pm_templates = response.data.templates; // response.data now also has an 'any_errors' member we could check
           if ($scope.pm_templates.length) $scope.pm_template = _.first($scope.pm_templates);
           return response.data;
         }).catch(function (error) {
@@ -385,13 +390,17 @@ angular.module('BE.seed.controller.data_upload_modal', [])
       $scope.get_pm_report = function (pm_username, pm_password, pm_template) {
         spinner_utility.show();
         $scope.pm_buttons_enabled = false;
+        $scope.pm_warning_message = false;
         $http.post('/api/v2_1/portfolio_manager/report/', {
           username: pm_username,
           password: pm_password,
           template: pm_template
         }).then(function (response) {
+          if (response.data.any_errors) {
+            $scope.pm_warning_message = 'Issues encountered generating report, but I will keep trying!';
+          }
           response = $http.post('/api/v2/upload/create_from_pm_import/', {
-            properties: response.data.properties,
+            properties: response.data.properties, // response.data now also has an 'any_errors' member we could check
             import_record_id: $scope.dataset.id
           });
           return response;

--- a/seed/static/seed/partials/data_upload_modal.html
+++ b/seed/static/seed/partials/data_upload_modal.html
@@ -204,6 +204,7 @@
     <!-- Step 13: Portfolio Manager Data Import -->
     <div class="data_upload_steps pm_import" ng-switch-when="13">
         <div class="alert alert-danger" ng-show="pm_error_alert">{$ pm_error_alert $}</div>
+        <div class="alert alert-warning" ng-show="pm_warning_message">{$ pm_warning_message $}</div>
         <div class="row" style="padding-bottom:10px">
             <label class="control-label col-lg-4 col-sm-4" for="inputPMUsername">Portfolio Manager Username</label>
             <div class="col-lg-8 col-sm-8">

--- a/seed/views/portfoliomanager.py
+++ b/seed/views/portfoliomanager.py
@@ -164,10 +164,18 @@ class PortfolioManagerImport(object):
         if 'rows' not in template_object:
             raise PMExcept("Could not find rows key in template response; aborting.")
         templates = template_object["rows"]
+        return_templates = []
         for t in templates:
-            _log.debug("Found template,\n id=" + str(t["id"]) + "\n name=" + str(t["name"]))
-
-        return templates
+            if "id" not in t and "name" not in t:
+                _log.debug("Template retrieved from PortfolioManager but with no id or name keys")
+            elif "id" not in t:
+                _log.debug("Template retrieved but did not include \"id\" key; name = " + str(t["name"]))
+            elif "name" not in t:
+                _log.debug("Template retrieved but did not include \"name\" key; id = " + str(t["id"]))
+            else:
+                _log.debug("Found template,\n id=" + str(t["id"]) + "\n name=" + str(t["name"]))
+                return_templates.append(t)
+        return return_templates
 
     @staticmethod
     def get_template_by_name(templates, template_name):


### PR DESCRIPTION
#### Any background context you want to provide?
Issue #1583 describes an error where the user got 500 errors when trying to connect to PM.  Looking at Sentry, it looks like the connection to PM was successful, but something bad was coming through in the response.  The templates weren't fully formed.  It's possible the report template isn't well formed on PM or something.

#### What's this PR do?
This PR adds extra error handling to the template response.  Instead of blindly assuming that each template row will have id and name keys, it checks for them explicitly.  If they aren't there, a debug message is thrown, and that template is not included in the list offered to the user to select from.

#### How should this be manually tested?
For well-formed responses, like those I receive on my own machine with our test PM account, this won't change anything.  For responses that fail because of a bad template response, log messages should be thrown, but the user should simply see the list of valid templates.

#### What are the relevant tickets?
#1583

#### Screenshots (if appropriate)

#### Definition of Done:
- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [ ] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [ ] Does this PR require a regression test? All fixes require a regression test.
- [ ] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?