### PR TITLE
Allows env to control postgres port in SEED docker image

### DIFF
--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 from config.settings.common import *  # noqa
 
 # Gather all the settings from the docker environment variables
-ENV_VARS = ['POSTGRES_DB', 'POSTGRES_USER', 'POSTGRES_PASSWORD', ]
+ENV_VARS = ['POSTGRES_DB', 'POSTGRES_PORT', 'POSTGRES_USER', 'POSTGRES_PASSWORD', ]
 
 # The optional vars will set the SERVER_EMAIL information as needed
 OPTIONAL_ENV_VARS = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SES_REGION_NAME',
@@ -47,7 +47,7 @@ DATABASES = {
         'USER': POSTGRES_USER,
         'PASSWORD': POSTGRES_PASSWORD,
         'HOST': "db-postgres",
-        'PORT': 5432,
+        'PORT': POSTGRES_PORT,
     }
 }
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,6 +1,7 @@
 # Docker Compose for deployment using a local registry.
 # Must set the following environment variables
 #   POSTGRES_DB
+#   POSTGRES_PORT
 #   POSTGRES_USER
 #   POSTGRES_PASSWORD
 #   SEED_ADMIN_USER
@@ -50,6 +51,7 @@ services:
       - AWS_SES_REGION_ENDPOINT
       - SERVER_EMAIL
       - POSTGRES_DB
+      - POSTGRES_PORT=5432
       - POSTGRES_USER
       - POSTGRES_PASSWORD
       # - REDIS_PASSWORD
@@ -80,6 +82,7 @@ services:
     image: 127.0.0.1:5000/seed
     environment:
       - POSTGRES_DB
+      - POSTGRES_PORT=5432
       - POSTGRES_USER
       - POSTGRES_PASSWORD
       - SECRET_KEY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - AWS_SES_REGION_ENDPOINT
       - SERVER_EMAIL
       - POSTGRES_DB=seed
+      - POSTGRES_PORT=5432
       - POSTGRES_USER=seed
       - POSTGRES_PASSWORD=super-secret-password
       # - REDIS_PASSWORD=optional-need-to-configure-redis
@@ -53,6 +54,7 @@ services:
     command: /seed/docker/start_celery_docker.sh
     environment:
       - POSTGRES_DB=seed
+      - POSTGRES_PORT=5432
       - POSTGRES_USER=seed
       - POSTGRES_PASSWORD=super-secret-password
       # - REDIS_PASSWORD=optional-need-to-configure-redis


### PR DESCRIPTION
#### Any background context you want to provide?

Setting the postgresql port via an env var is consistent with the
other settings versus hard-coding.

#### What's this PR do?

This PR allows the port used by a SEED docker container to communicate with a postgres installation to be re-mapped eg. in a docker-compose file. Our use case was to allow a local dev installation of postgres to co-exist with one running in a container. (The local dev one typically claims 5432).

#### How should this be manually tested?

This should be a no-op if one's using the `docker-compose.yml` or `docker-compose.local.yml` provided at the root of the repo.

Testing:

1. Build a new docker container with `docker build .`
2. Change the `web` and `web-celery` images in `docker-compose.yml` to point at the image ID of the newly-created docker image.
3. Run `docker-compose up` and test that the SEED instance on `http://localhost:8000` can still log in, create cycles, etc. This will indicate that the port is being correctly fed through from the environment.

#### What are the relevant tickets?

n/a

#### Screenshots (if appropriate)

n/a
