### PR TITLE
Show Sub-Organisation Data

### DIFF
--- a/seed/models/columns.py
+++ b/seed/models/columns.py
@@ -136,6 +136,7 @@ class Column(models.Model):
         'extra_data',
         'lot_number',
         'normalized_address',
+        'organization',
         'updated',
     ]
 
@@ -210,6 +211,18 @@ class Column(models.Model):
             'column_name': 'custom_id_1',
             'table_name': 'TaxLotState',
             'display_name': 'Custom ID 1',
+            'data_type': 'string',
+        }, {
+            # This should never be mapped to!
+            'column_name': 'organization',
+            'table_name': 'PropertyState',
+            'display_name': 'Organization',
+            'data_type': 'string',
+        }, {
+            # This should never be mapped to!
+            'column_name': 'organization',
+            'table_name': 'TaxLotState',
+            'display_name': 'Organization',
             'data_type': 'string',
         }, {
             'column_name': 'address_line_1',

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -302,7 +302,7 @@ angular.module('BE.seed.controller.inventory_list', [])
               var data = new Array($scope.selectedOrder.length);
 
               if ($scope.inventory_type === 'properties') {
-                return inventory_service.get_properties(1, undefined, undefined, -1, selectedOrder).then(function (inventory_data) {
+                return inventory_service.get_properties(1, undefined, undefined, -1, false, selectedOrder).then(function (inventory_data) {
                   _.forEach(selectedOrder, function (id, index) {
                     var match = _.find(inventory_data.results, {id: id});
                     if (match) {
@@ -596,7 +596,7 @@ angular.module('BE.seed.controller.inventory_list', [])
         spinner_utility.show();
         var promise;
         if ($scope.inventory_type === 'properties') {
-          promise = inventory_service.get_properties($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle, _.has($scope.currentProfile, 'id') ? $scope.currentProfile.id : undefined).then(function (properties) {
+          promise = inventory_service.get_properties($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle, _.has($scope.currentProfile, 'id') ? $scope.currentProfile.id : undefined, $scope.showSubOrgData).then(function (properties) {
             processData(properties.results);
             $scope.pagination = properties.pagination;
             spinner_utility.hide();
@@ -629,6 +629,12 @@ angular.module('BE.seed.controller.inventory_list', [])
         label_service.get_labels($scope.inventory_type).then(function (current_labels) {
           updateApplicableLabels(current_labels);
         });
+      };
+
+      $scope.toggle_sub_org_data = function() {
+        // TODO: In refresh_objects(), showSubOrgData is false. Need to find
+        // out why
+        refresh_objects();
       };
 
       processData();

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -312,7 +312,7 @@ angular.module('BE.seed.controller.inventory_list', [])
                   return data;
                 });
               } else if ($scope.inventory_type === 'taxlots') {
-                return inventory_service.get_taxlots(1, undefined, undefined, -1, selectedOrder).then(function (inventory_data) {
+                return inventory_service.get_taxlots(1, undefined, undefined, -1, false, selectedOrder).then(function (inventory_data) {
                   _.forEach(selectedOrder, function (id, index) {
                     var match = _.find(inventory_data.results, {id: id});
                     if (match) {
@@ -602,7 +602,7 @@ angular.module('BE.seed.controller.inventory_list', [])
             spinner_utility.hide();
           });
         } else if ($scope.inventory_type === 'taxlots') {
-          promise = inventory_service.get_taxlots($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle, _.has($scope.currentProfile, 'id') ? $scope.currentProfile.id : undefined).then(function (taxlots) {
+          promise = inventory_service.get_taxlots($scope.pagination.page, $scope.number_per_page, $scope.cycle.selected_cycle, _.has($scope.currentProfile, 'id') ? $scope.currentProfile.id : undefined, $scope.showSubOrgData).then(function (taxlots) {
             processData(taxlots.results);
             $scope.pagination = taxlots.pagination;
             spinner_utility.hide();
@@ -632,8 +632,6 @@ angular.module('BE.seed.controller.inventory_list', [])
       };
 
       $scope.toggle_sub_org_data = function() {
-        // TODO: In refresh_objects(), showSubOrgData is false. Need to find
-        // out why
         refresh_objects();
       };
 

--- a/seed/static/seed/js/controllers/inventory_map_controller.js
+++ b/seed/static/seed/js/controllers/inventory_map_controller.js
@@ -575,7 +575,7 @@ angular.module('BE.seed.controller.inventory_map', [])
           $scope.data = inventory_service.get_properties(1, undefined, $scope.cycle.selected_cycle, undefined, false).results;
           $state.reload();
         } else if ($scope.inventory_type === 'taxlots') {
-          $scope.data = inventory_service.get_taxlots(1, undefined, $scope.cycle.selected_cycle, undefined).results;
+          $scope.data = inventory_service.get_taxlots(1, undefined, $scope.cycle.selected_cycle, undefined, false).results;
           $state.reload();
         }
       };

--- a/seed/static/seed/js/controllers/inventory_map_controller.js
+++ b/seed/static/seed/js/controllers/inventory_map_controller.js
@@ -572,7 +572,7 @@ angular.module('BE.seed.controller.inventory_map', [])
 
       var refreshUsingCycle = function () {
         if ($scope.inventory_type === 'properties') {
-          $scope.data = inventory_service.get_properties(1, undefined, $scope.cycle.selected_cycle, undefined).results;
+          $scope.data = inventory_service.get_properties(1, undefined, $scope.cycle.selected_cycle, undefined, false).results;
           $state.reload();
         } else if ($scope.inventory_type === 'taxlots') {
           $scope.data = inventory_service.get_taxlots(1, undefined, $scope.cycle.selected_cycle, undefined).results;

--- a/seed/static/seed/js/controllers/pairing_controller.js
+++ b/seed/static/seed/js/controllers/pairing_controller.js
@@ -79,7 +79,7 @@ angular.module('BE.seed.controller.pairing', []).controller('pairing_controller'
       // var taxlotColumnNames = _.map($scope.taxlotColumns, 'name');
 
       var promises = [];
-      promises.push(inventory_service.get_properties(1, undefined, $scope.cycle.selected_cycle, undefined));
+      promises.push(inventory_service.get_properties(1, undefined, $scope.cycle.selected_cycle, undefined, false));
       promises.push(inventory_service.get_taxlots(1, undefined, $scope.cycle.selected_cycle, undefined));
 
       return $q.all(promises).then(function (results) {

--- a/seed/static/seed/js/controllers/pairing_controller.js
+++ b/seed/static/seed/js/controllers/pairing_controller.js
@@ -80,7 +80,7 @@ angular.module('BE.seed.controller.pairing', []).controller('pairing_controller'
 
       var promises = [];
       promises.push(inventory_service.get_properties(1, undefined, $scope.cycle.selected_cycle, undefined, false));
-      promises.push(inventory_service.get_taxlots(1, undefined, $scope.cycle.selected_cycle, undefined));
+      promises.push(inventory_service.get_taxlots(1, undefined, $scope.cycle.selected_cycle, undefined, false));
 
       return $q.all(promises).then(function (results) {
         $scope.propertyData = results[0].results;

--- a/seed/static/seed/js/controllers/show_populated_columns_modal_controller.js
+++ b/seed/static/seed/js/controllers/show_populated_columns_modal_controller.js
@@ -40,7 +40,7 @@ angular.module('BE.seed.controller.show_populated_columns_modal', [])
             return inv.results;
           });
         } else if ($scope.inventory_type === 'taxlots') {
-          promise = inventory_service.get_taxlots(1, undefined, $scope.cycle, -1).then(function (inv) {
+          promise = inventory_service.get_taxlots(1, undefined, $scope.cycle, -1, false).then(function (inv) {
             return inv.results;
           });
         }

--- a/seed/static/seed/js/controllers/show_populated_columns_modal_controller.js
+++ b/seed/static/seed/js/controllers/show_populated_columns_modal_controller.js
@@ -36,7 +36,7 @@ angular.module('BE.seed.controller.show_populated_columns_modal', [])
 
         var promise;
         if ($scope.inventory_type === 'properties') {
-          promise = inventory_service.get_properties(1, undefined, $scope.cycle, -1).then(function (inv) {
+          promise = inventory_service.get_properties(1, undefined, $scope.cycle, -1, false).then(function (inv) {
             return inv.results;
           });
         } else if ($scope.inventory_type === 'taxlots') {

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -579,7 +579,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
             return inventory_service.get_properties(1, undefined, undefined, -1, false);
           }],
           taxlotInventory: ['inventory_service', function (inventory_service) {
-            return inventory_service.get_taxlots(1, undefined, undefined, -1);
+            return inventory_service.get_taxlots(1, undefined, undefined, -1, false);
           }],
           cycles: ['cycle_service', function (cycle_service) {
             return cycle_service.get_cycles();
@@ -1078,7 +1078,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
             if ($stateParams.inventory_type === 'properties') {
               return inventory_service.get_properties(1, undefined, undefined, profile_id, false);
             } else if ($stateParams.inventory_type === 'taxlots') {
-              return inventory_service.get_taxlots(1, undefined, undefined, profile_id);
+              return inventory_service.get_taxlots(1, undefined, undefined, profile_id, false);
             }
           }],
           cycles: ['cycle_service', function (cycle_service) {
@@ -1124,7 +1124,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
             // if ($stateParams.inventory_type === 'properties') {
             return inventory_service.get_properties(1, undefined, undefined, undefined, false);
             // } else if ($stateParams.inventory_type === 'taxlots') {
-            //   return inventory_service.get_taxlots(1, undefined, undefined, undefined);
+            //   return inventory_service.get_taxlots(1, undefined, undefined, undefined, false);
             // }
           }],
           cycles: ['cycle_service', function (cycle_service) {

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -576,7 +576,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
             });
           }],
           propertyInventory: ['inventory_service', function (inventory_service) {
-            return inventory_service.get_properties(1, undefined, undefined, -1);
+            return inventory_service.get_properties(1, undefined, undefined, -1, false);
           }],
           taxlotInventory: ['inventory_service', function (inventory_service) {
             return inventory_service.get_taxlots(1, undefined, undefined, -1);
@@ -1076,7 +1076,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           inventory: ['$stateParams', 'inventory_service', 'current_profile', function ($stateParams, inventory_service, current_profile) {
             var profile_id = _.has(current_profile, 'id') ? current_profile.id : undefined;
             if ($stateParams.inventory_type === 'properties') {
-              return inventory_service.get_properties(1, undefined, undefined, profile_id);
+              return inventory_service.get_properties(1, undefined, undefined, profile_id, false);
             } else if ($stateParams.inventory_type === 'taxlots') {
               return inventory_service.get_taxlots(1, undefined, undefined, profile_id);
             }
@@ -1122,7 +1122,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
         resolve: {
           inventory: ['$stateParams', 'inventory_service', function ($stateParams, inventory_service) {
             // if ($stateParams.inventory_type === 'properties') {
-            return inventory_service.get_properties(1, undefined, undefined, undefined);
+            return inventory_service.get_properties(1, undefined, undefined, undefined, false);
             // } else if ($stateParams.inventory_type === 'taxlots') {
             //   return inventory_service.get_taxlots(1, undefined, undefined, undefined);
             // }

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -215,11 +215,15 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
     };
 
 
-    inventory_service.get_taxlots = function (page, per_page, cycle, profile_id, inventory_ids) {
+    inventory_service.get_taxlots = function (page, per_page, cycle, profile_id, show_sub_org_data, inventory_ids) {
+
+      if (show_sub_org_data == undefined) show_sub_org_data = false;
+
       var params = {
         organization_id: user_service.get_organization().id,
         page: page,
-        per_page: per_page || 999999999
+        per_page: per_page || 999999999,
+        show_sub_org_data: show_sub_org_data 
       };
 
       return cycle_service.get_cycles().then(function (cycles) {

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -18,12 +18,15 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       total_taxlots_for_user: 0
     };
 
-    inventory_service.get_properties = function (page, per_page, cycle, profile_id, inventory_ids) {
+    inventory_service.get_properties = function (page, per_page, cycle, profile_id, show_sub_org_data, inventory_ids) {
+      
+      if (show_sub_org_data == undefined) show_sub_org_data = false;
 
       var params = {
         organization_id: user_service.get_organization().id,
         page: page,
-        per_page: per_page || 999999999
+        per_page: per_page || 999999999,
+        show_sub_org_data: show_sub_org_data 
       };
 
       return cycle_service.get_cycles().then(function (cycles) {

--- a/seed/static/seed/partials/inventory_list.html
+++ b/seed/static/seed/partials/inventory_list.html
@@ -102,6 +102,13 @@
             </div>
         </span>
 
+        <span>
+            <div class="form-check">
+                <input type="checkbox" ng-model="showSubOrgData" ng-change="toggle_sub_org_data()">
+                <span>{$:: 'Show data from sub-organizations' | translate $}</span>
+            </div>
+        </span>
+
         <span ng-show="profiles.length > 0">
             <label>{$:: 'List Settings Profile' | translate $}:</label>
             <div style="display: inline-block;">


### PR DESCRIPTION
#### What's this PR do?
This PR adds support to show data from sub-organisations in the parent organisation's inventory list. It does this by adding an optional parameter to the `/api/v2/properties/filter/` and `/api/v2/taxlots/filter/` endpoints to toggle `show_sub_org_data`. When this is `true`, the filtered list extends the query to include properties/tax lots from sub-organisations as well.

It also adds a column to show the Organisation ID for each property in the inventory. This helps to determine if the property is from the parent organisation or a sub-organisation.

#### How should this be manually tested?
1. Add data to an organisation
1. Add a sub-organisation and make yourself the owner
1. Add data to the sub-organisation
1. Go to the inventory for the parent organisation
1. Set 'Show data from sub-organizations`
1. The number of properties should reflect the sum total of both organisations' properties.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/7299909/69059206-c1349700-0a1d-11ea-80f9-24288c4beb25.png)
