### PR TITLE
Remove unneeded auth classes. Fix BuildingSync and HPXML API endpoints

### DIFF
--- a/seed/api/v2/views.py
+++ b/seed/api/v2/views.py
@@ -1,8 +1,6 @@
 from django.http import JsonResponse
 from rest_framework import viewsets
-from rest_framework.authentication import SessionAuthentication
 
-from seed.authentication import SEEDAuthentication
 from seed.decorators import ajax_request_class
 from seed.utils.api import api_endpoint_class
 from seed.utils.cache import get_cache

--- a/seed/api/v2/views.py
+++ b/seed/api/v2/views.py
@@ -10,7 +10,6 @@ from seed.utils.cache import get_cache
 
 class ProgressViewSetV2(viewsets.ViewSet):
     raise_exception = True
-    authentication_classes = (SessionAuthentication, SEEDAuthentication)
 
     @api_endpoint_class
     @ajax_request_class

--- a/seed/api/v2_1/views.py
+++ b/seed/api/v2_1/views.py
@@ -16,7 +16,6 @@ from django_filters import CharFilter, DateFilter
 from django_filters.rest_framework import FilterSet
 from rest_framework import status
 from rest_framework.decorators import detail_route
-
 from seed.building_sync.building_sync import BuildingSync
 from seed.hpxml.hpxml import HPXML
 from seed.lib.superperms.orgs.decorators import has_perm_class
@@ -25,8 +24,6 @@ from seed.models import (
     PropertyState,
     BuildingFile,
     Cycle,
-    # PropertyMeasure,
-    # Simulation,
 )
 from seed.serializers.properties import (
     PropertyViewAsStateSerializer,

--- a/seed/api/v2_1/views.py
+++ b/seed/api/v2_1/views.py
@@ -122,6 +122,12 @@ class PropertyViewSetV21(SEEDOrgReadOnlyModelViewSet):
         return PropertyView.objects.filter(property__organization_id=org_id).order_by('-state__id')
 
     def _get_property_view(self, pk, cycle_pk):
+        """
+        Return a property view based on the property id and cycle
+        :param pk: ID of property (not property view)
+        :param cycle_pk: ID of the cycle
+        :return: dict, propety view and status
+        """
         try:
             property_view = PropertyView.objects.select_related(
                 'property', 'cycle', 'state'
@@ -161,31 +167,16 @@ class PropertyViewSetV21(SEEDOrgReadOnlyModelViewSet):
               type: integer
               required: true
               paramType: query
-            - name: cycle_id
-              type: integer
-              required: true
-              paramType: query
         """
-        # organization_id = request.data['organization_id']
-        cycle_id = request.query_params.get('cycle_id', None)
-
-        if not cycle_id:
-            return JsonResponse({
-                'success': False,
-                'message': "Cycle ID is not defined"
-            })
-        else:
-            cycle = Cycle.objects.get(pk=cycle_id)
-
         try:
             # TODO: not checking organization? Is that right?
             # TODO: this needs to call _get_property_view and use the property pk, not the property_view pk.
             #   or we need to state the v2.1 of API uses property views instead of property
-            property_view = PropertyView.objects.select_related('state').get(pk=pk, cycle=cycle)
+            property_view = PropertyView.objects.select_related('state').get(pk=pk)
         except PropertyView.DoesNotExist:
             return JsonResponse({
                 'success': False,
-                'message': 'Cannot match a PropertyView with pk=%s; cycle_id=%s' % (pk, cycle_id)
+                'message': 'Cannot match a PropertyView with pk=%s' % pk
             })
 
         bs = BuildingSync()
@@ -215,28 +206,14 @@ class PropertyViewSetV21(SEEDOrgReadOnlyModelViewSet):
               type: integer
               required: true
               paramType: query
-            - name: cycle_id
-              type: integer
-              required: true
-              paramType: query
         """
-        cycle_id = request.query_params.get('cycle_id', None)
-
-        if not cycle_id:
-            return JsonResponse({
-                'success': False,
-                'message': "Cycle ID is not defined"
-            })
-        else:
-            cycle = Cycle.objects.get(pk=cycle_id)
-
         # Organization is checked in the orgfilter of the ViewSet
         try:
-            property_view = PropertyView.objects.select_related('state').get(pk=pk, cycle=cycle)
+            property_view = PropertyView.objects.select_related('state').get(pk=pk)
         except PropertyView.DoesNotExist:
             return JsonResponse({
                 'success': False,
-                'message': 'Cannot match a PropertyView with pk=%s; cycle_id=%s' % (pk, cycle_id)
+                'message': 'Cannot match a PropertyView with pk=%s' % pk
             })
 
         hpxml = HPXML()

--- a/seed/building_sync/building_sync.py
+++ b/seed/building_sync/building_sync.py
@@ -9,6 +9,7 @@ import copy
 import json
 import logging
 import os
+from quantityfield import ureg
 from collections import OrderedDict
 
 import xmltodict
@@ -225,8 +226,7 @@ class BuildingSync(object):
             if value:
                 full_path = "{}.{}".format(process_struct['root'], v['path'])
 
-                if v.get('key_path_name', None) and v.get('value_path_name', None) and v.get(
-                        'key_path_value', None):
+                if v.get('key_path_name', None) and v.get('value_path_name', None) and v.get('key_path_value', None):
                     # iterate over the paths and find the correct node to set
                     self._set_compound_node(
                         full_path,
@@ -339,7 +339,10 @@ class BuildingSync(object):
                             new_sub_item = {key_path_name: key_path_value, value_path_name: value}
                             data[p].append(new_sub_item)
                 else:
-                    data[p] = {key_path_name: key_path_value, value_path_name: value}
+                    if isinstance(value, ureg.Quantity):
+                        data[p] = {key_path_name: key_path_value, value_path_name: value.magnitude}
+                    else:
+                        data[p] = {key_path_name: key_path_value, value_path_name: value}
 
                 return True
             else:

--- a/seed/data_importer/views.py
+++ b/seed/data_importer/views.py
@@ -4,15 +4,15 @@
 :copyright (c) 2014 - 2018, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
 """
-import csv
 import base64
+import csv
 import hashlib
 import hmac
 import json
 import logging
 import os
-import pint
 
+import pint
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -24,11 +24,9 @@ from django.db.models import Q
 from django.http import HttpResponse, JsonResponse
 from django.utils.timezone import make_naive
 from rest_framework import serializers, status, viewsets
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import api_view, detail_route, list_route, parser_classes, permission_classes
 from rest_framework.parsers import MultiPartParser, FormParser
 
-from seed.authentication import SEEDAuthentication
 from seed.data_importer.models import (
     ImportFile,
     ImportRecord
@@ -529,7 +527,6 @@ class MappingResultsResponseSerializer(serializers.Serializer):
 
 class ImportFileViewSet(viewsets.ViewSet):
     raise_exception = True
-    authentication_classes = (SessionAuthentication, SEEDAuthentication)
     queryset = ImportFile.objects.all()
 
     @api_endpoint_class

--- a/seed/hpxml/hpxml.py
+++ b/seed/hpxml/hpxml.py
@@ -8,6 +8,7 @@
 import logging
 import os
 import functools
+from quantityfield import ureg
 from copy import deepcopy
 
 try:
@@ -130,6 +131,10 @@ class HPXML(object):
                 el.getparent().remove(el)
             if value is None or el is None:
                 continue
+
+            # set the value to magnitude if it is a quantity
+            if isinstance(value, ureg.Quantity):
+                value = value.magnitude
             setattr(el.getparent(), el.tag[el.tag.index('}') + 1:],
                     unicode(value) if not isinstance(value, basestring) else value)
 

--- a/seed/landing/models.py
+++ b/seed/landing/models.py
@@ -103,8 +103,7 @@ class SEEDUser(AbstractBaseUser, PermissionsMixin):
         if not auth_header.startswith('Bearer') or not getattr(request, 'user', None):
             try:
                 if not auth_header.startswith('Basic'):
-                    raise exceptions.AuthenticationFailed(
-                        "Only Basic HTTP_AUTHORIZATION is supported")
+                    raise exceptions.AuthenticationFailed("Only Basic HTTP_AUTHORIZATION is supported")
 
                 auth_header = auth_header.split()[1]
                 auth_header = base64.urlsafe_b64decode(auth_header)
@@ -112,8 +111,7 @@ class SEEDUser(AbstractBaseUser, PermissionsMixin):
                 user = SEEDUser.objects.get(api_key=api_key, username=username)
                 return user
             except ValueError:
-                raise exceptions.AuthenticationFailed(
-                    "Invalid HTTP_AUTHORIZATION Header")
+                raise exceptions.AuthenticationFailed("Invalid HTTP_AUTHORIZATION Header")
             except SEEDUser.DoesNotExist:
                 raise exceptions.AuthenticationFailed("Invalid API key")
 

--- a/seed/test_helpers/fake.py
+++ b/seed/test_helpers/fake.py
@@ -224,6 +224,7 @@ class FakePropertyStateFactory(BaseFake):
             'postal_code': "970{}".format(self.fake.numerify(text='##')),
             'year_built': self.fake.random_int(min=1880, max=2015),
             'site_eui': self.fake.random_int(min=50, max=600),
+            'gross_floor_area': self.fake.random_number(digits=6),
             'owner': owner.name,
             'owner_email': owner.email,
             'owner_telephone': owner.telephone,

--- a/seed/tests/test_building_file_views.py
+++ b/seed/tests/test_building_file_views.py
@@ -57,8 +57,7 @@ class InventoryViewTests(DeleteModelsTestCase):
 
         # go to buildingsync endpoint
         params = {
-            'organization_id': self.org.pk,
-            'cycle_id': self.cycle.id,
+            'organization_id': self.org.pk
         }
         url = reverse('api:v2.1:properties-building-sync', args=[pv.id])
         response = self.client.get(url, params)
@@ -73,8 +72,7 @@ class InventoryViewTests(DeleteModelsTestCase):
 
         # go to buildingsync endpoint
         params = {
-            'organization_id': self.org.pk,
-            'cycle_id': self.cycle.id,
+            'organization_id': self.org.pk
         }
         url = reverse('api:v2.1:properties-hpxml', args=[pv.id])
         response = self.client.get(url, params)

--- a/seed/tests/test_building_file_views.py
+++ b/seed/tests/test_building_file_views.py
@@ -1,0 +1,81 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2018, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+from datetime import datetime
+
+from django.core.urlresolvers import reverse
+from django.utils import timezone
+
+from seed.landing.models import SEEDUser as User
+from seed.lib.superperms.orgs.models import Organization, OrganizationUser
+from seed.models import (
+    PropertyView,
+    StatusLabel,
+)
+from seed.test_helpers.fake import (
+    FakeCycleFactory, FakeColumnFactory,
+    FakePropertyFactory, FakePropertyStateFactory,
+    FakeTaxLotStateFactory
+)
+from seed.tests.util import DeleteModelsTestCase
+
+
+class InventoryViewTests(DeleteModelsTestCase):
+    def setUp(self):
+        user_details = {
+            'username': 'test_user@demo.com',
+            'password': 'test_pass',
+            'email': 'test_user@demo.com'
+        }
+        self.user = User.objects.create_superuser(**user_details)
+        self.org = Organization.objects.create()
+        self.column_factory = FakeColumnFactory(organization=self.org)
+        self.cycle_factory = FakeCycleFactory(organization=self.org,
+                                              user=self.user)
+        self.property_factory = FakePropertyFactory(organization=self.org)
+        self.property_state_factory = FakePropertyStateFactory(organization=self.org)
+        self.taxlot_state_factory = FakeTaxLotStateFactory(organization=self.org)
+        self.org_user = OrganizationUser.objects.create(
+            user=self.user, organization=self.org
+        )
+        self.cycle = self.cycle_factory.get_cycle(
+            start=datetime(2010, 10, 10, tzinfo=timezone.get_current_timezone()))
+        self.status_label = StatusLabel.objects.create(
+            name='test', super_organization=self.org
+        )
+        self.client.login(**user_details)
+
+    def test_get_building_sync(self):
+        state = self.property_state_factory.get_property_state()
+        prprty = self.property_factory.get_property()
+        pv = PropertyView.objects.create(
+            property=prprty, cycle=self.cycle, state=state
+        )
+
+        # go to buildingsync endpoint
+        params = {
+            'organization_id': self.org.pk,
+            'cycle_id': self.cycle.id,
+        }
+        url = reverse('api:v2.1:properties-building-sync', args=[pv.id])
+        response = self.client.get(url, params)
+        self.assertIn('<auc:FloorAreaValue>%s.0</auc:FloorAreaValue>' % state.gross_floor_area, response.content)
+
+    def test_get_hpxml(self):
+        state = self.property_state_factory.get_property_state()
+        prprty = self.property_factory.get_property()
+        pv = PropertyView.objects.create(
+            property=prprty, cycle=self.cycle, state=state
+        )
+
+        # go to buildingsync endpoint
+        params = {
+            'organization_id': self.org.pk,
+            'cycle_id': self.cycle.id,
+        }
+        url = reverse('api:v2.1:properties-hpxml', args=[pv.id])
+        response = self.client.get(url, params)
+        self.assertIn('<GrossFloorArea>%s.0</GrossFloorArea>' % state.gross_floor_area, response.content)

--- a/seed/utils/viewsets.py
+++ b/seed/utils/viewsets.py
@@ -34,7 +34,7 @@ from seed.utils.api import (
 AUTHENTICATION_CLASSES = (
     OAuth2Authentication,
     SessionAuthentication,
-    SEEDAuthentication
+    SEEDAuthentication,
 )
 PARSER_CLASSES = (FormParser, MultiPartParser, JSONParser)
 RENDERER_CLASSES = (JSONRenderer,)


### PR DESCRIPTION
#### Any background context you want to provide?
BuildingSync and HPXML were displaying quantities in the elements.

#### What's this PR do?
Cast the Quantity fields to their magnitudes before persisting to the XML's (BuildingSync and HPXML).

#### How should this be manually tested?
Unit tests were added. 

Go to the following endpoints via the API:
*  <host>/api/v2.1/properties/234/building_sync/?cycle_id=x
*  <host>/api/v2.1/properties/234/hpxml/?cycle_id=x

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?