### PR TITLE
#1989 - Unmerge loses pairing

### DIFF
--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -503,6 +503,10 @@ class PropertyViewSet(GenericViewSet, ProfileIdMixin):
                 'message': 'property view with id {} does not exist'.format(pk)
             }
 
+        # Duplicate pairing
+        paired_view_ids = list(TaxLotProperty.objects.filter(property_view_id=old_view.id)
+                               .order_by('taxlot_view_id').values_list('taxlot_view_id', flat=True))
+
         # Capture previous associated labels
         label_ids = list(old_view.labels.all().values_list('id', flat=True))
 
@@ -586,10 +590,6 @@ class PropertyViewSet(GenericViewSet, ProfileIdMixin):
 
         # Delete the audit log entry for the merge
         log.delete()
-
-        # Duplicate pairing
-        paired_view_ids = list(TaxLotProperty.objects.filter(property_view_id=old_view.id)
-                               .order_by('taxlot_view_id').values_list('taxlot_view_id', flat=True))
 
         old_view.delete()
         new_view1.save()

--- a/seed/views/taxlots.py
+++ b/seed/views/taxlots.py
@@ -321,6 +321,11 @@ class TaxLotViewSet(GenericViewSet, ProfileIdMixin):
                 'message': 'taxlot view with id {} does not exist'.format(pk)
             }
 
+        # Duplicate pairing
+        paired_view_ids = list(TaxLotProperty.objects.filter(taxlot_view_id=old_view.id)
+                               .order_by('property_view_id').values_list('property_view_id',
+                                                                         flat=True))
+
         # Capture previous associated labels
         label_ids = list(old_view.labels.all().values_list('id', flat=True))
 
@@ -401,11 +406,6 @@ class TaxLotViewSet(GenericViewSet, ProfileIdMixin):
 
         # Delete the audit log entry for the merge
         log.delete()
-
-        # Duplicate pairing
-        paired_view_ids = list(TaxLotProperty.objects.filter(taxlot_view_id=old_view.id)
-                               .order_by('property_view_id').values_list('property_view_id',
-                                                                         flat=True))
 
         old_view.delete()
         new_view1.save()


### PR DESCRIPTION
#### Any background context you want to provide?
Pairings should persist to both records produced from an unmerge. This was not happening, though the logic was in place - the execution wasn't quite right.  Specifically, deleting the original "target" record (the one being unmerged) occurred before the pairing relationships could be captured. 

#### What's this PR do?
Fixes the error above by capturing pairings sooner in the unmerge process.

#### How should this be manually tested?
Unmerge records having pairs and see that each resulting record has the pairs of the "target" record. 

Oddly enough, there is a passing test for this in the test suite, but that test seems to have been giving false positives. 
https://github.com/SEED-platform/seed/blob/200cca45bd5538b988ff9836b8133b993789a383/seed/tests/test_taxlot_views.py#L116
I suspect that this is caused by the automatic use of transactions in the test suite.

#### What are the relevant tickets?
#1989 


