### PR TITLE
No measures in BuildingSync scenario

### DIFF
--- a/bin/backup_database.sh
+++ b/bin/backup_database.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
 # Nightly backups - crontab
-# 0 0 * * * /home/ubuntu/prj/seed/bin/backup_database.sh <db_name> <db_username> <db_password>
+# 0 0 * * * /home/ubuntu/prj/seed/bin/backup_database.sh <db_name> <db_username> <db_password> <media_dir>
 
 DB_NAME=$1
 DB_USERNAME=$2
 # Set PGPASSWORD as pg_dump uses this env var.
 DB_PASSWORD=$3
+MEDIA_DIR=$4
 
 function file_name(){
     echo ${BACKUP_DIR}/${DB_NAME}_$(date '+%Y%m%d_%H%M%S').dump
+}
+
+function media_file_name(){
+    echo ${BACKUP_DIR}/${DB_NAME}_media_$(date '+%Y%m%d_%H%M%S').tgz
 }
 
 if [[ (-z ${DB_NAME}) || (-z ${DB_USERNAME}) || (-z ${DB_PASSWORD}) ]] ; then
@@ -28,3 +33,8 @@ unset PGPASSWORD
 
 # Delete files older than 45 days
 find ${BACKUP_DIR} -mtime +45 -type f -name '*.dump' -delete
+
+# Also backup the media directory (uploads, especially buildingsync)
+if [[ (! -z ${MEDIA_DIR}) ]] ; then
+  tar zcvf $(media_file_name) ${MEDIA_DIR}
+fi

--- a/seed/models/building_file.py
+++ b/seed/models/building_file.py
@@ -218,8 +218,8 @@ class BuildingFile(models.Model):
                 if len(ref_case) == 1:
                     scenario.reference_case = ref_case.first()
 
-            # set the list of measures
-            for measure_name in s['measures']:
+            # set the list of measures. Note that this can be empty (e.g. baseline has no measures)
+            for measure_name in s.get('measures', []):
                 # find the join measure in the database
                 measure = None
                 try:

--- a/seed/static/seed/partials/inventory_detail.html
+++ b/seed/static/seed/partials/inventory_detail.html
@@ -240,7 +240,6 @@
                             </thead>
                             <tbody>
                                 <tr ng-repeat="file in item_state.files">
-                                    console.dir(item_state.files)
                                     <td> {$ file.file_type $}</td>
                                     <td><a href='{$ file.file $}'>{$ file.filename $}</a></td>
                                     <td>{$ file.created | date: 'yyyy-MM-dd h:mm a' $}</a></td>


### PR DESCRIPTION
#### Any background context you want to provide?
When uploading a BuildingSync file to an existing property and the BuildingSync file has a scenario with no measures, the app would crash.

#### What's this PR do?
* Fixes the crashing when no measures are in a scenario
* Add backup for the media data

#### How should this be manually tested?
If you have a buildingsync file that has a scenario with no measures, then use that.

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?