### PR TITLE
minor issues with PropertyStateWritableSerializer and GreenAssessment…

### DIFF
--- a/seed/serializers/certification.py
+++ b/seed/serializers/certification.py
@@ -144,7 +144,7 @@ class GreenAssessmentPropertySerializer(OrgValidateMixin, serializers.ModelSeria
     metric = serializers.FloatField(required=False, allow_null=True)
     rating = serializers.CharField(
         required=False, allow_null=True, max_length=100)
-    expiration_date = serializers.DateField()
+    expiration_date = serializers.DateField(allow_null=True, required=False)
     # ensure reuqest.users org matches that of view and assessment
     org_validators = [ASSESSMENT_VALIDATOR, PROPERTY_VIEW_VALIDATOR]
 

--- a/seed/serializers/properties.py
+++ b/seed/serializers/properties.py
@@ -378,8 +378,8 @@ class PropertyViewAsStateSerializer(serializers.ModelSerializer):
                 state = PropertyStateWritableSerializer(
                     instance=state_obj
                 ).data
-            except ValueError:
-                state = json.loads(state)
+            except TypeError:
+                pass  # already a PropertyStateWritableSerializer object
             required = True if self.context['request'].method in ['PUT', 'POST'] else False
             org = state.get('organization')
             org_id = org if org else org_id
@@ -413,8 +413,9 @@ class PropertyViewAsStateSerializer(serializers.ModelSerializer):
                     missing.append(field)
         # type validation
         for field in required_fields:
-            if data.get(field) and not isinstance(data[field], (basestring, int)):
-                wrong_type.append((field, type(field)))
+            if field != 'state':  # state is a writeable serializer field
+                if data.get(field) and not isinstance(data[field], (basestring, int)):
+                    wrong_type.append((field, type(field)))
         for fields in unique_together:
             field_vals = {}
             for field in fields:


### PR DESCRIPTION
…PropertySerializer

#### Any background context you want to provide?
Since the "state" field in the PropertyViewAsStateSerializer is a nested writable serializer field which allows the creation of a PropertyState record simultaneously with the creation of a PropertyView, the type validation based on PropertyView model fields was causing the nested creation to break with "int() argument must be a string, a bytes-like object or a number, not 'dict'".
Likewise, since the serializer automatically renders data sent to "state" as PropertyStateWritableSerializer data, the  json.loads call was also raising a TypeError: "the JSON object must be str, bytes or bytearray, not 'dict'"
#### What's this PR do?
#### How should this be manually tested?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
