### PR TITLE
Fix backups, lock kombu

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,3 @@
 #### How should this be manually tested?
 #### What are the relevant tickets?
 #### Screenshots (if appropriate)
-#### Definition of Done:
-- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
-- [ ] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
-- [ ] Does this PR require a regression test? All fixes require a regression test.
-- [ ] Does this add new dependencies? If so, do pip or npm requirements need to be updated?

--- a/bin/backup_database.sh
+++ b/bin/backup_database.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Nightly backups - crontab
-# 0 0 * * * /home/ubuntu/prj/seed/bin/backup_database.sh <db_name> <db_username> <db_password> <media_dir>
+# 0 0 * * * /home/ubuntu/prj/seed/bin/backup_database.sh <db_name> <db_username> <db_password> <media_dir> >> /home/ubuntu/seed-backups/cron.log 2>&1
 
 DB_NAME=$1
 DB_USERNAME=$2

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -21,6 +21,9 @@ services:
       - $HOME/seed-backups:/backups
     ports:
       - "5432:5432"
+    logging:
+      options:
+        max-size: 50m
     deploy:
       restart_policy:
         condition: on-failure
@@ -29,6 +32,9 @@ services:
         window: 120s
   db-redis:
     image: 127.0.0.1:5000/redis
+    logging:
+      options:
+        max-size: 50m
     deploy:
       restart_policy:
         condition: on-failure
@@ -60,6 +66,9 @@ services:
       - seed_media:/seed/media
     ports:
       - "80:80"
+    logging:
+      options:
+        max-size: 50m
     deploy:
       restart_policy:
         condition: on-failure
@@ -84,6 +93,9 @@ services:
     volumes:
       - seed_media:/seed/media
     command: /seed/docker/start_celery_docker.sh
+    logging:
+      options:
+        max-size: 50m
     deploy:
       restart_policy:
         condition: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
       - seed_pgdata:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+    logging:
+      options:
+        max-size: 50m
   db-redis:
     image: redis:5.0.1
   web:
@@ -40,6 +43,9 @@ services:
       - seed_media:/seed/media
     ports:
       - "80:80"
+    logging:
+      options:
+        max-size: 50m
   web-celery:
     image: seedplatform/seed:latest
     build: .
@@ -57,6 +63,9 @@ services:
       - web
     volumes:
       - seed_media:/seed/media
+    logging:
+      options:
+        max-size: 50m
   oep-city-1:
     # This is a placeholder. If needed, follow the instructions to enable: https://cloud.docker.com/u/seedplatform/repository/docker/seedplatform/oep
     image: seedplatform/oep:1.1
@@ -64,6 +73,9 @@ services:
       - web
     environment:
       - OEP_DISABLED=true
+    logging:
+      options:
+        max-size: 50m
 volumes:
   seed_pgdata:
     external: true

--- a/docker/backup_database.sh
+++ b/docker/backup_database.sh
@@ -6,7 +6,7 @@
 # system. Also, the location of the backups is hardcoded to ~/seed-backups.
 
 # To create nightly backups, add the following to your crontab
-# 0 0 * * * /home/ubuntu/prj/seed/docker/backup_database.sh <db_name> <db_username>
+# 0 0 * * * /home/ubuntu/prj/seed/docker/backup_database.sh <db_name> <db_username> >> /home/ubuntu/seed-backups/cron.log 2>&1
 
 DB_NAME=$1
 DB_USERNAME=$2
@@ -25,7 +25,7 @@ if [[ (-z ${DB_NAME}) || (-z ${DB_USERNAME}) ]] ; then
 fi
 
 # currently the backup directory is hard coded
-BACKUP_DIR=~/seed-backups
+BACKUP_DIR=/home/ubuntu/seed-backups
 mkdir -p ${BACKUP_DIR}
 
 # db_password is set from the environment variables in docker-compose. The docker stack must
@@ -37,7 +37,7 @@ docker exec $(docker ps -f "name=db-postgres" --format "{{.ID}}") pg_dump -U ${D
 # Backup the media directory (uploads, especially buildingsync). In docker-land this is
 # just a container volume, so create a new container with the volume attached and tar it up.
 echo "docker run --rm -it -v seed_media:/backup/media -v $BACKUP_DIR:/backup/dir/ alpine:3.8 tar zcvf $(media_file_name) /backup/media"
-docker run --rm -it -v seed_media:/backup/media -v $BACKUP_DIR:/backup/dir/ alpine:3.8 tar zcvf $(media_file_name) /backup/media
+docker run --rm -v seed_media:/backup/media -v $BACKUP_DIR:/backup/dir/ alpine:3.8 tar zcvf $(media_file_name) /backup/media
 
 # Delete files older than 45 days.
 find ${BACKUP_DIR} -mtime +45 -type f -name '*.dump' -delete

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,6 +10,7 @@ modeltranslation==0.25
 psycopg2-binary==2.7.5
 
 # background process management
+kombu==4.2.2.post1  # 4.4 breaks celery without upgrading py-redis (redis below)
 celery==4.2.1
 django-redis-cache==1.7.1
 django_compressor==2.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,8 +3,8 @@
 
 # general
 autopep8==1.4
-coverage==4.5.1
-coveralls==1.5.1
+coverage==4.5.2
+coveralls==1.6.0
 tox==2.9.1
 
 # python testing
@@ -16,7 +16,7 @@ coveralls-merge==0.0.3
 vcrpy==2.0.1
 
 # static code analysis
-flake8==3.5.0
+flake8==3.7.7
 pycodestyle==2.3.1
 
 # documentation and spelling


### PR DESCRIPTION
#### Any background context you want to provide?
The latest release of Kombu breaks celery.

#### What's this PR do?
* lock version of Kombu
* Restrict size of docker logs
* Fix docker backup script to use TTY 

#### How should this be manually tested?
N/A

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this add new dependencies? If so, do pip or npm requirements need to be updated?
