### PR TITLE
Fix Inventory Export and Displaying of Extra Data Fields in Inventory

### DIFF
--- a/seed/models/tax_lot_properties.py
+++ b/seed/models/tax_lot_properties.py
@@ -13,6 +13,7 @@ from itertools import chain
 from django.apps import apps
 from django.db import models
 from django.utils.timezone import make_naive
+
 from seed.models.columns import Column
 
 logger = logging.getLogger(__name__)
@@ -182,10 +183,12 @@ class TaxLotProperty(models.Model):
             filtered_fields = set([col['column_name'] for col in related_columns if col['id'] in show_columns])
 
         for related_view in related_views:
-            related_dict = TaxLotProperty.model_to_dict_with_mapping(related_view.state,
-                                                                     related_column_name_mapping,
-                                                                     fields=filtered_fields,
-                                                                     exclude=['extra_data'])
+            related_dict = TaxLotProperty.model_to_dict_with_mapping(
+                related_view.state,
+                related_column_name_mapping,
+                fields=filtered_fields,
+                exclude=['extra_data']
+            )
 
             related_dict[lookups['related_state_id']] = related_view.state.id
 

--- a/seed/models/tax_lot_properties.py
+++ b/seed/models/tax_lot_properties.py
@@ -182,6 +182,12 @@ class TaxLotProperty(models.Model):
         else:
             filtered_fields = set([col['column_name'] for col in related_columns if col['id'] in show_columns])
 
+        # get the list of extra data fields by name for use in TaxLotProperty.extra_data_to_dict_with_mapping
+        extra_data_fields = []
+        for col in obj_columns:
+            if col['is_extra_data'] and col['related']:
+                extra_data_fields.append(col['column_name'])
+
         for related_view in related_views:
             related_dict = TaxLotProperty.model_to_dict_with_mapping(
                 related_view.state,
@@ -216,7 +222,8 @@ class TaxLotProperty(models.Model):
                 related_dict.items() +
                 TaxLotProperty.extra_data_to_dict_with_mapping(
                     related_view.state.extra_data,
-                    related_column_name_mapping, fields=show_columns
+                    related_column_name_mapping,
+                    fields=extra_data_fields
                 ).items()
             )
             related_map[related_view.pk] = related_dict
@@ -282,6 +289,12 @@ class TaxLotProperty(models.Model):
         else:
             filtered_fields = set([col['column_name'] for col in obj_columns if col['id'] in show_columns])
 
+        # get the list of extra data fields by name for use in TaxLotProperty.extra_data_to_dict_with_mapping
+        extra_data_fields = []
+        for col in obj_columns:
+            if col['is_extra_data'] and not col['related']:
+                extra_data_fields.append(col['column_name'])
+
         for obj in object_list:
             # Each object in the response is built from the state data, with related data added on.
             obj_dict = TaxLotProperty.model_to_dict_with_mapping(obj.state,
@@ -294,7 +307,7 @@ class TaxLotProperty(models.Model):
                 TaxLotProperty.extra_data_to_dict_with_mapping(
                     obj.state.extra_data,
                     obj_column_name_mapping,
-                    fields=show_columns
+                    fields=extra_data_fields
                 ).items()
             )
 

--- a/seed/static/seed/js/controllers/export_inventory_modal_controller.js
+++ b/seed/static/seed/js/controllers/export_inventory_modal_controller.js
@@ -10,7 +10,9 @@ angular.module('BE.seed.controller.export_inventory_modal', []).controller('expo
   'cycle_id',
   'ids',
   'columns',
-  'inventory_type', function ($http, $scope, $uibModalInstance, user_service, cycle_id, ids, columns, inventory_type) {
+  'inventory_type',
+  'profile_id',
+  function ($http, $scope, $uibModalInstance, user_service, cycle_id, ids, columns, inventory_type, profile_id) {
     $scope.export_name = '';
     $scope.export_type = 'csv';
 
@@ -21,14 +23,14 @@ angular.module('BE.seed.controller.export_inventory_modal', []).controller('expo
       if (!_.endsWith(filename, ext)) filename += ext;
 
       return $http.post('/api/v2.1/tax_lot_properties/csv/', {
-        columns: columns,
         ids: ids,
-        filename: filename
+        filename: filename,
+        profile_id: profile_id
       }, {
         params: {
           organization_id: user_service.get_organization().id,
           cycle_id: cycle_id,
-          inventory_type: inventory_type
+          inventory_type: inventory_type,
         }
       }).then(function (response) {
         var blob = new Blob([response.data], {type: 'text/csv'});

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -635,6 +635,9 @@ angular.module('BE.seed.controller.inventory_list', [])
             },
             inventory_type: function () {
               return $scope.inventory_type;
+            },
+            profile_id: function () {
+              return $scope.currentProfile.id;
             }
 
           }

--- a/seed/tests/test_column_list_settings.py
+++ b/seed/tests/test_column_list_settings.py
@@ -50,3 +50,41 @@ class TestColumnListSettings(TestCase):
         self.assertEqual(new_list_setting.columns.count(), 1)
         self.assertEqual(new_list_setting.columnlistsettingcolumn_set.count(), 1)
         self.assertEqual(new_list_setting.columnlistsettingcolumn_set.first().column.column_name, 'Second Column')
+
+    def test_returning_columns_no_profile(self):
+        # do not set up a profile and return the columns, should be all columns
+        ids, name_mappings, objs = ColumnListSetting.return_columns(self.fake_org, None)
+
+        # not the most robust tests, but they are least check for non-zero results
+        self.assertIsInstance(ids[0], int)
+        self.assertIsInstance(name_mappings.keys()[0], unicode)
+        self.assertIsInstance(name_mappings.values()[0], unicode)
+
+    def test_returning_columns_with_profile(self):
+        col1 = Column.objects.create(
+            column_name=u'New Column',
+            table_name=u'PropertyState',
+            organization=self.fake_org,
+            is_extra_data=True,
+        )
+        col2 = Column.objects.create(
+            column_name=u'Second Column',
+            table_name=u'PropertyState',
+            organization=self.fake_org,
+            is_extra_data=True,
+        )
+
+        new_list_setting = ColumnListSetting.objects.create(name='example list setting')
+        ColumnListSettingColumn.objects.create(column=col1, column_list_setting=new_list_setting, order=1, pinned=False)
+        ColumnListSettingColumn.objects.create(column=col2, column_list_setting=new_list_setting, order=2, pinned=True)
+
+        # do not set up a profile and return the columns, should be all columns
+        ids, name_mappings, objs = ColumnListSetting.return_columns(self.fake_org, new_list_setting.id)
+
+        # print ids
+        # print name_mappings
+
+        # not the most robust tests, but they are least check for non-zero results
+        self.assertIsInstance(ids[0], int)
+        self.assertIsInstance(name_mappings.keys()[0], unicode)
+        self.assertIsInstance(name_mappings.values()[0], unicode)

--- a/seed/utils/organizations.py
+++ b/seed/utils/organizations.py
@@ -4,13 +4,14 @@
 :copyright (c) 2014 - 2018, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
 """
-from django.apps import apps
 
 from seed.lib.superperms.orgs.models import (
     Organization,
     OrganizationUser,
+
 )
 from seed.models import Column
+from seed.models.data_quality import DataQualityCheck
 
 
 def create_organization(user=None, org_name='', *args, **kwargs):
@@ -51,6 +52,6 @@ def create_organization(user=None, org_name='', *args, **kwargs):
         Column.objects.create(**details)
 
     # create the default rules for this organization
-    apps.get_model('seed', 'DataQualityCheck').retrieve(organization.id)
+    DataQualityCheck.retrieve(organization.id)
 
     return organization, organization_user, user_added


### PR DESCRIPTION
#### Any background context you want to provide?
* The export inventory was broken since the profile deployment
* Extra data was not being displayed in the inventory view (but the data was in the database)

#### What's this PR do?
* Fix export and extra data display

#### How should this be manually tested?
* Import data, making sure to map some of the data to extra data
* Go to the inventory page
* Select a few rows
* Go to Actions -> Export Selected
* Make sure file looks right (with all the data)
* Create a profile
* Re export the data
* Make sure only the selected columns exist

Also, verify that data in extra data are now in the GUI and in the CSV.

#### What are the relevant tickets?
#1669 

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?