### PR TITLE
Docker build failes with libgeos error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,36 +3,43 @@
 # DESCRIPTION:      Image with seed platform and dependencies running in development mode
 # TO_BUILD_AND_RUN: docker-compose build && docker-compose up
 
-FROM alpine:3.8
+# This Dockerfile has been updated to pull from our last known good build of SEED (v2.6.1).
+# Version 3.7.2-r2 of geos has introduced and incompatible library:
+#    https://pkgs.alpinelinux.org/package/edge/testing/x86_64/geos
+#FROM alpine:3.8
 
-RUN apk add --no-cache python \
-        python3-dev \
-        postgresql-dev \
-        alpine-sdk \
-        pcre \
-        pcre-dev \
-        libxslt-dev \
-        linux-headers \
-        libffi-dev \
-        bash \
-        bash-completion \
-        npm \
-        nginx && \
-    apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main openssl && \
-    apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ geos gdal && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    python -m ensurepip && \
-    rm -r /usr/lib/python*/ensurepip && \
-    ln -sf /usr/bin/pip3 /usr/bin/pip && \
-    pip install --upgrade pip setuptools && \
-    pip install git+https://github.com/Supervisor/supervisor@837c159ae51f3 && \
-    mkdir -p /var/log/supervisord/ && \
-    rm -r /root/.cache && \
-    addgroup -g 1000 uwsgi && \
-    adduser -G uwsgi -H -u 1000 -S uwsgi && \
-    mkdir -p /run/nginx && \
-    echo "daemon off;" >> /etc/nginx/nginx.conf && \
-    rm -f /etc/nginx/conf.d/default.conf
+FROM seedplatform/seed:2.6.1
+
+# DO NOT UPGRADE until libgeos and shapely fix the connection.
+#RUN apk add --no-cache python \
+#        python3-dev \
+#        postgresql-dev \
+#        alpine-sdk \
+#        pcre \
+#        pcre-dev \
+#        libxslt-dev \
+#        linux-headers \
+#        libffi-dev \
+#        bash \
+#        bash-completion \
+#        npm \
+#        nginx && \
+#    apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main openssl && \
+#
+#    apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ geos gdal && \
+#    ln -sf /usr/bin/python3 /usr/bin/python && \
+#    python -m ensurepip && \
+#    rm -r /usr/lib/python*/ensurepip && \
+#    ln -sf /usr/bin/pip3 /usr/bin/pip && \
+#    pip install --upgrade pip setuptools && \
+#    pip install git+https://github.com/Supervisor/supervisor@837c159ae51f3 && \
+#    mkdir -p /var/log/supervisord/ && \
+#    rm -r /root/.cache && \
+#    addgroup -g 1000 uwsgi && \
+#    adduser -G uwsgi -H -u 1000 -S uwsgi && \
+#    mkdir -p /run/nginx && \
+#    echo "daemon off;" >> /etc/nginx/nginx.conf && \
+#    rm -f /etc/nginx/conf.d/default.conf
 
 ## Note on some of the commands above:
 ##   - create the uwsgi user and group to have id of 1000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SEED",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Standard Energy Efficiency Data (SEED) Platform™",
   "license": "SEE LICENSE IN LICENSE",
   "directories": {


### PR DESCRIPTION
#### Any background context you want to provide?
The latest version of libgeos (released 10/5/2019) does not work with the shapely library. It actually appears that libgeos.so does not work at all on alpine.

```
/ # ldd /usr/lib/libgeos.so
ldd (0x7fcc14fd7000)
libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x7fcc14c84000)
libc.musl-x86_64.so.1 => ldd (0x7fcc14fd7000)
libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x7fcc14a72000)
Error relocating /usr/lib/libgeos.so: _ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEC1Ev: symbol not found
Error relocating /usr/lib/libgeos.so: _ZNSt13runtime_errorC2EOS_: symbol not found
Error relocating /usr/lib/libgeos.so: _ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEC1Ev: symbol not found
```

#### What's this PR do?
* Pull the base image from Docker hub (SEED Version 2.6.1)
* Comment out installing all the OS dependencies in Dockerfile

#### How should this be manually tested?
```
docker-compose build
docker-compose up
```

* Verify SEED functionality
* Verify SEED Version (2.6.2) from Info page

#### What are the relevant tickets?
#2005 

#### Screenshots (if appropriate)
