### PR TITLE
Pairing hotfix label hooks

### DIFF
--- a/seed/management/commands/add_member_to_org.py
+++ b/seed/management/commands/add_member_to_org.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright (c) 2014 - 2018, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:copyright (c) 2014 - 2019, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
 """
 from django.core.management.base import BaseCommand

--- a/seed/models/data_quality.py
+++ b/seed/models/data_quality.py
@@ -927,27 +927,29 @@ class DataQualityCheck(models.Model):
             label_org_id = rule.status_label.super_organization_id
 
             if rule.table_name == 'PropertyState':
-                property_org_id = Property.objects.get(pk=linked_id).organization_id
-                if property_org_id == label_org_id:
+                property_parent_org_id = Property.objects.get(pk=linked_id).organization.get_parent().id
+                if property_parent_org_id == label_org_id:
                     label_class.objects.get_or_create(property_id=linked_id,
                                                       statuslabel_id=rule.status_label_id)
                 else:
                     raise IntegrityError(
-                        'Label with org_id={} cannot be applied to a record with org_id={}.'.format(
+                        'Label with super_organization_id={} cannot be applied to a property with parent '
+                        'organization_id={}.'.format(
                             label_org_id,
-                            property_org_id
+                            property_parent_org_id
                         )
                     )
             else:
-                taxlot_org_id = TaxLot.objects.get(pk=linked_id).organization_id
-                if taxlot_org_id == label_org_id:
+                taxlot_parent_org_id = TaxLot.objects.get(pk=linked_id).organization.get_parent().id
+                if taxlot_parent_org_id == label_org_id:
                     label_class.objects.get_or_create(taxlot_id=linked_id,
                                                       statuslabel_id=rule.status_label_id)
                 else:
                     raise IntegrityError(
-                        'Label with org_id={} cannot be applied to a record with org_id={}.'.format(
+                        'Label with super_organization_id={} cannot be applied to a taxlot with parent '
+                        'organization_id={}.'.format(
                             label_org_id,
-                            taxlot_org_id
+                            taxlot_parent_org_id
                         )
                     )
             return True

--- a/seed/models/data_quality.py
+++ b/seed/models/data_quality.py
@@ -13,7 +13,7 @@ from random import randint
 import pytz
 from builtins import str
 from django.apps import apps
-from django.db import models
+from django.db import models, IntegrityError
 from django.utils.timezone import get_current_timezone, make_aware, make_naive
 from past.builtins import basestring
 from quantityfield import ureg
@@ -22,7 +22,9 @@ from seed.lib.superperms.orgs.models import Organization
 from seed.models import (
     Column,
     StatusLabel,
+    Property,
     PropertyView,
+    TaxLot,
     TaxLotView
 )
 from seed.models import obj_to_dict
@@ -922,12 +924,32 @@ class DataQualityCheck(models.Model):
         """
 
         if rule.status_label_id is not None and linked_id is not None:
+            label_org_id = rule.status_label.super_organization_id
+
             if rule.table_name == 'PropertyState':
-                label_class.objects.get_or_create(property_id=linked_id,
-                                                  statuslabel_id=rule.status_label_id)
+                property_org_id = Property.objects.get(pk=linked_id).organization_id
+                if property_org_id == label_org_id:
+                    label_class.objects.get_or_create(property_id=linked_id,
+                                                      statuslabel_id=rule.status_label_id)
+                else:
+                    raise IntegrityError(
+                        'Label with org_id={} cannot be applied to a record with org_id={}.'.format(
+                            label_org_id,
+                            property_org_id
+                        )
+                    )
             else:
-                label_class.objects.get_or_create(taxlot_id=linked_id,
-                                                  statuslabel_id=rule.status_label_id)
+                taxlot_org_id = TaxLot.objects.get(pk=linked_id).organization_id
+                if taxlot_org_id == label_org_id:
+                    label_class.objects.get_or_create(taxlot_id=linked_id,
+                                                      statuslabel_id=rule.status_label_id)
+                else:
+                    raise IntegrityError(
+                        'Label with org_id={} cannot be applied to a record with org_id={}.'.format(
+                            label_org_id,
+                            taxlot_org_id
+                        )
+                    )
             return True
 
     def remove_status_label(self, label_class, rule, linked_id):

--- a/seed/models/properties.py
+++ b/seed/models/properties.py
@@ -17,7 +17,7 @@ from django.contrib.postgres.fields import JSONField
 from django.contrib.gis.db import models as geomodels
 from django.db import IntegrityError
 from django.db import models
-from django.db.models.signals import pre_delete, pre_save, post_save
+from django.db.models.signals import pre_delete, pre_save, post_save, m2m_changed
 from django.dispatch import receiver
 from django.forms.models import model_to_dict
 from quantityfield.fields import QuantityField
@@ -39,7 +39,11 @@ from seed.models import (
     TaxLotProperty
 )
 from seed.utils.address import normalize_address_str
-from seed.utils.generic import split_model_fields, obj_to_dict
+from seed.utils.generic import (
+    compare_orgs_between_label_and_target,
+    split_model_fields,
+    obj_to_dict,
+)
 from seed.utils.time import convert_datestr
 from seed.utils.time import convert_to_js_timestamp
 
@@ -801,3 +805,6 @@ def sync_latitude_longitude_and_long_lat(sender, instance, **kwargs):
         elif (latitude_change or longitude_change) and not lat_and_long_both_populated:
             instance.long_lat = None
             instance.geocoding_confidence = None
+
+
+m2m_changed.connect(compare_orgs_between_label_and_target, sender=Property.labels.through)

--- a/seed/models/tax_lots.py
+++ b/seed/models/tax_lots.py
@@ -14,7 +14,7 @@ from os import path
 from django.contrib.gis.db import models as geomodels
 from django.contrib.postgres.fields import JSONField
 from django.db import models
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, m2m_changed
 from django.dispatch import receiver
 
 from seed.data_importer.models import ImportFile
@@ -30,7 +30,11 @@ from seed.models import (
     MERGE_STATE_UNKNOWN,
 )
 from seed.utils.address import normalize_address_str
-from seed.utils.generic import split_model_fields, obj_to_dict
+from seed.utils.generic import (
+    compare_orgs_between_label_and_target,
+    split_model_fields,
+    obj_to_dict,
+)
 from seed.utils.time import convert_to_js_timestamp
 from .auditlog import AUDIT_IMPORT
 from .auditlog import DATA_UPDATE_TYPE
@@ -480,3 +484,6 @@ class TaxLotAuditLog(models.Model):
 
     class Meta:
         index_together = [['state', 'name'], ['parent_state1', 'parent_state2']]
+
+
+m2m_changed.connect(compare_orgs_between_label_and_target, sender=TaxLot.labels.through)

--- a/seed/tests/test_labels.py
+++ b/seed/tests/test_labels.py
@@ -1,0 +1,114 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2019, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author 'Piper Merriam <pipermerriam@gmail.com>', Paul Munday<paul@paulmunday.net>
+
+Unit tests for seed/views/labels.py
+"""
+from django.db import IntegrityError
+from django.db import transaction
+
+from seed.landing.models import SEEDUser as User
+from seed.models import (
+    Property,
+    StatusLabel as Label,
+    TaxLot,
+)
+from seed.models.data_quality import DataQualityCheck, Rule
+from seed.tests.util import DeleteModelsTestCase
+from seed.utils.organizations import create_organization
+from seed.views.labels import (
+    UpdateInventoryLabelsAPIView,
+)
+
+
+class TestLabelIntegrityChecks(DeleteModelsTestCase):
+    def setUp(self):
+        self.api_view = UpdateInventoryLabelsAPIView()
+
+        # Models can't  be imported directly hence self
+        self.PropertyLabels = self.api_view.models['property']
+        self.TaxlotLabels = self.api_view.models['taxlot']
+
+        self.user_details = {
+            'username': 'test_user@demo.com',
+            'password': 'test_pass',
+            'email': 'test_user@demo.com'
+        }
+        self.user = User.objects.create_superuser(**self.user_details)
+        self.org, _, _ = create_organization(self.user)
+
+        org_2, _, _ = create_organization(self.user)
+        self.org_2_status_label = Label.objects.create(
+            name='org_2_label', super_organization=org_2
+        )
+
+    def test_error_occurs_when_trying_to_apply_a_label_to_property_from_a_different_org(self):
+        org_1_property = Property.objects.create(organization=self.org)
+
+        # Via Label API View
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                self.api_view.add_labels(
+                    self.api_view.models['property'].objects.none(),
+                    'property',
+                    [org_1_property.id],
+                    [self.org_2_status_label.id]
+                )
+
+        # Via Property Model
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                org_1_property.labels.add(self.org_2_status_label)
+
+        # Via PropertyState Rule with Label
+        org_1_dq = DataQualityCheck.objects.get(organization=self.org)
+        org_1_ps_rule = org_1_dq.rules.filter(table_name='PropertyState').first()
+        # Purposely give an Org 1 Rule an Org 2 Label
+        org_1_ps_rule.status_label = self.org_2_status_label
+        org_1_ps_rule.save()
+
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                org_1_dq.update_status_label(
+                    self.PropertyLabels,
+                    Rule.objects.get(pk=org_1_ps_rule.id),
+                    org_1_property.id,
+                )
+
+        self.assertFalse(Property.objects.get(pk=org_1_property.id).labels.all().exists())
+
+    def test_error_occurs_when_trying_to_apply_a_label_to_taxlot_from_a_different_org(self):
+        # Repeat for TaxLot
+        org_1_taxlot = TaxLot.objects.create(organization=self.org)
+
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                self.api_view.add_labels(
+                    self.api_view.models['taxlot'].objects.none(),
+                    'taxlot',
+                    [org_1_taxlot.id],
+                    [self.org_2_status_label.id]
+                )
+
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                org_1_taxlot.labels.add(self.org_2_status_label)
+
+        # Via TaxLot Rule with Label
+        org_1_dq = DataQualityCheck.objects.get(organization=self.org)
+        org_1_tls_rule = org_1_dq.rules.filter(table_name='TaxLotState').first()
+        # Purposely give an Org 1 Rule an Org 2 Label
+        org_1_tls_rule.status_label = self.org_2_status_label
+        org_1_tls_rule.save()
+
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                org_1_dq.update_status_label(
+                    self.TaxlotLabels,
+                    Rule.objects.get(pk=org_1_tls_rule.id),
+                    org_1_taxlot.id,
+                )
+
+        self.assertFalse(TaxLot.objects.get(pk=org_1_taxlot.id).labels.all().exists())

--- a/seed/tests/test_labels_api_views.py
+++ b/seed/tests/test_labels_api_views.py
@@ -6,13 +6,17 @@
 
 Unit tests for seed/views/labels.py
 """
+from django.db import IntegrityError
+from django.db import transaction
 from django.core.urlresolvers import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from seed.landing.models import SEEDUser as User
 from seed.models import (
+    Property,
     StatusLabel as Label,
+    TaxLot,
 )
 from seed.test_helpers.fake import (
     mock_queryset_factory,
@@ -115,12 +119,7 @@ class TestUpdateInventoryLabelsAPIView(DeleteModelsTestCase):
         # Models can't  be imported directly hence self
         self.PropertyLabels = self.api_view.models['property']
         self.TaxlotLabels = self.api_view.models['taxlot']
-        self.mock_property_queryset = mock_queryset_factory(
-            self.PropertyLabels,
-            flatten=True,
-            property_id=range(1, 11),
-            statuslabel_id=[1] * 3 + [2] * 3 + [3] * 2 + [4] * 2
-        )
+
         self.user_details = {
             'username': 'test_user@demo.com',
             'password': 'test_pass',
@@ -132,6 +131,24 @@ class TestUpdateInventoryLabelsAPIView(DeleteModelsTestCase):
             name='test', super_organization=self.org
         )
         self.client.login(**self.user_details)
+
+        self.label_1 = Label.objects.all()[0]
+        self.label_2 = Label.objects.all()[1]
+        self.label_3 = Label.objects.all()[2]
+        self.label_4 = Label.objects.all()[3]
+
+        # Create some real Properties and StatusLabels since validations happen
+        for i in range(1, 11):
+            Property.objects.create(organization=self.org)
+
+        self.property_ids = Property.objects.all().order_by('id').values_list('id', flat=True)
+
+        self.mock_property_label_qs = mock_queryset_factory(
+            self.PropertyLabels,
+            flatten=True,
+            property_id=self.property_ids,
+            statuslabel_id=[self.label_1.id] * 3 + [self.label_2.id] * 3 + [self.label_3.id] * 2 + [self.label_4.id] * 2
+        )
 
     def test_get_label_desc(self):
         add_label_ids = [self.status_label.id]
@@ -148,37 +165,47 @@ class TestUpdateInventoryLabelsAPIView(DeleteModelsTestCase):
 
     def test_get_inventory_id(self):
         result = self.api_view.get_inventory_id(
-            self.mock_property_queryset[0], 'property'
+            self.mock_property_label_qs[0], 'property'
         )
-        self.assertEqual(result, 1)
+        self.assertEqual(result, self.property_ids[0])
 
     def test_exclude(self):
         result = self.api_view.exclude(
-            self.mock_property_queryset, 'property', [3, 4]
+            self.mock_property_label_qs, 'property', [self.label_3.id, self.label_4.id]
         )
-        expected = {3: [7, 8], 4: [9, 10]}
+
+        pid_7 = self.property_ids[6]
+        pid_8 = self.property_ids[7]
+        pid_9 = self.property_ids[8]
+        pid_10 = self.property_ids[9]
+
+        expected = {self.label_3.id: [pid_7, pid_8], self.label_4.id: [pid_9, pid_10]}
         self.assertEqual(result, expected)
 
     def test_label_factory(self):
-        result = self.api_view.label_factory('property', 100, 100)
+        result = self.api_view.label_factory('property', self.label_1.id, self.property_ids[0])
         self.assertEqual(
             result.__class__.__name__, self.PropertyLabels.__name__
         )
-        self.assertEqual(result.property_id, 100)
-        self.assertEqual(result.statuslabel_id, 100)
+        self.assertEqual(result.property_id, self.property_ids[0])
+        self.assertEqual(result.statuslabel_id, self.label_1.id)
 
     def test_add_remove_labels(self):
+        pid_1 = self.property_ids[0]
+        pid_2 = self.property_ids[1]
+        pid_3 = self.property_ids[2]
+
         result = self.api_view.add_labels(
-            self.mock_property_queryset, 'property',
-            [1, 2, 3], [5, 6]
+            self.mock_property_label_qs, 'property',
+            [pid_1, pid_2, pid_3], [self.label_2.id, self.label_3.id]
         )
-        self.assertEqual(result, [1, 2, 3] * 2)
+        self.assertEqual(result, [pid_1, pid_2, pid_3] * 2)
         qs = self.PropertyLabels.objects.all()
         self.assertEqual(len(qs), 6)
-        self.assertEqual(qs[0].property_id, 1)
-        self.assertEqual(qs[0].statuslabel_id, 5)
+        self.assertEqual(qs[0].property_id, pid_1)
+        self.assertEqual(qs[0].statuslabel_id, self.label_2.id)
 
-        result = self.api_view.remove_labels(qs, 'property', [5, 6])
+        result = self.api_view.remove_labels(qs, 'property', [self.label_2.id, self.label_3.id])
         qs = self.PropertyLabels.objects.all()
         self.assertEqual(len(qs), 0)
 
@@ -193,10 +220,14 @@ class TestUpdateInventoryLabelsAPIView(DeleteModelsTestCase):
             r, self.org.id
         )
 
+        pid_1 = self.property_ids[0]
+        pid_2 = self.property_ids[1]
+        pid_3 = self.property_ids[2]
+
         post_params = {
             'add_label_ids': [self.status_label.id],
             'remove_label_ids': [],
-            'inventory_ids': [1, 2, 3],
+            'inventory_ids': [pid_1, pid_2, pid_3],
         }
         response = client.put(
             url, post_params, format='json'
@@ -215,7 +246,7 @@ class TestUpdateInventoryLabelsAPIView(DeleteModelsTestCase):
         post_params = {
             'add_label_ids': [],
             'remove_label_ids': [self.status_label.id],
-            'inventory_ids': [1, 2, 3],
+            'inventory_ids': [pid_1, pid_2, pid_3],
         }
         response = client.put(
             url, post_params, format='json'
@@ -230,3 +261,44 @@ class TestUpdateInventoryLabelsAPIView(DeleteModelsTestCase):
         self.assertEqual(label['color'], self.status_label.color)
         self.assertEqual(label['id'], self.status_label.id)
         self.assertEqual(label['name'], self.status_label.name)
+
+    def test_error_occurs_when_trying_to_apply_a_label_from_a_different_org(self):
+        org_2, _, _ = create_organization(self.user)
+        org_2_status_label = Label.objects.create(
+            name='org_2_label', super_organization=org_2
+        )
+
+        org_1_property = Property.objects.create(organization=self.org)
+
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                self.api_view.add_labels(
+                    self.api_view.models['property'].objects.none(),
+                    'property',
+                    [org_1_property.id],
+                    [org_2_status_label.id]
+                )
+
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                org_1_property.labels.add(org_2_status_label)
+
+        self.assertFalse(Property.objects.get(pk=org_1_property.id).labels.all().exists())
+
+        # Repeat for TaxLot
+        org_1_taxlot = TaxLot.objects.create(organization=self.org)
+
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                self.api_view.add_labels(
+                    self.api_view.models['taxlot'].objects.none(),
+                    'taxlot',
+                    [org_1_taxlot.id],
+                    [org_2_status_label.id]
+                )
+
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                org_1_taxlot.labels.add(org_2_status_label)
+
+        self.assertFalse(TaxLot.objects.get(pk=org_1_taxlot.id).labels.all().exists())

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -846,19 +846,19 @@ class InventoryViewTests(DeleteModelsTestCase):
 
         self.assertEquals(len(results['taxlots']), 1)
 
-        rtaxlot = results['taxlots'][0]
-        self.assertEqual(rtaxlot['id'], taxlot.pk)
+        rtaxlot_view = results['taxlots'][0]
+        self.assertEqual(rtaxlot_view['id'], taxlot_view.pk)
         self.assertDictContainsSubset(
             {'id': taxlot.pk, 'organization': self.org.pk, 'labels': []},
-            rtaxlot['taxlot'],
+            rtaxlot_view['taxlot'],
         )
 
-        tcycle = rtaxlot['cycle']
+        tcycle = rtaxlot_view['cycle']
         self.assertEquals(tcycle['name'], '2010 Annual')
         self.assertEquals(tcycle['user'], self.user.pk)
         self.assertEquals(tcycle['organization'], self.org.pk)
 
-        tstate = rtaxlot['state']
+        tstate = rtaxlot_view['state']
         self.assertEqual(tstate['id'], taxlot_state.pk)
         self.assertEqual(tstate['address_line_1'], taxlot_state.address_line_1)
 
@@ -903,35 +903,35 @@ class InventoryViewTests(DeleteModelsTestCase):
 
         self.assertEquals(len(results['taxlots']), 2)
 
-        rtaxlot_1 = results['taxlots'][0]
-        self.assertEqual(rtaxlot_1['id'], taxlot_1.pk)
+        rtaxlot_view_1 = results['taxlots'][0]
+        self.assertEqual(rtaxlot_view_1['id'], taxlot_view_1.pk)
         self.assertDictContainsSubset(
             {'id': taxlot_1.pk, 'organization': self.org.pk, 'labels': []},
-            rtaxlot_1['taxlot'],
+            rtaxlot_view_1['taxlot'],
         )
 
-        tcycle_1 = rtaxlot_1['cycle']
+        tcycle_1 = rtaxlot_view_1['cycle']
         self.assertEquals(tcycle_1['name'], '2010 Annual')
         self.assertEquals(tcycle_1['user'], self.user.pk)
         self.assertEquals(tcycle_1['organization'], self.org.pk)
 
-        tstate_1 = rtaxlot_1['state']
+        tstate_1 = rtaxlot_view_1['state']
         self.assertEqual(tstate_1['id'], taxlot_state_1.pk)
         self.assertEqual(tstate_1['address_line_1'], taxlot_state_1.address_line_1)
 
-        rtaxlot_2 = results['taxlots'][1]
-        self.assertEqual(rtaxlot_2['id'], taxlot_2.pk)
+        rtaxlot_view_2 = results['taxlots'][1]
+        self.assertEqual(rtaxlot_view_2['id'], taxlot_view_2.pk)
         self.assertDictContainsSubset(
             {'id': taxlot_2.pk, 'organization': self.org.pk, 'labels': []},
-            rtaxlot_2['taxlot'],
+            rtaxlot_view_2['taxlot'],
         )
 
-        tcycle_2 = rtaxlot_2['cycle']
+        tcycle_2 = rtaxlot_view_2['cycle']
         self.assertEquals(tcycle_2['name'], '2010 Annual')
         self.assertEquals(tcycle_2['user'], self.user.pk)
         self.assertEquals(tcycle_2['organization'], self.org.pk)
 
-        tstate_2 = rtaxlot_2['state']
+        tstate_2 = rtaxlot_view_2['state']
         self.assertEqual(tstate_2['id'], taxlot_state_2.pk)
         self.assertEqual(tstate_2['address_line_1'], taxlot_state_2.address_line_1)
 

--- a/seed/utils/generic.py
+++ b/seed/utils/generic.py
@@ -111,10 +111,11 @@ def json_serializer(obj):
 def compare_orgs_between_label_and_target(sender, pk_set, instance, model, action, **kwargs):
     for id in pk_set:
         label = model.objects.get(pk=id)
-        if instance.organization_id != label.super_organization_id:
+        if instance.organization.get_parent().id != label.super_organization_id:
             raise IntegrityError(
-                'Label with org_id={} cannot be applied to a record with org_id={}.'.format(
+                'Label with super_organization_id={} cannot be applied to a record with parent '
+                'organization_id={}.'.format(
                     label.super_organization_id,
-                    instance.organization_id
+                    instance.organization.get_parent().id
                 )
             )

--- a/seed/utils/generic.py
+++ b/seed/utils/generic.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 from django.contrib.postgres.fields import JSONField
 from django.core import serializers
+from django.db import IntegrityError
 from past.builtins import basestring
 
 
@@ -105,3 +106,15 @@ def json_serializer(obj):
     if isinstance(obj, datetime):
         serial = obj.isoformat()
         return serial
+
+
+def compare_orgs_between_label_and_target(sender, pk_set, instance, model, action, **kwargs):
+    for id in pk_set:
+        label = model.objects.get(pk=id)
+        if instance.organization_id != label.super_organization_id:
+            raise IntegrityError(
+                'Label with org_id={} cannot be applied to a record with org_id={}.'.format(
+                    label.super_organization_id,
+                    instance.organization_id
+                )
+            )

--- a/seed/views/labels.py
+++ b/seed/views/labels.py
@@ -179,9 +179,10 @@ class UpdateInventoryLabelsAPIView(APIView):
         Model = self.models[inventory_type]
 
         # Ensure the the label org and inventory org are the same
-        inventory_org_id = getattr(Model, inventory_type).get_queryset().get(pk=inventory_id).organization_id
-        label_org_id = Model.statuslabel.get_queryset().get(pk=label_id).super_organization_id
-        if inventory_org_id == label_org_id:
+        inventory_parent_org_id = getattr(Model, inventory_type).get_queryset().get(pk=inventory_id).organization\
+            .get_parent().id
+        label_super_org_id = Model.statuslabel.get_queryset().get(pk=label_id).super_organization_id
+        if inventory_parent_org_id == label_super_org_id:
             create_dict = {
                 'statuslabel_id': label_id,
                 "{}_id".format(inventory_type): inventory_id
@@ -190,9 +191,10 @@ class UpdateInventoryLabelsAPIView(APIView):
             return Model(**create_dict)
         else:
             raise IntegrityError(
-                'Label with org_id={} cannot be applied to a record with org_id={}.'.format(
-                    label_org_id,
-                    inventory_org_id
+                'Label with super_organization_id={} cannot be applied to a record with parent '
+                'organization_id={}.'.format(
+                    label_super_org_id,
+                    inventory_parent_org_id
                 )
             )
 


### PR DESCRIPTION
The goal of this PR is to include checks that ensure a Label organization and Property/TaxLot organization matches before they are associated together.

1. A pre_save check has been added for when the code starts from the Property (or TaxLot) model and associates labels that way `property.labels.add(label)`.
2. Custom logic has been added where associations were made with a `bulk_create` which bypasses any pre_save type signals. This happens via the Label API endpoint.
3. Custom logic has been added where an association is created using the through model (Property_label or TaxLot_label). This happens during DQ checks and Labeled Rules are broken.

Follow up Issue: #1887 