### PR TITLE
Fixed showing extra_data in the merge modal

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -23,6 +23,7 @@ angular.module('BE.seed.controller.inventory_list', [])
     'spinner_utility',
     'naturalSort',
     '$translate',
+    'uiGridConstants',
     'i18nService', // from ui-grid
     function (
       $scope,
@@ -44,6 +45,7 @@ angular.module('BE.seed.controller.inventory_list', [])
       spinner_utility,
       naturalSort,
       $translate,
+      uiGridConstants,
       i18nService
     ) {
       spinner_utility.show();
@@ -443,7 +445,8 @@ angular.module('BE.seed.controller.inventory_list', [])
       });
 
       // Data
-      var processData = function () {
+      var processData = function (data) {
+        if (_.isUndefined(data)) data = $scope.data;
         var visibleColumns = _.map($scope.columns, 'name')
           .concat(['$$treeLevel', 'notes_count', 'id', 'property_state_id', 'property_view_id', 'taxlot_state_id', 'taxlot_view_id']);
 
@@ -453,7 +456,6 @@ angular.module('BE.seed.controller.inventory_list', [])
         }, {});
         var columnNamesToAggregate = _.keys(columnsToAggregate);
 
-        var data = $scope.data;
         var roots = data.length;
         for (var i = 0, trueIndex = 0; i < roots; ++i, ++trueIndex) {
           data[trueIndex].$$treeLevel = 0;
@@ -504,21 +506,23 @@ angular.module('BE.seed.controller.inventory_list', [])
 
       var refresh_objects = function () {
         spinner_utility.show();
+        var promise;
         if ($scope.inventory_type === 'properties') {
-          inventory_service.get_properties($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle, _.has($scope.currentProfile, 'id') ? $scope.currentProfile.id : undefined).then(function (properties) {
-            $scope.data = properties.results;
+          promise = inventory_service.get_properties($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle, _.has($scope.currentProfile, 'id') ? $scope.currentProfile.id : undefined).then(function (properties) {
+            processData(properties.results);
             $scope.pagination = properties.pagination;
-            processData();
             spinner_utility.hide();
           });
         } else if ($scope.inventory_type === 'taxlots') {
-          inventory_service.get_taxlots($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle, _.has($scope.currentProfile, 'id') ? $scope.currentProfile.id : undefined).then(function (taxlots) {
-            $scope.data = taxlots.results;
+          promise = inventory_service.get_taxlots($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle, _.has($scope.currentProfile, 'id') ? $scope.currentProfile.id : undefined).then(function (taxlots) {
+            processData(taxlots.results);
             $scope.pagination = taxlots.pagination;
-            processData();
             spinner_utility.hide();
           });
         }
+        return promise.then(function () {
+          $scope.gridApi.core.notifyDataChange(uiGridConstants.dataChange.EDIT);
+        });
       };
 
       $scope.update_cycle = function (cycle) {

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -295,7 +295,7 @@ angular.module('BE.seed.controller.inventory_list', [])
               var data = new Array($scope.selectedOrder.length);
 
               if ($scope.inventory_type === 'properties') {
-                return inventory_service.get_properties(1, undefined, undefined, undefined, selectedOrder).then(function (inventory_data) {
+                return inventory_service.get_properties(1, undefined, undefined, -1, selectedOrder).then(function (inventory_data) {
                   _.forEach(selectedOrder, function (id, index) {
                     var match = _.find(inventory_data.results, {id: id});
                     if (match) {
@@ -305,7 +305,7 @@ angular.module('BE.seed.controller.inventory_list', [])
                   return data;
                 });
               } else if ($scope.inventory_type === 'taxlots') {
-                return inventory_service.get_taxlots(1, undefined, undefined, undefined, selectedOrder).then(function (inventory_data) {
+                return inventory_service.get_taxlots(1, undefined, undefined, -1, selectedOrder).then(function (inventory_data) {
                   _.forEach(selectedOrder, function (id, index) {
                     var match = _.find(inventory_data.results, {id: id});
                     if (match) {


### PR DESCRIPTION
#### What's this PR do?
1. When manually merging records from the inventory list view, the merge-modal dialog now shows all populated extra_data columns in addition to the defaults
2. If a column filter is set and you either change the current cycle or merge records then the updated inventory will appear correctly after that action
#### How should this be manually tested?
1. Set an arbitrary column filter
2. Change cycles and ensure that rows appear after doing so
3. Merge records that have extra_data fields and ensure that those fields appear in the merge preview in the merge modal
#### What are the relevant tickets?
#1812