### PR TITLE
Skip PM tests while PM is down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ src/
 *node_modules*
 bower_components/
 
+# JetBrainz tends to suggest a venv directory in the project root for virtual environments
+venv/
+
 package-lock.json
 dump.rdb
 log/*.log

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,8 +51,8 @@ lxml==4.2.5
 probablepeople==0.5.4
 
 enum34==1.1.6  # enum34 needs to be specified to support cryptography and oauth2
+oauthlib==2.0.2
 jwt-oauth2>=0.1.1
 django-oauth-toolkit==0.12.0
-django-braces>=1.11.0
 
 future==0.16.0

--- a/seed/tests/test_portfoliomanager.py
+++ b/seed/tests/test_portfoliomanager.py
@@ -28,14 +28,17 @@ pm_skip_test_check = skipIf(
 )
 
 # override this decorator for more pressing conditions
-pm_avail_check = requests.get('https://isthewallbuilt.us/api')
-string_response = pm_avail_check.content.decode("utf-8").strip()
-if string_response == 'yes':
-    government_going = True
-else:
-    government_going = False
-if not government_going:
-    pm_skip_test_check = skip('Government shutdown has forced ESPM to shut down temporarily, test cannot run')
+try:
+    pm_avail_check = requests.get('http://isthewallbuilt.us/api', timeout=5)
+    string_response = pm_avail_check.content.decode("utf-8").strip()
+    if string_response == 'yes':
+        skip_due_to_espm_down = True
+    else:
+        skip_due_to_espm_down = False
+    if skip_due_to_espm_down:
+        pm_skip_test_check = skip('ESPM is likely down temporarily, ESPM tests will not run')
+except Exception:
+    pass
 
 
 class PortfolioManagerImportTest(TestCase):

--- a/seed/tests/test_portfoliomanager.py
+++ b/seed/tests/test_portfoliomanager.py
@@ -30,9 +30,8 @@ pm_skip_test_check = skipIf(
 # override this decorator for more pressing conditions
 try:
     pm_avail_check = requests.get('http://isthewallbuilt.us/api.json', timeout=5)
-    string_response = pm_avail_check.content.decode("utf-8").strip()
-    data = json.loads(string_response)
-    if data['status'] == 'yes':
+    string_response = pm_avail_check.json()['status']
+    if string_response == 'no':
         skip_due_to_espm_down = True
     else:
         skip_due_to_espm_down = False

--- a/seed/tests/test_portfoliomanager.py
+++ b/seed/tests/test_portfoliomanager.py
@@ -29,9 +29,10 @@ pm_skip_test_check = skipIf(
 
 # override this decorator for more pressing conditions
 try:
-    pm_avail_check = requests.get('http://isthewallbuilt.us/api', timeout=5)
+    pm_avail_check = requests.get('http://isthewallbuilt.us/api.json', timeout=5)
     string_response = pm_avail_check.content.decode("utf-8").strip()
-    if string_response == 'yes':
+    data = json.loads(string_response)
+    if data['status'] == 'yes':
         skip_due_to_espm_down = True
     else:
         skip_due_to_espm_down = False


### PR DESCRIPTION
#### Any background context you want to provide?
Due to reasons, PM is currently unavailable.  The SEED-PM connection is tested with several unit tests.  Once PM went down, these tests starting failing, as they should.  But this issue with PM should not really cause SEED's test dashboard to be red, so we'll skip these for now.

#### What's this PR do?
Adds some logic to try to determine whether ESPM is actually available.  Even during this "down" time, the site is still running, so we can't just check the return code from the request.  

#### How should this be manually tested?
Just run the entire test suite of SEED, it should now all pass, with a few skipped.

#### What are the relevant tickets?
I don't believe there are any yet, I was just informed the tests were failing, and why.