### PR TITLE
Fix some portfolio manager child data request stuff

### DIFF
--- a/seed/tests/test_portfoliomanager.py
+++ b/seed/tests/test_portfoliomanager.py
@@ -151,7 +151,15 @@ class PortfolioManagerViewTests(TestCase):
     def test_report_invalid_credentials(self):
         resp = self.client.post(
             reverse_lazy('api:v2.1:portfolio_manager-report'),
-            json.dumps({'password': 'nothing', 'username': 'nothing', 'template': {'id': 1, 'name': 'template_name'}}),
+            json.dumps(
+                {
+                    'password': 'nothing',
+                    'username': 'nothing',
+                    'template': {
+                        'id': 1, 'name': 'template_name', 'z_seed_child_row': False
+                    }
+                }
+            ),
             content_type='application/json',
         )
         # resp should have status, message, and code = 400


### PR DESCRIPTION
#### Any background context you want to provide?
The portfolio manager workflow was designed around using a single template, and having SEED generate and then download that report.  A new workflow was encountered, where the templates could have child data requests that behave a bit differently.

#### What's this PR do?
With this PR, we now checks to see if the current row in PM has any child rows such as these:
![image](https://user-images.githubusercontent.com/849824/40019744-b446e256-5785-11e8-9c1a-2249995b2a7a.png)
If those are encountered, we keep track of those rows as slightly different entities.  If the user selects a regular template row to report on, the code behaves as it has, and generates a report then downloads it and imports the data, exactly as it currently does.  So we haven't broken anything.  But if a child row is selected, there is no generation step, instead we just directly call the server with a query string and it gives us back the XML data.  So we now should be able to support the new workflow.

#### How should this be manually tested?
- Test template list request with invalid authentication, it should fail
- Test template list request with valid authentication, it should succeed
  - if there are child data requests, they should show up under the parent row:
![image](https://user-images.githubusercontent.com/849824/40019914-3dc84394-5786-11e8-9bd8-2d7b89918663.png)
  - (I thought about indenting these, but that might introduce a bit of unnecessary complexity, so I didn't attempt it right now)
- Test report generation for the parent object, if it has properties, it should import them, if it is empty, it should gracefully fail to import
- Test report generation for any child objects, again their success should be dependent on whether the request is properly formed on PM

#### What are the relevant tickets?
#1621 

#### Screenshots (if appropriate)
Above

#### Definition of Done:
- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [ ] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [ ] Does this PR require a regression test? All fixes require a regression test.
- [ ] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?