### PR TITLE
1633 multiple ubids, single taxlot

### DIFF
--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -888,6 +888,7 @@ def _finish_matching(import_file, progress_key, data):
             'id').values_list('id', flat=True)
     )
 
+    # TODO: The organization should not come from the import_file. This makes testing tough
     _data_quality_check(import_file.import_record.super_organization,
                         property_state_ids,
                         taxlot_state_ids,
@@ -958,8 +959,7 @@ def filter_duplicated_states(unmatched_states):
     for (ndx, hashval) in enumerate(hash_values):
         equality_classes[hashval].append(ndx)
 
-    canonical_states = [unmatched_states[equality_list[0]] for equality_list in
-                        equality_classes.values()]
+    canonical_states = [unmatched_states[equality_list[0]] for equality_list in equality_classes.values()]
     canonical_state_ids = set([s.pk for s in canonical_states])
     noncanonical_states = [u for u in unmatched_states if u.pk not in canonical_state_ids]
 
@@ -1009,14 +1009,9 @@ class EquivalencePartitioner(object):
         the two objects are definitely different object)
         """
 
-        self.equiv_comparison_key_func = self.make_resolved_key_calculation_function(
-            equivalence_class_description)
-
-        self.equiv_canonical_key_func = self.make_canonical_key_calculation_function(
-            equivalence_class_description)
-
-        self.identity_key_func = self.make_canonical_key_calculation_function(
-            [(x,) for x in identity_fields])
+        self.equiv_comparison_key_func = self.make_resolved_key_calculation_function(equivalence_class_description)
+        self.equiv_canonical_key_func = self.make_canonical_key_calculation_function(equivalence_class_description)
+        self.identity_key_func = self.make_canonical_key_calculation_function([(x,) for x in identity_fields])
 
         return
 
@@ -1085,9 +1080,11 @@ class EquivalencePartitioner(object):
     def make_resolved_key_calculation_function(kls, list_of_fieldlists):
         # This "resolves" the object to the best potential value in
         # each field.
-        return (lambda obj: tuple(
-            [kls._get_resolved_value_from_object(obj, list_of_fields) for list_of_fields in
-             list_of_fieldlists]))
+        return (
+            lambda obj: tuple(
+                [kls._get_resolved_value_from_object(obj, list_of_fields) for list_of_fields in list_of_fieldlists]
+            )
+        )
 
     @staticmethod
     def _get_resolved_value_from_object(obj, list_of_fields):
@@ -1156,8 +1153,7 @@ class EquivalencePartitioner(object):
             identity_key = self.calculate_identity_key(obj)
 
             for class_key in equivalence_classes:
-                if self.calculate_key_equivalence(class_key,
-                                                  cmp_key) and not self.identities_are_different(
+                if self.calculate_key_equivalence(class_key, cmp_key) and not self.identities_are_different(
                         identities_for_equivalence[class_key], identity_key):
 
                     equivalence_classes[class_key].append(ndx)
@@ -1194,6 +1190,8 @@ def match_and_merge_unmatched_objects(unmatched_states, partitioner):
         else:
             return default
 
+    # create lambda function to sort the properties/taxlots by release_data first, then generation_date, and finally
+    # the primary key
     keyfunction = lambda ndx: (getattrdef(unmatched_states[ndx], "release_date", None),
                                getattrdef(unmatched_states[ndx], "generation_date", None),
                                getattrdef(unmatched_states[ndx], "pk", None))
@@ -1215,10 +1213,11 @@ def match_and_merge_unmatched_objects(unmatched_states, partitioner):
         unmatched_state_class = [unmatched_states[ndx] for ndx in class_ndxs]
         merged_result = unmatched_state_class[0]
         for unmatched in unmatched_state_class[1:]:
-            merged_result, changes = save_state_match(merged_result, unmatched)
+            merged_result = save_state_match(merged_result, unmatched)
 
-        else:
-            merged_objects.append(merged_result)
+        # 5/22/18 - I think this needs to be always run, not only if there wasn't more than one unmatched.
+        # else:
+        merged_objects.append(merged_result)
 
     # _log.debug("DONE with map_and_merge_unmatched_objects")
     return merged_objects, equivalence_classes.keys()
@@ -1226,14 +1225,10 @@ def match_and_merge_unmatched_objects(unmatched_states, partitioner):
 
 def merge_unmatched_into_views(unmatched_states, partitioner, org, import_file):
     """
-    This is fairly inefficient, because we grab all the
-    organization's entire PropertyViews at once.  Surely this can be
-    improved, but the logic is unusual/particularly dynamic here, so
-    hopefully this can be refactored into a better, purely database
-    approach... Perhaps existing_view_states can wrap database
-    calls. Still the abstractions are subtly different (can I
-    refactor the partitioner to use Query objects); it may require a
-    bit of thinking.
+    This is fairly inefficient, because we grab all the organization's entire PropertyViews at once.  Surely this can
+    be improved, but the logic is unusual/particularly dynamic here, so hopefully this can be refactored into a better,
+    purely database approach... Perhaps existing_view_states can wrap database calls. Still the abstractions are
+    subtly different (can I refactor the partitioner to use Query objects); it may require a bit of thinking.
 
     :param unmatched_states:
     :param partitioner:
@@ -1242,6 +1237,7 @@ def merge_unmatched_into_views(unmatched_states, partitioner, org, import_file):
     :return:
     """
 
+    # Cycle coming from the import_file does not make sense here. Makes testing hard. Should be an argument.
     current_match_cycle = import_file.cycle
 
     if isinstance(unmatched_states[0], PropertyState):
@@ -1267,7 +1263,6 @@ def merge_unmatched_into_views(unmatched_states, partitioner, org, import_file):
     matched_views = []
 
     for unmatched in unmatched_states:
-
         unmatched_state_hash = hash_state_object(unmatched)
         if unmatched_state_hash in existing_view_state_hashes:
             # If an exact duplicate exists, delete the unmatched state
@@ -1290,7 +1285,7 @@ def merge_unmatched_into_views(unmatched_states, partitioner, org, import_file):
                         current_view = existing_view_states[key][current_match_cycle]
                         current_state = current_view.state
 
-                        merged_state, change_ = save_state_match(current_state, unmatched)
+                        merged_state = save_state_match(current_state, unmatched)
 
                         current_view.state = merged_state
                         current_view.save()
@@ -1499,12 +1494,20 @@ def query_property_matches(properties, pm_id, custom_id, ubid):
 
 
 def save_state_match(state1, state2):
+    """
+    Merge the contents of state2 into state1
+
+    :param state1: PropertyState or TaxLotState
+    :param state2: PropertyState or TaxLotState
+    :return: state1, after merge
+    """
     merged_state = type(state1).objects.create(organization=state1.organization)
 
-    merged_state, changes = merging.merge_state(merged_state,
-                                                state1, state2,
-                                                merging.get_state_attrs([state1, state2]),
-                                                default=state2)
+    merged_state = merging.merge_state(merged_state,
+                                       state1,
+                                       state2,
+                                       merging.get_state_attrs([state1, state2]),
+                                       default=state2)
 
     AuditLogClass = PropertyAuditLog if isinstance(merged_state, PropertyState) else TaxLotAuditLog
 
@@ -1526,16 +1529,11 @@ def save_state_match(state1, state2):
                                  import_filename=None,
                                  record_type=AUDIT_IMPORT)
 
-    # print "merging two properties {}/{}".format(ps1_pk, ps2_pk)
-    # pp(ps1)
-    # pp(ps2)
-    # pp(merged_property_state)
-
     # Set the merged_state to merged
     merged_state.merge_state = MERGE_STATE_MERGED
     merged_state.save()
 
-    return merged_state, False
+    return merged_state
 
 
 def pair_new_states(merged_property_views, merged_taxlot_views):
@@ -1627,8 +1625,7 @@ def pair_new_states(merged_property_views, merged_taxlot_views):
         else:
             property_keys[k] = property_keys_orig[k]
 
-    taxlot_keys = dict(
-        [(taxlot_m2m_keygen.calculate_comparison_key(p), p.pk) for p in taxlot_objects])
+    taxlot_keys = dict([(taxlot_m2m_keygen.calculate_comparison_key(p), p.pk) for p in taxlot_objects])
 
     # property_comparison_keys = {property_m2m_keygen.calculate_comparison_key_key(p): p.pk for p in property_objects}
     # property_canonical_keys = {property_m2m_keygen.calculate_canonical_key(p): p.pk for p in property_objects}

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1550,17 +1550,21 @@ def pair_new_states(merged_property_views, merged_taxlot_views):
     # Not sure what the below cycle code does.
     cycle = chain(merged_property_views, merged_taxlot_views).next().cycle
 
-    tax_cmp_fmt = [('jurisdiction_tax_lot_id', 'custom_id_1'),
-                   ('custom_id_1',),
-                   ('normalized_address',),
-                   ('custom_id_1',),
-                   ('custom_id_1',)]
+    tax_cmp_fmt = [
+        ('jurisdiction_tax_lot_id', 'custom_id_1'),
+        ('custom_id_1',),
+        ('normalized_address',),
+        ('custom_id_1',),
+    ]
 
-    prop_cmp_fmt = [('lot_number', 'custom_id_1'),
-                    ('custom_id_1',),
-                    ('normalized_address',),
-                    ('pm_property_id',),
-                    ('jurisdiction_property_id',)]
+    prop_cmp_fmt = [
+        ('lot_number', 'custom_id_1'),
+        ('ubid',),
+        ('custom_id_1',),
+        ('normalized_address',),
+        ('pm_property_id',),
+        ('jurisdiction_property_id',),
+    ]
 
     tax_comparison_fields = sorted(list(set(chain.from_iterable(tax_cmp_fmt))))
     prop_comparison_fields = sorted(list(set(chain.from_iterable(prop_cmp_fmt))))
@@ -1583,8 +1587,7 @@ def pair_new_states(merged_property_views, merged_taxlot_views):
     global property_m2m_keygen
 
     taxlot_m2m_keygen = EquivalencePartitioner(tax_cmp_fmt, ["jurisdiction_tax_lot_id"])
-    property_m2m_keygen = EquivalencePartitioner(prop_cmp_fmt,
-                                                 ["pm_property_id", "jurisdiction_property_id"])
+    property_m2m_keygen = EquivalencePartitioner(prop_cmp_fmt, ["pm_property_id", "jurisdiction_property_id"])
 
     property_views = PropertyView.objects.filter(state__organization=org, cycle=cycle).values_list(
         *prop_comparison_field_names)

--- a/seed/data_importer/tests/test_merge.py
+++ b/seed/data_importer/tests/test_merge.py
@@ -12,12 +12,15 @@ from seed.data_importer.tasks import _match_properties_and_taxlots, save_state_m
 from seed.landing.models import SEEDUser as User
 from seed.models import (
     PropertyState,
+    PropertyView,
     TaxLotState,
     ImportFile,
     ImportRecord,
     PropertyAuditLog,
     DATA_STATE_MAPPING,
     MERGE_STATE_MERGED,
+    TaxLotProperty,
+    TaxLotView,
 )
 from seed.test_helpers.fake import (
     FakeCycleFactory,
@@ -71,8 +74,14 @@ class PropertyViewTests(DeleteModelsTestCase):
             cycle=self.cycle,
         )
 
+    def test_match_properties_and_taxlots_with_address(self):
         # create an ImportFile for testing purposes. Seems like we would want to run this matching just on a
         # list of properties and taxlots.
+        #
+        # This emulates importing the following
+        #   Address,                Juridiction Tax Lot
+        #   742 Evergreen Terrace,  100;101;110;111
+
         lot_numbers = '100;101;110;111'
         for i in range(10):
             self.property_state_factory.get_property_state(
@@ -90,7 +99,6 @@ class PropertyViewTests(DeleteModelsTestCase):
                 data_state=DATA_STATE_MAPPING,
             )
 
-    def test_match_properties_and_taxlots(self):
         for ps in PropertyState.objects.filter(organization=self.org):
             print "%s -- %s -- %s" % (ps.lot_number, ps.import_file_id, ps.address_line_1)
             # pv = PropertyView.objects.get(state=ps, cycle=self.cycle)
@@ -100,15 +108,165 @@ class PropertyViewTests(DeleteModelsTestCase):
             print "%s -- %s" % (tl.import_file_id, tl.jurisdiction_tax_lot_id)
 
         # for tlm in TaxLotProperty.objects.filter()
-        result = _match_properties_and_taxlots(self.import_file.id)
-        print result
+        _match_properties_and_taxlots(self.import_file.id)
 
-        # there should only be one propertystate that got merged down
+        for pv in PropertyView.objects.filter(state__organization=self.org):
+            print "%s -- %s" % (pv.state, pv.cycle)
 
-        # TaxLotProperty.objects.filter(property_view_id=pv_pk).count() == 0
+        # should only have 1 propertyview and 4 taxlot views
+        self.assertEqual(PropertyView.objects.filter(state__organization=self.org).count(), 1)
+        self.assertEqual(TaxLotView.objects.filter(state__organization=self.org).count(), 4)
+        pv = PropertyView.objects.filter(state__organization=self.org).first()
+
+        # there should be 4 relationships in the taxlotproperty associated with view, one each for the taxlots defined
+        self.assertEqual(TaxLotProperty.objects.filter(property_view_id=pv).count(), 4)
+
+    def test_match_properties_and_taxlots_with_address_no_lot_number(self):
+        # create an ImportFile for testing purposes. Seems like we would want to run this matching just on a
+        # list of properties and taxlots.
         #
-        # for ps in PropertyState.objects.filter(organization=self.org, merge_state=MERGE_STATE_MERGED):
-        #     print "%s -- %s -- %s -- %s" % (ps.merge_state, ps.lot_number, ps.import_file_id, ps.address_line_1)
+        # This emulates importing the following
+        #   Address,                Juridiction Tax Lot
+        #   742 Evergreen Terrace,  100
+        #   742 Evergreen Terrace,  101
+        #   742 Evergreen Terrace,  110
+        #   742 Evergreen Terrace,  111
+
+        lot_numbers = '100;101;110;111'
+        for lot_number in lot_numbers.split(';'):
+            self.property_state_factory.get_property_state(
+                address_line_1='742 Evergreen Terrace',
+                lot_number=lot_number,
+                import_file_id=self.import_file.id,
+                data_state=DATA_STATE_MAPPING,
+            )
+
+            self.taxlot_state_factory.get_taxlot_state(
+                address_line_1=None,
+                jurisdiction_tax_lot_id=lot_number,
+                import_file_id=self.import_file.id,
+                data_state=DATA_STATE_MAPPING,
+            )
+
+        for ps in PropertyState.objects.filter(organization=self.org):
+            print "%s -- %s -- %s" % (ps.lot_number, ps.import_file_id, ps.address_line_1)
+
+        for tl in TaxLotState.objects.filter(organization=self.org):
+            print "%s -- %s" % (tl.import_file_id, tl.jurisdiction_tax_lot_id)
+
+        _match_properties_and_taxlots(self.import_file.id)
+
+        for pv in PropertyView.objects.filter(state__organization=self.org):
+            print "%s -- %s" % (pv.state, pv.cycle)
+
+        # should only have 1 propertyview and 4 taxlot views
+        self.assertEqual(PropertyView.objects.filter(state__organization=self.org).count(), 1)
+        self.assertEqual(TaxLotView.objects.filter(state__organization=self.org).count(), 4)
+        pv = PropertyView.objects.filter(state__organization=self.org).first()
+
+        # there should be 4 relationships in the taxlotproperty associated with view, one each for the taxlots defined
+        # note that this should be 4, but that is not how it works right now.... so coding this as
+        # expected behavior (see issue 1633)
+        self.assertEqual(TaxLotProperty.objects.filter(property_view_id=pv).count(), 1)
+
+    def test_match_properties_and_taxlots_with_ubid(self):
+        # create an ImportFile for testing purposes. Seems like we would want to run this matching just on a
+        # list of properties and taxlots.
+        #
+        # This emulates importing the following
+        #   UBID,    Juridiction Tax Lot
+        #   ubid_100,     lot_1
+        #   ubid_101,     lot_1
+        #   ubid_110,     lot_1
+        #   ubid_111,     lot_1
+
+        ids = [('ubid_100', 'lot_1'), ('ubid_101', 'lot_1'), ('ubid_110', 'lot_1'), ('ubid_111', 'lot_1')]
+        for id in ids:
+            self.property_state_factory.get_property_state(
+                no_default_data=True,
+                ubid=id[0],
+                lot_number=id[1],
+                import_file_id=self.import_file.id,
+                data_state=DATA_STATE_MAPPING,
+            )
+
+        self.taxlot_state_factory.get_taxlot_state(
+            no_default_data=True,
+            jurisdiction_tax_lot_id=ids[0][1],
+            import_file_id=self.import_file.id,
+            data_state=DATA_STATE_MAPPING,
+        )
+
+        for ps in PropertyState.objects.filter(organization=self.org):
+            print "%s -- %s -- %s" % (ps.lot_number, ps.import_file_id, ps.ubid)
+            # pv = PropertyView.objects.get(state=ps, cycle=self.cycle)
+            # TaxLotProperty.objects.filter()
+
+        for tl in TaxLotState.objects.filter(organization=self.org):
+            print "%s -- %s" % (tl.import_file_id, tl.jurisdiction_tax_lot_id)
+
+        # for tlm in TaxLotProperty.objects.filter()
+        _match_properties_and_taxlots(self.import_file.id)
+
+        for pv in PropertyView.objects.filter(state__organization=self.org):
+            print "%s -- %s" % (pv.state.ubid, pv.cycle)
+
+        # should only have 1 propertyview and 4 taxlot views
+        self.assertEqual(PropertyView.objects.filter(state__organization=self.org).count(), 4)
+        self.assertEqual(TaxLotView.objects.filter(state__organization=self.org).count(), 1)
+        tlv = TaxLotView.objects.filter(state__organization=self.org).first()
+
+        # there should be 4 relationships in the taxlotproperty associated with view, one each for the taxlots defined
+        self.assertEqual(TaxLotProperty.objects.filter(taxlot_view_id=tlv).count(), 4)
+
+    def test_match_properties_and_taxlots_with_custom_id(self):
+        # create an ImportFile for testing purposes. Seems like we would want to run this matching just on a
+        # list of properties and taxlots.
+        #
+        # This emulates importing the following
+        #   Custom ID 1,    Juridiction Tax Lot
+        #   custom_100,     lot_1
+        #   custom_101,     lot_1
+        #   custom_110,     lot_1
+        #   custom_111,     lot_1
+        ids = [('custom_100', 'lot_1'), ('custom_101', 'lot_1'), ('custom_110', 'lot_1'), ('custom_111', 'lot_1')]
+        for id in ids:
+            self.property_state_factory.get_property_state(
+                no_default_data=True,
+                custom_id_1=id[0],
+                lot_number=id[1],
+                import_file_id=self.import_file.id,
+                data_state=DATA_STATE_MAPPING,
+            )
+
+        self.taxlot_state_factory.get_taxlot_state(
+            no_default_data=True,
+            jurisdiction_tax_lot_id=ids[0][1],
+            import_file_id=self.import_file.id,
+            data_state=DATA_STATE_MAPPING,
+        )
+
+        for ps in PropertyState.objects.filter(organization=self.org):
+            print "%s -- %s -- %s" % (ps.lot_number, ps.import_file_id, ps.custom_id_1)
+            # pv = PropertyView.objects.get(state=ps, cycle=self.cycle)
+            # TaxLotProperty.objects.filter()
+
+        for tl in TaxLotState.objects.filter(organization=self.org):
+            print "%s -- %s" % (tl.import_file_id, tl.jurisdiction_tax_lot_id)
+
+        # for tlm in TaxLotProperty.objects.filter()
+        _match_properties_and_taxlots(self.import_file.id)
+
+        for pv in PropertyView.objects.filter(state__organization=self.org):
+            print "%s -- %s" % (pv.state, pv.cycle)
+
+        # should only have 1 propertyview and 4 taxlot views
+        self.assertEqual(PropertyView.objects.filter(state__organization=self.org).count(), 4)
+        self.assertEqual(TaxLotView.objects.filter(state__organization=self.org).count(), 1)
+        tlv = TaxLotView.objects.filter(state__organization=self.org).first()
+
+        # there should be 4 relationships in the taxlotproperty associated with view, one each for the taxlots defined
+        self.assertEqual(TaxLotProperty.objects.filter(taxlot_view_id=tlv).count(), 4)
 
     def test_save_state_match(self):
         # create a couple states to merge together

--- a/seed/data_importer/tests/test_merge.py
+++ b/seed/data_importer/tests/test_merge.py
@@ -1,0 +1,129 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2018, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+from datetime import datetime
+
+from django.utils import timezone
+
+from seed.data_importer.tasks import _match_properties_and_taxlots, save_state_match
+from seed.landing.models import SEEDUser as User
+from seed.models import (
+    PropertyState,
+    TaxLotState,
+    ImportFile,
+    ImportRecord,
+    PropertyAuditLog,
+    DATA_STATE_MAPPING,
+    MERGE_STATE_MERGED,
+)
+from seed.test_helpers.fake import (
+    FakeCycleFactory,
+    FakePropertyFactory,
+    FakePropertyStateFactory,
+    FakeTaxLotStateFactory,
+    FakeTaxLotViewFactory,
+    FakePropertyViewFactory,
+)
+from seed.tests.util import DeleteModelsTestCase
+from seed.utils.organizations import create_organization
+
+COLUMNS_TO_SEND = [
+    'project_id',
+    'address_line_1',
+    'city',
+    'state_province',
+    'postal_code',
+    'pm_parent_property_id',
+    'calculated_taxlot_ids',
+    'primary',
+    'extra_data_field',
+    'jurisdiction_tax_lot_id'
+]
+
+
+# These tests mostly use V2.1 API except for when writing back to the API for updates
+class PropertyViewTests(DeleteModelsTestCase):
+    def setUp(self):
+        user_details = {
+            'username': 'test_user@demo.com',
+            'password': 'test_pass',
+            'email': 'test_user@demo.com'
+        }
+        self.user = User.objects.create_superuser(**user_details)
+        self.org, self.org_user, _ = create_organization(self.user)
+        self.cycle_factory = FakeCycleFactory(organization=self.org, user=self.user)
+        self.cycle = self.cycle_factory.get_cycle(
+            start=datetime(2010, 10, 10, tzinfo=timezone.get_current_timezone())
+        )
+        self.property_factory = FakePropertyFactory(organization=self.org)
+        self.property_state_factory = FakePropertyStateFactory(organization=self.org)
+        self.property_view_factory = FakePropertyViewFactory(organization=self.org, cycle=self.cycle)
+        self.taxlot_state_factory = FakeTaxLotStateFactory(organization=self.org)
+        self.taxlot_view_factory = FakeTaxLotViewFactory(organization=self.org, cycle=self.cycle)
+
+        # create 10 addresses that are exactly the same
+        import_record = ImportRecord.objects.create(super_organization=self.org)
+        self.import_file = ImportFile.objects.create(
+            import_record=import_record,
+            cycle=self.cycle,
+        )
+
+        # create an ImportFile for testing purposes. Seems like we would want to run this matching just on a
+        # list of properties and taxlots.
+        lot_numbers = '100;101;110;111'
+        for i in range(10):
+            self.property_state_factory.get_property_state(
+                address_line_1='742 Evergreen Terrace',
+                lot_number=lot_numbers,
+                import_file_id=self.import_file.id,
+                data_state=DATA_STATE_MAPPING,
+            )
+
+        for lot_number in lot_numbers.split(';'):
+            self.taxlot_state_factory.get_taxlot_state(
+                address_line_1=None,
+                jurisdiction_tax_lot_id=lot_number,
+                import_file_id=self.import_file.id,
+                data_state=DATA_STATE_MAPPING,
+            )
+
+    def test_match_properties_and_taxlots(self):
+        for ps in PropertyState.objects.filter(organization=self.org):
+            print "%s -- %s -- %s" % (ps.lot_number, ps.import_file_id, ps.address_line_1)
+            # pv = PropertyView.objects.get(state=ps, cycle=self.cycle)
+            # TaxLotProperty.objects.filter()
+
+        for tl in TaxLotState.objects.filter(organization=self.org):
+            print "%s -- %s" % (tl.import_file_id, tl.jurisdiction_tax_lot_id)
+
+        # for tlm in TaxLotProperty.objects.filter()
+        result = _match_properties_and_taxlots(self.import_file.id)
+        print result
+
+        # there should only be one propertystate that got merged down
+
+        # TaxLotProperty.objects.filter(property_view_id=pv_pk).count() == 0
+        #
+        # for ps in PropertyState.objects.filter(organization=self.org, merge_state=MERGE_STATE_MERGED):
+        #     print "%s -- %s -- %s -- %s" % (ps.merge_state, ps.lot_number, ps.import_file_id, ps.address_line_1)
+
+    def test_save_state_match(self):
+        # create a couple states to merge together
+        ps_1 = self.property_state_factory.get_property_state(property_name="this should persist")
+        ps_2 = self.property_state_factory.get_property_state(extra_data={"extra_1": "this should exist too"})
+
+        merged_state = save_state_match(ps_1, ps_2)
+
+        self.assertEqual(merged_state.merge_state, MERGE_STATE_MERGED)
+        self.assertEqual(merged_state.property_name, ps_1.property_name)
+        self.assertEqual(merged_state.extra_data['extra_1'], "this should exist too")
+
+        # verify that the audit log is correct.
+        pal = PropertyAuditLog.objects.get(organization=self.org, state=merged_state)
+        self.assertEqual(pal.name, 'System Match')
+        self.assertEqual(pal.parent_state1, ps_1)
+        self.assertEqual(pal.parent_state2, ps_2)
+        self.assertEqual(pal.description, 'Automatic Merge')

--- a/seed/data_importer/tests/test_merge.py
+++ b/seed/data_importer/tests/test_merge.py
@@ -79,7 +79,7 @@ class PropertyViewTests(DeleteModelsTestCase):
         # list of properties and taxlots.
         #
         # This emulates importing the following
-        #   Address,                Juridiction Tax Lot
+        #   Address,                Jurisdiction Tax Lot
         #   742 Evergreen Terrace,  100;101;110;111
 
         lot_numbers = '100;101;110;111'
@@ -113,12 +113,12 @@ class PropertyViewTests(DeleteModelsTestCase):
         for pv in PropertyView.objects.filter(state__organization=self.org):
             print "%s -- %s" % (pv.state, pv.cycle)
 
-        # should only have 1 propertyview and 4 taxlot views
+        # should only have 1 PropertyView and 4 taxlot views
         self.assertEqual(PropertyView.objects.filter(state__organization=self.org).count(), 1)
         self.assertEqual(TaxLotView.objects.filter(state__organization=self.org).count(), 4)
         pv = PropertyView.objects.filter(state__organization=self.org).first()
 
-        # there should be 4 relationships in the taxlotproperty associated with view, one each for the taxlots defined
+        # there should be 4 relationships in the TaxLotProperty associated with view, one each for the taxlots defined
         self.assertEqual(TaxLotProperty.objects.filter(property_view_id=pv).count(), 4)
 
     def test_match_properties_and_taxlots_with_address_no_lot_number(self):
@@ -126,7 +126,7 @@ class PropertyViewTests(DeleteModelsTestCase):
         # list of properties and taxlots.
         #
         # This emulates importing the following
-        #   Address,                Juridiction Tax Lot
+        #   Address,                Jurisdiction Tax Lot
         #   742 Evergreen Terrace,  100
         #   742 Evergreen Terrace,  101
         #   742 Evergreen Terrace,  110
@@ -159,22 +159,20 @@ class PropertyViewTests(DeleteModelsTestCase):
         for pv in PropertyView.objects.filter(state__organization=self.org):
             print "%s -- %s" % (pv.state, pv.cycle)
 
-        # should only have 1 propertyview and 4 taxlot views
+        # should only have 1 PropertyView and 4 taxlot views
         self.assertEqual(PropertyView.objects.filter(state__organization=self.org).count(), 1)
         self.assertEqual(TaxLotView.objects.filter(state__organization=self.org).count(), 4)
         pv = PropertyView.objects.filter(state__organization=self.org).first()
 
-        # there should be 4 relationships in the taxlotproperty associated with view, one each for the taxlots defined
-        # note that this should be 4, but that is not how it works right now.... so coding this as
-        # expected behavior (see issue 1633)
-        self.assertEqual(TaxLotProperty.objects.filter(property_view_id=pv).count(), 1)
+        # there should be 4 relationships in the TaxLotProperty associated with view, one each for the taxlots defined
+        self.assertEqual(TaxLotProperty.objects.filter(property_view_id=pv).count(), 4)
 
     def test_match_properties_and_taxlots_with_ubid(self):
         # create an ImportFile for testing purposes. Seems like we would want to run this matching just on a
         # list of properties and taxlots.
         #
         # This emulates importing the following
-        #   UBID,    Juridiction Tax Lot
+        #   UBID,    Jurisdiction Tax Lot
         #   ubid_100,     lot_1
         #   ubid_101,     lot_1
         #   ubid_110,     lot_1
@@ -211,12 +209,12 @@ class PropertyViewTests(DeleteModelsTestCase):
         for pv in PropertyView.objects.filter(state__organization=self.org):
             print "%s -- %s" % (pv.state.ubid, pv.cycle)
 
-        # should only have 1 propertyview and 4 taxlot views
+        # should only have 1 PropertyView and 4 taxlot views
         self.assertEqual(PropertyView.objects.filter(state__organization=self.org).count(), 4)
         self.assertEqual(TaxLotView.objects.filter(state__organization=self.org).count(), 1)
         tlv = TaxLotView.objects.filter(state__organization=self.org).first()
 
-        # there should be 4 relationships in the taxlotproperty associated with view, one each for the taxlots defined
+        # there should be 4 relationships in the TaxLotProperty associated with view, one each for the taxlots defined
         self.assertEqual(TaxLotProperty.objects.filter(taxlot_view_id=tlv).count(), 4)
 
     def test_match_properties_and_taxlots_with_custom_id(self):
@@ -224,7 +222,7 @@ class PropertyViewTests(DeleteModelsTestCase):
         # list of properties and taxlots.
         #
         # This emulates importing the following
-        #   Custom ID 1,    Juridiction Tax Lot
+        #   Custom ID 1,    Jurisdiction Tax Lot
         #   custom_100,     lot_1
         #   custom_101,     lot_1
         #   custom_110,     lot_1
@@ -260,12 +258,12 @@ class PropertyViewTests(DeleteModelsTestCase):
         for pv in PropertyView.objects.filter(state__organization=self.org):
             print "%s -- %s" % (pv.state, pv.cycle)
 
-        # should only have 1 propertyview and 4 taxlot views
+        # should only have 1 PropertyView and 4 taxlot views
         self.assertEqual(PropertyView.objects.filter(state__organization=self.org).count(), 4)
         self.assertEqual(TaxLotView.objects.filter(state__organization=self.org).count(), 1)
         tlv = TaxLotView.objects.filter(state__organization=self.org).first()
 
-        # there should be 4 relationships in the taxlotproperty associated with view, one each for the taxlots defined
+        # there should be 4 relationships in the TaxLotProperty associated with view, one each for the taxlots defined
         self.assertEqual(TaxLotProperty.objects.filter(taxlot_view_id=tlv).count(), 4)
 
     def test_save_state_match(self):

--- a/seed/data_importer/views.py
+++ b/seed/data_importer/views.py
@@ -1135,11 +1135,11 @@ class ImportFileViewSet(viewsets.ViewSet):
         state2 = state.objects.get(id=source_state_id)
 
         merged_state = state.objects.create(organization_id=organization_id)
-        merged_state, changes = merging.merge_state(merged_state,
-                                                    state1,
-                                                    state2,
-                                                    merging.get_state_attrs([state1, state2]),
-                                                    default=state2)
+        merged_state = merging.merge_state(merged_state,
+                                           state1,
+                                           state2,
+                                           merging.get_state_attrs([state1, state2]),
+                                           default=state2)
 
         state_1_audit_log = audit_log.objects.filter(state=state1).first()
         state_2_audit_log = audit_log.objects.filter(state=state2).first()

--- a/seed/lib/merging/merging.py
+++ b/seed/lib/merging/merging.py
@@ -135,7 +135,6 @@ def merge_state(merged_state, state1, state2, can_attrs, default=None):
     :return: inst(``merged_state``), updated.
     """
     default = default or state2
-    changes = []
     for attr in can_attrs:
         # Do we have any differences between these fields? - Check if not None instead of if value.
         attr_values = list(set([value for value in can_attrs[attr].values() if value is not None]))
@@ -169,4 +168,4 @@ def merge_state(merged_state, state1, state2, can_attrs, default=None):
     if isinstance(merged_state, PropertyState):
         PropertyState.merge_relationships(merged_state, state1, state2)
 
-    return merged_state, changes
+    return merged_state

--- a/seed/models/building_file.py
+++ b/seed/models/building_file.py
@@ -239,10 +239,10 @@ class BuildingFile(models.Model):
 
             # assume the same cycle id as the former state.
             # should merge_state also copy/move over the relationships?
-            merged_state, changed = merge_state(merged_state,
-                                                property_view.state,
-                                                property_state,
-                                                get_state_attrs([property_view.state, property_state]))
+            merged_state = merge_state(merged_state,
+                                       property_view.state,
+                                       property_state,
+                                       get_state_attrs([property_view.state, property_state]))
 
             # log the merge
             # Not a fan of the parent1/parent2 logic here, seems error prone, what this

--- a/seed/test_helpers/fake.py
+++ b/seed/test_helpers/fake.py
@@ -235,7 +235,12 @@ class FakePropertyStateFactory(BaseFake):
 
     def get_property_state(self, organization=None, **kw):
         """Return a property state populated with pseudo random data"""
-        property_details = self.get_details()
+        property_details = {}
+        if 'no_default_data' not in kw.keys():
+            property_details = self.get_details()
+        else:
+            del kw['no_default_data']
+
         property_details.update(kw)
         ps = PropertyState.objects.create(
             organization=self._get_attr('organization', self.organization),
@@ -595,9 +600,14 @@ class FakeTaxLotStateFactory(BaseFake):
 
     def get_taxlot_state(self, organization=None, **kw):
         """Return a taxlot state populated with pseudo random data"""
-        org = self._get_attr('organization', organization)
-        taxlot_details = self.get_details()
+        taxlot_details = {}
+        if 'no_default_data' not in kw.keys():
+            taxlot_details = self.get_details()
+        else:
+            del kw['no_default_data']
         taxlot_details.update(kw)
+
+        org = self._get_attr('organization', organization)
         tls = TaxLotState.objects.create(organization=org, **taxlot_details)
         TaxLotAuditLog.objects.create(
             organization=org, state=tls, record_type=AUDIT_IMPORT, name='Import Creation'

--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -597,6 +597,10 @@ class PropertyViewSet(GenericViewSet):
             state2.merge_state = MERGE_STATE_NEW
         else:
             state2.merge_state = MERGE_STATE_MERGED
+        # In most cases data_state will already be 3 (DATA_STATE_MATCHING), but if one of the parents was a
+        # de-duplicated record then data_state will be 0. This step ensures that the new states will be 3.
+        state1.data_state = DATA_STATE_MATCHING
+        state2.data_state = DATA_STATE_MATCHING
         state1.save()
         state2.save()
 

--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -420,11 +420,11 @@ class PropertyViewSet(GenericViewSet):
             state2 = state.objects.get(id=state_ids[index])
 
             merged_state = state.objects.create(organization_id=organization_id)
-            merged_state, changes = merging.merge_state(merged_state,
-                                                        state1,
-                                                        state2,
-                                                        merging.get_state_attrs([state1, state2]),
-                                                        default=state2)
+            merged_state = merging.merge_state(merged_state,
+                                               state1,
+                                               state2,
+                                               merging.get_state_attrs([state1, state2]),
+                                               default=state2)
 
             state_1_audit_log = audit_log.objects.filter(state=state1).first()
             state_2_audit_log = audit_log.objects.filter(state=state2).first()

--- a/seed/views/taxlots.py
+++ b/seed/views/taxlots.py
@@ -263,11 +263,11 @@ class TaxLotViewSet(GenericViewSet):
             state2 = state.objects.get(id=state_ids[index])
 
             merged_state = state.objects.create(organization_id=organization_id)
-            merged_state, changes = merging.merge_state(merged_state,
-                                                        state1,
-                                                        state2,
-                                                        merging.get_state_attrs([state1, state2]),
-                                                        default=state2)
+            merged_state = merging.merge_state(merged_state,
+                                               state1,
+                                               state2,
+                                               merging.get_state_attrs([state1, state2]),
+                                               default=state2)
 
             state_1_audit_log = audit_log.objects.filter(state=state1).first()
             state_2_audit_log = audit_log.objects.filter(state=state2).first()

--- a/seed/views/taxlots.py
+++ b/seed/views/taxlots.py
@@ -436,6 +436,10 @@ class TaxLotViewSet(GenericViewSet):
             state2.merge_state = MERGE_STATE_NEW
         else:
             state2.merge_state = MERGE_STATE_MERGED
+        # In most cases data_state will already be 3 (DATA_STATE_MATCHING), but if one of the parents was a
+        # de-duplicated record then data_state will be 0. This step ensures that the new states will be 3.
+        state1.data_state = DATA_STATE_MATCHING
+        state2.data_state = DATA_STATE_MATCHING
         state1.save()
         state2.save()
 


### PR DESCRIPTION
#### Any background context you want to provide?
Pairing was not pairing on UBID.

#### What's this PR do?
This PR adds the UBID item to the list of columns to compare for pairing. This PR also adds several tests. The tests are for the current behavior.

It also corrects the handling of records within a single import file that are automatically merged together (with regard to unmerging and properly accumulating tax lot pairings)

#### How should this be manually tested?
Import file with UBID and jurisdiction tax lot id.

| UBID     | Jurisdiction Tax Lot ID |
|----------|-------------------------|
| ubid_001 | lot_1                   |
| ubid_002 | lot_1                   |
| ubid_003 | lot_1                   |

The resulting inventory list should have 3 property states, and one tax lot--all linked with each other.

Also follow the tests in #1639

#### What are the relevant tickets?
#1633, #1639, #1649

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?