### PR TITLE
Limit log count to 5 before rotating

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -25,6 +25,7 @@ services:
     logging:
       options:
         max-size: 50m
+        max-file: 5
     deploy:
       restart_policy:
         condition: on-failure
@@ -36,6 +37,7 @@ services:
     logging:
       options:
         max-size: 50m
+        max-file: 5
     deploy:
       restart_policy:
         condition: on-failure
@@ -72,6 +74,7 @@ services:
     logging:
       options:
         max-size: 50m
+        max-file: 5
     deploy:
       restart_policy:
         condition: on-failure
@@ -100,6 +103,7 @@ services:
     logging:
       options:
         max-size: 50m
+        max-file: 5
     deploy:
       restart_policy:
         condition: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     logging:
       options:
         max-size: 50m
+        max-file: 5
   db-redis:
     image: redis:5.0.1
   web:
@@ -48,6 +49,7 @@ services:
     logging:
       options:
         max-size: 50m
+        max-file: 5
   web-celery:
     image: seedplatform/seed:latest
     build: .
@@ -70,6 +72,7 @@ services:
     logging:
       options:
         max-size: 50m
+        max-file: 5
   oep-city-1:
     # This is a placeholder. If needed, follow the instructions to enable: https://cloud.docker.com/u/seedplatform/repository/docker/seedplatform/oep
     image: seedplatform/oep:1.2
@@ -80,6 +83,7 @@ services:
     logging:
       options:
         max-size: 50m
+        max-file: 5
 volumes:
   seed_pgdata:
     external: true


### PR DESCRIPTION
#### Any background context you want to provide?
Docker logs were getting too large causing out of space errors.

#### What's this PR do?
Limits logs to 5 files (50MB each)

#### How should this be manually tested?
* If deploying using a docker-compose file that is not under version control, then manually add `max-file: 5` to your docker file.

#### What are the relevant tickets?
#1923 

#### Screenshots (if appropriate)
N/A