### PR TITLE
Use kBtu during imports

### DIFF
--- a/seed/data_importer/views.py
+++ b/seed/data_importer/views.py
@@ -247,11 +247,9 @@ class LocalUploaderViewSet(viewsets.ViewSet):
                 return {'success': False, 'message': 'Could not cast value to float: \"%s\"' % string_value}
             original_unit_string = pm_value['@uom']
             if original_unit_string == u'kBtu':
-                new_val = float_value * 1000  # convert to btu manually
-                pint_val = new_val * units.BTU
+                pint_val = float_value * units.kBTU
             elif original_unit_string == u'kBtu/ft²':
-                new_val = float_value * 1000  # convert to btu manually
-                pint_val = new_val * units.BTU / units.sq_ft
+                pint_val = float_value * units.kBTU / units.sq_ft
             elif original_unit_string == u'Metric Tons CO2e':
                 pint_val = float_value * units.metric_ton
             elif original_unit_string == u'kgCO2e/ft²':


### PR DESCRIPTION
#### Any background context you want to provide?
During PM imports, the value was converted to BTU and assigned a proper pint unit quantity.  Unfortunately, this unit did not persist with the data throughout the entire import process.  Because the data gets written to an import_file locally and then processed from there like a normal import, the unit did not get carried along.  I mistakenly thought Pint didn't have kBTU as it isn't listed in the definition file.  However, the btu unit can be tagged with a kilo prefix, so that's what I changed this to do.

#### What's this PR do?
When we import from PM, we now keep the numeric value as it was from PM, and tag it with kBTU (even though that isn't necessarily persisted).  This should allow the normal import process to grab the data in what it thinks is kBTU and everything will be good.

#### How should this be manually tested?
Test a pm import file process and a pm import process and make sure both come in with the same units.

#### What are the relevant tickets?
#1632 

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?