### PR TITLE
Create default columns managed task

### DIFF
--- a/seed/data_importer/views.py
+++ b/seed/data_importer/views.py
@@ -1889,7 +1889,7 @@ class ImportFileViewSet(viewsets.ViewSet):
                 if destination_field is None:
                     suggested_mappings[m][1] = u''
 
-        # Fix the table name, eventually move this to the build_column_mapping and build_pm_mapping
+        # Fix the table name, eventually move this to the build_column_mapping
         for m in suggested_mappings:
             table, _destination_field, _confidence = suggested_mappings[m]
             if not table:

--- a/seed/lib/mappings/test.py
+++ b/seed/lib/mappings/test.py
@@ -1,0 +1,51 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2018, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+import logging
+
+from django.test import TestCase
+
+from seed.lib.mappings.mapping_columns import MappingColumns
+
+logger = logging.getLogger(__name__)
+
+
+class TestMappingColumns(TestCase):
+    def test_unicode_in_destination(self):
+        raw_columns = ['foot', 'ankle', 'stomach']
+        dest_columns = ['big foot', 'crankle', u'estómago']
+        results = MappingColumns(raw_columns, dest_columns)
+
+        expected = {
+            'foot': ['_', 'big foot', 45],
+            'ankle': ['_', 'crankle', 90],
+            'stomach': ['_', u'est\xf3mago', 69]
+        }
+        self.assertDictEqual(expected, results.final_mappings)
+
+    def test_unicode_in_raw(self):
+        raw_columns = ['big foot', 'crankle', u'estómago']
+        dest_columns = ['foot', 'ankle', 'stomach', u'estooomago']
+        results = MappingColumns(raw_columns, dest_columns)
+
+        expected = {
+            'crankle': ['_', 'ankle', 90],
+            'big foot': ['_', 'foot', 45],
+            u'est\xf3mago': ['_', u'estooomago', 83]
+        }
+        self.assertDictEqual(expected, results.final_mappings)
+
+    def test_resolve_duplicate(self):
+        raw_columns = ['estomago', 'stomach']
+        dest_columns = [u'estómago']
+        results = MappingColumns(raw_columns, dest_columns)
+
+        # Note that the stomach will resolve as 'PropertyState' by default.
+        expected = {
+            'estomago': ['_', u'est\xf3mago', 94],
+            'stomach': ['PropertyState', 'stomach', 100]
+        }
+        self.assertDictEqual(expected, results.final_mappings)

--- a/seed/lib/mcm/mapper.py
+++ b/seed/lib/mcm/mapper.py
@@ -6,29 +6,20 @@
 """
 
 import copy
+import itertools
 import logging
 import re
-
-import itertools
 from datetime import datetime, date
+
+from django.apps import apps
 
 from cleaners import default_cleaner
 from seed.lib.mappings.mapping_columns import MappingColumns
-from django.apps import apps
 
 _log = logging.getLogger(__name__)
 
 
-def build_pm_mapping():
-    """
-    Build the Portfolio Manager mappings.
-
-    :return:
-    """
-
-    return True
-
-
+# TODO: Remove this method in favor of calling MappingColumns directly
 def build_column_mapping(raw_columns, dest_columns, previous_mapping=None, map_args=None,
                          default_mappings=None, thresh=0):
     """
@@ -57,7 +48,8 @@ def build_column_mapping(raw_columns, dest_columns, previous_mapping=None, map_a
     """
 
     return MappingColumns(raw_columns, dest_columns, previous_mapping=previous_mapping,
-                          map_args=map_args, default_mappings=default_mappings, threshold=thresh).final_mappings
+                          map_args=map_args, default_mappings=default_mappings,
+                          threshold=thresh).final_mappings
 
 
 def apply_initial_data(model, initial_data):
@@ -108,7 +100,8 @@ def apply_column_value(raw_column_name, column_value, model, mapping, is_extra_d
         if cleaner:
             # Get the list of Quantity fields from the Column object in SEED. This is non-ideal, since the
             # rest of the mapping code does not use SEED models. Perhaps make this an argument.
-            if (model.__class__.__name__, mapped_column_name) in apps.get_model('seed', 'Column').QUANTITY_UNIT_COLUMNS:
+            if (model.__class__.__name__, mapped_column_name) in apps.get_model('seed',
+                                                                                'Column').QUANTITY_UNIT_COLUMNS:
                 # clean against the database type first
                 cleaned_value = cleaner.clean_value(column_value, mapped_column_name)
 

--- a/seed/management/commands/create_default_columns.py
+++ b/seed/management/commands/create_default_columns.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright (c) 2014 - 2018, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+from django.core.management.base import BaseCommand
+
+from seed.lib.superperms.orgs.models import Organization
+from seed.models import Column
+from seed.utils.organizations import _create_default_columns
+
+
+class Command(BaseCommand):
+    help = 'Creates the default columns of an organization if there are none'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--org_id',
+                            default=None,
+                            help='Organization to add defaut columns',
+                            action='store')
+
+    def handle(self, *args, **options):
+        if options['org_id']:
+            orgs = Organization.objects.filter(pk=options['org_id'])
+        else:
+            orgs = Organization.objects.all().order_by('id')
+
+        for org in orgs:
+            self.stdout.write("Checking if organization %s has any columns" % org.id)
+            if Column.objects.filter(organization=org).count() == 0:
+                self.stdout.write("  Organization has no columns, adding")
+                _create_default_columns(org.id)
+            else:
+                self.stdout.write("  Organization already has columns, skipping")


### PR DESCRIPTION
#### Any background context you want to provide?
During migration, some organizations may not have received the default columns. Without the default columns many of the screens won't work correctly.

#### What's this PR do?
Adds a managed task to allow the user to manually create the default columns. Default columns will only be created in organizations that have no existing columns.


#### How should this be manually tested?
In a test database, remove all the columns of an existing organization. It is easiest to create a new org and remove the columns since the column list settings and column mappings do not exist in a vanilla organization.
```
# Check and create default columns in all organization that do not have columns
./manage.py create_default_columns

# Check and create default columns for a specific organization
./manage.py create_default_columns --org_id 8
```

#### What are the relevant tickets?
None
#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?