### PR TITLE
Data Quality Dimensionality Hotfix

### DIFF
--- a/seed/models/data_quality.py
+++ b/seed/models/data_quality.py
@@ -647,7 +647,7 @@ class DataQualityCheck(models.Model):
                     # TODO cleanup after the cleaner is better able to handle fields with units on import
                     # If the rule doesn't specify units only consider the value for the purposes of numerical comparison
                     if isinstance(value, ureg.Quantity) and rule.units == '':
-                         value = value.magnitude
+                        value = value.magnitude
                 elif rule.field in row.extra_data:
                     value = row.extra_data[rule.field]
                     try:

--- a/seed/models/data_quality.py
+++ b/seed/models/data_quality.py
@@ -55,7 +55,10 @@ def format_pint_violation(rule, source_value):
     formatted_min = formatted_max = None
     incoming_data_units = source_value.units
     rule_units = ureg(rule.units)
-    rule_value = source_value.to(rule_units)
+    if rule_units.dimensionless:
+        rule_value = source_value
+    else:
+        rule_value = source_value.to(rule_units)
 
     pretty_source_units = pretty_units(source_value)
     pretty_rule_units = pretty_units(rule_value)
@@ -641,6 +644,10 @@ class DataQualityCheck(models.Model):
 
                 if hasattr(row, rule.field):
                     value = getattr(row, rule.field)
+                    # TODO cleanup after the cleaner is better able to handle fields with units on import
+                    # If the rule doesn't specify units only consider the value for the purposes of numerical comparison
+                    if isinstance(value, ureg.Quantity) and rule.units == '':
+                         value = value.magnitude
                 elif rule.field in row.extra_data:
                     value = row.extra_data[rule.field]
                     try:

--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -60,7 +60,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
       ];
 
       $scope.units = [
-        {id: null, label: ''},
+        {id: '', label: ''},
         {id: 'ft**2', label: 'square feet'},
         {id: 'm**2', label: 'square metres'},
         {id: 'kBtu/ft**2/year', label: 'kBtu/sq. ft./year'},


### PR DESCRIPTION
#### Any background context you want to provide?
Related dimensionality bug to #1837 
#### What's this PR do?
Fixes a corner case where the dimensionality of units could not be converted and data quality checks fail silently

Also fixes a bug where a data quality rule with units could not be saved as unit-less
#### How should this be manually tested?
1. Create a data quality rule for a field with units (e.g. `site_eui`) that the file you upload will definitely violate in at least 1 row
2. Follow the steps to reproduce from the dimensionality bug: #1837
3. On the mapping review page the data quality results should successfully load (no infinite spinner or 500 network error)
4. Test your `site_eui` data quality rule to have units, and again as unit-less