### PR TITLE
421 reports no data and X-Axis options

### DIFF
--- a/seed/static/seed/js/controllers/inventory_reports_controller.js
+++ b/seed/static/seed/js/controllers/inventory_reports_controller.js
@@ -15,6 +15,7 @@ angular.module('BE.seed.controller.inventory_reports', [])
     '$stateParams',
     'inventory_reports_service',
     'simple_modal_service',
+    'columns',
     'cycles',
     'organization_payload',
     'flippers',
@@ -25,6 +26,7 @@ angular.module('BE.seed.controller.inventory_reports', [])
               $stateParams,
               inventory_reports_service,
               simple_modal_service,
+              columns,
               cycles,
               organization_payload,
               flippers,
@@ -75,58 +77,54 @@ angular.module('BE.seed.controller.inventory_reports', [])
         return str;
       };
 
+      var parse_axis_label = function(column) {
+        if (column.column_name.includes('eui')) {
+          return translateAxisLabel(column.displayName, eui_units());
+        } else if (column.column_name.includes('area')) {
+          return translateAxisLabel(column.displayName, area_units());
+        } else {
+          return $translate.instant(column.displayName);
+        };
+      };
+
       /* SCOPE VARS */
       /* ~~~~~~~~~~ */
 
       /** Chart variables :
-       these next two arrays, $scope.xAxisVars and $scope.yAxisVars, define the various properties
+       These next two scoped arrays, $scope.xAxisVars and $scope.yAxisVars, define the various properties
        of the variables the user can select for graphing.
 
-       Each object contains information used by the dropdown controls as well as information
-       used to customize the chart specifically for that value (e.g. axisTickFormat)
+       Each object contains information used by the dropdown controls.
 
+       $scope.xAxisVars consists of columns specified as numeric types.
+
+       $scope.uAxisVars consists of manually defined columns specified.
        Ideally, if we need to add new variables, we should just be able to add a new object to
        either of these arrays. (However, at first when adding new variables we might need to add
        new functionality to the directive to handle any idiosyncrasies of graphing that new variable.)
        */
-      $scope.xAxisVars = [
-        {
-          name: $translate.instant('Site EUI'),                     //short name for variable, used in pulldown
-          label: $translate.instant('Site Energy Use Intensity'),   //full name for variable
-          varName: 'site_eui',                  //name of variable, to be sent to server
-          axisLabel: translateAxisLabel('Site EUI', eui_units()),     //label to be used in charts, should include units
-          axisType: 'Measure',                  //DimpleJS property for axis type
-          axisTickFormat: ',.0f'                //DimpleJS property for axis tick format
-        }, {
-          name: $translate.instant('Source EUI'),
-          label: $translate.instant('Source Energy Use Intensity'),
-          varName: 'source_eui',
-          axisLabel: translateAxisLabel('Source EUI', eui_units()),
-          axisType: 'Measure',
-          axisTickFormat: ',.0f'
-        }, {
-          name: $translate.instant('Weather Norm. Site EUI'),
-          label: $translate.instant('Weather Normalized Site Energy Use Intensity'),
-          varName: 'site_eui_weather_normalized',
-          axisLabel: translateAxisLabel('Weather Normalized Site EUI', eui_units()),
-          axisType: 'Measure',
-          axisTickFormat: ',.0f'
-        }, {
-          name: $translate.instant('Weather Norm. Source EUI'),
-          label: $translate.instant('Weather Normalized Source Energy Use Intensity'),
-          varName: 'source_eui_weather_normalized',
-          axisLabel: translateAxisLabel('Weather Normalized Source EUI', eui_units()),
-          axisType: 'Measure',
-          axisTickFormat: ',.0f'
-        }, {
-          name: $translate.instant('ENERGY STAR Score'),
-          label: $translate.instant('ENERGY STAR Score'),
-          varName: 'energy_score',
-          axisLabel: translateAxisLabel('ENERGY STAR Score'),
-          axisType: 'Measure',
-          axisTickFormat: ',.0f'
+
+      var acceptable_column_types = [
+        'area',
+        'eui',
+        'float',
+        'integer',
+        'number',
+      ]
+      var filtered_columns = _.filter(columns, function (column) {
+          return _.includes(acceptable_column_types, column.data_type);
+      });
+
+      $scope.xAxisVars = _.map(filtered_columns, function (column) {
+        return {
+          name: $translate.instant(column.displayName),    //short name for variable, used in pulldown
+          label: $translate.instant(column.displayName),   //full name for variable
+          varName: column.column_name,                     //name of variable, to be sent to server
+          axisLabel: parse_axis_label(column),             //label to be used in charts, should include units
+          axisType: 'Measure',                             //DimpleJS property for axis type
+          axisTickFormat: ',.0f'                           //DimpleJS property for axis tick format
         }
-      ];
+      });
 
       $scope.yAxisVars = [
         {

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -358,6 +358,33 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
         templateUrl: static_url + 'seed/partials/inventory_reports.html',
         controller: 'inventory_reports_controller',
         resolve: {
+          columns: ['$stateParams', 'user_service', 'inventory_service', 'naturalSort', function ($stateParams, user_service, inventory_service, naturalSort) {
+            var organization_id = user_service.get_organization().id;
+            console.log(organization_id);
+            if ($stateParams.inventory_type === 'properties') {
+              return inventory_service.get_property_columns_for_org(organization_id).then(function (columns) {
+                columns = _.reject(columns, 'related');
+                columns = _.map(columns, function (col) {
+                  return _.omit(col, ['pinnedLeft', 'related']);
+                });
+                columns.sort(function (a, b) {
+                  return naturalSort(a.displayName, b.displayName);
+                });
+                return columns;
+              });
+            } else if ($stateParams.inventory_type === 'taxlots') {
+              return inventory_service.get_taxlot_columns_for_org(organization_id).then(function (columns) {
+                columns = _.reject(columns, 'related');
+                columns = _.map(columns, function (col) {
+                  return _.omit(col, ['pinnedLeft', 'related']);
+                });
+                columns.sort(function (a, b) {
+                  return naturalSort(a.displayName, b.displayName);
+                });
+                return columns;
+              });
+            }
+          }],
           cycles: ['cycle_service', function (cycle_service) {
             return cycle_service.get_cycles();
           }],

--- a/seed/views/reports.py
+++ b/seed/views/reports.py
@@ -144,26 +144,21 @@ class Report(DecoratorMixin(drf_api_endpoint), ViewSet):
                 params['organization_id'], cycles,
                 params['x_var'], params['y_var'], campus_only
             )
-            empty = True
             for datum in data:
                 if datum['property_counts']['num_properties_w-data'] != 0:
                     empty = False
                     break
-            if empty:
-                result = {'status': 'error', 'message': 'No data found'}
-                status_code = status.HTTP_404_NOT_FOUND
-            else:
-                property_counts = []
-                chart_data = []
-                for datum in data:
-                    property_counts.append(datum['property_counts'])
-                    chart_data.extend(datum['chart_data'])
-                data = {
-                    'property_counts': property_counts,
-                    'chart_data': chart_data,
-                }
-                result = {'status': 'success', 'data': data}
-                status_code = status.HTTP_200_OK
+            property_counts = []
+            chart_data = []
+            for datum in data:
+                property_counts.append(datum['property_counts'])
+                chart_data.extend(datum['chart_data'])
+            data = {
+                'property_counts': property_counts,
+                'chart_data': chart_data,
+            }
+            result = {'status': 'success', 'data': data}
+            status_code = status.HTTP_200_OK
         return Response(result, status=status_code)
 
     def get_aggregated_property_report_data(self, request):

--- a/seed/views/reports.py
+++ b/seed/views/reports.py
@@ -125,19 +125,10 @@ class Report(DecoratorMixin(drf_api_endpoint), ViewSet):
         params = {}
         missing_params = []
         error = ''
-        valid_values = [
-            'site_eui', 'source_eui', 'site_eui_weather_normalized',
-            'source_eui_weather_normalized', 'energy_score',
-            'gross_floor_area', 'use_description', 'year_built'
-        ]
         for param in ['x_var', 'y_var', 'organization_id', 'start', 'end']:
             val = request.query_params.get(param, None)
             if not val:
                 missing_params.append(param)
-            elif param in ['x_var', 'y_var'] and val not in valid_values:
-                error = "{} {} is not a valid value for {}.".format(
-                    error, val, param
-                )
             else:
                 params[param] = val
         if missing_params:
@@ -177,10 +168,6 @@ class Report(DecoratorMixin(drf_api_endpoint), ViewSet):
 
     def get_aggregated_property_report_data(self, request):
         campus_only = request.query_params.get('campus_only', False)
-        valid_x_values = [
-            'site_eui', 'source_eui', 'site_eui_weather_normalized',
-            'source_eui_weather_normalized', 'energy_score',
-        ]
         valid_y_values = ['gross_floor_area', 'use_description', 'year_built']
         params = {}
         missing_params = []
@@ -190,10 +177,6 @@ class Report(DecoratorMixin(drf_api_endpoint), ViewSet):
             val = request.query_params.get(param, None)
             if not val:
                 missing_params.append(param)
-            elif param == 'x_var' and val not in valid_x_values:
-                error = "{} {} is not a valid value for {}.".format(
-                    error, val, param
-                )
             elif param == 'y_var' and val not in valid_y_values:
                 error = "{} {} is not a valid value for {}.".format(
                     error, val, param

--- a/seed/views/reports.py
+++ b/seed/views/reports.py
@@ -146,7 +146,6 @@ class Report(DecoratorMixin(drf_api_endpoint), ViewSet):
             )
             for datum in data:
                 if datum['property_counts']['num_properties_w-data'] != 0:
-                    empty = False
                     break
             property_counts = []
             chart_data = []


### PR DESCRIPTION
#### Any background context you want to provide?
The Inventory Report page had a bug where no data meant a bad HTTP request (404). Also on that same page, X-Axis choices were hard-coded.

#### What's this PR do?
The no data bug has been fixed, and X-Axis choices are now all columns with numeric types.

#### How should this be manually tested?
**NOTE**: I had a pretty limited dataset, and I'm less confident in my ability to map columns correctly - I'm not very familiar with building/energy terminology. 
Please test this locally by updating the type of one of the org's columns to be numeric. Then go back into the Inventory Report page to graph different columns.

#### What are the relevant tickets?
Issue #421

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?