### PR TITLE
Fixed missing pinned parameter when the value is undefined

### DIFF
--- a/seed/static/seed/js/controllers/inventory_settings_controller.js
+++ b/seed/static/seed/js/controllers/inventory_settings_controller.js
@@ -159,7 +159,7 @@ angular.module('BE.seed.controller.inventory_settings', [])
               column_name: row.entity.column_name,
               id: row.entity.id,
               order: columns.length + 1,
-              pinned: row.entity.pinnedLeft,
+              pinned: Boolean(row.entity.pinnedLeft),
               table_name: row.entity.table_name
             });
           }


### PR DESCRIPTION
#### What's this PR do?
Fixes a 500 error when the `pinned` parameter is missing due to the value being `undefined`.
#### How should this be manually tested?
1. Delete all settings profiles for one of the property/taxlot list views
1. Refresh the page
1. Select some columns to save
1. Click `New` and name the settings profile
1. Save
#### What are the relevant tickets?
#1627 