### PR TITLE
Relax PostGIS contraint in docker container

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,13 +1,12 @@
 FROM postgres:11.2
 
 ENV POSTGIS_MAJOR 2.5
-ENV POSTGIS_VERSION 2.5.2+dfsg-1~exp1.pgdg90+1
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-        postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
-        postgis=$POSTGIS_VERSION \
+        postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
+        postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
+        postgis-$POSTGIS_MAJOR \
         apt-transport-https ca-certificates wget && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
#### Any background context you want to provide?
The version of PostGIS was over specified

#### What's this PR do?
Relaxes the constraint to be only the major version of postgres and postgis.

#### How should this be manually tested?
* `docker-compose build --no-cache`
* Monkey testing

#### What are the relevant tickets?
#1996 

#### Screenshots (if appropriate)
