### PR TITLE
Fix the reversed column order when saving a new settings profile

### DIFF
--- a/seed/static/seed/js/controllers/settings_profile_modal_controller.js
+++ b/seed/static/seed/js/controllers/settings_profile_modal_controller.js
@@ -42,6 +42,7 @@ angular.module('BE.seed.controller.settings_profile_modal', [])
             inventory_type: $scope.inventory_type,
             columns: $scope.data
           }).then(function (result) {
+            result.columns = _.sortBy(result.columns, ['order', 'column_name']);
             $uibModalInstance.close(result);
           });
         }


### PR DESCRIPTION
#### What's this PR do?
Fixes the reversed order of columns after saving a [detail] settings profile
#### How should this be manually tested?
See #1694
#### What are the relevant tickets?
#1694 
