### PR TITLE
Merged indicator

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -467,6 +467,24 @@ angular.module('BE.seed.controller.inventory_list', [])
         return _.defaults(col, options, defaults);
       });
       $scope.columns.unshift({
+        name: 'merged_indicator',
+        displayName: '',
+        cellTemplate: '<div class="ui-grid-row-header-link">' +
+        '  <div class="ui-grid-cell-contents merged-indicator">' +
+        '    <i class="fa fa-code-fork" ng-class="{\'text-muted\': !row.entity.merged_indicator, \'text-info\': row.entity.merged_indicator}"></i>' +
+        '  </div>' +
+        '</div>',
+        enableColumnMenu: false,
+        enableColumnMoving: false,
+        enableColumnResizing: false,
+        enableFiltering: false,
+        enableHiding: false,
+        enableSorting: false,
+        exporterSuppressExport: true,
+        pinnedLeft: true,
+        visible: true,
+        width: 30
+      }, {
         name: 'notes_count',
         displayName: '',
         cellTemplate: '<div class="ui-grid-row-header-link">' +
@@ -518,7 +536,7 @@ angular.module('BE.seed.controller.inventory_list', [])
       var processData = function (data) {
         if (_.isUndefined(data)) data = $scope.data;
         var visibleColumns = _.map($scope.columns, 'name')
-          .concat(['$$treeLevel', 'notes_count', 'id', 'property_state_id', 'property_view_id', 'taxlot_state_id', 'taxlot_view_id']);
+          .concat(['$$treeLevel', 'notes_count', 'merged_indicator', 'id', 'property_state_id', 'property_view_id', 'taxlot_state_id', 'taxlot_view_id']);
 
         var columnsToAggregate = _.filter($scope.columns, 'treeAggregationType').reduce(function (obj, col) {
           obj[col.name] = col.treeAggregationType;

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -807,7 +807,7 @@ angular.module('BE.seed.controller.inventory_list', [])
       function currentColumns () {
         // Save all columns except first 3
         var gridCols = _.filter($scope.gridApi.grid.columns, function (col) {
-          return !_.includes(['treeBaseRowHeaderCol', 'selectionRowHeaderCol', 'notes_count', 'id'], col.name) && col.visible;
+          return !_.includes(['treeBaseRowHeaderCol', 'selectionRowHeaderCol', 'notes_count', 'merged_indicator', 'id'], col.name) && col.visible;
         });
 
         // Ensure pinned ordering first
@@ -904,19 +904,25 @@ angular.module('BE.seed.controller.inventory_list', [])
           });
 
           gridApi.colMovable.on.columnPositionChanged($scope, function () {
-            // Ensure that 'notes_count' and 'id' remain first
-            var col, idIndex;
-            idIndex = _.findIndex($scope.gridApi.grid.columns, {name: 'notes_count'});
-            if (idIndex !== 2) {
-              col = $scope.gridApi.grid.columns[idIndex];
-              $scope.gridApi.grid.columns.splice(idIndex, 1);
+            // Ensure that 'merged_indicator', 'notes_count', and 'id' remain first
+            var col, staticColIndex;
+            staticColIndex = _.findIndex($scope.gridApi.grid.columns, {name: 'merged_indicator'});
+            if (staticColIndex !== 2) {
+              col = $scope.gridApi.grid.columns[staticColIndex];
+              $scope.gridApi.grid.columns.splice(staticColIndex, 1);
               $scope.gridApi.grid.columns.splice(2, 0, col);
             }
-            idIndex = _.findIndex($scope.gridApi.grid.columns, {name: 'id'});
-            if (idIndex !== 3) {
-              col = $scope.gridApi.grid.columns[idIndex];
-              $scope.gridApi.grid.columns.splice(idIndex, 1);
+            staticColIndex = _.findIndex($scope.gridApi.grid.columns, {name: 'notes_count'});
+            if (staticColIndex !== 3) {
+              col = $scope.gridApi.grid.columns[staticColIndex];
+              $scope.gridApi.grid.columns.splice(staticColIndex, 1);
               $scope.gridApi.grid.columns.splice(3, 0, col);
+            }
+            staticColIndex = _.findIndex($scope.gridApi.grid.columns, {name: 'id'});
+            if (staticColIndex !== 4) {
+              col = $scope.gridApi.grid.columns[staticColIndex];
+              $scope.gridApi.grid.columns.splice(staticColIndex, 1);
+              $scope.gridApi.grid.columns.splice(4, 0, col);
             }
             saveSettings();
           });

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -3409,6 +3409,22 @@ $pairedCellWidth: 60px;
   }
 }
 
+.merged-indicator {
+  -webkit-transform: scaleY(-1);
+  transform: scaleY(-1);
+  padding-top: 8px;
+
+  i.fa {
+    font-size: 16px;
+    padding-left: 5px;
+
+    &.text-muted {
+      color: #222;
+      opacity: 0.1;
+    }
+  }
+}
+
 .settings_profile {
   padding-top: 10px !important;
 

--- a/seed/tests/test_property_views.py
+++ b/seed/tests/test_property_views.py
@@ -25,7 +25,10 @@ from seed.data_importer.models import (
     ImportFile,
     ImportRecord,
 )
+from seed.data_importer.tasks import match_buildings
+
 from seed.models import (
+    DATA_STATE_MAPPING,
     Meter,
     MeterReading,
     Property,
@@ -47,7 +50,7 @@ from seed.test_helpers.fake import (
     FakePropertyViewFactory,
     FakeColumnListSettingsFactory,
 )
-from seed.tests.util import DeleteModelsTestCase
+from seed.tests.util import DataMappingBaseTestCase
 from seed.utils.organizations import create_organization
 
 COLUMNS_TO_SEND = [
@@ -63,7 +66,7 @@ COLUMNS_TO_SEND = [
 
 
 # These tests mostly use V2.1 API except for when writing back to the API for updates
-class PropertyViewTests(DeleteModelsTestCase):
+class PropertyViewTests(DataMappingBaseTestCase):
     def setUp(self):
         user_details = {
             'username': 'test_user@demo.com',
@@ -131,6 +134,46 @@ class PropertyViewTests(DeleteModelsTestCase):
         )
         self.assertGreater(datetime.strptime(data['property']['updated'], "%Y-%m-%dT%H:%M:%S.%fZ"),
                            datetime.strptime(db_updated_time, "%Y-%m-%dT%H:%M:%S.%fZ"))
+
+    def test_merged_indicators_provided_on_filter_endpoint(self):
+        _import_record, import_file_1 = self.create_import_file(self.user, self.org, self.cycle)
+
+        base_details = {
+            'address_line_1': '123 Match Street',
+            'import_file_id': import_file_1.id,
+            'data_state': DATA_STATE_MAPPING,
+            'no_default_data': False,
+        }
+        self.property_state_factory.get_property_state(**base_details)
+
+        # set import_file_1 mapping done so that record is "created for users to view".
+        import_file_1.mapping_done = True
+        import_file_1.save()
+        match_buildings(import_file_1.id)
+
+        _import_record_2, import_file_2 = self.create_import_file(self.user, self.org, self.cycle)
+
+        url = reverse('api:v2:properties-filter') + '?cycle_id={}&organization_id={}&page=1&per_page=999999999'.format(self.cycle.pk, self.org.pk)
+        response = self.client.post(url)
+        data = json.loads(response.content)
+
+        self.assertFalse(data['results'][0]['merged_indicator'])
+
+        # make sure merged_indicator is True when merge occurs
+        base_details['city'] = 'Denver'
+        base_details['import_file_id'] = import_file_2.id
+        self.property_state_factory.get_property_state(**base_details)
+
+        # set import_file_2 mapping done so that match merging can occur.
+        import_file_2.mapping_done = True
+        import_file_2.save()
+        match_buildings(import_file_2.id)
+
+        url = reverse('api:v2:properties-filter') + '?cycle_id={}&organization_id={}&page=1&per_page=999999999'.format(self.cycle.pk, self.org.pk)
+        response = self.client.post(url)
+        data = json.loads(response.content)
+
+        self.assertTrue(data['results'][0]['merged_indicator'])
 
     def test_list_properties_with_profile_id(self):
         state = self.property_state_factory.get_property_state(extra_data={"field_1": "value_1"})
@@ -280,7 +323,7 @@ class PropertyViewTests(DeleteModelsTestCase):
         self.assertEqual(b'false', false_result.content)
 
 
-class PropertyMergeViewTests(DeleteModelsTestCase):
+class PropertyMergeViewTests(DataMappingBaseTestCase):
     def setUp(self):
         user_details = {
             'username': 'test_user@demo.com',
@@ -646,7 +689,7 @@ class PropertyMergeViewTests(DeleteModelsTestCase):
         self.assertEqual(PropertyView.objects.filter(property_id=persisting_property_id).count(), 1)
 
 
-class PropertyUnmergeViewTests(DeleteModelsTestCase):
+class PropertyUnmergeViewTests(DataMappingBaseTestCase):
     def setUp(self):
         user_details = {
             'username': 'test_user@demo.com',

--- a/seed/tests/test_taxlot_views.py
+++ b/seed/tests/test_taxlot_views.py
@@ -11,8 +11,10 @@ from datetime import datetime
 from django.core.urlresolvers import reverse
 from django.utils.timezone import get_current_timezone
 
+from seed.data_importer.tasks import match_buildings
 from seed.landing.models import SEEDUser as User
 from seed.models import (
+    DATA_STATE_MAPPING,
     PropertyView,
     TaxLot,
     TaxLotProperty,
@@ -27,11 +29,67 @@ from seed.test_helpers.fake import (
     FakeTaxLotFactory,
     FakeTaxLotStateFactory,
 )
-from seed.tests.util import DeleteModelsTestCase
+from seed.tests.util import DataMappingBaseTestCase
 from seed.utils.organizations import create_organization
 
 
-class TaxLotMergeUnmergeViewTests(DeleteModelsTestCase):
+class TaxLotViewTests(DataMappingBaseTestCase):
+    def setUp(self):
+        user_details = {
+            'username': 'test_user@demo.com',
+            'password': 'test_pass',
+            'email': 'test_user@demo.com'
+        }
+        self.user = User.objects.create_superuser(**user_details)
+        self.org, self.org_user, _ = create_organization(self.user)
+        self.cycle_factory = FakeCycleFactory(organization=self.org, user=self.user)
+        self.taxlot_state_factory = FakeTaxLotStateFactory(organization=self.org)
+        self.cycle = self.cycle_factory.get_cycle(
+            start=datetime(2010, 10, 10, tzinfo=get_current_timezone()))
+        self.client.login(**user_details)
+
+    def test_merged_indicators_provided_on_filter_endpoint(self):
+        _import_record, import_file_1 = self.create_import_file(self.user, self.org, self.cycle)
+
+        base_details = {
+            'address_line_1': '123 Match Street',
+            'import_file_id': import_file_1.id,
+            'data_state': DATA_STATE_MAPPING,
+            'no_default_data': False,
+        }
+        self.taxlot_state_factory.get_taxlot_state(**base_details)
+
+        # set import_file_1 mapping done so that record is "created for users to view".
+        import_file_1.mapping_done = True
+        import_file_1.save()
+        match_buildings(import_file_1.id)
+
+        _import_record_2, import_file_2 = self.create_import_file(self.user, self.org, self.cycle)
+
+        url = reverse('api:v2:taxlots-filter') + '?cycle_id={}&organization_id={}&page=1&per_page=999999999'.format(self.cycle.pk, self.org.pk)
+        response = self.client.post(url)
+        data = json.loads(response.content)
+
+        self.assertFalse(data['results'][0]['merged_indicator'])
+
+        # make sure merged_indicator is True when merge occurs
+        base_details['city'] = 'Denver'
+        base_details['import_file_id'] = import_file_2.id
+        self.taxlot_state_factory.get_taxlot_state(**base_details)
+
+        # set import_file_2 mapping done so that match merging can occur.
+        import_file_2.mapping_done = True
+        import_file_2.save()
+        match_buildings(import_file_2.id)
+
+        url = reverse('api:v2:taxlots-filter') + '?cycle_id={}&organization_id={}&page=1&per_page=999999999'.format(self.cycle.pk, self.org.pk)
+        response = self.client.post(url)
+        data = json.loads(response.content)
+
+        self.assertTrue(data['results'][0]['merged_indicator'])
+
+
+class TaxLotMergeUnmergeViewTests(DataMappingBaseTestCase):
     def setUp(self):
         user_details = {
             'username': 'test_user@demo.com',


### PR DESCRIPTION
#### Any background context you want to provide?
See ticket linked below.

#### What's this PR do?
- TaxLotProperty's get_related returns merged_indicator for both "base" and related records
- Inventory List pages show merged indicator for records

#### How should this be manually tested?
Visit one of the inventory list pages and for all records that were products of automatic or manual merges, see a merged indicator. 

#### What are the relevant tickets?
#1409 

#### Screenshots (if appropriate)
<img width="701" alt="Screen Shot 2019-10-27 at 7 06 32 PM" src="https://user-images.githubusercontent.com/30608004/67645302-724b8400-f8ed-11e9-9fca-91fa90c26cbb.png">
