### PR TITLE
Fixes column renaming issues

### DIFF
--- a/seed/models/columns.py
+++ b/seed/models/columns.py
@@ -643,7 +643,8 @@ class Column(models.Model):
         try:
             with transaction.atomic():
                 # check if the new_column already exists
-                new_column = Column.objects.filter(table_name=self.table_name, column_name=new_column_name)
+                new_column = Column.objects.filter(table_name=self.table_name, column_name=new_column_name,
+                                                   organization=self.organization)
                 if len(new_column) > 0:
                     if not force:
                         return [False, 'New column already exists, specify overwrite data if desired']
@@ -680,14 +681,14 @@ class Column(models.Model):
                 # go through the data and move it to the new field. I'm not sure yet on how long this is
                 # going to take to run, so we may have to move this to a background task
                 orig_data = STR_TO_CLASS[self.table_name].objects.filter(
-                    organization=new_column.organization,
+                    organization=self.organization,
                     data_state=DATA_STATE_MATCHING
                 )
                 if new_column.is_extra_data:
                     if self.is_extra_data:
                         for datum in orig_data:
-                            datum.extra_data[new_column.column_name] = datum.extra_data[self.column_name]
-                            del datum.extra_data[self.column_name]
+                            datum.extra_data[new_column.column_name] = datum.extra_data.get(self.column_name, None)
+                            datum.extra_data.pop(self.column_name, None)
                             datum.save()
                     else:
                         for datum in orig_data:
@@ -698,8 +699,8 @@ class Column(models.Model):
                 else:
                     if self.is_extra_data:
                         for datum in orig_data:
-                            setattr(datum, new_column.column_name, datum.extra_data[self.column_name])
-                            del datum.extra_data[self.column_name]
+                            setattr(datum, new_column.column_name, datum.extra_data.get(self.column_name, None))
+                            datum.extra_data.pop(self.column_name, None)
                             datum.save()
                     else:
                         for datum in orig_data:
@@ -1312,7 +1313,7 @@ class Column(models.Model):
     @staticmethod
     def retrieve_priorities(org_id):
         """
-        Return the list of priorties for the columns. Result will be in the form of:
+        Return the list of priorities for the columns. Result will be in the form of:
 
         .. code-block:: json
 


### PR DESCRIPTION
#### What's this PR do?
Fixes two issues:
- New columns were not being created if even a single organization had a column with that name.  If the current org didn't have the column but another org did it could lose the data by adding it to extra_data without an actual column to access the data.  If no orgs had that column it would be created for the wrong org.
- Fixes a KeyError when trying to access extra_data keys that may not exist
#### How should this be manually tested?
- Have multiple orgs, and using the most-recently created org test renaming columns and verify that the data is correct afterwards.
- Rename an existing extra_data column to a different existing extra_data column, and then do the exact same rename a second time.  This should result in all `null` values for the new column
#### What are the relevant tickets?
#1903 
#### Relevant screenshots?
Extra_data diff:
![image](https://user-images.githubusercontent.com/411466/59948149-7aba1c80-942c-11e9-8d1e-1f155849586c.png)

