### PR TITLE
Footprint preview

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,6 +54,8 @@ xmltodict==0.11.0
 requests==2.20.0
 lxml==4.2.5
 probablepeople==0.5.4
+# Parsing and managing geojson data (this is only used in managed tasks at the moment)
+geojson==2.4.1
 
 # pnnl/buildingid
 -e git+https://github.com/SEED-platform/buildingid.git@475dfd6e0a10a8b0cd0cd06194eab72c31a00194#egg=buildingid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,6 +26,3 @@ sphinx_rtd_theme==0.4.2
 
 # For running the server
 uWSGI==2.0.17.1
-
-# Parsing and managing geojson data (this is only used in managed tasks at the moment)
-geojson==2.4.1

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -430,7 +430,7 @@ angular.module('BE.seed.controller.inventory_list', [])
         var options = {};
         if (col.column_name === 'property_footprint' && col.table_name === 'PropertyState') {
           col.cellTemplate = '<div class="ui-grid-cell-contents" uib-tooltip-html="grid.appScope.polygon(row.entity, \'PropertyState\')" tooltip-append-to-body="true" tooltip-popup-delay="500">{{COL_FIELD CUSTOM_FILTERS}}</div>';
-        } else if (col.column_name === '' && col.table_name === 'TaxLotState') {
+        } else if (col.column_name === 'taxlot_footprint' && col.table_name === 'TaxLotState') {
           col.cellTemplate = '<div class="ui-grid-cell-contents" uib-tooltip-html="grid.appScope.polygon(row.entity, \'TaxLotState\')" tooltip-append-to-body="true" tooltip-popup-delay="500">{{COL_FIELD CUSTOM_FILTERS}}</div>';
         } else {
           col.cellTemplate = '<div class="ui-grid-cell-contents" uib-tooltip="{{COL_FIELD CUSTOM_FILTERS}}" tooltip-append-to-body="true" tooltip-popup-delay="500">{{COL_FIELD CUSTOM_FILTERS}}</div>';

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -355,19 +355,23 @@ angular.module('BE.seed.controller.inventory_list', [])
           var coords = Terraformer.toMercator(footprint).coordinates[0];
           var envelope = Terraformer.Tools.calculateEnvelope(footprint);
 
-          // 1px padding to allow for svg stroke
-          var scale = (outputSize - 2) / Math.max(envelope.h, envelope.w);
+          // padding to allow for svg stroke
+          var padding = 2;
+          var scale = (outputSize - padding) / Math.max(envelope.h, envelope.w);
 
-          var xOffset = (outputSize - envelope.w * scale) / 2;
-          var yOffset = (outputSize - envelope.h * scale) / 2;
+          var width = (envelope.w <= envelope.h) ? Math.ceil(envelope.w * scale + padding) : outputSize;
+          var height = (envelope.h <= envelope.w) ? Math.ceil(envelope.h * scale + padding) : outputSize;
+
+          var xOffset = (width - envelope.w * scale) / 2;
+          var yOffset = (height - envelope.h * scale) / 2;
 
           var points = _.map(coords, function(coord) {
             var x = _.round((coord[0] - envelope.x) * scale + xOffset, 2);
-            var y = _.round(outputSize - ((coord[1] - envelope.y) * scale + yOffset), 2);
+            var y = _.round(height - ((coord[1] - envelope.y) * scale + yOffset), 2);
             return x + ',' + y;
           });
 
-          var svg = '<svg height="' + outputSize + '" width="' + outputSize + '"><polygon points="' + _.initial(points).join(' ') + '" style="fill:#ffab66;stroke:#aaa;stroke-width:1;" /></svg>';
+          var svg = '<svg height="' + height + '" width="' + width + '"><polygon points="' + _.initial(points).join(' ') + '" style="fill:#ffab66;stroke:#aaa;stroke-width:1;" /></svg>';
 
           cache[record.id] = $sce.trustAsHtml(svg);
         }

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -8,6 +8,7 @@ angular.module('BE.seed.controller.inventory_list', [])
     '$filter',
     '$window',
     '$uibModal',
+    '$sce',
     '$stateParams',
     'inventory_service',
     'label_service',
@@ -31,6 +32,7 @@ angular.module('BE.seed.controller.inventory_list', [])
       $filter,
       $window,
       $uibModal,
+      $sce,
       $stateParams,
       inventory_service,
       label_service,
@@ -332,6 +334,46 @@ angular.module('BE.seed.controller.inventory_list', [])
         });
       };
 
+      var propertyPolygonCache = {};
+      var taxlotPolygonCache = {};
+      var propertyFootprintColumn = _.find($scope.columns, {column_name: 'property_footprint', table_name: 'PropertyState'});
+      var taxlotFootprintColumn = _.find($scope.columns, {column_name: 'taxlot_footprint', table_name: 'TaxLotState'});
+      $scope.polygon = function (record, tableName) {
+        var outputSize = 180;
+
+        var cache, field;
+        if (tableName === 'PropertyState') {
+          cache = propertyPolygonCache;
+          field = propertyFootprintColumn.name;
+        } else {
+          cache = taxlotPolygonCache;
+          field = taxlotFootprintColumn.name;
+        }
+
+        if (!_.has(cache, record.id)) {
+          var footprint = Terraformer.WKT.parse(record[field]);
+          var coords = Terraformer.toMercator(footprint).coordinates[0];
+          var envelope = Terraformer.Tools.calculateEnvelope(footprint);
+
+          // 1px padding to allow for svg stroke
+          var scale = (outputSize - 2) / Math.max(envelope.h, envelope.w);
+
+          var xOffset = (outputSize - envelope.w * scale) / 2;
+          var yOffset = (outputSize - envelope.h * scale) / 2;
+
+          var points = _.map(coords, function(coord) {
+            var x = _.round((coord[0] - envelope.x) * scale + xOffset, 2);
+            var y = _.round(outputSize - ((coord[1] - envelope.y) * scale + yOffset), 2);
+            return x + ',' + y;
+          });
+
+          var svg = '<svg height="' + outputSize + '" width="' + outputSize + '"><polygon points="' + _.initial(points).join(' ') + '" style="fill:#ffab66;stroke:#aaa;stroke-width:1;" /></svg>';
+
+          cache[record.id] = $sce.trustAsHtml(svg);
+        }
+        return cache[record.id];
+      };
+
       $scope.run_data_quality_check = function () {
         spinner_utility.show();
 
@@ -386,7 +428,13 @@ angular.module('BE.seed.controller.inventory_list', [])
       };
       _.map($scope.columns, function (col) {
         var options = {};
-        col.cellTemplate = '<div class="ui-grid-cell-contents" uib-tooltip="{{COL_FIELD CUSTOM_FILTERS}}" tooltip-append-to-body="true" tooltip-popup-delay="500">{{COL_FIELD CUSTOM_FILTERS}}</div>';
+        if (col.column_name === 'property_footprint' && col.table_name === 'PropertyState') {
+          col.cellTemplate = '<div class="ui-grid-cell-contents" uib-tooltip-html="grid.appScope.polygon(row.entity, \'PropertyState\')" tooltip-append-to-body="true" tooltip-popup-delay="500">{{COL_FIELD CUSTOM_FILTERS}}</div>';
+        } else if (col.column_name === '' && col.table_name === 'TaxLotState') {
+          col.cellTemplate = '<div class="ui-grid-cell-contents" uib-tooltip-html="grid.appScope.polygon(row.entity, \'TaxLotState\')" tooltip-append-to-body="true" tooltip-popup-delay="500">{{COL_FIELD CUSTOM_FILTERS}}</div>';
+        } else {
+          col.cellTemplate = '<div class="ui-grid-cell-contents" uib-tooltip="{{COL_FIELD CUSTOM_FILTERS}}" tooltip-append-to-body="true" tooltip-popup-delay="500">{{COL_FIELD CUSTOM_FILTERS}}</div>';
+        }
         if (col.data_type === 'datetime') {
           options.cellFilter = 'date:\'yyyy-MM-dd h:mm a\'';
           options.filter = inventory_service.dateFilter();

--- a/seed/templates/seed/base.html
+++ b/seed/templates/seed/base.html
@@ -114,6 +114,8 @@
         <script src="/static/node_modules/angular-dragula/dist/angular-dragula.min.js"></script>
         <script src="/static/node_modules/ng-focus-if/focusIf.min.js"></script>
         <script src="/static/node_modules/file-saver/FileSaver.min.js"></script>
+        <script src="/static/node_modules/terraformer/terraformer.js"></script>
+        <script src="/static/node_modules/terraformer-wkt-parser/terraformer-wkt-parser.min.js"></script>
 
         <!-- reports -->
         <script src="/static/node_modules/d3/d3.min.js"></script>

--- a/seed/templates/seed/jasmine_tests/AngularJSTests.html
+++ b/seed/templates/seed/jasmine_tests/AngularJSTests.html
@@ -31,6 +31,8 @@
 
     <script src="{{STATIC_URL}}node_modules/angular-ui-grid/ui-grid.min.js"></script>
     <script src="{{STATIC_URL}}node_modules/ui-grid-draggable-rows/js/draggable-rows.js"></script>
+    <script src="{{STATIC_URL}}node_modules/terraformer/terraformer.js"></script>
+    <script src="{{STATIC_URL}}node_modules/terraformer-wkt-parser/terraformer-wkt-parser.min.js"></script>
 
 
     <script src="{{STATIC_URL}}node_modules/fine-uploader/all.fine-uploader/all.fine-uploader.core.min.js" ></script>

--- a/seed/views/tax_lot_properties.py
+++ b/seed/views/tax_lot_properties.py
@@ -271,7 +271,7 @@ class TaxLotPropertyViewSet(GenericViewSet):
             elif feature["properties"].get("taxlot_state_id") is not None:
                 feature["properties"]["stroke"] = "#10A0A0"  # buildings color
             feature["properties"]["marker-color"] = "#E74C3C"
-            #feature["properties"]["stroke-width"] = 3
+            # feature["properties"]["stroke-width"] = 3
             feature["properties"]["fill-opacity"] = 0
 
             # append feature

--- a/vendors/package.json
+++ b/vendors/package.json
@@ -34,6 +34,8 @@
     "ol-ext": "=3.1.0",
     "raven-js": "~3.22.1",
     "spin.js": "~2.3.2",
+    "terraformer": "~1.0.9",
+    "terraformer-wkt-parser": "~1.2.0",
     "ui-grid-draggable-rows": "~0.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
#### What's this PR do?
Renders (and caches to prevent re-processing) building footprints when hovering over a property or taxlot footprint column
#### How should this be manually tested?
##### Run `npm install` first
Import a file with footprints and hover over the footprint column in the inventory list view
(May require additional error handling around empty or malformed footprint fields)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/411466/55271035-57883280-526c-11e9-93a4-765d9db838cb.png)
