### PR TITLE
1879 profile id v21

### DIFF
--- a/seed/api/v2_1/views.py
+++ b/seed/api/v2_1/views.py
@@ -28,12 +28,13 @@ from seed.models import (
 from seed.serializers.properties import (
     PropertyViewAsStateSerializer,
 )
+from seed.utils.api import OrgMixin
 from seed.utils.viewsets import (
     SEEDOrgReadOnlyModelViewSet
 )
 
 
-class PropertyViewFilterSet(FilterSet):
+class PropertyViewFilterSet(FilterSet, OrgMixin):
     """
     Advanced filtering for PropertyView sets version 2.1.
     """

--- a/seed/models/column_list_settings.py
+++ b/seed/models/column_list_settings.py
@@ -47,13 +47,13 @@ class ColumnListSetting(models.Model):
     @classmethod
     def return_columns(cls, organization_id, profile_id, inventory_type='properties'):
         """
-        Return a list of columns based on the profile_id. If the profile ID doesn't exist, then it will return
-        the list of raw database fields for the organization (i.e. all the fields).
+        Return a list of columns based on the profile_id. If the profile ID doesn't exist, then it
+        will return the list of raw database fields for the organization (i.e. all the fields).
 
-        :param organization_id:
-        :param profile_id:
-        :param inventory_type:
-        :return:
+        :param organization_id: int, ID of the organization
+        :param profile_id: int, ID of the profile id to retrieve
+        :param inventory_type: str, type of inventory (either properties or taxlots)
+        :return: list, column_ids, column_name_mappings, and selected_columns_from_database
         """
         try:
             profile = ColumnListSetting.objects.get(

--- a/seed/models/tax_lot_properties.py
+++ b/seed/models/tax_lot_properties.py
@@ -11,8 +11,8 @@ from collections import defaultdict
 from itertools import chain
 
 from django.apps import apps
-from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.db.models import GeometryField
+from django.contrib.gis.geos import GEOSGeometry
 from django.db import models
 from django.db.models import Count
 from django.utils.timezone import make_naive
@@ -186,6 +186,7 @@ class TaxLotProperty(models.Model):
         related_views = apps.get_model('seed', lookups['related_class']).objects.select_related(
             lookups['select_related'], 'state', 'cycle').filter(pk__in=related_ids)
 
+        # bunch of work to get only the column names that are requested in the show_columns field
         related_columns = []
         related_column_name_mapping = {}
         obj_columns = []
@@ -273,7 +274,7 @@ class TaxLotProperty(models.Model):
                 prop_to_jurisdiction_tl[name].append(pth)
 
         join_note_counts = {x[0]: x[1] for x in Note.objects.filter(**{lookups['related_query_in']: related_ids})
-                            .values_list(lookups['related_view_id']).order_by().annotate(Count(lookups['related_view_id']))}
+            .values_list(lookups['related_view_id']).order_by().annotate(Count(lookups['related_view_id']))}
 
         # A mapping of object's view pk to a list of related state info for a related view
         join_map = {}
@@ -323,14 +324,16 @@ class TaxLotProperty(models.Model):
                                               and col['id'] in show_columns])
 
         obj_note_counts = {x[0]: x[1] for x in Note.objects.filter(**{lookups['obj_query_in']: ids})
-                           .values_list(lookups['obj_view_id']).order_by().annotate(Count(lookups['obj_view_id']))}
+            .values_list(lookups['obj_view_id']).order_by().annotate(Count(lookups['obj_view_id']))}
 
         for obj in object_list:
             # Each object in the response is built from the state data, with related data added on.
-            obj_dict = TaxLotProperty.model_to_dict_with_mapping(obj.state,
-                                                                 obj_column_name_mapping,
-                                                                 fields=filtered_fields,
-                                                                 exclude=['extra_data'])
+            obj_dict = TaxLotProperty.model_to_dict_with_mapping(
+                obj.state,
+                obj_column_name_mapping,
+                fields=filtered_fields,
+                exclude=['extra_data']
+            )
 
             # Only add extra data columns if a settings profile was used
             if show_columns is not None:

--- a/seed/models/tax_lot_properties.py
+++ b/seed/models/tax_lot_properties.py
@@ -274,7 +274,7 @@ class TaxLotProperty(models.Model):
                 prop_to_jurisdiction_tl[name].append(pth)
 
         join_note_counts = {x[0]: x[1] for x in Note.objects.filter(**{lookups['related_query_in']: related_ids})
-            .values_list(lookups['related_view_id']).order_by().annotate(Count(lookups['related_view_id']))}
+                            .values_list(lookups['related_view_id']).order_by().annotate(Count(lookups['related_view_id']))}
 
         # A mapping of object's view pk to a list of related state info for a related view
         join_map = {}
@@ -324,7 +324,7 @@ class TaxLotProperty(models.Model):
                                               and col['id'] in show_columns])
 
         obj_note_counts = {x[0]: x[1] for x in Note.objects.filter(**{lookups['obj_query_in']: ids})
-            .values_list(lookups['obj_view_id']).order_by().annotate(Count(lookups['obj_view_id']))}
+                           .values_list(lookups['obj_view_id']).order_by().annotate(Count(lookups['obj_view_id']))}
 
         for obj in object_list:
             # Each object in the response is built from the state data, with related data added on.

--- a/seed/serializers/properties.py
+++ b/seed/serializers/properties.py
@@ -314,10 +314,13 @@ class PropertyViewListSerializer(serializers.ListSerializer, OrgMixin, ProfileId
             view_ids = [view.id for view in iterable]
             results = []
 
-            # grab the organization and profile_id
-            org_id = self.get_organization(self.context['request'])
-            profile_id = self.context['request'].query_params.get('profile_id', None)
-            show_columns = self.get_show_columns(org_id, profile_id)
+            # grab the organization and profile_id. In testing the context is none in some cases.
+            if self.context.get('request') is not None:
+                org_id = self.get_organization(self.context['request'])
+                profile_id = self.context['request'].query_params.get('profile_id', None)
+                show_columns = self.get_show_columns(org_id, profile_id)
+            else:
+                show_columns = None
 
             for item in iterable:
                 cycle = [

--- a/seed/serializers/properties.py
+++ b/seed/serializers/properties.py
@@ -20,7 +20,6 @@ from rest_framework.fields import empty
 from seed.models import (
     AUDIT_USER_CREATE,
     AUDIT_USER_EDIT,
-    Column,
     GreenAssessmentProperty,
     PropertyAuditLog,
     Property,
@@ -38,6 +37,7 @@ from seed.serializers.measures import PropertyMeasureSerializer
 from seed.serializers.pint import PintQuantitySerializerField
 from seed.serializers.scenarios import ScenarioSerializer
 from seed.serializers.taxlots import TaxLotViewSerializer
+from seed.utils.api import OrgMixin, ProfileIdMixin
 
 # expose internal model
 PropertyLabel = apps.get_model('seed', 'Property_labels')
@@ -171,21 +171,40 @@ class PropertyStateSerializer(serializers.ModelSerializer):
             'organization': {'read_only': True}
         }
 
-    def __init__(self, instance=None, data=empty, all_extra_data_columns=None, **kwargs):
-        """Override __init__ for the optional all_extra_data_columns argument"""
-        self.all_extra_data_columns = all_extra_data_columns
+    def __init__(self, instance=None, data=empty, all_extra_data_columns=None, show_columns=None, **kwargs):
+        """
+        If show_columns is passed, then all_extra_data_columns is not needed since the extra_data columns are embedded
+        in the show_columns.
+
+        TODO: remove the use of all_extra_data_columns.
+
+        :param instance: instance to serialize
+        :param data: initial data
+        :param all_extra_data_columns:
+        :param show_columns: dict of list, Which columns to show in the form of c['fields']=[] and c['extra_data'].
+        """
+        if show_columns is not None:
+            self.all_extra_data_columns = show_columns['extra_data']
+        else:
+            self.all_extra_data_columns = all_extra_data_columns
+
         super(PropertyStateSerializer, self).__init__(instance=instance, data=data, **kwargs)
+
+        # remove the fields to display based on the show_columns list.
+        if show_columns is not None:
+            for field_name in set(self.fields) - set(show_columns['fields']):
+                self.fields.pop(field_name)
 
     def to_representation(self, data):
         """Overwritten to handle time conversion and extra_data null fields"""
         result = super(PropertyStateSerializer, self).to_representation(data)
 
         # Prepopulate the extra_data columns with a default of None so that they will appear in the result
+        # This will also handle the passing of the show_columns extra data list. If the show_columns isn't
+        # requiring a column, then it won't show up here.
         if self.all_extra_data_columns and data.extra_data:
             prepopulated_extra_data = {
-                col_name: data.extra_data.get(col_name, None)
-                for col_name
-                in self.all_extra_data_columns
+                col_name: data.extra_data.get(col_name, None) for col_name in self.all_extra_data_columns
             }
 
             result['extra_data'] = prepopulated_extra_data
@@ -273,7 +292,7 @@ class PropertyViewSerializer(serializers.ModelSerializer):
         fields = ('id', 'cycle', 'state', 'property')
 
 
-class PropertyViewListSerializer(serializers.ListSerializer):
+class PropertyViewListSerializer(serializers.ListSerializer, OrgMixin, ProfileIdMixin):
     """When serializing Property View as a list, omit history."""
 
     def to_representation(self, data):
@@ -282,6 +301,7 @@ class PropertyViewListSerializer(serializers.ListSerializer):
         # Not sure when the data is a models.Manager or a QuerySet. It seems
         # like this method, in general, is going to cause a bunch of issues as we
         # extend the data model.
+        # NL: Extending this method to add in profile_id lookup
         if isinstance(data, (models.Manager, models.QuerySet)):
             iterable = data.all().values(*PVFIELDS)
             view_ids = []
@@ -294,21 +314,20 @@ class PropertyViewListSerializer(serializers.ListSerializer):
             view_ids = [view.id for view in iterable]
             results = []
 
-            # If data is provided, grab extra_data columns to be shown in the result
-            if iterable:
-                organization_id = data[0].state.organization_id
-
-                all_extra_data_columns = Column.objects.filter(
-                    organization_id=organization_id,
-                    is_extra_data=True,
-                    table_name='PropertyState').values_list('column_name', flat=True)
+            # grab the organization and profile_id
+            org_id = self.get_organization(self.context['request'])
+            profile_id = self.context['request'].query_params.get('profile_id', None)
+            show_columns = self.get_show_columns(org_id, profile_id)
 
             for item in iterable:
                 cycle = [
                     (field, getattr(item.cycle, field, None)) for field in CYCLE_FIELDS
                 ]
                 cycle = OrderedDict(cycle)
-                state = PropertyStateSerializer(item.state, all_extra_data_columns=all_extra_data_columns).data
+                state = PropertyStateSerializer(
+                    item.state,
+                    show_columns=show_columns
+                ).data
                 representation = OrderedDict((
                     ('id', item.id),
                     ('property', item.property_id),
@@ -325,9 +344,7 @@ class PropertyViewListSerializer(serializers.ListSerializer):
         for certification in certifications:
             record = certset.setdefault(certification.view_id, [])
             record.append(
-                GreenAssessmentPropertyReadOnlySerializer(
-                    certification
-                ).data
+                GreenAssessmentPropertyReadOnlySerializer(certification).data
             )
         for row in results:
             row['certifications'] = certset.get(row['id'], None)
@@ -623,7 +640,8 @@ def unflatten_values(vdict, fkeys):
     :param fkeys: field names for foreign key (e.g. state for state__city)
     :type fkeys: list
     """
-    assert set(list(vdict.keys())).isdisjoint(set(fkeys)), "unflatten_values: {} has fields named in {}".format(vdict, fkeys)
+    assert set(list(vdict.keys())).isdisjoint(set(fkeys)), "unflatten_values: {} has fields named in {}".format(vdict,
+                                                                                                                fkeys)
     idents = tuple(["{}__".format(fkey) for fkey in fkeys])
     newdict = vdict.copy()
     for key, val in vdict.items():

--- a/seed/tests/test_properties_serializers.py
+++ b/seed/tests/test_properties_serializers.py
@@ -119,9 +119,7 @@ class TestPropertySerializers(DeleteModelsTestCase):
         serializer = PropertyViewListSerializer(
             child=PropertyViewSerializer()
         )
-        result = serializer.to_representation(
-            [property_view_1, property_view_2]
-        )
+        result = serializer.to_representation([property_view_1, property_view_2])
         self.assertEqual(result[0]['cycle']['id'], property_view_1.cycle_id)
         self.assertEqual(result[1]['cycle']['id'], property_view_2.cycle_id)
         self.assertEqual(result[0]['state']['id'], property_view_1.state_id)

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -19,6 +19,7 @@ from seed.lib.superperms.orgs.models import OrganizationUser
 from seed.models import (
     Column,
     ColumnMapping,
+    ColumnListSetting,
     PropertyView,
     StatusLabel,
     TaxLot,
@@ -27,9 +28,13 @@ from seed.models import (
     Unit,
 )
 from seed.test_helpers.fake import (
-    FakeCycleFactory, FakeColumnFactory,
-    FakePropertyFactory, FakePropertyStateFactory,
-    FakeTaxLotStateFactory
+    FakeCycleFactory,
+    FakeColumnFactory,
+    FakePropertyFactory,
+    FakePropertyStateFactory,
+    FakeTaxLotStateFactory,
+    FakeTaxLotFactory,
+    FakeColumnListSettingsFactory,
 )
 from seed.utils.organizations import create_organization
 
@@ -84,7 +89,7 @@ class GetDatasetsViewsTests(TestCase):
         import_record.save()
         response = self.client.get(reverse('api:v2:datasets-list'),
                                    {'organization_id': self.org.pk})
-        self.assertEqual(1, len(json.loads(response.content)['datasets']))
+        self.assertEqual(1, len(response.json()['datasets']))
 
     def test_get_datasets_count(self):
         import_record = ImportRecord.objects.create(owner=self.user)
@@ -93,7 +98,7 @@ class GetDatasetsViewsTests(TestCase):
         response = self.client.get(reverse('api:v2:datasets-count'),
                                    {'organization_id': self.org.pk})
         self.assertEqual(200, response.status_code)
-        j = json.loads(response.content)
+        j = response.json()
         self.assertEqual(j['status'], 'success')
         self.assertEqual(j['datasets_count'], 1)
 
@@ -104,7 +109,7 @@ class GetDatasetsViewsTests(TestCase):
         response = self.client.get(reverse('api:v2:datasets-count'),
                                    {'organization_id': 666})
         self.assertEqual(200, response.status_code)
-        j = json.loads(response.content)
+        j = response.json()
         self.assertEqual(j['status'], 'success')
         self.assertEqual(j['datasets_count'], 0)
 
@@ -116,7 +121,7 @@ class GetDatasetsViewsTests(TestCase):
             reverse('api:v2:datasets-detail', args=[import_record.pk]) + '?organization_id=' + str(
                 self.org.pk)
         )
-        self.assertEqual('success', json.loads(response.content)['status'])
+        self.assertEqual('success', response.json()['status'])
 
     def test_delete_dataset(self):
         import_record = ImportRecord.objects.create(owner=self.user)
@@ -128,7 +133,7 @@ class GetDatasetsViewsTests(TestCase):
                          args=[import_record.pk]) + '?organization_id=' + str(self.org.pk),
             content_type='application/json'
         )
-        self.assertEqual('success', json.loads(response.content)['status'])
+        self.assertEqual('success', response.json()['status'])
         self.assertFalse(
             ImportRecord.objects.filter(pk=import_record.pk).exists())
 
@@ -147,7 +152,7 @@ class GetDatasetsViewsTests(TestCase):
             content_type='application/json',
             data=json.dumps(post_data)
         )
-        self.assertEqual('success', json.loads(response.content)['status'])
+        self.assertEqual('success', response.json()['status'])
         self.assertTrue(ImportRecord.objects.filter(pk=import_record.pk,
                                                     name='new').exists())
 
@@ -178,7 +183,7 @@ class ImportFileViewsTests(TestCase):
     def test_get_import_file(self):
         response = self.client.get(
             reverse('api:v2:import_files-detail', args=[self.import_file.pk]))
-        self.assertEqual(self.import_file.pk, json.loads(response.content)['import_file']['id'])
+        self.assertEqual(self.import_file.pk, response.json()['import_file']['id'])
 
     def test_delete_file(self):
         url = reverse("api:v2:import_files-detail", args=[self.import_file.pk])
@@ -186,13 +191,13 @@ class ImportFileViewsTests(TestCase):
             url + '?organization_id=' + str(self.org.pk),
             content_type='application/json',
         )
-        self.assertEqual('success', json.loads(response.content)['status'])
+        self.assertEqual('success', response.json()['status'])
         self.assertFalse(ImportFile.objects.filter(pk=self.import_file.pk).exists())
 
     def test_get_matching_and_geocoding_results(self):
         response = self.client.get(
             '/api/v2/import_files/' + str(self.import_file.pk) + '/matching_and_geocoding_results/')
-        self.assertEqual('success', json.loads(response.content)['status'])
+        self.assertEqual('success', response.json()['status'])
 
 
 class TestMCMViews(TestCase):
@@ -254,7 +259,7 @@ class TestMCMViews(TestCase):
                          args=[self.import_file.pk]) + '?organization_id=' + str(self.org.pk),
             content_type='application/json'
         )
-        self.assertEqual('success', json.loads(response.content)['status'])
+        self.assertEqual('success', response.json()['status'])
 
     def test_get_column_mapping_suggestions_pm_file(self):
         response = self.client.get(
@@ -262,7 +267,7 @@ class TestMCMViews(TestCase):
                          args=[self.import_file.pk]) + '?organization_id=' + str(self.org.pk),
             content_type='application/json',
         )
-        self.assertEqual('success', json.loads(response.content)['status'])
+        self.assertEqual('success', response.json()['status'])
 
     def test_get_column_mapping_suggestions_with_columns(self):
         # create some mappings to model columns in the org
@@ -288,7 +293,7 @@ class TestMCMViews(TestCase):
                          args=[self.import_file.pk]) + '?organization_id=' + str(self.org.pk),
             content_type='application/json',
         )
-        self.assertEqual('success', json.loads(response.content)['status'])
+        self.assertEqual('success', response.json()['status'])
 
     def test_get_raw_column_names(self):
         """Good case for ``get_raw_column_names``."""
@@ -297,8 +302,7 @@ class TestMCMViews(TestCase):
             content_type='application/json'
         )
 
-        body = json.loads(resp.content)
-
+        body = resp.json()
         self.assertDictEqual(body, self.raw_columns_expected)
 
     def test_save_column_mappings(self):
@@ -336,7 +340,7 @@ class TestMCMViews(TestCase):
             content_type='application/json',
         )
 
-        self.assertDictEqual(json.loads(resp.content), {'status': 'success'})
+        self.assertDictEqual(resp.json(), {'status': 'success'})
 
         # test mapping a column that already has a global definition
         # should create a new column for that org with the same data
@@ -371,7 +375,7 @@ class TestMCMViews(TestCase):
             }),
             content_type='application/json',
         )
-        self.assertDictEqual(json.loads(resp.content), {'status': 'success'})
+        self.assertDictEqual(resp.json(), {'status': 'success'})
         self.assertEqual(ColumnMapping.objects.filter(super_organization=self.org).count(), 1)
 
         # the second user in the org makes the same save, which should not be
@@ -403,7 +407,7 @@ class TestMCMViews(TestCase):
         )
 
         # Sure enough, we haven't created a new ColumnMapping
-        self.assertDictEqual(json.loads(resp.content), {'status': 'success'})
+        self.assertDictEqual(resp.json(), {'status': 'success'})
         self.assertEqual(ColumnMapping.objects.filter(super_organization=self.org).count(), 1)
 
     def test_progress(self):
@@ -417,7 +421,7 @@ class TestMCMViews(TestCase):
                                content_type='application/json')
 
         self.assertEqual(resp.status_code, 200)
-        body = json.loads(resp.content)
+        body = resp.json()
         self.assertEqual(body.get('progress', None), 50)
         self.assertEqual(body.get('status_message', None), progress_data.data['status_message'])
 
@@ -432,7 +436,7 @@ class TestMCMViews(TestCase):
             }),
             content_type='application/json',
         )
-        data = json.loads(resp.content)
+        data = resp.json()
         self.assertEqual(data['name'], DATASET_NAME_1)
 
         resp = self.client.post(
@@ -442,7 +446,7 @@ class TestMCMViews(TestCase):
             }),
             content_type='application/json',
         )
-        data = json.loads(resp.content)
+        data = resp.json()
 
         self.assertEqual(data['name'], DATASET_NAME_2)
         the_id = data['id']
@@ -462,7 +466,7 @@ class TestMCMViews(TestCase):
             }),
             content_type='application/json',
         )
-        data_3 = json.loads(resp.content)
+        data_3 = resp.json()
         import_record = ImportRecord.objects.get(pk=data_3['id'])
 
         # test data set was created properly
@@ -486,16 +490,17 @@ class InventoryViewTests(DeleteModelsTestCase):
         self.user = User.objects.create_superuser(**user_details)
         self.org, _, _ = create_organization(self.user)
         self.column_factory = FakeColumnFactory(organization=self.org)
-        self.cycle_factory = FakeCycleFactory(organization=self.org,
-                                              user=self.user)
+        self.cycle_factory = FakeCycleFactory(organization=self.org, user=self.user)
         self.property_factory = FakePropertyFactory(organization=self.org)
         self.property_state_factory = FakePropertyStateFactory(organization=self.org)
+        self.taxlot_factory = FakeTaxLotFactory(organization=self.org)
         self.taxlot_state_factory = FakeTaxLotStateFactory(organization=self.org)
         self.cycle = self.cycle_factory.get_cycle(
             start=datetime(2010, 10, 10, tzinfo=timezone.get_current_timezone()))
         self.status_label = StatusLabel.objects.create(
             name='test', super_organization=self.org
         )
+        self.column_list_factory = FakeColumnListSettingsFactory(organization=self.org)
 
         self.client.login(**user_details)
 
@@ -516,10 +521,50 @@ class InventoryViewTests(DeleteModelsTestCase):
             'page', 1,
             'per_page', 999999999
         ), data={'profile_id': None})
-        result = json.loads(response.content)
+        result = response.json()
         results = result['results'][0]
         self.assertEquals(len(result['results']), 1)
         self.assertEquals(results[column_name_mappings['address_line_1']], state.address_line_1)
+
+    def test_get_properties_profile_id(self):
+        state = self.property_state_factory.get_property_state(extra_data={"field_1": "value_1"})
+        prprty = self.property_factory.get_property()
+        PropertyView.objects.create(
+            property=prprty, cycle=self.cycle, state=state
+        )
+
+        # save all the columns in the state to the database so we can setup column list settings
+        Column.save_column_names(state)
+        # get the columnlistsetting (default) for all columns
+        columnlistsetting = self.column_list_factory.get_columnlistsettings()
+
+        column_name_mappings = {}
+        for c in Column.retrieve_all(self.org.pk, 'property'):
+            if not c['related']:
+                column_name_mappings[c['column_name']] = c['name']
+
+        response = self.client.post('/api/v2/properties/filter/?{}={}&{}={}&{}={}'.format(
+            'organization_id', self.org.pk,
+            'page', 1,
+            'per_page', 999999999
+        ), data={'profile_id': columnlistsetting.pk})
+        result = response.json()
+        results = result['results'][0]
+        self.assertEquals(len(result['results']), 1)
+        self.assertEquals(results[column_name_mappings['field_1']], state.extra_data['field_1'])
+
+        # test with queryparam
+
+        response = self.client.post('/api/v2/properties/filter/?{}={}&{}={}&{}={}&{}={}'.format(
+            'organization_id', self.org.pk,
+            'page', 1,
+            'per_page', 999999999,
+            'profile_id', columnlistsetting.pk,
+        ))
+        result = response.json()
+        results = result['results'][0]
+        self.assertEquals(len(result['results']), 1)
+        self.assertEquals(results[column_name_mappings['field_1']], state.extra_data['field_1'])
 
     def test_get_properties_cycle_id(self):
         state = self.property_state_factory.get_property_state()
@@ -538,7 +583,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'page', 1,
             'per_page', 999999999
         ), data={'profile_id': None})
-        result = json.loads(response.content)
+        result = response.json()
         results = result['results'][0]
         self.assertEquals(len(result['results']), 1)
         self.assertEquals(results[column_name_mappings['address_line_1']], state.address_line_1)
@@ -563,7 +608,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'page', 1,
             'per_page', 999999999
         ), data={'profile_id': None})
-        result = json.loads(response.content)
+        result = response.json()
         results = result['results'][0]
 
         column_name_mappings = {}
@@ -593,7 +638,7 @@ class InventoryViewTests(DeleteModelsTestCase):
         }
         url = reverse('api:v2:properties-detail', args=[pv.id])
         response = self.client.get(url, params)
-        result = json.loads(response.content)
+        result = response.json()
         self.assertEqual(result['state']['gross_floor_area'], 3.14)
 
         # test writing the field -- does not work for pint fields, but other fields should persist fine
@@ -608,7 +653,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             }
         }
         response = self.client.put(url, data=json.dumps(params), content_type='application/json')
-        result = json.loads(response.content)
+        result = response.json()
         self.assertEqual(result['state']['gross_floor_area'], 11235.00)
         self.assertEqual(result['state']['site_eui'], 90.10)
 
@@ -644,7 +689,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             else:
                 column_name_mappings[c['column_name']] = c['name']
 
-        results = json.loads(response.content)
+        results = response.json()
         self.assertEquals(len(results['results']), 1)
         result = results['results'][0]
         self.assertTrue(result[column_name_mappings['campus']])
@@ -690,7 +735,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             else:
                 column_name_mappings[c['column_name']] = c['name']
 
-        results = json.loads(response.content)
+        results = response.json()
         self.assertEquals(len(results['results']), 1)
         result = results['results'][0]
         self.assertTrue(result[column_name_mappings['campus']])
@@ -731,7 +776,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'page', 1,
             'per_page', 999999999
         ), data={'profile_id': None})
-        result = json.loads(response.content)
+        result = response.json()
 
         column_name_mappings_related = {}
         column_name_mappings = {}
@@ -760,7 +805,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'page', 'one',
             'per_page', 999999999
         ), data={'profile_id': None})
-        result = json.loads(response.content)
+        result = response.json()
 
         self.assertEquals(len(result['results']), 1)
         pagination = result['pagination']
@@ -779,7 +824,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'per_page', 999999999
         )
         response = self.client.post(filter_properties_url, data={'profile_id': None})
-        result = json.loads(response.content)
+        result = response.json()
         self.assertEquals(len(result['results']), 0)
         pagination = result['pagination']
         self.assertEquals(pagination['page'], 1)
@@ -816,7 +861,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             '/api/v2/properties/' + str(property_view.id) + '/',
             params
         )
-        results = json.loads(response.content)
+        results = response.json()
 
         self.assertEqual(results['status'], 'success')
 
@@ -894,7 +939,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'organization_id': self.org.pk
         }
         response = self.client.get('/api/v2/properties/' + str(property_view.id) + '/', params)
-        results = json.loads(response.content)
+        results = response.json()
 
         rcycle = results['cycle']
         self.assertEquals(rcycle['name'], '2010 Annual')
@@ -972,7 +1017,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'per_page', 999999999,
             'cycle', self.cycle.pk
         ), data={'profile_id': None})
-        results = json.loads(response.content)['results']
+        results = response.json()['results']
 
         column_name_mappings_related = {}
         column_name_mappings = {}
@@ -1000,6 +1045,48 @@ class InventoryViewTests(DeleteModelsTestCase):
         # self.assertEquals(related['primary'], 'P')
         self.assertNotIn(column_name_mappings_related['extra_data_field'], related)
 
+    def test_get_taxlots_profile_id(self):
+        state = self.taxlot_state_factory.get_taxlot_state(extra_data={"field_1": "value_1"})
+        taxlot = self.taxlot_factory.get_taxlot()
+        TaxLotView.objects.create(
+            taxlot=taxlot, cycle=self.cycle, state=state
+        )
+
+        # save all the columns in the state to the database so we can setup column list settings
+        Column.save_column_names(state)
+        # get the columnlistsetting (default) for all columns
+        columnlistsetting = self.column_list_factory.get_columnlistsettings(
+            inventory_type=ColumnListSetting.VIEW_LIST_TAXLOT
+        )
+
+        column_name_mappings = {}
+        for c in Column.retrieve_all(self.org.pk, 'taxlot'):
+            if not c['related']:
+                column_name_mappings[c['column_name']] = c['name']
+
+        response = self.client.post('/api/v2/taxlots/filter/?{}={}&{}={}&{}={}'.format(
+            'organization_id', self.org.pk,
+            'page', 1,
+            'per_page', 999999999
+        ), data={'profile_id': columnlistsetting.pk})
+        result = response.json()
+        results = result['results'][0]
+        self.assertEquals(len(result['results']), 1)
+        self.assertEquals(results[column_name_mappings['field_1']], state.extra_data['field_1'])
+
+        # test with queryparam
+
+        response = self.client.post('/api/v2/taxlots/filter/?{}={}&{}={}&{}={}&{}={}'.format(
+            'organization_id', self.org.pk,
+            'page', 1,
+            'per_page', 999999999,
+            'profile_id', columnlistsetting.pk,
+        ))
+        result = response.json()
+        results = result['results'][0]
+        self.assertEquals(len(result['results']), 1)
+        self.assertEquals(results[column_name_mappings['field_1']], state.extra_data['field_1'])
+
     def test_get_taxlots_no_cycle_id(self):
         property_state = self.property_state_factory.get_property_state()
         property_property = self.property_factory.get_property()
@@ -1023,7 +1110,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'per_page', 999999999,
         )
         response = self.client.post(url, data={'profile_id': None})
-        results = json.loads(response.content)['results']
+        results = response.json()['results']
 
         self.assertEquals(len(results), 1)
 
@@ -1043,7 +1130,7 @@ class InventoryViewTests(DeleteModelsTestCase):
         )
         data = {'profile_id': None}
         response = self.client.post(url, data=data)
-        result = json.loads(response.content)
+        result = response.json()
 
         column_name_mappings_related = {}
         column_name_mappings = {}
@@ -1099,7 +1186,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'page', 1,
             'per_page', 999999999
         ), data={'profile_id': None})
-        results = json.loads(response.content)['results']
+        results = response.json()['results']
         self.assertEquals(len(results), 2)
 
         column_name_mappings_related = {}
@@ -1170,7 +1257,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'page', 1,
             'per_page', 999999999,
         ), data={'profile_id': None})
-        results = json.loads(response.content)['results']
+        results = response.json()['results']
 
         column_name_mappings_related = {}
         column_name_mappings = {}
@@ -1209,7 +1296,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'page', 'bad',
             'per_page', 999999999,
         ), data={'profile_id': None})
-        result = json.loads(response.content)
+        result = response.json()
 
         self.assertEquals(len(result['results']), 1)
         pagination = result['pagination']
@@ -1245,7 +1332,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'page', 1,
             'per_page', 999999999,
         ), data={'profile_id': None})
-        result = json.loads(response.content)
+        result = response.json()
 
         self.assertEquals(len(result['results']), 1)
         pagination = result['pagination']
@@ -1291,7 +1378,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'organization_id': self.org.pk,
         }
         response = self.client.get('/api/v2/taxlots/' + str(taxlot_view.id) + '/', params)
-        result = json.loads(response.content)
+        result = response.json()
 
         cycle = result['cycle']
         self.assertEqual(cycle['id'], self.cycle.pk)
@@ -1339,7 +1426,7 @@ class InventoryViewTests(DeleteModelsTestCase):
         response = self.client.get(
             reverse('api:v2:cycles-list'), params
         )
-        results = json.loads(response.content)
+        results = response.json()
         self.assertEqual(results['status'], 'success')
 
         self.assertEqual(len(results['cycles']), 2)
@@ -1364,7 +1451,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'per_page': 999999999,
         }
         response = self.client.get('/api/v2/properties/columns/', params)
-        results = json.loads(response.content)['columns']
+        results = response.json()['columns']
 
         self.assertTrue('id' in results[0])
 
@@ -1434,7 +1521,7 @@ class InventoryViewTests(DeleteModelsTestCase):
             'per_page': 999999999,
         }
         response = self.client.get('/api/v2/taxlots/columns/', params)
-        results = json.loads(response.content)['columns']
+        results = response.json()['columns']
 
         self.assertTrue('id' in results[0])
 

--- a/seed/utils/api.py
+++ b/seed/utils/api.py
@@ -273,7 +273,7 @@ class ProfileIdMixin(object):
                 inventory_type=ColumnListSetting.VIEW_LIST_PROPERTY
             )
             for col in list(ColumnListSettingColumn.objects.filter(column_list_setting_id=profile.id).values(
-                'column__column_name', 'column__is_extra_data')):
+                    'column__column_name', 'column__is_extra_data')):
                 if col['column__is_extra_data']:
                     show_columns['extra_data'].append(col['column__column_name'])
                 else:

--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -62,7 +62,7 @@ from seed.serializers.properties import (
 from seed.serializers.taxlots import (
     TaxLotViewSerializer,
 )
-from seed.utils.api import api_endpoint_class
+from seed.utils.api import ProfileIdMixin, api_endpoint_class
 from seed.utils.properties import (
     get_changed_fields,
     pair_unpair_property_taxlot,
@@ -200,7 +200,7 @@ class PropertyViewViewSet(SEEDOrgModelViewSet):
     queryset = PropertyView.objects.all().select_related('state')
 
 
-class PropertyViewSet(GenericViewSet):
+class PropertyViewSet(GenericViewSet, ProfileIdMixin):
     renderer_classes = (JSONRenderer,)
     serializer_class = PropertySerializer
 
@@ -209,6 +209,9 @@ class PropertyViewSet(GenericViewSet):
         per_page = request.query_params.get('per_page', 1)
         org_id = request.query_params.get('organization_id', None)
         cycle_id = request.query_params.get('cycle')
+        # check if there is a query paramater for the profile_id. If so, then use that one
+        profile_id = request.query_params.get('profile_id', profile_id)
+
         if not org_id:
             return JsonResponse(
                 {'status': 'error', 'message': 'Need to pass organization_id as query parameter'},
@@ -259,6 +262,8 @@ class PropertyViewSet(GenericViewSet):
         # Retrieve all the columns that are in the db for this organization
         columns_from_database = Column.retrieve_all(org_id, 'property', False)
 
+        # This uses an old method of returning the show_columns. There is a new method that
+        # is prefered in v2.1 API with the ProfileIdMixin.
         if profile_id is None:
             show_columns = None
         elif profile_id == -1:
@@ -394,6 +399,12 @@ class PropertyViewSet(GenericViewSet):
                 profile_id = None
             else:
                 profile_id = request.data['profile_id']
+
+                # ensure that profile_id is an int
+                try:
+                    profile_id = int(profile_id)
+                except TypeError:
+                    pass
 
         return self._get_filtered_results(request, profile_id=profile_id)
 
@@ -917,7 +928,8 @@ class PropertyViewSet(GenericViewSet):
                 is_extra_data=True,
                 table_name='PropertyState').values_list('column_name', flat=True)
 
-            result['state'] = PropertyStateSerializer(property_view.state, all_extra_data_columns=all_extra_data_columns).data
+            result['state'] = PropertyStateSerializer(property_view.state,
+                                                      all_extra_data_columns=all_extra_data_columns).data
             result['taxlots'] = self._get_taxlots(property_view.pk)
             result['history'], master = self.get_history(property_view)
             result = update_result_with_master(result, master)

--- a/seed/views/taxlots.py
+++ b/seed/views/taxlots.py
@@ -33,6 +33,7 @@ from seed.models import (
     MERGE_STATE_DELETE,
     Column,
     ColumnListSetting,
+    ColumnListSettingColumn,
     Cycle,
     Note,
     PropertyView,

--- a/seed/views/taxlots.py
+++ b/seed/views/taxlots.py
@@ -32,6 +32,7 @@ from seed.models import (
     MERGE_STATE_MERGED,
     MERGE_STATE_DELETE,
     Column,
+    ColumnListSetting,
     Cycle,
     Note,
     PropertyView,

--- a/seed/views/taxlots.py
+++ b/seed/views/taxlots.py
@@ -32,8 +32,6 @@ from seed.models import (
     MERGE_STATE_MERGED,
     MERGE_STATE_DELETE,
     Column,
-    ColumnListSetting,
-    ColumnListSettingColumn,
     Cycle,
     Note,
     PropertyView,
@@ -55,7 +53,7 @@ from seed.serializers.taxlots import (
     TaxLotStateSerializer,
     TaxLotViewSerializer
 )
-from seed.utils.api import api_endpoint_class
+from seed.utils.api import api_endpoint_class, ProfileIdMixin
 from seed.utils.properties import (
     get_changed_fields,
     pair_unpair_property_taxlot,
@@ -68,7 +66,7 @@ DISPLAY_RAW_EXTRADATA = True
 DISPLAY_RAW_EXTRADATA_TIME = True
 
 
-class TaxLotViewSet(GenericViewSet):
+class TaxLotViewSet(GenericViewSet, ProfileIdMixin):
     renderer_classes = (JSONRenderer,)
     serializer_class = TaxLotSerializer
 
@@ -77,6 +75,8 @@ class TaxLotViewSet(GenericViewSet):
         per_page = request.query_params.get('per_page', 1)
         org_id = request.query_params.get('organization_id', None)
         cycle_id = request.query_params.get('cycle')
+        # check if there is a query paramater for the profile_id. If so, then use that one
+        profile_id = request.query_params.get('profile_id', profile_id)
         if not org_id:
             return JsonResponse(
                 {'status': 'error', 'message': 'Need to pass organization_id as query parameter'},
@@ -127,6 +127,8 @@ class TaxLotViewSet(GenericViewSet):
         # Retrieve all the columns that are in the db for this organization
         columns_from_database = Column.retrieve_all(org_id, 'taxlot', False)
 
+        # This uses an old method of returning the show_columns. There is a new method that
+        # is prefered in v2.1 API with the ProfileIdMixin.
         if profile_id is None:
             show_columns = None
         elif profile_id == -1:


### PR DESCRIPTION
Note that this is based off of master (called 2.5.2-patch0).

#### Any background context you want to provide
The listing of properties between version 2 and 2.1 of the API differed in the sense that there was not a way to remove fields in the 2.1 results using the profile_id setup.

#### What's this PR do?
* Adds the profile_id to the properties list for version 2.1 API
* Adds new helper method for extracting the show_columns from a profile_id

#### How should this be manually tested?
* Import data
* Create a profile on the properties list
* Go to the URL for the v2.1 API call and include profile_id in query param  
  `{{SEEDURL}}/api/v2.1/properties/?organization_id={{organization_id}}&profile_id={{profile_id}}
* Make sure that the state data are only the fields in the profile_id.

#### What are the relevant tickets?
#1879 

#### Screenshots (if appropriate)
n/a
