### PR TITLE
Return PropertyView ID from Label Filter API

### DIFF
--- a/seed/serializers/labels.py
+++ b/seed/serializers/labels.py
@@ -58,8 +58,8 @@ class LabelSerializer(serializers.ModelSerializer):
 
             # Limit results to ones attached to view
             if self.inventory.model is Property:
-                filtered_result = PropertyView.objects.filter(property_id__in=result).values_list('pk', flat=True)
+                filtered_result = PropertyView.objects.filter(property_id__in=result).values_list('property_id', flat=True)
             elif self.inventory.model is TaxLot:
-                filtered_result = TaxLotView.objects.filter(taxlot_id__in=result).values_list('pk', flat=True)
+                filtered_result = TaxLotView.objects.filter(taxlot_id__in=result).values_list('taxlot_id', flat=True)
 
         return filtered_result

--- a/seed/serializers/labels.py
+++ b/seed/serializers/labels.py
@@ -58,8 +58,8 @@ class LabelSerializer(serializers.ModelSerializer):
 
             # Limit results to ones attached to view
             if self.inventory.model is Property:
-                filtered_result = PropertyView.objects.filter(property_id__in=result).values_list('property_id', flat=True)
+                filtered_result = PropertyView.objects.filter(property_id__in=result).values_list('pk', flat=True)
             elif self.inventory.model is TaxLot:
-                filtered_result = TaxLotView.objects.filter(taxlot_id__in=result).values_list('taxlot_id', flat=True)
+                filtered_result = TaxLotView.objects.filter(taxlot_id__in=result).values_list('pk', flat=True)
 
         return filtered_result

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -182,7 +182,12 @@ angular.module('BE.seed.controller.inventory_list', [])
       };
 
       function updateApplicableLabels() {
-        var inventoryIds = _.map($scope.data, 'id').sort();
+        var inventoryIds;
+        if ($scope.inventory_type === 'properties') {
+          inventoryIds = _.map($scope.data, 'property_view_id').sort();
+        } else {
+          inventoryIds = _.map($scope.data, 'taxlot_view_id').sort();
+        }
         $scope.labels = _.filter(labels, function (label) {
           return _.some(label.is_applied, function (id) {
             return _.includes(inventoryIds, id);
@@ -210,11 +215,17 @@ angular.module('BE.seed.controller.inventory_list', [])
 
         if ($scope.selected_labels.length) {
           _.forEach($scope.gridApi.grid.rows, function (row) {
+            var view_id;
+            if ($scope.inventory_type === 'properties') {
+              view_id = row.entity.property_view_id;
+            } else {
+              view_id = row.entity.taxlot_view_id;
+            }
             if ($scope.labelLogic === 'exclude') {
-              if ((_.includes(ids, row.entity.id) && row.treeLevel === 0) || !_.has(row, 'treeLevel')) $scope.gridApi.core.setRowInvisible(row);
+              if ((_.includes(ids, view_id) && row.treeLevel === 0) || !_.has(row, 'treeLevel')) $scope.gridApi.core.setRowInvisible(row);
               else $scope.gridApi.core.clearRowInvisible(row);
             } else {
-              if ((!_.includes(ids, row.entity.id) && row.treeLevel === 0) || !_.has(row, 'treeLevel')) $scope.gridApi.core.setRowInvisible(row);
+              if ((!_.includes(ids, view_id) && row.treeLevel === 0) || !_.has(row, 'treeLevel')) $scope.gridApi.core.setRowInvisible(row);
               else $scope.gridApi.core.clearRowInvisible(row);
             }
           });


### PR DESCRIPTION
#### Any background context you want to provide?
The result of the /api/v2/labels/filter returns the property ID which makes little since due to the fact that other API calls typically use the property view id (e.g. /api/v2/properties/<property_view_id>.

`{id: 4142, name: "Call", color: "blue", organization_id: 278, is_applied: [498379]}`

#### What's this PR do?
Change the backend and frontend to return property_view_id

#### How should this be manually tested?
* unit tests.
* in existing database, add label, check to make sure it is assigned to the right property. 
* Check API call to ensure tha the is_applied id is the property_view id.

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?