### PR TITLE
Dimensionality Error and Column Mapping Fixes

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -116,7 +116,7 @@ echo "Tagging local containers"
 docker tag seedplatform/seed:latest 127.0.0.1:5000/seed
 docker tag postgres:11.1 127.0.0.1:5000/postgres
 docker tag redis:5.0.1 127.0.0.1:5000/redis
-docker tag seedplatform/oep:1.0.0-SNAPSHOT 127.0.0.1:5000/oep
+docker tag seedplatform/oep:1.1 127.0.0.1:5000/oep
 
 sleep 3
 echo "Pushing tagged versions to local registry"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - seed_media:/seed/media
   oep-city-1:
     # This is a placeholder. If needed, follow the instructions to enable: https://cloud.docker.com/u/seedplatform/repository/docker/seedplatform/oep
-    image: seedplatform/oep:1.0.0-SNAPSHOT
+    image: seedplatform/oep:1.1
     depends_on:
       - web
     environment:

--- a/seed/lib/mcm/cleaners.py
+++ b/seed/lib/mcm/cleaners.py
@@ -40,7 +40,7 @@ def default_cleaner(value, *args):
         if fuzzy_in_set(value.lower(), NONE_SYNONYMS):
             return None
         # guard against `''` coming in from an Excel empty cell
-        if (value == ''):
+        if value == '':
             return None
     return value
 
@@ -144,6 +144,11 @@ def int_cleaner(value, *args):
 
 def pint_cleaner(value, units, *args):
     """Try to convert value to a meaningful (magnitude, units) object."""
+
+    # If value is already a Quantity don't multiply the units
+    if isinstance(value, ureg.Quantity):
+        return value
+
     value = float_cleaner(value)
     # API breakage if None does not return None
     if value is None:

--- a/seed/views/column_mappings.py
+++ b/seed/views/column_mappings.py
@@ -8,6 +8,7 @@
 import logging
 
 import coreapi
+from django.db.models import Q
 from django.http import JsonResponse, Http404
 from django.shortcuts import get_object_or_404
 from rest_framework import status
@@ -52,7 +53,12 @@ class ColumnMappingViewSet(OrgValidateMixin, SEEDOrgCreateUpdateModelViewSet):
     parser_classes = (JSONParser, FormParser)
     filter_backends = (ColumnMappingViewSetFilterBackend,)
     orgfilter = 'super_organization_id'
-    queryset = ColumnMapping.objects.all()
+    # Do not return column mappings where the column_raw or the column_mapped fields are NULL.
+    # This needs to be cleaned up in the near future to have the API clean up the column mappings
+    # upon the deletion of a column.
+    queryset = ColumnMapping.objects.exclude(
+        Q(column_mapped__isnull=True) | Q(column_raw__isnull=True)
+    )
 
     @ajax_request_class
     def retrieve(self, request, pk=None):

--- a/seed/views/column_mappings.py
+++ b/seed/views/column_mappings.py
@@ -29,7 +29,7 @@ from seed.utils.viewsets import SEEDOrgCreateUpdateModelViewSet
 _log = logging.getLogger(__name__)
 
 
-class ColumnMappingiewSetFilterBackend(BaseFilterBackend):
+class ColumnMappingViewSetFilterBackend(BaseFilterBackend):
     """
     Specify the schema for the column view set. This allows the user to see the other
     required columns in Swagger.
@@ -50,7 +50,7 @@ class ColumnMappingViewSet(OrgValidateMixin, SEEDOrgCreateUpdateModelViewSet):
     model = ColumnMapping
     pagination_class = NoPagination
     parser_classes = (JSONParser, FormParser)
-    filter_backends = (ColumnMappingiewSetFilterBackend,)
+    filter_backends = (ColumnMappingViewSetFilterBackend,)
     orgfilter = 'super_organization_id'
     queryset = ColumnMapping.objects.all()
 


### PR DESCRIPTION
#### Any background context you want to provide?

If the user deleted a column using API, then the column mapping was not removed. This left a column mapping object that pointed to a null column resulting in errors with viewing the column mappings.

In addition, when mapping data that had quantity units attached, there was a case when the units would be multiplied twice, resulting in a dimensionality error.

#### What's this PR do?

* Only return column mappings where both the raw and mapped columns exist
* Do not multiple units twice when cleaning data upon import

#### How should this be manually tested?
N/A

#### What are the relevant tickets?
#1837 #1838

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, do pip or npm requirements need to be updated?
