### PR TITLE
made PropertyStateWritableSerializer fields not required

### DIFF
--- a/seed/serializers/properties.py
+++ b/seed/serializers/properties.py
@@ -195,28 +195,30 @@ class PropertyStateWritableSerializer(serializers.ModelSerializer):
     """
     Used by PropertyViewAsState as a nested serializer
 
-    Not sure why this is different than PropertyStateSerializer
+    This serializer is for use with the PropertyViewAsStateSerializer such that
+    PropertyState can be created and updated through a single call to the
+    associated PropertyViewViewSet.
     """
     extra_data = serializers.JSONField(required=False)
     measures = PropertyMeasureSerializer(source='propertymeasure_set', many=True, read_only=True)
     scenarios = ScenarioSerializer(many=True, read_only=True)
     files = BuildingFileSerializer(source='building_files', many=True, read_only=True)
-    analysis_state = ChoiceField(choices=PropertyState.ANALYSIS_STATE_TYPES)
+    analysis_state = ChoiceField(choices=PropertyState.ANALYSIS_STATE_TYPES, required=False)
 
     # to support the old state serializer method with the PROPERTY_STATE_FIELDS variables
     import_file_id = serializers.IntegerField(allow_null=True, read_only=True)
-    organization_id = serializers.IntegerField()
+    organization_id = serializers.IntegerField(read_only=True)
 
     # support the pint objects
-    conditioned_floor_area = PintQuantitySerializerField(allow_null=True)
-    gross_floor_area = PintQuantitySerializerField(allow_null=True)
-    occupied_floor_area = PintQuantitySerializerField(allow_null=True)
-    site_eui = PintQuantitySerializerField(allow_null=True)
-    site_eui_modeled = PintQuantitySerializerField(allow_null=True)
-    source_eui_weather_normalized = PintQuantitySerializerField(allow_null=True)
-    source_eui = PintQuantitySerializerField(allow_null=True)
-    source_eui_modeled = PintQuantitySerializerField(allow_null=True)
-    site_eui_weather_normalized = PintQuantitySerializerField(allow_null=True)
+    conditioned_floor_area = PintQuantitySerializerField(allow_null=True, required=False)
+    gross_floor_area = PintQuantitySerializerField(allow_null=True, required=False)
+    occupied_floor_area = PintQuantitySerializerField(allow_null=True, required=False)
+    site_eui = PintQuantitySerializerField(allow_null=True, required=False)
+    site_eui_modeled = PintQuantitySerializerField(allow_null=True, required=False)
+    source_eui_weather_normalized = PintQuantitySerializerField(allow_null=True, required=False)
+    source_eui = PintQuantitySerializerField(allow_null=True, required=False)
+    source_eui_modeled = PintQuantitySerializerField(allow_null=True, required=False)
+    site_eui_weather_normalized = PintQuantitySerializerField(allow_null=True, required=False)
 
     class Meta:
         fields = '__all__'
@@ -437,7 +439,7 @@ class PropertyViewAsStateSerializer(serializers.ModelSerializer):
         cycle_id = conv_value(validated_data.pop('cycle'))
         validated_data['cycle_id'] = cycle_id
         new_property_state_serializer = PropertyStateWritableSerializer(data=state)
-        if new_property_state_serializer.is_valid():
+        if new_property_state_serializer.is_valid(raise_exception=True):
             new_state = new_property_state_serializer.save()
         instance = PropertyView.objects.create(
             state=new_state, **validated_data


### PR DESCRIPTION
#### Any background context you want to provide?
allow_null still requires the field to be present, so I set all the new fields to 'required=False'
I also changed organization_id to read_only to prevent collision where the organization is being assigned through the PropertyViewAsState serializer methods.
btw, I am not sure why Paul set this up as separate serializer other than the non-'writeable' has 'organization' set as read_only; I just know it works to be able to do the PropertyState update and create from nested inside the 'property_views' endpoint.
#### What's this PR do?
#### How should this be manually tested?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Definition of Done:
- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [ ] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [ ] Does this PR require a regression test? All fixes require a regression test.
- [ ] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?