### PR TITLE
force running npm install inside the vendors directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,8 +6,9 @@
 ./deploy.sh
 **/*.pyc
 collected_static
+docs
 media
 node_modules
-seed/static/vendors
+vendors/node_modules
 config/settings/local_untracked.py
 config/settings/local_untracked.py.dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,12 @@ RUN pip install -r requirements/aws.txt
 COPY ./package.json /seed/package.json
 COPY ./vendors/package.json /seed/vendors/package.json
 COPY ./README.md /seed/README.md
-COPY ./bin/install_javascript_dependencies.sh /seed/bin/install_javascript_dependencies.sh
-RUN npm update && /seed/bin/install_javascript_dependencies.sh
+RUN npm update && npm install
+WORKDIR /seed/vendors
+RUN npm install
 
 ### Copy over the remaining part of the SEED application and some helpers
+WORKDIR /seed
 COPY . /seed/
 COPY ./docker/wait-for-it.sh /usr/local/wait-for-it.sh
 

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -120,10 +120,9 @@ HIGH_DEPENDENCY_APPS = ('seed.landing',)  # 'landing' contains SEEDUser
 
 INSTALLED_APPS = HIGH_DEPENDENCY_APPS + INSTALLED_APPS + SEED_CORE_APPS
 
-# apps to auto load name spaced URLs for JS use (see seed.urls and seed.main.views.home)
+# apps to auto load name spaced URLs for JS use (see seed.urls)
 SEED_URL_APPS = (
     'seed',
-    'audit_logs',
 )
 
 MEDIA_URL = '/media/'
@@ -138,12 +137,12 @@ COMPRESS_CSS_FILTERS = [
     'compressor.filters.cssmin.CSSMinFilter'
 ]
 STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'seed/landing/static'),
     os.path.join(BASE_DIR, 'seed/static'),
     os.path.join(BASE_DIR, 'vendors')
 ]
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'compressor.finders.CompressorFinder',
 )
 COMPRESS_PRECOMPILERS = (


### PR DESCRIPTION
#### Any background context you want to provide?
Collected static files were not loading correctly when deploying with Docker. This worked if the user installed the static files (`npm install`) on the base box before running docker compose commands.

#### What's this PR do?
* fixes the static files in docker

#### How should this be manually tested?
* deploy and verify all works as expected.

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, do pip or npm requirements need to be updated?
