### PR TITLE
Inventory list labels scoped whenever labels are reloaded

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -189,14 +189,14 @@ angular.module('BE.seed.controller.inventory_list', [])
         });
       };
 
-      function updateApplicableLabels () {
+      function updateApplicableLabels (current_labels) {
         var inventoryIds;
         if ($scope.inventory_type === 'properties') {
           inventoryIds = _.map($scope.data, 'property_view_id').sort();
         } else {
           inventoryIds = _.map($scope.data, 'taxlot_view_id').sort();
         }
-        $scope.labels = _.filter(labels, function (label) {
+        $scope.labels = _.filter(current_labels, function (label) {
           return _.some(label.is_applied, function (id) {
             return _.includes(inventoryIds, id);
           });
@@ -570,7 +570,7 @@ angular.module('BE.seed.controller.inventory_list', [])
           _.merge(data[relatedIndex], aggregations);
         }
         $scope.data = data;
-        updateApplicableLabels();
+        get_labels();
         $scope.updateQueued = true;
       };
 
@@ -607,17 +607,15 @@ angular.module('BE.seed.controller.inventory_list', [])
         });
       };
 
-      processData();
-
       var get_labels = function () {
         label_service.get_labels([], {
           inventory_type: $scope.inventory_type
-        }).then(function (labels) {
-          $scope.labels = _.filter(labels, function (label) {
-            return !_.isEmpty(label.is_applied);
-          });
+        }).then(function (current_labels) {
+          updateApplicableLabels(current_labels);
         });
       };
+
+      processData();
 
       $scope.open_ubid_modal = function () {
         $uibModal.open({


### PR DESCRIPTION
#### Any background context you want to provide?
On the list page, whenever labels were refreshed (without the whole page refreshing), the possible labels list to choose from inadvertently included labels used in other cycles (and not the current cycle).

This happened after labels were added or removed from records and right after DQ checks (regardless of whether checks resulted in labels being applied to records).

See ticket listed below.

#### What's this PR do?
Generalized the "load labels" logic to scope the relevant labels to those within the current cycle. Applied this logic on page load as well.

#### How should this be manually tested?
For an org with label-having-records, identify labels that are unique to different cycles. When any of the above mentioned actions are taken, see that only the labels unique to the current cycle show up in the cycle options dropdown.

#### What are the relevant tickets?
#1818 

#### Screenshots (if appropriate)
