### PR TITLE
Refresh initial matching criteria for all orgs

### DIFF
--- a/seed/migrations/0112_refresh_matching_criteria.py
+++ b/seed/migrations/0112_refresh_matching_criteria.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models, transaction
+
+
+def forwards(apps, schema_editor):
+    Column = apps.get_model("seed", "Column")
+
+    with transaction.atomic():
+        propertystate_matching_criteria = [
+            'address_line_1',  # Technically this was normalized_address, but matching logic handles this as such
+            'custom_id_1',
+            'pm_property_id',
+            'ubid',
+        ]
+
+        taxlotstate_matching_criteria = [
+            'address_line_1',  # Technically this was normalized_address, but matching logic handles this as such
+            'custom_id_1',
+            'jurisdiction_tax_lot_id',
+            'ulid'
+        ]
+
+        # Ensure ONLY initial matching criteria is set to True
+        Column.objects.filter(
+            table_name='PropertyState',
+            column_name__in=propertystate_matching_criteria
+        ).update(is_matching_criteria=True)
+        Column.objects.filter(table_name='PropertyState').\
+            exclude(column_name__in=propertystate_matching_criteria).\
+            update(is_matching_criteria=False)
+
+        Column.objects.filter(
+            table_name='TaxLotState',
+            column_name__in=taxlotstate_matching_criteria
+        ).update(is_matching_criteria=True)
+        Column.objects.filter(table_name='TaxLotState').\
+            exclude(column_name__in=taxlotstate_matching_criteria).\
+            update(is_matching_criteria=False)
+
+        # Also, the Column records NOT attached to any table type should definitely NOT be matching criteria.
+        Column.objects.filter(table_name='').update(is_matching_criteria=False)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('seed', '0111_rehash'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards),
+    ]

--- a/seed/migrations/0112_refresh_matching_criteria.py
+++ b/seed/migrations/0112_refresh_matching_criteria.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations, models, transaction
+from django.db import migrations, transaction
 
 
 def forwards(apps, schema_editor):


### PR DESCRIPTION
#### Any background context you want to provide?
During the implementation of recent matching updates, users were given the ability to customize/choose matching criteria columns for each organization. In order to transition from pre-defined matching criteria to custom matching criteria, an initial set of matching criteria was specified for each org and the possible record types, properties and tax lots.

Unfortunately, the migration used to set this initial matching criteria across all organizations was not correctly defined. There were too many columns that were updated to be matching criteria, and some of these were extra_data columns 😨.

This caused all file imports to fail for some organizations because extra_data columns were being included in first-level database queries (i.e. `PropertyState.objects.filter(extra_data_1=...`).

#### What's this PR do?
This PR includes a migration that corrects this mistake. Specifically, the following columns are specified as matching criteria
For properties:
- address_line_1
- custom_id_1
- pm_property_id
- ubid

For tax lots:
- address_line_1
- custom_id_1
- jurisdiction_tax_lot_id
- ulid

All others, should explicitly be set to not be considered matching criteria.

#### How should this be manually tested?
1. Replicate an error caused by some extra data columns being specified as matching criteria. Using a snapshot of the latest production database, sign in to any of the following organizations: ID: 156, 256, 270, 289
Try to import records via import file and see that the application hangs at 33% as described in the issue listed below.
2. Run migration
3. Imports should be successful among any of those organizations now.

#### What are the relevant tickets?
#1970 

#### Screenshots (if appropriate)
