### PR TITLE
1807 no extra data

### DIFF
--- a/seed/data_importer/views.py
+++ b/seed/data_importer/views.py
@@ -864,7 +864,8 @@ class ImportFileViewSet(viewsets.ViewSet):
                 prop_dict.update(
                     TaxLotProperty.extra_data_to_dict_with_mapping(
                         prop.extra_data,
-                        property_column_name_mapping
+                        property_column_name_mapping,
+                        fields=prop.extra_data.keys(),
                     ).items()
                 )
                 property_results.append(prop_dict)
@@ -889,7 +890,8 @@ class ImportFileViewSet(viewsets.ViewSet):
                 tax_lot_dict.update(
                     TaxLotProperty.extra_data_to_dict_with_mapping(
                         tax_lot.extra_data,
-                        taxlot_column_name_mapping
+                        taxlot_column_name_mapping,
+                        fields=tax_lot.extra_data.keys(),
                     ).items()
                 )
                 tax_lot_results.append(tax_lot_dict)
@@ -1603,9 +1605,9 @@ class ImportFileViewSet(viewsets.ViewSet):
         import_file = ImportFile.objects.get(pk=pk)
         organization = import_file.import_record.super_organization
         mappings = body.get('mappings', [])
-        status = Column.create_mappings(mappings, organization, request.user, import_file.id)
+        result = Column.create_mappings(mappings, organization, request.user, import_file.id)
 
-        if status:
+        if result:
             return JsonResponse({'status': 'success'})
         else:
             return JsonResponse({'status': 'error'})

--- a/seed/lib/mappings/data/pm-mapping.json
+++ b/seed/lib/mappings/data/pm-mapping.json
@@ -129,6 +129,15 @@
     "display_name": "Gross Floor Area",
     "to_field": "gross_floor_area",
     "to_table_name": "PropertyState",
+    "from_field": "Gross Floor Area",
+    "units": "ft**2",
+    "type": "float",
+    "schema": ""
+  },
+  {
+    "display_name": "Gross Floor Area",
+    "to_field": "gross_floor_area",
+    "to_table_name": "PropertyState",
     "from_field": "propGrossFloorArea",
     "units": "ft**2",
     "type": "float",


### PR DESCRIPTION
#### Any background context you want to provide?
There was an issue where only 'actual' database fields were showing up in the mappings review screen. 

#### What's this PR do?
* Enable showing of all columns on the mapping review page
* Allow "Gross Floor Area" to be a known column for ESPM. This prevents the column from being an 'extra data' column. 

#### How should this be manually tested?
Follow instructions on issue #1807 

#### What are the relevant tickets?
#1807 

