### PR TITLE
Fix to include extra_data fields when loading the pairing page

### DIFF
--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -556,10 +556,10 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
             });
           }],
           propertyInventory: ['inventory_service', function (inventory_service) {
-            return inventory_service.get_properties(1, undefined, undefined, undefined);
+            return inventory_service.get_properties(1, undefined, undefined, -1);
           }],
           taxlotInventory: ['inventory_service', function (inventory_service) {
-            return inventory_service.get_taxlots(1, undefined, undefined, undefined);
+            return inventory_service.get_taxlots(1, undefined, undefined, -1);
           }],
           cycles: ['cycle_service', function (cycle_service) {
             return cycle_service.get_cycles();


### PR DESCRIPTION
#### What's this PR do?
extra_data field data wasn't included on page load of the pairing page.  This PR changes it to include all fields

fixes #1875 