### PR TITLE
New org cycle range

### DIFF
--- a/seed/models/cycles.py
+++ b/seed/models/cycles.py
@@ -39,7 +39,7 @@ class Cycle(models.Model):
                 name=cycle_name,
                 organization=organization,
                 start=datetime(year, 1, 1, tzinfo=timezone.get_current_timezone()),
-                end=datetime(year + 1, 12, 31, tzinfo=timezone.get_current_timezone())
+                end=datetime(year + 1, 1, 1, tzinfo=timezone.get_current_timezone())
             )
         else:
             return cycle


### PR DESCRIPTION
#### What's this PR do?
The default new cycle range was `01-01-2017` to `12-31-2018`, now it's `01-01-2017` to **`01-01-2018`**
#### How should this be manually tested?
Create a new org and check the Existing Cycles org page to verify the end date.
#### What are the relevant tickets?
#1586