### PR TITLE
Fix Read the Docs and swagger

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -138,12 +138,11 @@ COMPRESS_CSS_FILTERS = [
     'compressor.filters.cssmin.CSSMinFilter'
 ]
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'seed/landing/static'),
-    os.path.join(BASE_DIR, 'seed/static'),
     os.path.join(BASE_DIR, 'vendors')
 ]
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'compressor.finders.CompressorFinder',
 )
 COMPRESS_PRECOMPILERS = (

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,12 +15,17 @@
 import os
 import sys
 import json
+from shutil import copyfile
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
-# sets the default settings module for read the docs
+# Copy over the local_untracked if it does not exist yet.
+if not os.path.exists('../../config/settings/local_untracked.py'):
+    copyfile('../../config/settings/local_untracked.py.dist',
+             '../../config/settings/local_untracked.py')
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.dev")
 sys.path.insert(0, os.path.abspath('../..'))
 


### PR DESCRIPTION
#### Any background context you want to provide?

* Read the docs was not building since we migrated to python 3.x
* Swagger broke during the pipeline upgrade

#### What's this PR do?

* fixes the read the docs. Note that past versions of SEED will not be rebuilt in RTD.
* find the static assets using the AppDirectoriesFinder instead of specifying in the STATICFILES_DIRS.

#### How should this be manually tested?

Best to test by building in docker from scratch and ensuring that all the static assets are found when running SEED (and swagger).

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, do pip or npm requirements need to be updated?
