### PR TITLE
Add libffi-dev and libssl-dev to docker and documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python-pip \
         python-dev \
         python-gdbm \
+        libffi-dev \
         libpcre3 \
         libpcre3-dev \
+        libssl-dev \
         libxml2-dev \
         libxslt1-dev \
         nginx \

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "bootstrap": "~3.3.7",
     "d3": "=3.5.2",
     "dimple": "=2.2.0",
-    "file-saver": "^1.3.3",
+    "file-saver": "=1.3.3",
     "fine-uploader": "git://github.com/FineUploader/fine-uploader.git#3.9.1",
     "font-awesome": "~4.4.0",
     "jasmine-core": "=1.3.1",

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -102,6 +102,7 @@ INSTALLED_APPS = (
     'rest_framework_swagger',
     'oauth2_provider',
     'oauth2_jwt_provider',
+    'crispy_forms',  # needed to squash warnings around collectstatic with rest_framework
 )
 
 SEED_CORE_APPS = (

--- a/docs/source/aws.rst
+++ b/docs/source/aws.rst
@@ -22,7 +22,7 @@ Ubuntu server 14.04 or newer.
     sudo apt-get upgrade
     sudo apt-get install -y libpq-dev python-dev python-pip libatlas-base-dev \
     gfortran build-essential g++ npm libxml2-dev libxslt1-dev git mercurial \
-    libssl-dev curl uwsgi-core uwsgi-plugin-python
+    libssl-dev libffi-dev curl uwsgi-core uwsgi-plugin-python
 
 
 PostgreSQL and Redis are not included in the above commands. For a quick installation on AWS it

--- a/docs/source/linux.rst
+++ b/docs/source/linux.rst
@@ -26,7 +26,7 @@ Install the following base packages to run SEED:
     sudo apt-get upgrade
     sudo apt-get install libpq-dev python-dev python-pip libatlas-base-dev \
     gfortran build-essential g++ npm libxml2-dev libxslt1-dev git mercurial \
-    libssl-dev curl uwsgi-core uwsgi-plugin-python
+    libssl-dev libffi-dev curl uwsgi-core uwsgi-plugin-python
     sudo apt-get install redis-server
     sudo apt-get install postgresql postgresql-contrib
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -53,6 +53,7 @@ requests==2.18.4
 lxml==4.1.1
 probablepeople==0.5.4
 
+enum34==1.1.6  # enum34 needs to be specified to support cryptography and oauth2
 jwt-oauth2>=0.1.0
 django-oauth-toolkit==0.12.0
 django-braces>=1.11.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,7 @@ django==1.11.6
 dj-database-url==0.4.2
 django-autoslug==1.9.3
 django-storages==1.6.5
+django-crispy-forms==1.7.2
 modeltranslation==0.25
 
 # Persistence stores


### PR DESCRIPTION
#### Any background context you want to provide?
The docker containers were not building successfully (or any fresh installation) due to the newer version of FileSaver.js.

The oauth2 work did not work on new machines due to the missing libffi and libssl packages.

#### What's this PR do?
* Add libssl-dev and libffi-dev to installation instructions and docker containers.
* Restrict FileSaver.js to version 1.3.3

#### How should this be manually tested?
Only should impact deployment. Manually test.

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?