### PR TITLE
Fixed the spinner visibility during routing transitions

### DIFF
--- a/seed/static/seed/js/controllers/menu_controller.js
+++ b/seed/static/seed/js/controllers/menu_controller.js
@@ -48,46 +48,16 @@ angular.module('BE.seed.controller.menu', [])
       $scope.search_input = '';
       $scope.organizations_count = 0;
       $scope.menu = {
-        loading: false,
-        route_load_error: false,
         user: {}
       };
       $scope.saving_indicator = false;
       $scope.is_initial_state = $scope.expanded_controller === $scope.collapsed_controller;
 
-      $rootScope.$on('$stateChangeError', function (event, toState, toParams, fromState, fromParams, error) {
-        $scope.menu.loading = false;
-        $scope.menu.route_load_error = true;
-        $log.error(error);
-        if (error === 'not authorized' || error === 'Your page could not be located!') {
-          $scope.menu.error_message = $translate.instant(error);
-        }
-        spinner_utility.hide();
-      });
-      $rootScope.$on('$stateChangeStart', function (event, toState, toParams) {
-        if (modified_service.isModified()) {
-          event.preventDefault();
-
-          modified_service.showModifiedDialog().then(function () {
-            modified_service.resetModified();
-            $state.go(toState, toParams);
-          });
-
-        } else {
-          $scope.menu.loading = toState.controller === 'mapping_controller';
-          spinner_utility.show();
-        }
-      });
-      $rootScope.$on('$stateChangeSuccess', function () {
-        $scope.menu.loading = false;
-        $scope.menu.route_load_error = false;
-        spinner_utility.hide();
-      });
-      $rootScope.$on('$stateNotFound', function (event, unfoundState) {
-        $log.error('State not found:', unfoundState.to);
-      });
+      $scope.hide_load_error = function () {
+        $rootScope.route_load_error = false;
+      };
       $scope.$on('app_error', function (event, data) {
-        $scope.menu.route_load_error = true;
+        $rootScope.route_load_error = true;
         $scope.menu.error_message = data.message;
       });
       $scope.$on('show_saving', function () {

--- a/seed/templates/seed/index.html
+++ b/seed/templates/seed/index.html
@@ -14,14 +14,13 @@
             {% include "seed/_header.html" %}
 
             <div class="page">
-                <div class="alert warning" ng-show="menu.route_load_error">
+                <div class="alert warning" ng-show="route_load_error">
                     <div class="alert alert-danger">
-                        <button type="button" class="close" ng-click="menu.route_load_error = false">&times;</button>
-                        {$ menu.error_message || ('There was an error loading the page' | translate) $}
+                        <button type="button" class="close" ng-click="hide_load_error()">&times;</button>
+                        {$ load_error_message || ('There was an error loading the page' | translate) $}
                     </div>
                 </div>
-                <div class="section_tab_container" ng-show="menu.loading"><p translate>Please wait while your data is loaded...</p></div>
-                <div ng-hide="menu.loading" ui-view></div>
+                <div ui-view></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
#### Any background context you want to provide?
The loading spinner that used to appear when clicking on new pages stopped showing up after upgrading the angular ui-router.

#### What's this PR do?
Restores the spinner behavior

#### How should this be manually tested?
Check that the spinner is visible during page transitions, particularly for long-running transitions like going to the inventory list view.

#1702 