### PR TITLE
#1990 - Attempting to view an invalid inventory detail page now prope…

### DIFF
--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -879,7 +879,7 @@ class PropertyViewSet(GenericViewSet, ProfileIdMixin):
             result = update_result_with_master(result, master)
             return JsonResponse(result, encoder=PintJSONEncoder, status=status.HTTP_200_OK)
         else:
-            return JsonResponse(result)
+            return JsonResponse(result, status=status.HTTP_404_NOT_FOUND)
 
     @api_endpoint_class
     @ajax_request_class

--- a/seed/views/taxlots.py
+++ b/seed/views/taxlots.py
@@ -661,7 +661,7 @@ class TaxLotViewSet(GenericViewSet, ProfileIdMixin):
             result = update_result_with_master(result, master)
             return JsonResponse(result, status=status.HTTP_200_OK)
         else:
-            return JsonResponse(result, status_code=status.HTTP_404_NOT_FOUND)
+            return JsonResponse(result, status=status.HTTP_404_NOT_FOUND)
 
     @api_endpoint_class
     @ajax_request_class


### PR DESCRIPTION
#### What's this PR do?
Returns 404 for all invalid views (nonexistent and those belong to other organizations)
#### How should this be manually tested?
Browse to http://localhost:8000/app/#/properties/999999999 and http://localhost:8000/app/#/taxlots/999999999 and verify that the alerts are shown on the page
#### What are the relevant tickets?
#1990 
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/411466/67127958-a7522b00-f1b7-11e9-929b-cba5d593b6eb.png)
![image](https://user-images.githubusercontent.com/411466/67128022-c9e44400-f1b7-11e9-8a13-ffc047168b5e.png)
