### PR TITLE
ID in CSV causing Excel to throw warnings

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -637,9 +637,13 @@ angular.module('BE.seed.controller.inventory_list', [])
               return $scope.inventory_type;
             },
             profile_id: function () {
-              return $scope.currentProfile.id;
+              // Check to see if the profile id is set
+              if ($scope.currentProfile) {
+                return $scope.currentProfile.id;
+              } else {
+                return null;
+              }
             }
-
           }
         });
       };

--- a/seed/views/tax_lot_properties.py
+++ b/seed/views/tax_lot_properties.py
@@ -142,8 +142,12 @@ class TaxLotPropertyViewSet(GenericViewSet):
             order_dict = {obj_id: index for index, obj_id in enumerate(ids)}
             data.sort(key=lambda x: order_dict[x['id']])  # x is the property/taxlot object
 
-        # header
-        writer.writerow(column_name_mappings.values())
+        # check the first item in the header and make sure that it isn't ID (it can be id, or iD).
+        # excel doesn't like the first item to be ID in a CSV
+        header = column_name_mappings.values()
+        if header[0] == 'ID':
+            header[0] = 'id'
+        writer.writerow(header)
 
         # iterate over the results to preserve column order and write row.
         for datum in data:


### PR DESCRIPTION
#### Any background context you want to provide?
If a CSV's first cell is ID, then Excel (on Windows) thinks it is a symbolically linked file. The first cell can be anything else (e.g. id, Id, iD). 

#### What's this PR do?
* Fixes CSV export
* This also fixes the export if the user does not have a list setting defined.

#### How should this be manually tested?
* From existing inventory, select some rows, then export using drop down menu. 
* Ensure file does not have ID (uppercased) as first cell
* Also, go to an inventory without a list setting. Do the same thing and make sure there are no angular errors.

#### What are the relevant tickets?
#1672 

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?