### PR TITLE
Support latest API of Unique Building ID

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -53,8 +53,8 @@ probablepeople==0.5.4
 # Parsing and managing geojson data (this is only used in managed tasks at the moment)
 geojson==2.4.1
 
-# pnnl/buildingid
--e git+https://github.com/SEED-platform/buildingid.git@fd9067f70ae40f6ae3bf2bad6e31b5d2a9e8b150#egg=buildingid
+# pnnl/buildingid-py
+-e git+https://github.com/SEED-platform/buildingid.git@f68219df82191563cc2aca818e0b0fa1b32dd52d#egg=buildingid
 
 enum34==1.1.6  # enum34 needs to be specified to support cryptography and oauth2
 oauthlib==2.0.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -22,7 +22,7 @@ pycodestyle==2.5.0
 # documentation and spelling
 Sphinx==1.8.1
 sphinxcontrib-spelling==4.2.0
-sphinx_rtd_theme==0.4.2
+sphinx_rtd_theme==0.4.3
 
 # For running the server
 uWSGI==2.0.17.1

--- a/seed/tests/test_utils_ubid.py
+++ b/seed/tests/test_utils_ubid.py
@@ -159,39 +159,6 @@ class UbidUtilMethods(TestCase):
         self.assertIsNone(bounding_box_wkt(refreshed_taxlot))
         self.assertIsNone(centroid_wkt(refreshed_taxlot))
 
-    def test_decode_ubids_is_successful_when_v2_format_C_NW_SE_UBID_provided(self):
-        property_details = self.property_state_factory.get_details()
-        property_details['organization_id'] = self.org.id
-        # Old format (v2) is not longer supported
-        # property_details['ubid'] = '849VQJH6+95J-849VQJH5+VGW-849VQJG6+XV8'
-        property_details['ubid'] = '849VQJH6+95J-51-58-42-50'
-
-        property = PropertyState(**property_details)
-        property.save()
-        properties = PropertyState.objects.filter(pk=property.id)
-
-        decode_unique_ids(properties)
-        refreshed_property = PropertyState.objects.get(pk=property.id)
-
-        property_bounding_box_wkt = (
-            "POLYGON ((-122.3877812499996 37.77739999999996, "
-            "-122.3877812499996 37.77975000000004, "
-            "-122.3911875000003 37.77975000000004, "
-            "-122.3911875000003 37.77739999999996, "
-            "-122.3877812499996 37.77739999999996))"
-        )
-        property_centroid_wkt = (
-            "POLYGON ((-122.38959375 37.77845, "
-            "-122.38959375 37.778475, "
-            "-122.389625 37.778475, "
-            "-122.389625 37.77845, "
-            "-122.38959375 37.77845))"
-        )
-        self.assertEqual(property_bounding_box_wkt, bounding_box_wkt(refreshed_property))
-        self.assertEqual(property_centroid_wkt, centroid_wkt(refreshed_property))
-        self.assertEqual(refreshed_property.latitude, 37.778575)
-        self.assertEqual(refreshed_property.longitude, -122.389484375)
-
     def test_decode_ubids_doesnt_throw_an_error_if_an_invalid_ubid_is_provided(self):
         property_details = self.property_state_factory.get_details()
         property_details['organization_id'] = self.org.id

--- a/seed/tests/test_utils_ubid.py
+++ b/seed/tests/test_utils_ubid.py
@@ -162,7 +162,9 @@ class UbidUtilMethods(TestCase):
     def test_decode_ubids_is_successful_when_v2_format_C_NW_SE_UBID_provided(self):
         property_details = self.property_state_factory.get_details()
         property_details['organization_id'] = self.org.id
-        property_details['ubid'] = '849VQJH6+95J-849VQJH5+VGW-849VQJG6+XV8'
+        # Old format (v2) is not longer supported
+        # property_details['ubid'] = '849VQJH6+95J-849VQJH5+VGW-849VQJG6+XV8'
+        property_details['ubid'] = '849VQJH6+95J-51-58-42-50'
 
         property = PropertyState(**property_details)
         property.save()
@@ -170,12 +172,13 @@ class UbidUtilMethods(TestCase):
 
         decode_unique_ids(properties)
         refreshed_property = PropertyState.objects.get(pk=property.id)
+
         property_bounding_box_wkt = (
-            "POLYGON ((-122.38778125 37.77740000000001, "
-            "-122.38778125 37.77975000000001, "
-            "-122.3911875 37.77975000000001, "
-            "-122.3911875 37.77740000000001, "
-            "-122.38778125 37.77740000000001))"
+            "POLYGON ((-122.3877812499996 37.77739999999996, "
+            "-122.3877812499996 37.77975000000004, "
+            "-122.3911875000003 37.77975000000004, "
+            "-122.3911875000003 37.77739999999996, "
+            "-122.3877812499996 37.77739999999996))"
         )
         property_centroid_wkt = (
             "POLYGON ((-122.38959375 37.77845, "


### PR DESCRIPTION
#### Any background context you want to provide?
There was a small change to the API in the UBID API.

#### What's this PR do?
Enables use of new UBID API. Note that UBID-V2 is no longer supported, only V3.

#### How should this be manually tested?
The unit tests should cover the tests. Otherwise, import one of the covered building sample files and verify that the UBID imports and that the GeoJSON exports look correct in geojson.io.

#### What are the relevant tickets?
#1930 

#### Screenshots (if appropriate)
