### PR TITLE
Fix `Only Show Populated` to use the current cycle

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -165,8 +165,8 @@ angular.module('BE.seed.controller.inventory_list', [])
             currentProfile: function () {
               return $scope.currentProfile;
             },
-            cycle_id: function () {
-              return $scope.cycle.selected_cycle.id;
+            cycle: function () {
+              return $scope.cycle.selected_cycle;
             },
             inventory_type: function () {
               return $stateParams.inventory_type;

--- a/seed/static/seed/js/controllers/show_populated_columns_modal_controller.js
+++ b/seed/static/seed/js/controllers/show_populated_columns_modal_controller.js
@@ -13,12 +13,12 @@ angular.module('BE.seed.controller.show_populated_columns_modal', [])
     'spinner_utility',
     'columns',
     'currentProfile',
-    'cycle_id',
+    'cycle',
     'inventory_type',
-    function ($scope, $window, $uibModalInstance, Notification, inventory_service, modified_service, spinner_utility, columns, currentProfile, cycle_id, inventory_type) {
+    function ($scope, $window, $uibModalInstance, Notification, inventory_service, modified_service, spinner_utility, columns, currentProfile, cycle, inventory_type) {
       $scope.columns = columns;
       $scope.currentProfile = currentProfile;
-      $scope.cycle_id = cycle_id;
+      $scope.cycle = cycle;
       $scope.inventory_type = inventory_type;
 
       _.forEach($scope.columns, function (col) {
@@ -36,11 +36,11 @@ angular.module('BE.seed.controller.show_populated_columns_modal', [])
 
         var promise;
         if ($scope.inventory_type === 'properties') {
-          promise = inventory_service.get_properties(1, undefined, cycle_id, []).then(function (inv) {
+          promise = inventory_service.get_properties(1, undefined, $scope.cycle, []).then(function (inv) {
             return inv.results;
           });
         } else if ($scope.inventory_type === 'taxlots') {
-          promise = inventory_service.get_taxlots(1, undefined, cycle_id, []).then(function (inv) {
+          promise = inventory_service.get_taxlots(1, undefined, $scope.cycle, []).then(function (inv) {
             return inv.results;
           });
         }

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -31,7 +31,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         var validCycleIds = _.map(cycles.cycles, 'id');
 
         var lastCycleId = inventory_service.get_last_cycle();
-        if (cycle) {
+        if (_.has(cycle, 'id')) {
           params.cycle = cycle.id;
           inventory_service.save_last_cycle(cycle.id);
         } else if (_.includes(validCycleIds, lastCycleId)) {


### PR DESCRIPTION
#### Any background context you want to provide?
The `Only Show Populated Columns` feature wasn't always requesting the correct inventory records if multiple cycles were present, and in that case could select the wrong columns.
#### What's this PR do?
Fixes the cycle id that was passed to the inventory data request.
#### How should this be manually tested?
- Create two cycles, e.g. 2016 and 2017
- Import different data into one or both cycles
- Run the  `Only Show Populated Columns` feature for both cycles
- Check that the correct columns are shown for data belonging to the current cycle