### PR TITLE
Fixed the angular-sanitize semantic versioning

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
     "angular-bootstrap": "~1.3.3",
     "angular-cookies": "~1.6.8",
     "angular-mocks": "~1.6.8",
+	"angular-sanitize": "~1.6.8",
     "angular-ui-grid": "=4.0.2",
     "angular-ui-notification": "~0.3.5",
     "angular-ui-router": "~0.3.2",
@@ -36,13 +37,12 @@
     "ng-tags-input": "~3.0.0",
     "spin.js": "~2.3.2",
     "ui-grid-draggable-rows": "~0.3.2",
-    "angular-dragula": "^1.2.8",
-    "ng-focus-if": "^1.0.7",
-    "angular-translate": "^2.16.0",
-    "angular-translate-loader-static-files": "^2.16.0",
-    "angular-sanitize": "^1.6.6",
-    "angular-translate-interpolation-messageformat": "^2.16.0",
-    "raven-js": "^3.22.1"
+    "angular-dragula": "~1.2.8",
+    "ng-focus-if": "~1.0.7",
+    "angular-translate": "~2.16.0",
+    "angular-translate-loader-static-files": "~2.16.0",
+    "angular-translate-interpolation-messageformat": "~2.16.0",
+    "raven-js": "~3.22.1"
   },
   "resolutions": {
     "angular": "~1.6.8",


### PR DESCRIPTION
#### Any background context you want to provide?
Running `bower install` installs 1.6.x Angular dependencies, except with 1.x.x Angular-Sanitize which is currently resolving to `1.7.0`
#### What's this PR do?
Corrects the version of angular-sanitize to 1.6.x
#### How should this be manually tested?
Remove the `bower_components` directory, run `bower install`, and check that SEED loads correctly
