### PR TITLE
ensure unique name for api TestOrg

### DIFF
--- a/seed/tests/api/test_modules.py
+++ b/seed/tests/api/test_modules.py
@@ -8,6 +8,7 @@ import datetime as dt
 import json
 import pprint
 import time
+import uuid
 
 import requests
 from builtins import str
@@ -277,9 +278,10 @@ def account(header, main_url, username, log):
     # Create an organization
     print('API Function: create_org\n'),
     partmsg = 'create_org'
+    org_name = 'TestOrg_{}'.format(str(uuid.uuid4()))
     payload = {
         'user_id': user_pk,
-        'organization_name': 'TestOrg_JoZ2wSd2boQWifGau3qxdFFu76oIy9r0'  # hopefully ensuring a unique org name
+        'organization_name': org_name  # hopefully ensuring a unique org name
     }
     result = requests.post(main_url + '/api/v2/organizations/',
                            headers=header,


### PR DESCRIPTION
#### Any background context you want to provide?
Running api hosting tests were breaking on delete organization because of Redis password issues.  Attempts to rerun tests while troubleshooting would then break at creating an organization because the organization with the original hard coded name still existed. 

#### What's this PR do?
Uses uuid to ensure unique organization name for api create/delete organization tests.

#### How should this be manually tested?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
