### PR TITLE
Fixed showing of default pairing columns

### DIFF
--- a/seed/static/seed/js/services/pairing_service.js
+++ b/seed/static/seed/js/services/pairing_service.js
@@ -101,9 +101,9 @@ angular.module('BE.seed.service.pairing', []).factory('pairing_service', [
         return pairing_service.reorderSettings(localColumns.concat(columns));
       } else {
         var filteredColumns = [];
-        filteredColumns = filteredColumns.concat(_.remove(columns, {name: 'address_line_1'}));
-        filteredColumns = filteredColumns.concat(_.remove(columns, {name: 'pm_property_id'}));
-        filteredColumns = filteredColumns.concat(_.remove(columns, {name: 'custom_id_1'}));
+        filteredColumns = filteredColumns.concat(_.remove(columns, {column_name: 'address_line_1', table_name: 'PropertyState'}));
+        filteredColumns = filteredColumns.concat(_.remove(columns, {column_name: 'pm_property_id', table_name: 'PropertyState'}));
+        filteredColumns = filteredColumns.concat(_.remove(columns, {column_name: 'custom_id_1', table_name: 'PropertyState'}));
         _.forEach(columns, function (col) {
           col.visible = false;
         });
@@ -149,8 +149,8 @@ angular.module('BE.seed.service.pairing', []).factory('pairing_service', [
         return pairing_service.reorderSettings(localColumns.concat(columns));
       } else {
         var filteredColumns = [];
-        filteredColumns = filteredColumns.concat(_.remove(columns, {name: 'address_line_1'}));
-        filteredColumns = filteredColumns.concat(_.remove(columns, {name: 'jurisdiction_tax_lot_id'}));
+        filteredColumns = filteredColumns.concat(_.remove(columns, {column_name: 'address_line_1', table_name: 'TaxLotState'}));
+        filteredColumns = filteredColumns.concat(_.remove(columns, {column_name: 'jurisdiction_tax_lot_id', table_name: 'TaxLotState'}));
         _.forEach(columns, function (col) {
           col.visible = false;
         });


### PR DESCRIPTION
#### What's this PR do?
After the backend column refactor, going to the pairing page for the first time (without ever modifying the saved settings) results in no columns shown.  This restores the default column visibility
#### How should this be manually tested?
- Create a new org
- Import a file
- Go to the pairing page
- Check that some default columns are visible (3 property, 2 taxlot)