### PR TITLE
added oauth, add_columns endpoint, and adjusted pint handling

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -100,6 +100,8 @@ INSTALLED_APPS = (
     'django_filters',
     'rest_framework',
     'rest_framework_swagger',
+    'oauth2_provider',
+    'oauth2_jwt_provider',
 )
 
 SEED_CORE_APPS = (
@@ -262,6 +264,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Django Rest Framework
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
+        'oauth2_provider.ext.rest_framework.OAuth2Authentication',
         'rest_framework.authentication.SessionAuthentication',
         'seed.authentication.SEEDAuthentication',
     ),

--- a/config/settings/local_untracked.py.dist
+++ b/config/settings/local_untracked.py.dist
@@ -93,5 +93,11 @@ LOGGING = {
     },
 }
 
-
-
+# Token request Url is a common choice for audience
+# see https://tools.ietf.org/html/rfc7523#section-3 and
+# https://github.com/GreenBuildingRegistry/jwt-oauth2 for additional details
+OAUTH2_JWT_PROVIDER = {
+    'JWT_AUDIENCE': 'https://example.com/oauth/token/',
+    'DEVELOPER_GROUP': 'developers',
+    'TRUSTED_OAUTH_GROUP': 'trusted_developers',
+}

--- a/config/urls.py
+++ b/config/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     # API
     url(r'^api/swagger/', get_swagger_view(title='SEED API'), name='swagger'),
     url(r'^api/', include(api, namespace='api')),
+    url(r'^oauth/', include('oauth2_jwt_provider.urls', namespace='oauth2_provider'))
 ]
 
 handler404 = 'seed.views.main.error404'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,3 +51,8 @@ xmltodict==0.11.0
 requests==2.18.4
 lxml==4.1.1
 probablepeople==0.5.4
+
+jwt-oauth2>=0.1.0
+django-oauth-toolkit==0.12.0
+django-braces>=1.11.0
+

--- a/seed/filtersets.py
+++ b/seed/filtersets.py
@@ -58,7 +58,7 @@ class GAPropertyFilterSet(FilterSet):
 
     class Meta:
         model = GreenAssessmentProperty
-        fields = ('year', 'assessment', 'rating')
+        fields = ('year', 'assessment', 'rating', 'view')
 
 
 class LabelFilterSet(FilterSet):
@@ -89,7 +89,7 @@ class CycleFilterSet(FilterSet):
         """
         max_time_diff = 26
         name = "{} Calendar Year".format(value)
-        cycles = queryset.filter(name__contains=name)
+        cycles = queryset.filter(name__icontains=name)
         if not cycles:
             start = make_aware(datetime(int(value), 1, 1), pytz.UTC)
             end = start + relativedelta(years=1) - relativedelta(seconds=1)
@@ -111,6 +111,21 @@ class PropertyViewFilterSet(FilterSet):
     """
     cycle_start = DateFilter(name='cycle__start', lookup_expr='lte')
     cycle_end = DateFilter(name='cycle__end', lookup_expr='gte')
+    address_line_1 = CharFilter(
+        name='state__address_line_1', lookup_expr='iexact'
+    )
+    address_line_2 = CharFilter(
+        name='state__address_line_2', lookup_expr='iexact'
+    )
+    city = CharFilter(
+        name='state__city', lookup_expr='iexact'
+    )
+    state = CharFilter(
+        name='state__state', lookup_expr='iexact'
+    )
+    postal_code = CharFilter(
+        name='state__postal_code', lookup_expr='iexact'
+    )
 
     class Meta:
         model = PropertyView
@@ -120,7 +135,7 @@ class PropertyViewFilterSet(FilterSet):
 class PropertyStateFilterSet(FilterSet):
     """Provide advanced filtering for PropertyState
 
-    Filter options for propertstate by energy_score (gte), city,
+    Filter options for propertystate by energy_score (gte), city,
     pm_parent_property_id, and property_identifier.
 
     The property_identifier filter provides a single query parameter key for

--- a/seed/landing/models.py
+++ b/seed/landing/models.py
@@ -100,8 +100,7 @@ class SEEDUser(AbstractBaseUser, PermissionsMixin):
         if not auth_header:
             return None
 
-        if not auth_header.startswith(
-                'Bearer') or not getattr(request, 'user', None):
+        if not auth_header.startswith('Bearer') or not getattr(request, 'user', None):
             try:
                 if not auth_header.startswith('Basic'):
                     raise exceptions.AuthenticationFailed(

--- a/seed/landing/models.py
+++ b/seed/landing/models.py
@@ -100,19 +100,23 @@ class SEEDUser(AbstractBaseUser, PermissionsMixin):
         if not auth_header:
             return None
 
-        try:
-            if not auth_header.startswith('Basic'):
-                raise exceptions.AuthenticationFailed("Only Basic HTTP_AUTHORIZATION is supported")
+        if not auth_header.startswith(
+                'Bearer') or not getattr(request, 'user', None):
+            try:
+                if not auth_header.startswith('Basic'):
+                    raise exceptions.AuthenticationFailed(
+                        "Only Basic HTTP_AUTHORIZATION is supported")
 
-            auth_header = auth_header.split()[1]
-            auth_header = base64.urlsafe_b64decode(auth_header)
-            username, api_key = auth_header.split(':')
-            user = SEEDUser.objects.get(api_key=api_key, username=username)
-            return user
-        except ValueError:
-            raise exceptions.AuthenticationFailed("Invalid HTTP_AUTHORIZATION Header")
-        except SEEDUser.DoesNotExist:
-            raise exceptions.AuthenticationFailed("Invalid API key")
+                auth_header = auth_header.split()[1]
+                auth_header = base64.urlsafe_b64decode(auth_header)
+                username, api_key = auth_header.split(':')
+                user = SEEDUser.objects.get(api_key=api_key, username=username)
+                return user
+            except ValueError:
+                raise exceptions.AuthenticationFailed(
+                    "Invalid HTTP_AUTHORIZATION Header")
+            except SEEDUser.DoesNotExist:
+                raise exceptions.AuthenticationFailed("Invalid API key")
 
     def get_absolute_url(self):
         return "/users/%s/" % urlquote(self.username)

--- a/seed/models/certification.py
+++ b/seed/models/certification.py
@@ -143,6 +143,7 @@ class GreenAssessmentProperty(models.Model):
         'year': ('GreenVerification{}Year', 'Assessment Year'),
         'target_date': (None, 'Assessment Recognition Target Date'),
         'eligibility': (None, 'Assessment Eligibility'),
+        'date': ('GreenVerification{}Date', None)
     }
 
     def __unicode__(self):

--- a/seed/renderers.py
+++ b/seed/renderers.py
@@ -22,9 +22,6 @@ override View(Set) methods unnecessarily, if e.g. ModelViewSet is used.
 from rest_framework import status
 from rest_framework.renderers import JSONRenderer
 
-from seed.lib.superperms.orgs.models import Organization
-from seed.serializers.pint import apply_display_unit_preferences
-
 
 class SEEDJSONRenderer(JSONRenderer):
     """

--- a/seed/renderers.py
+++ b/seed/renderers.py
@@ -73,17 +73,6 @@ class SEEDJSONRenderer(JSONRenderer):
         if pagination:
             data['pagination'] = pagination
 
-        if "properties" in data and len(data["properties"]) > 0:
-            # good enough to just use the org_id of the first property state to
-            # get display preferences for the Quantity values. Hard to imagine
-            # a situation where we'd want to vary units running down a column of
-            # data per-org.
-            org_id = data["properties"][0]["state"]["organization_id"]
-            org = Organization.objects.get(pk=org_id)
-            for i in range(len(data["properties"])):
-                data["properties"][i]["state"] = \
-                    apply_display_unit_preferences(org, data["properties"][i]["state"])
-
         return super(SEEDJSONRenderer, self).render(
             data,
             accepted_media_type=accepted_media_type,

--- a/seed/serializers/certification.py
+++ b/seed/serializers/certification.py
@@ -7,7 +7,7 @@ required approvals from the U.S. Department of Energy) and contributors.
 All rights reserved.  # NOQA
 :author Paul Munday <paul@paulmunday.net>
 """
-from collections import OrderedDict, Sequence
+from collections import OrderedDict
 from datetime import timedelta
 
 from django.core.exceptions import ValidationError

--- a/seed/serializers/columns.py
+++ b/seed/serializers/columns.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2018, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Department of Energy) and contributors.
+All rights reserved.  # NOQA
+
+:author Fable Turas <fable@raintechpdx.com>
+"""
+
+# Imports from Standard Library
+
+# Imports from Third Party Modules
+
+# Imports from Django
+from rest_framework import serializers
+
+# Local Imports
+
+from seed.models import Column
+
+# Constants
+
+# Data Structure Definitions
+
+# Private Functions
+
+# Public Classes and Functions
+
+
+class ColumnSerializer(serializers.ModelSerializer):
+    organization_id = serializers.PrimaryKeyRelatedField(
+        source='organization', read_only=True
+    )
+    unit_name = serializers.SlugRelatedField(
+        source='unit', slug_field='unit_name', read_only=True
+    )
+    unit_type = serializers.SlugRelatedField(
+        source='unit', slug_field='unit_type', read_only=True
+    )
+
+    class Meta:
+        model = Column
+        fields = (
+            'id', 'organization_id', 'table_name',
+            'column_name', 'is_extra_data', 'unit_name', 'unit_type'
+        )

--- a/seed/serializers/pint.py
+++ b/seed/serializers/pint.py
@@ -97,11 +97,11 @@ def add_pint_unit_suffix(organization, column):
 
     try:
         if column['dataType'] == "area":
-            column['displayName'] = \
-                format_column_name(column['displayName'], organization.display_units_area)
+            column['displayName'] = format_column_name(
+                column['displayName'], organization.display_units_area)
         elif column['dataType'] == "eui":
-            column['displayName'] = \
-                format_column_name(column['displayName'], organization.display_units_eui)
+            column['displayName'] = format_column_name(
+                column['displayName'], organization.display_units_eui)
     except KeyError:
         pass  # no transform needed if we can't detect dataType, nbd
     return column
@@ -125,9 +125,15 @@ class PintQuantitySerializerField(serializers.Field):
     """
 
     def to_representation(self, obj):
-        if isinstance(self.root.instance, PropertyView):
-            org_id = self.root.instance.state.organization_id
-            org = Organization.objects.get(pk=org_id)
+        if isinstance(obj, ureg.Quantity):
+            if isinstance(self.root.instance, list):
+                state = self.root.instance[0] if self.root.instance else None
+            else:
+                state = self.root.instance
+            try:
+                org = state.organization
+            except AttributeError:
+                org = state.state.organization
             value = collapse_unit(org, obj)
             return value
         else:

--- a/seed/serializers/pint.py
+++ b/seed/serializers/pint.py
@@ -11,9 +11,6 @@ from django.core.serializers.json import DjangoJSONEncoder
 from quantityfield import ureg
 from rest_framework import serializers
 
-from seed.lib.superperms.orgs.models import Organization
-from seed.models import PropertyView
-
 AREA_DIMENSIONALITY = '[length] ** 2'
 EUI_DIMENSIONALITY = '[mass] / [time] ** 3'
 

--- a/seed/tests/test_certification_models.py
+++ b/seed/tests/test_certification_models.py
@@ -9,6 +9,7 @@ All rights reserved.  # NOQA
 """
 # pylint:disable=no-name-in-module
 import datetime
+
 from django.core.exceptions import ValidationError
 
 from seed.landing.models import SEEDUser as User
@@ -16,20 +17,20 @@ from seed.lib.superperms.orgs.models import (
     Organization,
     OrganizationUser,
 )
-from seed.models import (
-    GreenAssessment,
-)
+
+from seed.models import GreenAssessment
+
 from seed.test_helpers.fake import (
     FakeGreenAssessmentFactory,
     FakeGreenAssessmentPropertyFactory,
     FakeGreenAssessmentURLFactory,
 )
+
 from seed.tests.util import DeleteModelsTestCase
 
 
 class GreenAssessmentTests(DeleteModelsTestCase):
-    """Tests for certification/Green Assesment models and methods"""
-
+    """Tests for certification/Green Assessment models and methods"""
     # pylint: disable=too-many-instance-attributes
 
     def setUp(self):
@@ -165,6 +166,7 @@ class GreenAssessmentTests(DeleteModelsTestCase):
         expected = {
             u'GreenBuildingVerificationType': 'Green Test Score',
             u'GreenVerificationBody': 'Green TS Inc',
+            u'GreenVerificationDate': self.start_date,
             u'GreenVerificationSource': 'Assessor',
             u'GreenVerificationStatus': 'Pending',
             u'GreenVerificationMetric': 5,
@@ -180,6 +182,7 @@ class GreenAssessmentTests(DeleteModelsTestCase):
         expected = {
             u'GreenBuildingVerificationType': 'Green Test Score',
             u'GreenVerificationGreenTestScoreBody': 'Green TS Inc',
+            u'GreenVerificationGreenTestScoreDate': self.start_date,
             u'GreenVerificationGreenTestScoreSource': 'Assessor',
             u'GreenVerificationGreenTestScoreStatus': 'Pending',
             u'GreenVerificationGreenTestScoreMetric': 5,

--- a/seed/tests/test_certification_serializers.py
+++ b/seed/tests/test_certification_serializers.py
@@ -9,10 +9,10 @@ All rights reserved
 
 Tests for serializers used by GreenAssessments/Energy Certifications
 """
-from collections import OrderedDict
-
 import datetime
 import mock
+from collections import OrderedDict
+
 from django.core.exceptions import ValidationError
 
 from seed.landing.models import SEEDUser as User
@@ -20,6 +20,17 @@ from seed.lib.superperms.orgs.models import (
     Organization,
     OrganizationUser,
 )
+
+from seed.models import (
+    Cycle,
+    GreenAssessment,
+    GreenAssessmentProperty,
+    GreenAssessmentURL,
+    Property,
+    PropertyState,
+    PropertyView,
+)
+
 from seed.serializers.certification import (
     GreenAssessmentURLField,
     PropertyViewField,
@@ -27,11 +38,13 @@ from seed.serializers.certification import (
     GreenAssessmentSerializer,
     GreenAssessmentPropertySerializer
 )
+
 from seed.test_helpers.fake import (
     FakePropertyViewFactory,
     FakeGreenAssessmentFactory,
     FakeGreenAssessmentPropertyFactory
 )
+
 from seed.tests.util import DeleteModelsTestCase
 from seed.utils.strings import titlecase
 
@@ -157,10 +170,7 @@ class TestGreenAssessmentPropertySerializer(DeleteModelsTestCase):
             'assessment': self.assessment,
             'view': self.property_view,
         }
-        self.urls = [
-            ('http://example.com', 'example.com'),
-            ('http://example.org', 'example.org')
-        ]
+        self.urls = ['http://example.com', 'http://example.org']
 
     @mock.patch('seed.serializers.certification.GreenAssessmentURL')
     def test_create(self, mock_url_model):
@@ -192,8 +202,7 @@ class TestGreenAssessmentPropertySerializer(DeleteModelsTestCase):
             property_assessment=instance
         )
         mock_url_model.assert_called_with(
-            url='http://example.org', property_assessment=gap,
-            description='example.org'
+            url='http://example.org', property_assessment=gap
         )
 
     def test_validate(self):

--- a/seed/tests/test_certification_serializers.py
+++ b/seed/tests/test_certification_serializers.py
@@ -21,16 +21,6 @@ from seed.lib.superperms.orgs.models import (
     OrganizationUser,
 )
 
-from seed.models import (
-    Cycle,
-    GreenAssessment,
-    GreenAssessmentProperty,
-    GreenAssessmentURL,
-    Property,
-    PropertyState,
-    PropertyView,
-)
-
 from seed.serializers.certification import (
     GreenAssessmentURLField,
     PropertyViewField,

--- a/seed/tests/test_properties_serializers.py
+++ b/seed/tests/test_properties_serializers.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 """
-copyright (c) 2014 -2016 The Regents of the University of California,
+copyright (c) 2014 -2018 The Regents of the University of California,
 through Lawrence Berkeley National Laboratory(subject to receipt of any
 required approvals from the US. Department of Energy) and contributors.
 All rights reserved
@@ -296,7 +296,7 @@ class TestPropertyViewAsStateSerializers(DeleteModelsTestCase):
         # for now convert the site_eui to a magnitude to get the test to pass
         # this really needs to be at another level
         data = self.serializer.current
-        data['state']['site_eui'] = data['state']['site_eui'].magnitude
+        # data['state']['site_eui'] = data['state']['site_eui'].magnitude
         self.assertEqual(data, expected)
 
     def test_get_certifications(self):
@@ -334,7 +334,7 @@ class TestPropertyViewAsStateSerializers(DeleteModelsTestCase):
 
         data = self.serializer.get_history(obj)
         # Really need to figure out how to get the serializer to save the magnitude correctly.
-        data[0]['state']['site_eui'] = data[0]['state']['site_eui'].magnitude
+        # data[0]['state']['site_eui'] = data[0]['state']['site_eui'].magnitude
 
         expected = [PropertyAuditLogReadOnlySerializer(self.audit_log2).data]
         self.assertEqual(data, expected)
@@ -364,9 +364,8 @@ class TestPropertyViewAsStateSerializers(DeleteModelsTestCase):
     def test_create(self, mock_serializer, mock_pview):
         """Test create"""
         mock_serializer.return_value.is_valid.return_value = True
-        mock_serializer.return_value.save.return_value = 'mock_state'
-        mock_property_view = mock.MagicMock()
-        mock_pview.objects.create.return_value = mock_property_view
+        mock_serializer.return_value.save.return_value = self.property_state
+        mock_pview.objects.create.return_value = self.property_view
         data = {
             'org_id': 1,
             'cycle': 2,
@@ -381,15 +380,14 @@ class TestPropertyViewAsStateSerializers(DeleteModelsTestCase):
         )
         self.assertTrue(mock_serializer.return_value.save.called)
         mock_pview.objects.create.assert_called_with(
-            state='mock_state', cycle_id=2, property_id=4, org_id=1
+            state=self.property_state, cycle_id=2, property_id=4, org_id=1
         )
 
     @mock.patch('seed.serializers.properties.PropertyStateWritableSerializer')
     def test_update_put(self, mock_serializer):
         """Test update with PUT"""
         mock_serializer.return_value.is_valid.return_value = True
-        mock_serializer.return_value.save.return_value = 'mock_state'
-        mock_property_view = mock.MagicMock()
+        mock_serializer.return_value.save.return_value = self.property_state
         mock_request = mock.MagicMock()
         data = {
             'org_id': 1,
@@ -401,7 +399,7 @@ class TestPropertyViewAsStateSerializers(DeleteModelsTestCase):
         serializer = PropertyViewAsStateSerializer()
         mock_request.METHOD = 'PUT'
         serializer.context = {'request': mock_request}
-        serializer.update(mock_property_view, data)
+        serializer.update(self.property_view, data)
         mock_serializer.assert_called_with(
             data={'test': 3}
         )
@@ -411,8 +409,7 @@ class TestPropertyViewAsStateSerializers(DeleteModelsTestCase):
     def test_update_patch(self, mock_serializer):
         """Test update with PATCH"""
         mock_serializer.return_value.is_valid.return_value = True
-        mock_serializer.return_value.save.return_value = 'mock_state'
-        mock_property_view = mock.MagicMock()
+        mock_serializer.return_value.save.return_value = self.property_state
         mock_request = mock.MagicMock()
         mock_request.method = 'PATCH'
         data = {
@@ -422,11 +419,10 @@ class TestPropertyViewAsStateSerializers(DeleteModelsTestCase):
             'property': 4
         }
         serializer = PropertyViewAsStateSerializer()
-        mock_property_view.state = 'pv_state'
         serializer.context = {'request': mock_request}
-        serializer.update(mock_property_view, data)
+        serializer.update(self.property_view, data)
         mock_serializer.assert_called_with(
-            'pv_state',
+            self.property_state,
             data={'test': 3}
         )
         self.assertTrue(mock_serializer.return_value.save.called)

--- a/seed/tests/test_properties_serializers.py
+++ b/seed/tests/test_properties_serializers.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 """
-copyright (c) 2014 -2018 The Regents of the University of California,
+copyright (c) 2014 - 2018 The Regents of the University of California,
 through Lawrence Berkeley National Laboratory(subject to receipt of any
 required approvals from the US. Department of Energy) and contributors.
 All rights reserved

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -762,7 +762,7 @@ class InventoryViewTests(DeleteModelsTestCase):
         url = reverse('api:v2:properties-detail', args=[pv.id])
         response = self.client.get(url, params)
         result = json.loads(response.content)
-        self.assertEqual(result['state']['gross_floor_area'], '3.14')
+        self.assertEqual(result['state']['gross_floor_area'], 3.14)
 
         # test writing the field -- does not work for pint fields, but other fields should persist fine
         # /api/v2/properties/4/?cycle_id=4&organization_id=3
@@ -776,8 +776,8 @@ class InventoryViewTests(DeleteModelsTestCase):
         }
         response = self.client.put(url, data=json.dumps(params), content_type='application/json')
         result = json.loads(response.content)
-        self.assertEqual(result['state']['gross_floor_area'], '11235.00')
-        self.assertEqual(result['state']['site_eui'], '90.10')
+        self.assertEqual(result['state']['gross_floor_area'], 11235.00)
+        self.assertEqual(result['state']['site_eui'], 90.10)
 
     def test_get_properties_with_taxlots(self):
         property_state = self.property_state_factory.get_property_state()

--- a/seed/utils/viewsets.py
+++ b/seed/utils/viewsets.py
@@ -17,6 +17,7 @@ parser_classes, authentication_classes, and pagination_classes attributes.
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
+from oauth2_provider.ext.rest_framework import OAuth2Authentication
 
 # Local Imports
 from seed.authentication import SEEDAuthentication
@@ -30,7 +31,11 @@ from seed.utils.api import (
 )
 
 # Constants
-AUTHENTICATION_CLASSES = (SessionAuthentication, SEEDAuthentication)
+AUTHENTICATION_CLASSES = (
+    OAuth2Authentication,
+    SessionAuthentication,
+    SEEDAuthentication
+)
 PARSER_CLASSES = (FormParser, MultiPartParser, JSONParser)
 RENDERER_CLASSES = (JSONRenderer,)
 PERMISSIONS_CLASSES = (SEEDOrgPermissions,)

--- a/seed/views/certification.py
+++ b/seed/views/certification.py
@@ -8,6 +8,10 @@ All rights reserved.  # NOQA
 :author Paul Munday <paul@paulmunday.net>
 """
 
+from rest_framework.decorators import detail_route
+from rest_framework import status
+from rest_framework.response import Response
+
 from seed.filtersets import GAPropertyFilterSet, GreenAssessmentFilterSet
 from seed.models import (
     GreenAssessment,
@@ -21,7 +25,10 @@ from seed.serializers.certification import (
     GreenAssessmentURLSerializer
 )
 
-from seed.utils.viewsets import (SEEDOrgModelViewSet, SEEDOrgCreateUpdateModelViewSet)
+from seed.utils.viewsets import (
+    SEEDOrgModelViewSet,
+    SEEDOrgCreateUpdateModelViewSet
+)
 
 
 class GreenAssessmentViewSet(SEEDOrgCreateUpdateModelViewSet):
@@ -172,6 +179,7 @@ class GreenAssessmentViewSet(SEEDOrgCreateUpdateModelViewSet):
 
 
 class GreenAssessmentURLViewSet(SEEDOrgModelViewSet):
+
     """API endpoint for viewing and creating green assessment urls.
 
         Returns::
@@ -289,7 +297,7 @@ class GreenAssessmentPropertyViewSet(SEEDOrgModelViewSet):
                         'rating': score if value is non-numeric,
                         'version': version of certification issued,
                         'date': date certification issued,
-                        'target_date': date achievement of certification expected,
+                        'target_date': date achievement of cert is expected,
                         'eligibility': BEDES eligibility,
                         'expiration_date': date certification expires,
                         'is_valid': state of certification validity,
@@ -306,180 +314,37 @@ class GreenAssessmentPropertyViewSet(SEEDOrgModelViewSet):
         Return an assessment property instance by pk if its associated
         assessment is within the specified organization.
 
-        :GET: Expects organization_id in query string.
-        :Parameters:
-            :Parameter: organization_id
-            :Description: organization_id for this user`s organization
-            :required: true
-            :Parameter: green assessment property pk
-            :Description: id for desired green assessment property
-            :required: true
-
     list:
         Return all green assessment properties available to user through
         associated green assessment via specified organization.
 
-        :GET: Expects organization_id in query string.
-        :Parameters:
-            :Parameter: organization_id
-            :Description: organization_id for this user`s organization
-            :required: true
     create:
-        Create a new green assessment property.
-
-        :POST: Expects organization_id in query string.
-        :Parameters:
-            :Parameter: organization_id
-            :Description: organization_id for this user`s organization
-            :required: true
-            :Parameter: source
-            :Description:  source of this certification e.g. assessor
-            :required: false
-            :Parameter: status
-            :Description:  status for multi-step processes
-            :required: false
-            :Parameter: status_date
-            :Description:  date status first applied
-            :required: false
-            :Parameter: metric
-            :Description:  score if value is numeric
-            :required: false
-            :Parameter: rating
-            :Description:  score if value is non-numeric
-            :required: false
-            :Parameter: version
-            :Description:  version of certification issued
-            :required: false
-            :Parameter: date
-            :Description:  date certification issued  ``YYYY-MM-DD``
-            :required: false
-            :Parameter: target_date
-            :Description:  date achievement expected ``YYYY-MM-DD``
-            :required: false
-            :Parameter: eligibility
-            :Description:  BEDES eligible if true
-            :required: false
-            :Parameter: urls
-            :Description:  array of related green assessment urls
-            :required: false
-            :Parameter: assessment
-            :Description:  id of associated green assessment
-            :required: true
-            :Parameter: view
-            :Description:  id of associated property view
-            :required: true
+        Create a new green assessment property within user`s specified org.
 
     delete:
         Remove an existing green assessment property.
 
-        :DELETE: Expects organization_id in query string.
-        :Parameters:
-            :Parameter: organization_id
-            :Description: organization_id for this user`s organization
-            :required: true
-            :Parameter: green assessment property pk
-            :Description: id for desired green assessment property
-            :required: true
-
     update:
         Update a green assessment property record.
 
-        :PUT: Expects organization_id in query string.
-        :Parameters:
-            :Parameter: organization_id
-            :Description: organization_id for this user`s organization
-            :required: true
-            :Parameter: green assessment pk
-            :Description: id for desired green assessment
-            :required: true
-            :Parameter: source
-            :Description:  source of this certification e.g. assessor
-            :required: false
-            :Parameter: status
-            :Description:  status for multi-step processes
-            :required: false
-            :Parameter: status_date
-            :Description:  date status first applied
-            :required: false
-            :Parameter: metric
-            :Description:  score if value is numeric
-            :required: false
-            :Parameter: rating
-            :Description:  score if value is non-numeric
-            :required: false
-            :Parameter: version
-            :Description:  version of certification issued
-            :required: false
-            :Parameter: date
-            :Description:  date certification issued  ``YYYY-MM-DD``
-            :required: false
-            :Parameter: target_date
-            :Description:  date achievement expected ``YYYY-MM-DD``
-            :required: false
-            :Parameter: eligibility
-            :Description:  BEDES eligible if true
-            :required: false
-            :Parameter: urls
-            :Description:  array of related green assessment urls
-            :required: false
-            :Parameter: assessment
-            :Description:  id of associated green assessment
-            :required: true
-            :Parameter: view
-            :Description:  id of associated property view
-            :required: true
-
-
     partial_update:
-        Update one or more fields on an existing green assessment.
-
-        :PUT: Expects organization_id in query string.
-        :Parameters:
-            :Parameter: organization_id
-            :Description: organization_id for this user`s organization
-            :required: true
-            :Parameter: green assessment pk
-            :Description: id for desired green assessment
-            :required: true
-            :Parameter: source
-            :Description:  source of this certification e.g. assessor
-            :required: false
-            :Parameter: status
-            :Description:  status for multi-step processes
-            :required: false
-            :Parameter: status_date
-            :Description:  date status first applied
-            :required: false
-            :Parameter: metric
-            :Description:  score if value is numeric
-            :required: false
-            :Parameter: rating
-            :Description:  score if value is non-numeric
-            :required: false
-            :Parameter: version
-            :Description:  version of certification issued
-            :required: false
-            :Parameter: date
-            :Description:  date certification issued  ``YYYY-MM-DD``
-            :required: false
-            :Parameter: target_date
-            :Description:  date achievement expected ``YYYY-MM-DD``
-            :required: false
-            :Parameter: eligibility
-            :Description:  BEDES eligible if true
-            :required: false
-            :Parameter: urls
-            :Description:  array of related green assessment urls
-            :required: false
-            :Parameter: assessment
-            :Description:  id of associated green assessment
-            :required: false
-            :Parameter: view
-            :Description:  id of associated property view
-            :required: false
-
+        Update one or more fields on an existing green assessment...
     """
     serializer_class = GreenAssessmentPropertySerializer
     model = GreenAssessmentProperty
     orgfilter = 'assessment__organization_id'
     filter_class = GAPropertyFilterSet
+
+    @detail_route(methods=['get'])
+    def reso_format(self, request, pk=None):
+        """Return an assessment property instance by pk in reso format"""
+        assessment = self.get_object()
+        status_code = status.HTTP_200_OK
+        return Response(assessment.to_reso_dict(), status=status_code)
+
+    @detail_route(methods=['get'])
+    def bedes_format(self, request, pk=None):
+        """Return an assessment property instance by pk in bedes format"""
+        assessment = self.get_object()
+        status_code = status.HTTP_200_OK
+        return Response(assessment.to_bedes_dict(), status=status_code)

--- a/seed/views/columns.py
+++ b/seed/views/columns.py
@@ -10,22 +10,23 @@ import logging
 from django.http import JsonResponse
 from rest_framework import status
 from rest_framework import viewsets
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import list_route
+from rest_framework.exceptions import NotFound, ParseError
+from rest_framework.response import Response
 
-from seed.authentication import SEEDAuthentication
 from seed.decorators import ajax_request_class, require_organization_id_class
 from seed.lib.superperms.orgs.decorators import has_perm_class
 from seed.lib.superperms.orgs.models import Organization, OrganizationUser
 from seed.models.columns import Column, ColumnMapping
-from seed.utils.api import api_endpoint_class
+from seed.utils.api import api_endpoint_class, OrgQuerySetMixin
+from seed.serializers.columns import ColumnSerializer
+from seed.models import PropertyState, TaxLotState
 
 _log = logging.getLogger(__name__)
 
 
-class ColumnViewSet(viewsets.ViewSet):
+class ColumnViewSet(OrgQuerySetMixin, viewsets.ViewSet):
     raise_exception = True
-    authentication_classes = (SessionAuthentication, SEEDAuthentication)
 
     @require_organization_id_class
     @api_endpoint_class
@@ -183,10 +184,44 @@ class ColumnViewSet(viewsets.ViewSet):
                 'message': 'organization with with id {} does not exist'.format(organization_id)
             }, status=status.HTTP_404_NOT_FOUND)
 
+    @list_route()
+    def add_column_names(self, request):
+        model_obj = None
+        inventory_pk = request.query_params.get('inventory_pk')
+        inventory_type = request.query_params.get('inventory_type', 'property')
+        if inventory_type in ['property', 'propertystate']:
+            if not inventory_pk:
+                model_obj = PropertyState.objects.order_by('-id').first()
+            try:
+                model_obj = PropertyState.objects.get(id=inventory_pk)
+            except PropertyState.DoesNotExist:
+                pass
+        elif inventory_type in ['taxlot', 'taxlotstate']:
+            if not inventory_pk:
+                model_obj = TaxLotState.objects.order_by('-id').first()
+            else:
+                try:
+                    model_obj = TaxLotState.objects.get(id=inventory_pk)
+                    inventory_type = 'taxlotstate'
+                except TaxLotState.DoesNotExist:
+                    pass
+        else:
+            msg = "{} is not a valid inventory type".format(inventory_type)
+            raise ParseError(msg)
+        if not model_obj:
+            msg = "No {} was found matching {}".format(
+                inventory_type, inventory_pk
+            )
+            raise NotFound(msg)
+        Column.save_column_names(model_obj)
+        org_id = self.get_organization(request)
+        columns = Column.retrieve_all(org_id, inventory_type, only_used=False)
+        columns = ColumnSerializer(columns, many=True)
+        return Response(columns, status=status.HTTP_200_OK)
+
 
 class ColumnMappingViewSet(viewsets.ViewSet):
     raise_exception = True
-    authentication_classes = (SessionAuthentication, SEEDAuthentication)
 
     @require_organization_id_class
     @api_endpoint_class

--- a/seed/views/columns.py
+++ b/seed/views/columns.py
@@ -186,6 +186,11 @@ class ColumnViewSet(OrgQuerySetMixin, viewsets.ViewSet):
 
     @list_route()
     def add_column_names(self, request):
+        """
+        Allow columns to be added based on an existing record.
+        This my be necessary to make column selections available when
+        records are upload through API endpoint rather than the frontend.
+        """
         model_obj = None
         inventory_pk = request.query_params.get('inventory_pk')
         inventory_type = request.query_params.get('inventory_type', 'property')

--- a/seed/views/data_quality.py
+++ b/seed/views/data_quality.py
@@ -9,10 +9,8 @@ import csv
 from celery.utils.log import get_task_logger
 from django.http import JsonResponse, HttpResponse
 from rest_framework import viewsets, serializers, status
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import list_route, detail_route
 
-from seed.authentication import SEEDAuthentication
 from seed.data_importer.tasks import do_checks
 from seed.decorators import ajax_request_class
 from seed.lib.superperms.orgs.decorators import has_perm_class
@@ -99,7 +97,6 @@ class DataQualityViews(viewsets.ViewSet):
     (1) Post, wait, get…
     (2) Respond with what changed
     """
-    authentication_classes = (SessionAuthentication, SEEDAuthentication)
 
     def create(self, request):
         """

--- a/seed/views/datasets.py
+++ b/seed/views/datasets.py
@@ -10,10 +10,8 @@ from django.http import JsonResponse
 from django.utils import timezone
 from rest_framework import status
 from rest_framework import viewsets
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import list_route
 
-from seed.authentication import SEEDAuthentication
 from seed.data_importer.models import ImportRecord
 from seed.decorators import ajax_request_class, require_organization_id_class
 from seed.lib.superperms.orgs.decorators import has_perm_class
@@ -27,7 +25,6 @@ _log = logging.getLogger(__name__)
 
 class DatasetViewSet(viewsets.ViewSet):
     raise_exception = True
-    authentication_classes = (SessionAuthentication, SEEDAuthentication)
 
     @require_organization_id_class
     @api_endpoint_class

--- a/seed/views/measures.py
+++ b/seed/views/measures.py
@@ -9,12 +9,10 @@
 from django.http import JsonResponse
 from rest_framework import status
 from rest_framework import viewsets
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import list_route
 from rest_framework.parsers import JSONParser, FormParser
 from rest_framework.renderers import JSONRenderer
 
-from seed.authentication import SEEDAuthentication
 from seed.models import (
     Measure,
 )
@@ -30,7 +28,6 @@ class MeasureViewSet(viewsets.ReadOnlyModelViewSet):
     by BuildingSync enumeration.json file.
     """
     serializer_class = MeasureSerializer
-    authentication_classes = [SessionAuthentication, SEEDAuthentication]
     parser_classes = (JSONParser, FormParser,)
     renderer_classes = (JSONRenderer,)
     queryset = Measure.objects.all()

--- a/seed/views/meters.py
+++ b/seed/views/meters.py
@@ -8,11 +8,9 @@
 
 from django.http import JsonResponse
 from rest_framework import viewsets
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import detail_route
 from rest_framework.parsers import JSONParser, FormParser
 
-from seed.authentication import SEEDAuthentication
 from seed.decorators import require_organization_id_class
 from seed.lib.superperms.orgs.decorators import has_perm_class
 from seed.models import (
@@ -25,7 +23,6 @@ from seed.utils.api import api_endpoint_class
 
 class MeterViewSet(viewsets.ViewSet):
     raise_exception = True
-    authentication_classes = (SessionAuthentication, SEEDAuthentication)
     parser_classes = (JSONParser, FormParser)
 
     @api_endpoint_class

--- a/seed/views/organizations.py
+++ b/seed/views/organizations.py
@@ -12,11 +12,9 @@ from django.http import JsonResponse
 from django.utils.decorators import method_decorator
 from rest_framework import status
 from rest_framework import viewsets, serializers
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import detail_route
 
 from seed import tasks
-from seed.authentication import SEEDAuthentication
 from seed.decorators import ajax_request_class
 from seed.decorators import get_prog_key
 from seed.landing.models import SEEDUser as User
@@ -205,7 +203,6 @@ class OrganizationUsersSerializer(serializers.Serializer):
 
 class OrganizationViewSet(viewsets.ViewSet):
     raise_exception = True
-    authentication_classes = (SessionAuthentication, SEEDAuthentication)
 
     @api_endpoint_class
     @ajax_request_class

--- a/seed/views/projects.py
+++ b/seed/views/projects.py
@@ -12,14 +12,12 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError
 from django.utils import timezone
 from rest_framework import viewsets, status
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import list_route
 from rest_framework.parsers import JSONParser
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
 from seed import search
-from seed.authentication import SEEDAuthentication
 from seed.decorators import (
     DecoratorMixin
 )
@@ -70,7 +68,6 @@ class ProjectViewSet(DecoratorMixin(drf_api_endpoint), viewsets.ModelViewSet):
     serializer_class = ProjectSerializer
     renderer_classes = (JSONRenderer,)
     parser_classes = (JSONParser,)
-    authentication_classes = (SessionAuthentication, SEEDAuthentication)
     query_set = Project.objects.none()
     ProjectViewModels = {
         'property': ProjectPropertyView, 'taxlot': ProjectTaxLotView

--- a/seed/views/scenarios.py
+++ b/seed/views/scenarios.py
@@ -4,11 +4,9 @@
 :copyright (c) 2014 - 2018, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
 """
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.parsers import JSONParser, FormParser
 from rest_framework.renderers import JSONRenderer
 
-from seed.authentication import SEEDAuthentication
 from seed.models import (
     Scenario,
 )
@@ -24,7 +22,6 @@ class ScenarioViewSet(SEEDOrgReadOnlyModelViewSet):
     API View for Scenarios. This only includes retrieve and list for now.
     """
     serializer_class = ScenarioSerializer
-    authentication_classes = [SessionAuthentication, SEEDAuthentication]
     parser_classes = (JSONParser, FormParser,)
     renderer_classes = (JSONRenderer,)
     queryset = Scenario.objects.all()

--- a/seed/views/users.py
+++ b/seed/views/users.py
@@ -12,10 +12,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
 from django.http import JsonResponse
 from rest_framework import viewsets, status, serializers
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import list_route, detail_route
 
-from seed.authentication import SEEDAuthentication
 from seed.models.data_quality import (
     DATA_TYPES as DATA_QUALITY_DATA_TYPES,
     SEVERITY as DATA_QUALITY_SEVERITY,
@@ -116,7 +114,6 @@ class ListUsersResponseSerializer(serializers.Serializer):
 
 class UserViewSet(viewsets.ViewSet):
     raise_exception = True
-    authentication_classes = (SessionAuthentication, SEEDAuthentication)
 
     def validate_request_user(self, pk, request):
         try:


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
1.  adds an 'add_column_names' endpoint that allows Columns to be added based on an existing record. We found this to be necessary to make column selections available when records are upload through api endpoint rather than the front end.
2. adds OAuth2 functionality, with a JWT Grant option.  See https://github.com/GreenBuildingRegistry/jwt-oauth2 for additional details and JWT Grant base client side setup.  SessionAuthentication and SEEDAuthentication were left in place.  The 'authentication_classes' attribute was removed from the views that had set these two classes explicitly so that the default athentication classes, which includes all three would be use.
3.  Removed pint handling from SEEDJSONRenderer and updated PintQuantitySerializerField to handle the remaining cases requiring collapse_unit.  Manually testing endpoints that depend on PropertyStateSerializer produced multiple failures (for example, 'history', where there were further nested 'state' serializations, or where the data_name was "properties" but the result was a single instance).  PintQuantitySerializerField should handle all instances of Quantity type fields

#### How should this be manually tested?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x ] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?
no