### PR TITLE
#1979 - Record edit failure

### DIFF
--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -1035,6 +1035,9 @@ class PropertyViewSet(GenericViewSet, ProfileIdMixin):
                 if log.name == 'Import Creation':
                     # Add new state by removing the existing ID.
                     property_state_data.pop('id')
+                    # Remove the import_file_id for the first edit of a new record
+                    # If the import file has been deleted and this value remains the serializer won't be valid
+                    property_state_data.pop('import_file')
                     new_property_state_serializer = PropertyStateSerializer(
                         data=property_state_data
                     )

--- a/seed/views/taxlots.py
+++ b/seed/views/taxlots.py
@@ -790,6 +790,9 @@ class TaxLotViewSet(GenericViewSet, ProfileIdMixin):
                 if log.name == 'Import Creation':
                     # Add new state by removing the existing ID.
                     taxlot_state_data.pop('id')
+                    # Remove the import_file_id for the first edit of a new record
+                    # If the import file has been deleted and this value remains the serializer won't be valid
+                    taxlot_state_data.pop('import_file')
                     new_taxlot_state_serializer = TaxLotStateSerializer(
                         data=taxlot_state_data
                     )


### PR DESCRIPTION
#### Any background context you want to provide?
Attempting to edit a new record that has never been merged that came from an import file that has since been deleted from the dataset will cause the edit to fail.

#### What's this PR do?
Instead of saving the `import_file_id` from the original PropertyState or TaxlotState on the first edit this change will remove it.  It's not used anyway, and all other actions, like merging, similarly set this field to None when that happens.

#### How should this be manually tested?
1. In an empty organization import a file (empty org just to ensure the records don't merge with anything)
2. Delete the import file from the dataset (or delete the dataset)
3. Attempt to edit any of the imported records - it should now succeed

#### What are the relevant tickets?
#1979
