### PR TITLE
move buildingsync/hpxml tests to respective dirs

### DIFF
--- a/seed/building_sync/tests/test_buildingsync.py
+++ b/seed/building_sync/tests/test_buildingsync.py
@@ -10,7 +10,6 @@ from os import path
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
-from config.settings.common import BASE_DIR
 from seed.models import User
 from seed.models.building_file import BuildingFile
 from seed.models.scenarios import Scenario

--- a/seed/building_sync/tests/test_buildingsync.py
+++ b/seed/building_sync/tests/test_buildingsync.py
@@ -36,10 +36,9 @@ class TestBuildingFiles(TestCase):
         self.assertEqual(BuildingFile.str_to_file_type('BuildingSync'), 1)
         self.assertEqual(BuildingFile.str_to_file_type('BUILDINGSYNC'), 1)
         self.assertEqual(BuildingFile.str_to_file_type('Unknown'), 0)
-        self.assertEqual(BuildingFile.str_to_file_type('hpxml'), 3)
 
     def test_buildingsync_constructor(self):
-        filename = path.join(BASE_DIR, 'seed', 'building_sync', 'tests', 'data', 'ex_1.xml')
+        filename = path.join(path.dirname(__file__), 'data', 'ex_1.xml')
         file = open(filename, 'rb')
         simple_uploaded_file = SimpleUploadedFile(file.name, file.read())
 
@@ -56,7 +55,7 @@ class TestBuildingFiles(TestCase):
         self.assertEqual(messages, {'errors': [], 'warnings': []})
 
     def test_buildingsync_constructor_diff_ns(self):
-        filename = path.join(BASE_DIR, 'seed', 'building_sync', 'tests', 'data', 'ex_1_different_namespace.xml')
+        filename = path.join(path.dirname(__file__), 'data', 'ex_1_different_namespace.xml')
         file = open(filename, 'rb')
         simple_uploaded_file = SimpleUploadedFile(file.name, file.read())
 
@@ -73,7 +72,7 @@ class TestBuildingFiles(TestCase):
 
     def test_buildingsync_constructor_single_scenario(self):
         # test having only 1 measure and 1 scenario
-        filename = path.join(BASE_DIR, 'seed', 'building_sync', 'tests', 'data', 'test_single_scenario.xml')
+        filename = path.join(path.dirname(__file__), 'data', 'test_single_scenario.xml')
         file = open(filename, 'rb')
         simple_uploaded_file = SimpleUploadedFile(file.name, file.read())
 
@@ -89,7 +88,7 @@ class TestBuildingFiles(TestCase):
         self.assertEqual(messages, {'errors': [], 'warnings': []})
 
     def test_buildingsync_bricr_import(self):
-        filename = path.join(BASE_DIR, 'seed', 'building_sync', 'tests', 'data', 'buildingsync_v2_0_bricr_workflow.xml')
+        filename = path.join(path.dirname(__file__), 'data', 'buildingsync_v2_0_bricr_workflow.xml')
         file = open(filename, 'rb')
         simple_uploaded_file = SimpleUploadedFile(file.name, file.read())
 
@@ -111,20 +110,3 @@ class TestBuildingFiles(TestCase):
         self.assertTrue(len(meters) > 0)
         readings = MeterReading.objects.filter(meter_id=meters[0].id)
         self.assertTrue(len(readings) > 0)
-
-    def test_hpxml_constructor(self):
-        filename = path.join(BASE_DIR, 'seed', 'hpxml', 'tests', 'data', 'audit.xml')
-        file = open(filename, 'rb')
-        simple_uploaded_file = SimpleUploadedFile(file.name, file.read())
-
-        bf = BuildingFile.objects.create(
-            file=simple_uploaded_file,
-            filename=filename,
-            file_type=BuildingFile.HPXML
-        )
-
-        status, property_state, property_view, messages = bf.process(self.org.id, self.org.cycles.first())
-        self.assertTrue(status)
-        self.assertEqual(property_state.owner, 'Jane Customer')
-        self.assertEqual(property_state.energy_score, 8)
-        self.assertEqual(messages, {'errors': [], 'warnings': []})

--- a/seed/building_sync/tests/test_buildingsync_views.py
+++ b/seed/building_sync/tests/test_buildingsync_views.py
@@ -188,19 +188,3 @@ class InventoryViewTests(DeleteModelsTestCase):
         response = self.client.get(url)
         self.assertIn('<auc:YearOfConstruction>1889</auc:YearOfConstruction>',
                       response.content.decode('utf-8'))
-
-    def test_get_hpxml(self):
-        state = self.property_state_factory.get_property_state()
-        prprty = self.property_factory.get_property()
-        pv = PropertyView.objects.create(
-            property=prprty, cycle=self.cycle, state=state
-        )
-
-        # go to buildingsync endpoint
-        params = {
-            'organization_id': self.org.pk
-        }
-        url = reverse('api:v2.1:properties-hpxml', args=[pv.id])
-        response = self.client.get(url, params)
-        self.assertIn('<GrossFloorArea>%s.0</GrossFloorArea>' % state.gross_floor_area,
-                      response.content.decode('utf-8'))

--- a/seed/building_sync/tests/test_buildingsync_views.py
+++ b/seed/building_sync/tests/test_buildingsync_views.py
@@ -69,8 +69,7 @@ class InventoryViewTests(DeleteModelsTestCase):
                       response.content.decode("utf-8"))
 
     def test_upload_and_get_building_sync(self):
-        # import_record =
-        filename = path.join(BASE_DIR, 'seed', 'building_sync', 'tests', 'data', 'ex_1.xml')
+        filename = path.join(path.dirname(__file__), 'data', 'ex_1.xml')
 
         url = reverse('api:v2:building_file-list')
         fsysparams = {
@@ -97,8 +96,7 @@ class InventoryViewTests(DeleteModelsTestCase):
 
     def test_upload_batch_building_sync(self):
         # import a zip file of BuildingSync xmls
-        # import_record =
-        filename = path.join(BASE_DIR, 'seed', 'building_sync', 'tests', 'data', 'valid_xml_ex1_ex2.zip')
+        filename = path.join(path.dirname(__file__), 'data', 'valid_xml_ex1_ex2.zip')
 
         url = '/api/v2/building_file/'
         fsysparams = {
@@ -118,8 +116,7 @@ class InventoryViewTests(DeleteModelsTestCase):
         self.assertEqual(result['data']['property_view']['state']['postal_code'], '94111')
 
     def test_upload_with_measure_duplicates(self):
-        # import_record =
-        filename = path.join(BASE_DIR, 'seed', 'building_sync', 'tests', 'data', 'buildingsync_ex01_measures.xml')
+        filename = path.join(path.dirname(__file__), 'data', 'buildingsync_ex01_measures.xml')
 
         url = reverse('api:v2:building_file-list')
         fsysparams = {
@@ -162,9 +159,7 @@ class InventoryViewTests(DeleteModelsTestCase):
         self.assertEqual(len(result['data']['property_view']['state']['scenarios']), 31)
 
     def test_upload_and_get_building_sync_diff_ns(self):
-        # import_record =
-        filename = path.join(BASE_DIR, 'seed', 'building_sync', 'tests', 'data',
-                             'ex_1_different_namespace.xml')
+        filename = path.join(path.dirname(__file__), 'data', 'ex_1_different_namespace.xml')
 
         url = reverse('api:v2:building_file-list')
 

--- a/seed/building_sync/tests/test_buildingsync_views.py
+++ b/seed/building_sync/tests/test_buildingsync_views.py
@@ -11,7 +11,6 @@ from os import path
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 
-from config.settings.common import BASE_DIR
 from seed.landing.models import SEEDUser as User
 from seed.models import (
     PropertyView,

--- a/seed/hpxml/tests/test_hpxml.py
+++ b/seed/hpxml/tests/test_hpxml.py
@@ -1,0 +1,49 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2019, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+
+from os import path
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from seed.models import User
+from seed.models.building_file import BuildingFile
+from seed.utils.organizations import create_organization
+
+
+class TestBuildingFiles(TestCase):
+    def setUp(self):
+        user_details = {
+            'username': 'test_user@demo.com',
+            'password': 'test_pass',
+            'email': 'test_user@demo.com'
+        }
+        self.user = User.objects.create_superuser(**user_details)
+        self.org, _, _ = create_organization(self.user)
+
+    def test_file_type_lookup(self):
+        self.assertEqual(BuildingFile.str_to_file_type(None), None)
+        self.assertEqual(BuildingFile.str_to_file_type(''), None)
+        self.assertEqual(BuildingFile.str_to_file_type('Unknown'), 0)
+        self.assertEqual(BuildingFile.str_to_file_type('hpxml'), 3)
+
+    def test_hpxml_constructor(self):
+        filename = path.join(path.dirname(__file__), 'data', 'audit.xml')
+        file = open(filename, 'rb')
+        simple_uploaded_file = SimpleUploadedFile(file.name, file.read())
+
+        bf = BuildingFile.objects.create(
+            file=simple_uploaded_file,
+            filename=filename,
+            file_type=BuildingFile.HPXML
+        )
+
+        status, property_state, property_view, messages = bf.process(self.org.id, self.org.cycles.first())
+        self.assertTrue(status)
+        self.assertEqual(property_state.owner, 'Jane Customer')
+        self.assertEqual(property_state.energy_score, 8)
+        self.assertEqual(messages, {'errors': [], 'warnings': []})

--- a/seed/hpxml/tests/test_hpxml_views.py
+++ b/seed/hpxml/tests/test_hpxml_views.py
@@ -1,0 +1,66 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2019, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+from datetime import datetime
+
+from django.core.urlresolvers import reverse
+from django.utils import timezone
+
+from seed.landing.models import SEEDUser as User
+from seed.models import (
+    PropertyView,
+    StatusLabel,
+)
+from seed.test_helpers.fake import (
+    FakeCycleFactory, FakeColumnFactory,
+    FakePropertyFactory, FakePropertyStateFactory,
+    FakeTaxLotStateFactory
+)
+from seed.tests.util import DeleteModelsTestCase
+from seed.utils.organizations import create_organization
+
+
+class InventoryViewTests(DeleteModelsTestCase):
+    def setUp(self):
+        user_details = {
+            'username': 'test_user@demo.com',
+            'password': 'test_pass',
+            'email': 'test_user@demo.com'
+        }
+        self.user = User.objects.create_superuser(**user_details)
+        self.org, _, _ = create_organization(self.user)
+        self.status_label = StatusLabel.objects.create(
+            name='test', super_organization=self.org
+        )
+
+        self.column_factory = FakeColumnFactory(organization=self.org)
+        self.cycle_factory = FakeCycleFactory(organization=self.org,
+                                              user=self.user)
+        self.property_factory = FakePropertyFactory(organization=self.org)
+        self.property_state_factory = FakePropertyStateFactory(organization=self.org)
+        self.taxlot_state_factory = FakeTaxLotStateFactory(organization=self.org)
+
+        self.cycle = self.cycle_factory.get_cycle(
+            start=datetime(2010, 10, 10, tzinfo=timezone.get_current_timezone())
+        )
+
+        self.client.login(**user_details)
+
+    def test_get_hpxml(self):
+        state = self.property_state_factory.get_property_state()
+        prprty = self.property_factory.get_property()
+        pv = PropertyView.objects.create(
+            property=prprty, cycle=self.cycle, state=state
+        )
+
+        # go to hpxml endpoint
+        params = {
+            'organization_id': self.org.pk
+        }
+        url = reverse('api:v2.1:properties-hpxml', args=[pv.id])
+        response = self.client.get(url, params)
+        self.assertIn('<GrossFloorArea>%s.0</GrossFloorArea>' % state.gross_floor_area,
+                      response.content.decode('utf-8'))


### PR DESCRIPTION
#### Any background context you want to provide?
Example files for BuildingSync and HPXML were in their respective project folders, but the tests were in the general seed/tests folder.

#### What's this PR do?
* breaks up the bsync and hpxml tests into their project folders

#### How should this be manually tested?
CI

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
