### PR TITLE
Return inventory records with only the columns specified

### DIFF
--- a/seed/data_importer/tests/test_merge.py
+++ b/seed/data_importer/tests/test_merge.py
@@ -40,8 +40,8 @@ COLUMNS_TO_SEND = [
     'state_province',
     'postal_code',
     'pm_parent_property_id',
-    'calculated_taxlot_ids',
-    'primary',
+    # 'calculated_taxlot_ids',
+    # 'primary',
     'extra_data_field',
     'jurisdiction_tax_lot_id'
 ]

--- a/seed/models/tax_lot_properties.py
+++ b/seed/models/tax_lot_properties.py
@@ -251,15 +251,15 @@ class TaxLotProperty(models.Model):
 
                 join_dict = related_map[getattr(join, lookups['related_view_id'])].copy()
                 join_dict.update({
-                    'primary': 'P' if join.primary else 'S',
-                    'calculated_taxlot_ids': '; '.join(jurisdiction_tax_lot_ids),
+                    # 'primary': 'P' if join.primary else 'S',
+                    # 'calculated_taxlot_ids': '; '.join(jurisdiction_tax_lot_ids),
                     lookups['related_view_id']: getattr(join, lookups['related_view_id'])
                 })
 
             else:
                 join_dict = related_map[getattr(join, lookups['related_view_id'])].copy()
                 join_dict.update({
-                    'primary': 'P' if join.primary else 'S',
+                    # 'primary': 'P' if join.primary else 'S',
                     lookups['related_view_id']: getattr(join, lookups['related_view_id'])
                 })
 

--- a/seed/static/seed/js/controllers/inventory_detail_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_controller.js
@@ -22,20 +22,33 @@ angular.module('BE.seed.controller.inventory_detail', [])
     'inventory_payload',
     'columns',
     'profiles',
+    'current_profile',
     'labels_payload',
-    function ($state, $scope, $uibModal, $log, $filter, $stateParams, $anchorScroll, $location, $window, urls, spinner_utility, label_service, inventory_service, matching_service, pairing_service, inventory_payload, columns, profiles, labels_payload) {
+    function ($state,
+              $scope,
+              $uibModal,
+              $log,
+              $filter,
+              $stateParams,
+              $anchorScroll,
+              $location,
+              $window,
+              urls,
+              spinner_utility,
+              label_service,
+              inventory_service,
+              matching_service,
+              pairing_service,
+              inventory_payload,
+              columns,
+              profiles,
+              current_profile,
+              labels_payload) {
       $scope.inventory_type = $stateParams.inventory_type;
 
       // Detail Settings Profile
       $scope.profiles = profiles;
-      var validProfileIds = _.map(profiles, 'id');
-      var lastProfileId = inventory_service.get_last_detail_profile($scope.inventory_type);
-      if (_.includes(validProfileIds, lastProfileId)) {
-        $scope.currentProfile = _.find($scope.profiles, {id: lastProfileId});
-      } else {
-        $scope.currentProfile = _.first($scope.profiles);
-        if ($scope.currentProfile) inventory_service.save_last_detail_profile($scope.currentProfile.id, $scope.inventory_type);
-      }
+      $scope.currentProfile = current_profile;
 
       if ($scope.currentProfile) {
         $scope.columns = [];

--- a/seed/static/seed/js/controllers/inventory_detail_settings_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_settings_controller.js
@@ -15,9 +15,23 @@ angular.module('BE.seed.controller.inventory_detail_settings', [])
     'urls',
     'columns',
     'profiles',
+    'current_profile',
     '$translate',
     'i18nService', // from ui-grid
-    function ($scope, $window, $stateParams, $uibModal, Notification, inventory_service, modified_service, user_service, urls, columns, profiles, $translate, i18nService) {
+    function ($scope,
+              $window,
+              $stateParams,
+              $uibModal,
+              Notification,
+              inventory_service,
+              modified_service,
+              user_service,
+              urls,
+              columns,
+              profiles,
+              current_profile,
+              $translate,
+              i18nService) {
 
       $scope.inventory_type = $stateParams.inventory_type;
       $scope.inventory = {
@@ -28,14 +42,7 @@ angular.module('BE.seed.controller.inventory_detail_settings', [])
       };
 
       $scope.profiles = profiles;
-      var validProfileIds = _.map(profiles, 'id');
-      var lastProfileId = inventory_service.get_last_detail_profile();
-      if (_.includes(validProfileIds, lastProfileId)) {
-        $scope.currentProfile = _.find($scope.profiles, {id: lastProfileId});
-      } else {
-        $scope.currentProfile = _.first($scope.profiles);
-        if ($scope.currentProfile) inventory_service.save_last_detail_profile($scope.currentProfile.id, $scope.inventory_type);
-      }
+      $scope.currentProfile = current_profile;
 
       var initializeRowSelections = function () {
         if ($scope.gridApi) {

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -16,6 +16,7 @@ angular.module('BE.seed.controller.inventory_list', [])
     'inventory',
     'cycles',
     'profiles',
+    'current_profile',
     'labels',
     'all_columns',
     'urls',
@@ -35,6 +36,7 @@ angular.module('BE.seed.controller.inventory_list', [])
               inventory,
               cycles,
               profiles,
+              current_profile,
               labels,
               all_columns,
               urls,
@@ -64,14 +66,7 @@ angular.module('BE.seed.controller.inventory_list', [])
 
       // List Settings Profile
       $scope.profiles = profiles;
-      var validProfileIds = _.map(profiles, 'id');
-      var lastProfileId = inventory_service.get_last_profile($scope.inventory_type);
-      if (_.includes(validProfileIds, lastProfileId)) {
-        $scope.currentProfile = _.find($scope.profiles, {id: lastProfileId});
-      } else {
-        $scope.currentProfile = _.first($scope.profiles);
-        if ($scope.currentProfile) inventory_service.save_last_profile($scope.currentProfile.id, $scope.inventory_type);
-      }
+      $scope.currentProfile = current_profile;
 
       if ($scope.currentProfile) {
         $scope.columns = [];
@@ -508,14 +503,14 @@ angular.module('BE.seed.controller.inventory_list', [])
         spinner_utility.show();
         var visibleColumns = _.map(_.filter($scope.columns, 'visible'), 'name');
         if ($scope.inventory_type === 'properties') {
-          inventory_service.get_properties($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle, visibleColumns).then(function (properties) {
+          inventory_service.get_properties($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle, _.has($scope.currentProfile, 'id') ? $scope.currentProfile.id : undefined).then(function (properties) {
             $scope.data = properties.results;
             $scope.pagination = properties.pagination;
             processData();
             spinner_utility.hide();
           });
         } else if ($scope.inventory_type === 'taxlots') {
-          inventory_service.get_taxlots($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle, visibleColumns).then(function (taxlots) {
+          inventory_service.get_taxlots($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle, _.has($scope.currentProfile, 'id') ? $scope.currentProfile.id : undefined).then(function (taxlots) {
             $scope.data = taxlots.results;
             $scope.pagination = taxlots.pagination;
             processData();

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -49,7 +49,6 @@ angular.module('BE.seed.controller.inventory_list', [])
       $scope.selectedParentCount = 0;
       $scope.selectedOrder = [];
 
-
       $scope.inventory_type = $stateParams.inventory_type;
       $scope.data = inventory.results;
       $scope.pagination = inventory.pagination;
@@ -261,30 +260,48 @@ angular.module('BE.seed.controller.inventory_list', [])
       };
 
       $scope.open_merge_modal = function () {
+        spinner_utility.show();
         var modalInstance = $uibModal.open({
           templateUrl: urls.static_url + 'seed/partials/merge_modal.html',
           controller: 'merge_modal_controller',
           windowClass: 'merge-modal',
           resolve: {
             columns: function () {
-              return _.map(_.reject($scope.columns, function (column) {
-                return _.includes(['id', 'notes_count'], column.name)
-                  || _.includes(['created', 'updated'], column.column_name)
-                  || (column.table_name === 'PropertyState' && _.includes(['analysis_end_time', 'analysis_start_time', 'analysis_state', 'analysis_state_message', 'campus', 'lot_number'], column.column_name));
-              }), function (column) {
-                return _.pick(column, ['column_name', 'displayName', 'id', 'is_extra_data', 'name', 'table_name']);
+              var func;
+              if ($stateParams.inventory_type === 'properties') func = inventory_service.get_mappable_property_columns;
+              else func = inventory_service.get_mappable_taxlot_columns;
+
+              return func().then(function (columns) {
+                return _.map(columns, function (column) {
+                  return _.pick(column, ['column_name', 'displayName', 'id', 'is_extra_data', 'name', 'table_name']);
+                });
               });
             },
             data: function () {
               var selectedOrder = $scope.selectedOrder.slice().reverse();
               var data = new Array($scope.selectedOrder.length);
-              _.forEach($scope.data, function (datum) {
-                if (datum.$$treeLevel === 0) {
-                  var index = _.indexOf(selectedOrder, datum.id);
-                  if (index !== -1) data[index] = datum;
-                }
-              });
-              return data;
+
+              if ($scope.inventory_type === 'properties') {
+                return inventory_service.get_properties(1, undefined, undefined, undefined).then(function (inventory_data) {
+                  _.forEach(selectedOrder, function (id, index) {
+                    var match = _.find(inventory_data.results, {id: id});
+                    if (match) {
+                      data[index] = match;
+                    }
+                  });
+                  return data;
+                });
+              } else if ($scope.inventory_type === 'taxlots') {
+                return inventory_service.get_taxlots(1, undefined, undefined, undefined).then(function (inventory_data) {
+                  _.forEach(selectedOrder, function (id, index) {
+                    var match = _.find(inventory_data.results, {id: id});
+                    if (match) {
+                      data[index] = match;
+                    }
+                  });
+                  return data;
+                });
+              }
             },
             inventory_type: function () {
               return $scope.inventory_type;
@@ -347,7 +364,6 @@ angular.module('BE.seed.controller.inventory_list', [])
         headerCellFilter: 'translate',
         minWidth: 75,
         width: 150
-        //type: 'string'
       };
       _.map($scope.columns, function (col) {
         var options = {};
@@ -415,9 +431,7 @@ angular.module('BE.seed.controller.inventory_list', [])
         var visibleColumns = _.map($scope.columns, 'name')
           .concat(['$$treeLevel', 'notes_count', 'id', 'property_state_id', 'property_view_id', 'taxlot_state_id', 'taxlot_view_id']);
 
-        var columnsToAggregate = _.filter($scope.columns, function (col) {
-          return col.treeAggregationType && _.includes(visibleColumns, col.name);
-        }).reduce(function (obj, col) {
+        var columnsToAggregate = _.filter($scope.columns, 'treeAggregationType').reduce(function (obj, col) {
           obj[col.name] = col.treeAggregationType;
           return obj;
         }, {});
@@ -431,34 +445,7 @@ angular.module('BE.seed.controller.inventory_list', [])
           var relatedIndex = trueIndex;
           var aggregations = {};
           for (var j = 0; j < related.length; ++j) {
-            // Rename nested keys
-            var map = {};
-            // list of fields that can be on both the PropertyState and TaxLotState
-            if ($scope.inventory_type === 'properties') {
-              map = {
-                address_line_1: 'tax_address_line_1',
-                address_line_2: 'tax_address_line_2',
-                city: 'tax_city',
-                state: 'tax_state',
-                postal_code: 'tax_postal_code',
-                custom_id_1: 'tax_custom_id_1',
-                updated: 'tax_updated',
-                created: 'tax_created'
-              };
-            } else if ($scope.inventory_type === 'taxlots') {
-              map = {
-                address_line_1: 'property_address_line_1',
-                address_line_2: 'property_address_line_2',
-                city: 'property_city',
-                state: 'property_state',
-                postal_code: 'property_postal_code',
-                custom_id_1: 'property_custom_id_1',
-                updated: 'property_updated',
-                created: 'property_created'
-              };
-            }
             var updated = _.reduce(related[j], function (result, value, key) {
-              key = map[key] || key;
               if (_.includes(columnNamesToAggregate, key)) aggregations[key] = (aggregations[key] || []).concat(_.split(value, '; '));
               result[key] = value;
               return result;
@@ -501,7 +488,6 @@ angular.module('BE.seed.controller.inventory_list', [])
 
       var refresh_objects = function () {
         spinner_utility.show();
-        var visibleColumns = _.map(_.filter($scope.columns, 'visible'), 'name');
         if ($scope.inventory_type === 'properties') {
           inventory_service.get_properties($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle, _.has($scope.currentProfile, 'id') ? $scope.currentProfile.id : undefined).then(function (properties) {
             $scope.data = properties.results;

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -282,7 +282,7 @@ angular.module('BE.seed.controller.inventory_list', [])
               var data = new Array($scope.selectedOrder.length);
 
               if ($scope.inventory_type === 'properties') {
-                return inventory_service.get_properties(1, undefined, undefined, undefined).then(function (inventory_data) {
+                return inventory_service.get_properties(1, undefined, undefined, undefined, selectedOrder).then(function (inventory_data) {
                   _.forEach(selectedOrder, function (id, index) {
                     var match = _.find(inventory_data.results, {id: id});
                     if (match) {
@@ -292,7 +292,7 @@ angular.module('BE.seed.controller.inventory_list', [])
                   return data;
                 });
               } else if ($scope.inventory_type === 'taxlots') {
-                return inventory_service.get_taxlots(1, undefined, undefined, undefined).then(function (inventory_data) {
+                return inventory_service.get_taxlots(1, undefined, undefined, undefined, selectedOrder).then(function (inventory_data) {
                   _.forEach(selectedOrder, function (id, index) {
                     var match = _.find(inventory_data.results, {id: id});
                     if (match) {

--- a/seed/static/seed/js/controllers/inventory_settings_controller.js
+++ b/seed/static/seed/js/controllers/inventory_settings_controller.js
@@ -16,11 +16,28 @@ angular.module('BE.seed.controller.inventory_settings', [])
     'urls',
     'all_columns',
     'profiles',
+    'current_profile',
     'shared_fields_payload',
     'flippers',
     '$translate',
     'i18nService', // from ui-grid
-    function ($scope, $window, $uibModalInstance, $stateParams, $uibModal, Notification, inventory_service, modified_service, user_service, urls, all_columns, profiles, shared_fields_payload, flippers, $translate, i18nService) {
+    function ($scope,
+              $window,
+              $uibModalInstance,
+              $stateParams,
+              $uibModal,
+              Notification,
+              inventory_service,
+              modified_service,
+              user_service,
+              urls,
+              all_columns,
+              profiles,
+              current_profile,
+              shared_fields_payload,
+              flippers,
+              $translate,
+              i18nService) {
 
       $scope.inventory_type = $stateParams.inventory_type;
       $scope.inventory = {
@@ -31,14 +48,7 @@ angular.module('BE.seed.controller.inventory_settings', [])
       };
 
       $scope.profiles = profiles;
-      var validProfileIds = _.map(profiles, 'id');
-      var lastProfileId = inventory_service.get_last_profile($scope.inventory_type);
-      if (_.includes(validProfileIds, lastProfileId)) {
-        $scope.currentProfile = _.find($scope.profiles, {id: lastProfileId});
-      } else {
-        $scope.currentProfile = _.first($scope.profiles);
-        if ($scope.currentProfile) inventory_service.save_last_profile($scope.currentProfile.id, $scope.inventory_type);
-      }
+      $scope.currentProfile = current_profile;
 
       var initializeRowSelections = function () {
         if ($scope.gridApi) {

--- a/seed/static/seed/js/controllers/inventory_settings_controller.js
+++ b/seed/static/seed/js/controllers/inventory_settings_controller.js
@@ -32,7 +32,7 @@ angular.module('BE.seed.controller.inventory_settings', [])
 
       $scope.profiles = profiles;
       var validProfileIds = _.map(profiles, 'id');
-      var lastProfileId = inventory_service.get_last_profile();
+      var lastProfileId = inventory_service.get_last_profile($scope.inventory_type);
       if (_.includes(validProfileIds, lastProfileId)) {
         $scope.currentProfile = _.find($scope.profiles, {id: lastProfileId});
       } else {

--- a/seed/static/seed/js/controllers/merge_modal_controller.js
+++ b/seed/static/seed/js/controllers/merge_modal_controller.js
@@ -8,12 +8,15 @@ angular.module('BE.seed.controller.merge_modal', [])
     'matching_service',
     '$uibModalInstance',
     'Notification',
+    'spinner_utility',
     'uiGridConstants',
     'naturalSort',
     'columns',
     'data',
     'inventory_type',
-    function ($scope, matching_service, $uibModalInstance, Notification, uiGridConstants, naturalSort, columns, data, inventory_type) {
+    function ($scope, matching_service, $uibModalInstance, Notification, spinner_utility, uiGridConstants, naturalSort, columns, data, inventory_type) {
+      spinner_utility.hide();
+
       $scope.inventory_type = inventory_type;
       $scope.data = data;
       $scope.result = [{}];

--- a/seed/static/seed/js/controllers/pairing_controller.js
+++ b/seed/static/seed/js/controllers/pairing_controller.js
@@ -77,8 +77,8 @@ angular.module('BE.seed.controller.pairing', []).controller('pairing_controller'
       var taxlotColumnNames = _.map($scope.taxlotColumns, 'name');
 
       var promises = [];
-      promises.push(inventory_service.get_properties(1, undefined, $scope.cycle.selected_cycle, propertyColumnNames));
-      promises.push(inventory_service.get_taxlots(1, undefined, $scope.cycle.selected_cycle, taxlotColumnNames));
+      promises.push(inventory_service.get_properties(1, undefined, $scope.cycle.selected_cycle, undefined));
+      promises.push(inventory_service.get_taxlots(1, undefined, $scope.cycle.selected_cycle, undefined));
 
       return $q.all(promises).then(function (results) {
         $scope.propertyData = results[0].results;

--- a/seed/static/seed/js/controllers/show_populated_columns_modal_controller.js
+++ b/seed/static/seed/js/controllers/show_populated_columns_modal_controller.js
@@ -36,11 +36,11 @@ angular.module('BE.seed.controller.show_populated_columns_modal', [])
 
         var promise;
         if ($scope.inventory_type === 'properties') {
-          promise = inventory_service.get_properties(1, undefined, $scope.cycle, []).then(function (inv) {
+          promise = inventory_service.get_properties(1, undefined, $scope.cycle, undefined).then(function (inv) {
             return inv.results;
           });
         } else if ($scope.inventory_type === 'taxlots') {
-          promise = inventory_service.get_taxlots(1, undefined, $scope.cycle, []).then(function (inv) {
+          promise = inventory_service.get_taxlots(1, undefined, $scope.cycle, undefined).then(function (inv) {
             return inv.results;
           });
         }

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -316,6 +316,16 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
             var inventory_type = $stateParams.inventory_type === 'properties' ? 'Property' : 'Tax Lot';
             return inventory_service.get_settings_profiles('List View Settings', inventory_type);
           }],
+          current_profile: ['$stateParams', 'inventory_service', 'profiles', function ($stateParams, inventory_service, profiles) {
+            var validProfileIds = _.map(profiles, 'id');
+            var lastProfileId = inventory_service.get_last_profile($stateParams.inventory_type);
+            if (_.includes(validProfileIds, lastProfileId)) {
+              return _.find(profiles, {id: lastProfileId});
+            }
+            var currentProfile = _.first(profiles);
+            if (currentProfile) inventory_service.save_last_profile(currentProfile.id, $stateParams.inventory_type);
+            return currentProfile;
+          }],
           shared_fields_payload: ['user_service', function (user_service) {
             return user_service.get_shared_buildings();
           }]
@@ -348,6 +358,16 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           profiles: ['$stateParams', 'inventory_service', function ($stateParams, inventory_service) {
             var inventory_type = $stateParams.inventory_type === 'properties' ? 'Property' : 'Tax Lot';
             return inventory_service.get_settings_profiles('Detail View Settings', inventory_type);
+          }],
+          current_profile: ['$stateParams', 'inventory_service', 'profiles', function ($stateParams, inventory_service, profiles) {
+            var validProfileIds = _.map(profiles, 'id');
+            var lastProfileId = inventory_service.get_last_detail_profile($stateParams.inventory_type);
+            if (_.includes(validProfileIds, lastProfileId)) {
+              return _.find(profiles, {id: lastProfileId});
+            }
+            var currentProfile = _.first(profiles);
+            if (currentProfile) inventory_service.save_last_detail_profile(currentProfile.id, $stateParams.inventory_type);
+            return currentProfile;
           }]
         }
       })
@@ -901,6 +921,16 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           profiles: ['$stateParams', 'inventory_service', function ($stateParams, inventory_service) {
             var inventory_type = $stateParams.inventory_type === 'properties' ? 'Property' : 'Tax Lot';
             return inventory_service.get_settings_profiles('Detail View Settings', inventory_type);
+          }],
+          current_profile: ['$stateParams', 'inventory_service', 'profiles', function ($stateParams, inventory_service, profiles) {
+            var validProfileIds = _.map(profiles, 'id');
+            var lastProfileId = inventory_service.get_last_detail_profile($stateParams.inventory_type);
+            if (_.includes(validProfileIds, lastProfileId)) {
+              return _.find(profiles, {id: lastProfileId});
+            }
+            var currentProfile = _.first(profiles);
+            if (currentProfile) inventory_service.save_last_detail_profile(currentProfile.id, $stateParams.inventory_type);
+            return currentProfile;
           }],
           labels_payload: ['$stateParams', 'label_service', 'inventory_payload', function ($stateParams, label_service, inventory_payload) {
             var inventory_id;

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -19,7 +19,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       total_taxlots_for_user: 0
     };
 
-    inventory_service.get_properties = function (page, per_page, cycle, columns) {
+    inventory_service.get_properties = function (page, per_page, cycle, profile_id) {
 
       var params = {
         organization_id: user_service.get_organization().id,
@@ -39,8 +39,8 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         }
 
         return $http.post('/api/v2/properties/filter/', {
-          // Ensure that the required meta fields are included.
-          columns: _.uniq(columns.concat(['property_state_id', 'taxlot_state_id', 'property_view_id', 'taxlot_view_id']))
+          // Pass the current profile (if one exists) to limit the column data that is returned
+          profile_id: profile_id
         }, {
           params: params
         }).then(function (response) {
@@ -203,7 +203,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
     };
 
 
-    inventory_service.get_taxlots = function (page, per_page, cycle, columns) {
+    inventory_service.get_taxlots = function (page, per_page, cycle, profile_id) {
       var params = {
         organization_id: user_service.get_organization().id,
         page: page,
@@ -222,8 +222,8 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         }
 
         return $http.post('/api/v2/taxlots/filter/', {
-          // Ensure that the required meta fields are included
-          columns: _.uniq(columns.concat(['property_state_id', 'taxlot_state_id', 'property_view_id', 'taxlot_view_id']))
+          // Pass the current profile (if one exists) to limit the column data that is returned
+          profile_id: profile_id
         }, {
           params: params
         }).then(function (response) {

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -19,7 +19,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       total_taxlots_for_user: 0
     };
 
-    inventory_service.get_properties = function (page, per_page, cycle, profile_id) {
+    inventory_service.get_properties = function (page, per_page, cycle, profile_id, inventory_ids) {
 
       var params = {
         organization_id: user_service.get_organization().id,
@@ -39,6 +39,8 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         }
 
         return $http.post('/api/v2/properties/filter/', {
+          // Pass the specific ids if they exist
+          inventory_ids: inventory_ids,
           // Pass the current profile (if one exists) to limit the column data that is returned
           profile_id: profile_id
         }, {
@@ -203,7 +205,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
     };
 
 
-    inventory_service.get_taxlots = function (page, per_page, cycle, profile_id) {
+    inventory_service.get_taxlots = function (page, per_page, cycle, profile_id, inventory_ids) {
       var params = {
         organization_id: user_service.get_organization().id,
         page: page,
@@ -222,6 +224,8 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         }
 
         return $http.post('/api/v2/taxlots/filter/', {
+          // Pass the specific ids if they exist
+          inventory_ids: inventory_ids,
           // Pass the current profile (if one exists) to limit the column data that is returned
           profile_id: profile_id
         }, {

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -418,17 +418,6 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         //   });
         // }
 
-        // TEMP: fix some columns
-        _.forEach(columns, function (col) {
-          if (col.name === 'created' && col.table_name === 'TaxLot') {
-            col.name = 'tax_created';
-            col.displayName = 'Created (Tax Lot)';
-          } else if (col.name === 'updated' && col.table_name === 'TaxLot') {
-            col.name = 'tax_updated';
-            col.displayName = 'Updated (Tax Lot)';
-          }
-        });
-
         // Check for problems
         var duplicates = _.filter(_.map(columns, 'name'), function (value, index, iteratee) {
           return _.includes(iteratee, value, index + 1);
@@ -441,6 +430,42 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       });
     };
 
+    inventory_service.get_mappable_property_columns = function () {
+      return $http.get('/api/v2/properties/mappable_columns/', {
+        params: {
+          organization_id: user_service.get_organization().id
+        }
+      }).then(function (response) {
+        // Remove empty columns
+        var columns = _.filter(response.data.columns, function (col) {
+          return !_.isEmpty(col.name);
+        });
+
+        // Rename display_name to displayName (ui-grid compatibility)
+        columns = _.map(columns, function (col) {
+          return _.mapKeys(col, function(value, key) {
+            return key === 'display_name' ? 'displayName' : key;
+          });
+        });
+
+        // Remove _orig columns
+        // if (flippers.is_active('release:orig_columns')) {
+        //   _.remove(columns, function (col) {
+        //     return /_orig/.test(col.name);
+        //   });
+        // }
+
+        // Check for problems
+        var duplicates = _.filter(_.map(columns, 'name'), function (value, index, iteratee) {
+          return _.includes(iteratee, value, index + 1);
+        });
+        if (duplicates.length) {
+          console.error('Duplicate property column names detected:', duplicates);
+        }
+
+        return columns;
+      });
+    };
 
     inventory_service.get_taxlot_columns = function () {
       return $http.get('/api/v2/taxlots/columns/', {
@@ -467,16 +492,42 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         //   });
         // }
 
-        // TEMP: fix some columns
-        _.forEach(columns, function (col) {
-          if (col.name === 'created' && col.table_name === 'Property') {
-            col.name = 'property_created';
-            col.displayName = 'Created (Property)';
-          } else if (col.name === 'updated' && col.table_name === 'Property') {
-            col.name = 'property_updated';
-            col.displayName = 'Updated (Property)';
-          }
+        // Check for problems
+        var duplicates = _.filter(_.map(columns, 'name'), function (value, index, iteratee) {
+          return _.includes(iteratee, value, index + 1);
         });
+        if (duplicates.length) {
+          console.error('Duplicate tax lot column names detected:', duplicates);
+        }
+
+        return columns;
+      });
+    };
+
+    inventory_service.get_mappable_taxlot_columns = function () {
+      return $http.get('/api/v2/taxlots/mappable_columns/', {
+        params: {
+          organization_id: user_service.get_organization().id
+        }
+      }).then(function (response) {
+        // Remove empty columns
+        var columns = _.filter(response.data.columns, function (col) {
+          return !_.isEmpty(col.name);
+        });
+
+        // Rename display_name to displayName (ui-grid compatibility)
+        columns = _.map(columns, function (col) {
+          return _.mapKeys(col, function(value, key) {
+            return key === 'display_name' ? 'displayName' : key;
+          });
+        });
+
+        // Remove _orig columns
+        // if (flippers.is_active('release:orig_columns')) {
+        //   _.remove(columns, function (col) {
+        //     return /_orig/.test(col.name);
+        //   });
+        // }
 
         // Check for problems
         var duplicates = _.filter(_.map(columns, 'name'), function (value, index, iteratee) {

--- a/seed/static/seed/tests/inventory_detail_controller.spec.js
+++ b/seed/static/seed/tests/inventory_detail_controller.spec.js
@@ -166,6 +166,7 @@ describe('controller: inventory_detail_controller', function () {
       inventory_payload: fake_payload,
       columns: fake_all_columns,
       profiles: [],
+      current_profile: undefined,
       labels_payload: {
         audit_logs: []
       }

--- a/seed/static/seed/tests/mapping_controller.spec.js
+++ b/seed/static/seed/tests/mapping_controller.spec.js
@@ -193,8 +193,6 @@ describe('controller: mapping_controller', function () {
     var mappings = mapping_controller_scope.mappings;
     var first_column = mappings[0];
 
-    console.log('mappings', mappings);
-
     expect(first_column.suggestion).toBe('PM Property ID');
   });
 

--- a/seed/static/seed/tests/property_detail_controller.spec.js
+++ b/seed/static/seed/tests/property_detail_controller.spec.js
@@ -249,6 +249,7 @@ describe('controller: inventory_detail_controller', function () {
         fields: fake_all_columns
       },
       profiles: [],
+      current_profile: undefined,
       labels_payload: mock_label_payload
 
     });

--- a/seed/static/seed/tests/taxlot_detail_controller.spec.js
+++ b/seed/static/seed/tests/taxlot_detail_controller.spec.js
@@ -162,6 +162,7 @@ describe('controller: inventory_detail_controller', function () {
         fields: fake_all_columns
       },
       profiles: [],
+      current_profile: undefined,
       labels_payload: mock_label_payload
 
     });

--- a/seed/tests/test_column_views.py
+++ b/seed/tests/test_column_views.py
@@ -25,8 +25,8 @@ DEFAULT_CUSTOM_COLUMNS = [
 from seed.tests.util import DeleteModelsTestCase
 
 COLUMNS_TO_SEND = DEFAULT_CUSTOM_COLUMNS + ['postal_code', 'pm_parent_property_id',
-                                            'calculated_taxlot_ids', 'primary', 'extra_data_field',
-                                            'jurisdiction_tax_lot_id', 'is secret lair',
+                                            # 'calculated_taxlot_ids', 'primary',
+                                            'extra_data_field', 'jurisdiction_tax_lot_id', 'is secret lair',
                                             'paint color', 'number of secret gadgets']
 
 

--- a/seed/tests/test_property_views.py
+++ b/seed/tests/test_property_views.py
@@ -33,8 +33,8 @@ COLUMNS_TO_SEND = [
     'state_province',
     'postal_code',
     'pm_parent_property_id',
-    'calculated_taxlot_ids',
-    'primary',
+    # 'calculated_taxlot_ids',
+    # 'primary',
     'extra_data_field',
     'jurisdiction_tax_lot_id'
 ]

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -726,7 +726,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'organization_id', self.org.pk,
             'page', 1,
             'per_page', 999999999
-        ), data={'columns': COLUMNS_TO_SEND})
+        ), data={'profile_id': None})
 
         column_name_mappings_related = {}
         column_name_mappings = {}
@@ -777,7 +777,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'organization_id', self.org.pk,
             'page', 1,
             'per_page', 999999999
-        ), data={'columns': COLUMNS_TO_SEND})
+        ), data={'profile_id': None})
         result = json.loads(response.content)
 
         column_name_mappings_related = {}
@@ -806,7 +806,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'organization_id', self.org.pk,
             'page', 'one',
             'per_page', 999999999
-        ), data={'columns': COLUMNS_TO_SEND})
+        ), data={'profile_id': None})
         result = json.loads(response.content)
 
         self.assertEquals(len(result['results']), 1)
@@ -825,7 +825,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'page', 10,
             'per_page', 999999999
         )
-        response = self.client.post(filter_properties_url, data={'columns': COLUMNS_TO_SEND})
+        response = self.client.post(filter_properties_url, data={'profile_id': None})
         result = json.loads(response.content)
         self.assertEquals(len(result['results']), 0)
         pagination = result['pagination']
@@ -1017,7 +1017,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'page', 1,
             'per_page', 999999999,
             'cycle', self.cycle.pk
-        ), data={'columns': COLUMNS_TO_SEND})
+        ), data={'profile_id': None})
         results = json.loads(response.content)['results']
 
         column_name_mappings_related = {}
@@ -1062,11 +1062,12 @@ class InventoryViewTests(DeleteModelsTestCase):
             property_view=property_view, taxlot_view=taxlot_view,
             cycle=self.cycle
         )
-        url = '/api/v2/taxlots/filter/?{}={}&{}={}'.format(
+        url = '/api/v2/taxlots/filter/?{}={}&{}={}&{}={}'.format(
             'organization_id', self.org.pk,
-            'page', 1
+            'page', 1,
+            'per_page', 999999999,
         )
-        response = self.client.post(url, data={'columns': COLUMNS_TO_SEND})
+        response = self.client.post(url, data={'profile_id': None})
         results = json.loads(response.content)['results']
 
         self.assertEquals(len(results), 1)
@@ -1085,7 +1086,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'page', 1,
             'per_page', 999999999
         )
-        data = {'columns': COLUMNS_TO_SEND}
+        data = {'profile_id': None}
         response = self.client.post(url, data=data)
         result = json.loads(response.content)
 
@@ -1139,7 +1140,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'cycle', self.cycle.pk,
             'page', 1,
             'per_page', 999999999
-        ), data={'columns': COLUMNS_TO_SEND})
+        ), data={'profile_id': None})
         results = json.loads(response.content)['results']
         self.assertEquals(len(results), 2)
 
@@ -1201,11 +1202,12 @@ class InventoryViewTests(DeleteModelsTestCase):
             property_view=property_view, taxlot_view=taxlot_view,
             cycle=self.cycle
         )
-        response = self.client.post('/api/v2/taxlots/filter/?{}={}&{}={}&{}={}'.format(
+        response = self.client.post('/api/v2/taxlots/filter/?{}={}&{}={}&{}={}&{}={}'.format(
             'organization_id', self.org.pk,
             'cycle', self.cycle.pk,
-            'page', 1
-        ), data={'columns': COLUMNS_TO_SEND})
+            'page', 1,
+            'per_page', 999999999,
+        ), data={'profile_id': None})
         results = json.loads(response.content)['results']
 
         column_name_mappings_related = {}
@@ -1240,11 +1242,12 @@ class InventoryViewTests(DeleteModelsTestCase):
             property_view=property_view, taxlot_view=taxlot_view,
             cycle=self.cycle
         )
-        response = self.client.post('/api/v2/taxlots/filter/?{}={}&{}={}&{}={}'.format(
+        response = self.client.post('/api/v2/taxlots/filter/?{}={}&{}={}&{}={}&{}={}'.format(
             'organization_id', self.org.pk,
             'cycle', self.cycle.pk,
-            'page', 'bad'
-        ), data={'columns': COLUMNS_TO_SEND})
+            'page', 'bad',
+            'per_page', 999999999,
+        ), data={'profile_id': None})
         result = json.loads(response.content)
 
         self.assertEquals(len(result['results']), 1)
@@ -1274,11 +1277,12 @@ class InventoryViewTests(DeleteModelsTestCase):
             property_view=property_view, taxlot_view=taxlot_view,
             cycle=self.cycle
         )
-        response = self.client.post('/api/v2/taxlots/filter/?{}={}&{}={}&{}={}'.format(
+        response = self.client.post('/api/v2/taxlots/filter/?{}={}&{}={}&{}={}&{}={}'.format(
             'organization_id', self.org.pk,
             'cycle', self.cycle.pk,
-            'page', 'bad'
-        ), data={'columns': COLUMNS_TO_SEND})
+            'page', 1,
+            'per_page', 999999999,
+        ), data={'profile_id': None})
         result = json.loads(response.content)
 
         self.assertEquals(len(result['results']), 1)
@@ -1290,32 +1294,6 @@ class InventoryViewTests(DeleteModelsTestCase):
         self.assertEquals(pagination['has_next'], False)
         self.assertEquals(pagination['has_previous'], False)
         self.assertEquals(pagination['total'], 1)
-
-    def test_get_taxlots_missing_jurisdiction_tax_lot_id(self):
-        property_state = self.property_state_factory.get_property_state(extra_data={'extra_data_field': 'edfval'})
-        property_property = self.property_factory.get_property(self.org)
-        property_view = PropertyView.objects.create(
-            property=property_property, cycle=self.cycle, state=property_state
-        )
-        taxlot_state = self.taxlot_state_factory.get_taxlot_state(
-            postal_code=property_state.postal_code,
-            jurisdiction_tax_lot_id=None
-        )
-        taxlot = TaxLot.objects.create(organization=self.org)
-        taxlot_view = TaxLotView.objects.create(
-            taxlot=taxlot, state=taxlot_state, cycle=self.cycle
-        )
-        TaxLotProperty.objects.create(
-            property_view=property_view, taxlot_view=taxlot_view,
-            cycle=self.cycle
-        )
-        response = self.client.post('/api/v2/taxlots/filter/?{}={}&{}={}&{}={}'.format(
-            'organization_id', self.org.pk,
-            'cycle', self.cycle.pk,
-            'page', 'bad'
-        ), data={'columns': COLUMNS_TO_SEND})
-        related = json.loads(response.content)['results'][0]['related'][0]
-        # self.assertEqual(related['calculated_taxlot_ids'], 'Missing')
 
     def test_get_taxlot(self):
         taxlot_state = self.taxlot_state_factory.get_taxlot_state()

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -46,8 +46,8 @@ DEFAULT_CUSTOM_COLUMNS = [
 from seed.tests.util import DeleteModelsTestCase
 
 COLUMNS_TO_SEND = DEFAULT_CUSTOM_COLUMNS + ['postal_code', 'pm_parent_property_id',
-                                            'calculated_taxlot_ids', 'primary', 'extra_data_field',
-                                            'jurisdiction_tax_lot_id', 'is secret lair',
+                                            # 'calculated_taxlot_ids', 'primary',
+                                            'extra_data_field', 'jurisdiction_tax_lot_id', 'is secret lair',
                                             'paint color', 'number of secret gadgets']
 
 
@@ -744,7 +744,7 @@ class InventoryViewTests(DeleteModelsTestCase):
         related = result['related'][0]
         self.assertEquals(related[column_name_mappings_related['postal_code']],
                           result[column_name_mappings['postal_code']])
-        self.assertEquals(related['primary'], 'P')
+        # self.assertEquals(related['primary'], 'P')
 
     def test_get_properties_taxlot_extra_data(self):
         extra_data = {
@@ -1039,9 +1039,9 @@ class InventoryViewTests(DeleteModelsTestCase):
         self.assertEquals(related[column_name_mappings_related['address_line_1']], property_state.address_line_1)
         self.assertEquals(related[column_name_mappings_related['pm_parent_property_id']],
                           property_state.pm_parent_property_id)
-        self.assertEquals(related['calculated_taxlot_ids'], taxlot_state.jurisdiction_tax_lot_id)
-        self.assertEquals(related['calculated_taxlot_ids'], result[column_name_mappings['jurisdiction_tax_lot_id']])
-        self.assertEquals(related['primary'], 'P')
+        # self.assertEquals(related['calculated_taxlot_ids'], taxlot_state.jurisdiction_tax_lot_id)
+        # self.assertEquals(related['calculated_taxlot_ids'], result[column_name_mappings['jurisdiction_tax_lot_id']])
+        # self.assertEquals(related['primary'], 'P')
         self.assertIn(column_name_mappings_related['extra_data_field'], related)
         self.assertEquals(related[column_name_mappings_related['extra_data_field']], 'edfval')
 
@@ -1104,7 +1104,7 @@ class InventoryViewTests(DeleteModelsTestCase):
         related_2 = result['results'][0]['related'][1]
         self.assertEqual(property_state.address_line_1, related_1[column_name_mappings_related['address_line_1']])
         self.assertEqual(property_state_1.address_line_1, related_2[column_name_mappings_related['address_line_1']])
-        self.assertEqual(taxlot_state.jurisdiction_tax_lot_id, related_1['calculated_taxlot_ids'])
+        # self.assertEqual(taxlot_state.jurisdiction_tax_lot_id, related_1['calculated_taxlot_ids'])
 
     def test_get_taxlots_multiple_taxlots(self):
         property_state = self.property_state_factory.get_property_state(extra_data={'extra_data_field': 'edfval'})
@@ -1159,10 +1159,10 @@ class InventoryViewTests(DeleteModelsTestCase):
         related = result['related'][0]
         self.assertEquals(related[column_name_mappings_related['address_line_1']], property_state.address_line_1)
         self.assertEquals(related[column_name_mappings_related['pm_parent_property_id']], property_state.pm_parent_property_id)
-        calculated_taxlot_ids = related['calculated_taxlot_ids'].split('; ')
-        self.assertIn(str(taxlot_state_1.jurisdiction_tax_lot_id), calculated_taxlot_ids)
-        self.assertIn(str(taxlot_state_2.jurisdiction_tax_lot_id), calculated_taxlot_ids)
-        self.assertEquals(related['primary'], 'P')
+        # calculated_taxlot_ids = related['calculated_taxlot_ids'].split('; ')
+        # self.assertIn(str(taxlot_state_1.jurisdiction_tax_lot_id), calculated_taxlot_ids)
+        # self.assertIn(str(taxlot_state_2.jurisdiction_tax_lot_id), calculated_taxlot_ids)
+        # self.assertEquals(related['primary'], 'P')
         self.assertIn(column_name_mappings_related['extra_data_field'], related)
         self.assertEquals(related[column_name_mappings_related['extra_data_field']], 'edfval')
 
@@ -1175,10 +1175,10 @@ class InventoryViewTests(DeleteModelsTestCase):
         self.assertEquals(related[column_name_mappings_related['address_line_1']], property_state.address_line_1)
         self.assertEquals(related[column_name_mappings_related['pm_parent_property_id']], property_state.pm_parent_property_id)
 
-        calculated_taxlot_ids = related['calculated_taxlot_ids'].split('; ')
-        self.assertIn(str(taxlot_state_1.jurisdiction_tax_lot_id), calculated_taxlot_ids)
-        self.assertIn(str(taxlot_state_2.jurisdiction_tax_lot_id), calculated_taxlot_ids)
-        self.assertEquals(related['primary'], 'P')
+        # calculated_taxlot_ids = related['calculated_taxlot_ids'].split('; ')
+        # self.assertIn(str(taxlot_state_1.jurisdiction_tax_lot_id), calculated_taxlot_ids)
+        # self.assertIn(str(taxlot_state_2.jurisdiction_tax_lot_id), calculated_taxlot_ids)
+        # self.assertEquals(related['primary'], 'P')
         self.assertIn(column_name_mappings_related['extra_data_field'], related)
         self.assertEquals(related[column_name_mappings_related['extra_data_field']], 'edfval')
 
@@ -1315,7 +1315,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'page', 'bad'
         ), data={'columns': COLUMNS_TO_SEND})
         related = json.loads(response.content)['results'][0]['related'][0]
-        self.assertEqual(related['calculated_taxlot_ids'], 'Missing')
+        # self.assertEqual(related['calculated_taxlot_ids'], 'Missing')
 
     def test_get_taxlot(self):
         taxlot_state = self.taxlot_state_factory.get_taxlot_state()

--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -230,9 +230,15 @@ class PropertyViewSet(GenericViewSet):
                     'results': []
                 })
 
-        property_views_list = PropertyView.objects.select_related('property', 'state', 'cycle') \
-            .filter(property__organization_id=org_id, cycle=cycle) \
-            .order_by('id')  # TODO: test adding .only(*fields['PropertyState'])
+        # Return property views limited to the 'inventory_ids' list.  Otherwise, if selected is empty, return all
+        if 'inventory_ids' in request.data and request.data['inventory_ids']:
+            property_views_list = PropertyView.objects.select_related('property', 'state', 'cycle') \
+                .filter(property_id__in=request.data['inventory_ids'], property__organization_id=org_id, cycle=cycle) \
+                .order_by('id')  # TODO: test adding .only(*fields['PropertyState'])
+        else:
+            property_views_list = PropertyView.objects.select_related('property', 'state', 'cycle') \
+                .filter(property__organization_id=org_id, cycle=cycle) \
+                .order_by('id')  # TODO: test adding .only(*fields['PropertyState'])
 
         paginator = Paginator(property_views_list, per_page)
 

--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -744,6 +744,25 @@ class PropertyViewSet(GenericViewSet):
 
     @api_endpoint_class
     @ajax_request_class
+    @has_perm_class('requires_viewer')
+    @list_route(methods=['GET'])
+    def mappable_columns(self, request):
+        """
+        List only property columns that are mappable
+        parameters:
+            - name: organization_id
+              description: The organization_id for this user's organization
+              required: true
+              paramType: query
+        """
+        organization_id = int(request.query_params.get('organization_id'))
+        columns = Column.retrieve_mapping_columns(organization_id, 'property')
+        organization = Organization.objects.get(pk=organization_id)
+
+        return JsonResponse({'status': 'success', 'columns': columns})
+
+    @api_endpoint_class
+    @ajax_request_class
     @has_perm_class('can_modify_data')
     @detail_route(methods=['DELETE'])
     def delete(self, request, pk=None):

--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -377,7 +377,10 @@ class PropertyViewSet(GenericViewSet):
         if 'profile_id' not in request.data:
             profile_id = None
         else:
-            profile_id = request.data['profile_id']
+            if request.data['profile_id'] == 'None':
+                profile_id = None
+            else:
+                profile_id = request.data['profile_id']
 
         return self._get_filtered_results(request, profile_id=profile_id)
 

--- a/seed/views/taxlots.py
+++ b/seed/views/taxlots.py
@@ -99,9 +99,15 @@ class TaxLotViewSet(GenericViewSet):
                     'results': []
                 })
 
-        taxlot_views_list = TaxLotView.objects.select_related('taxlot', 'state', 'cycle') \
-            .filter(taxlot__organization_id=org_id, cycle=cycle) \
-            .order_by('id')
+        # Return taxlot views limited to the 'inventory_ids' list.  Otherwise, if selected is empty, return all
+        if 'inventory_ids' in request.data and request.data['inventory_ids']:
+            taxlot_views_list = TaxLotView.objects.select_related('taxlot', 'state', 'cycle') \
+                .filter(taxlot_id__in=request.data['inventory_ids'], taxlot__organization_id=org_id, cycle=cycle) \
+                .order_by('id')
+        else:
+            taxlot_views_list = TaxLotView.objects.select_related('taxlot', 'state', 'cycle') \
+                .filter(taxlot__organization_id=org_id, cycle=cycle) \
+                .order_by('id')
 
         paginator = Paginator(taxlot_views_list, per_page)
 

--- a/seed/views/taxlots.py
+++ b/seed/views/taxlots.py
@@ -119,18 +119,21 @@ class TaxLotViewSet(GenericViewSet):
 
         columns_from_database = Column.retrieve_all(org_id, 'taxlot', False)
 
-        try:
-            profile = ColumnListSetting.objects.get(
-                organization=org,
-                id=profile_id,
-                settings_location=ColumnListSetting.VIEW_LIST,
-                inventory_type=ColumnListSetting.VIEW_LIST_PROPERTY
-            )
-            show_columns = list(ColumnListSettingColumn.objects.filter(
-                column_list_setting_id=profile.id
-            ).values_list('column_id', flat=True))
-        except ColumnListSetting.DoesNotExist:
+        if profile_id is None:
             show_columns = None
+        else:
+            try:
+                profile = ColumnListSetting.objects.get(
+                    organization=org,
+                    id=profile_id,
+                    settings_location=ColumnListSetting.VIEW_LIST,
+                    inventory_type=ColumnListSetting.VIEW_LIST_PROPERTY
+                )
+                show_columns = list(ColumnListSettingColumn.objects.filter(
+                    column_list_setting_id=profile.id
+                ).values_list('column_id', flat=True))
+            except ColumnListSetting.DoesNotExist:
+                show_columns = None
 
         related_results = TaxLotProperty.get_related(taxlot_views, show_columns, columns_from_database)
 
@@ -182,7 +185,7 @@ class TaxLotViewSet(GenericViewSet):
               required: false
               paramType: query
         """
-        return self._get_filtered_results(request, columns=None)
+        return self._get_filtered_results(request, profile_id=None)
 
     # @require_organization_id
     # @require_organization_membership
@@ -220,7 +223,7 @@ class TaxLotViewSet(GenericViewSet):
         else:
             profile_id = request.data['profile_id']
 
-        return self._get_filtered_results(request, profile_id)
+        return self._get_filtered_results(request, profile_id=profile_id)
 
     @api_endpoint_class
     @ajax_request_class
@@ -601,7 +604,6 @@ class TaxLotViewSet(GenericViewSet):
         """
         organization_id = int(request.query_params.get('organization_id'))
         columns = Column.retrieve_mapping_columns(organization_id, 'taxlot')
-        organization = Organization.objects.get(pk=organization_id)
 
         return JsonResponse({'status': 'success', 'columns': columns})
 

--- a/seed/views/taxlots.py
+++ b/seed/views/taxlots.py
@@ -20,6 +20,9 @@ from seed.data_importer.views import ImportFileViewSet
 from seed.decorators import ajax_request_class
 from seed.lib.merging import merging
 from seed.lib.superperms.orgs.decorators import has_perm_class
+from seed.lib.superperms.orgs.models import (
+    Organization
+)
 from seed.models import (
     AUDIT_IMPORT,
     AUDIT_USER_EDIT,
@@ -39,9 +42,6 @@ from seed.models import (
     TaxLotState,
     TaxLotView,
     TaxLot,
-)
-from seed.lib.superperms.orgs.models import (
-    Organization
 )
 from seed.serializers.pint import (
     apply_display_unit_preferences,
@@ -221,7 +221,10 @@ class TaxLotViewSet(GenericViewSet):
         if 'profile_id' not in request.data:
             profile_id = None
         else:
-            profile_id = request.data['profile_id']
+            if request.data['profile_id'] == 'None':
+                profile_id = None
+            else:
+                profile_id = request.data['profile_id']
 
         return self._get_filtered_results(request, profile_id=profile_id)
 


### PR DESCRIPTION
#### Any background context you want to provide?
- Previously we had an option to request only specific columns be returned from the backend to improve performance and reduce data transfer.  This PR restores that functionality.
#### What's this PR do?
- Passes an optional profile id to the inventory filter API to return data for the columns in that list settings profile
- Fetches all columns for only selected rows when opening the merge modal
- Added an API resource to return only columns that can be mapped
- Removed deprecated code that prepended `tax_` and `property_` to field names
- Commented unused `calculated_taxlot_ids` and `primary` fields
#### How should this be manually tested?
- On an org with no saved list settings, check that the data returned includes all columns
- Create a list setting (like with `Show only populated columns` and check that only those specific columns are returned.
- Try merging some records - check that only the specific selected records were loaded with all columns in the API response.
