### PR TITLE
Import mapping page - Group matching fields by table name

### DIFF
--- a/seed/static/seed/js/controllers/mapping_controller.js
+++ b/seed/static/seed/js/controllers/mapping_controller.js
@@ -84,10 +84,8 @@ angular.module('BE.seed.controller.mapping', [])
 
       $scope.isValidCycle = Boolean(_.find(cycles.cycles, {id: $scope.import_file.cycle}));
 
-      var matching_criteria_columns = [];
       matching_criteria_columns_payload.PropertyState = _.map(matching_criteria_columns_payload.PropertyState, function (column_name) {
         var display_name = _.find($scope.mappable_property_columns, {column_name: column_name}).display_name;
-        matching_criteria_columns.push(display_name);
         return {
           column_name: column_name,
           display_name: display_name
@@ -95,13 +93,12 @@ angular.module('BE.seed.controller.mapping', [])
       });
       matching_criteria_columns_payload.TaxLotState = _.map(matching_criteria_columns_payload.TaxLotState, function (column_name) {
         var display_name = _.find($scope.mappable_taxlot_columns, {column_name: column_name}).display_name;
-        matching_criteria_columns.push(display_name);
         return {
           column_name: column_name,
           display_name: display_name
         };
       });
-      $scope.matching_criteria_columns = _.uniq(matching_criteria_columns).sort().join(', ');
+
       $scope.property_matching_criteria_columns = _.map(matching_criteria_columns_payload.PropertyState, 'display_name').sort().join(', ');
       $scope.taxlot_matching_criteria_columns = _.map(matching_criteria_columns_payload.TaxLotState, 'display_name').sort().join(', ');
 

--- a/seed/static/seed/partials/mapping.html
+++ b/seed/static/seed/partials/mapping.html
@@ -27,8 +27,12 @@
                         <p translate>It is necessary to map your field names to SEED field names. You can select from the list that appears as you start to type, which is based on the Building Energy Data Exchange Specification (BEDES), or you can type in your own name, as well as typing in the field name from the original datafile.</p>
                         <p translate>In addition, you need to specify where the field should be associated with Tax Lot data or Property data. This will affect how the data is matched and merged, as well as how it is displayed in the Inventory view.</p>
                         <p>
-                            <span class="label label-info">{$:: 'FIELD_NAMES_FOR_MATCHING' | translate $}:</span>
-                            <span><strong>{$ matching_criteria_columns $}</strong></span>
+                            <span class="label label-info">{$:: 'FIELD_NAMES_FOR_MATCHING' | translate $} {$:: 'Properties' | translate $}:</span>
+                            <span><strong>{$ property_matching_criteria_columns $}</strong></span>
+                        </p>
+                        <p>
+                            <span class="label label-info">{$:: 'FIELD_NAMES_FOR_MATCHING' | translate $} {$:: 'Tax Lots' | translate $}:</span>
+                            <span><strong>{$ taxlot_matching_criteria_columns $}</strong></span>
                         </p>
                         <p translate>MATCHING_ADVICE</p>
                         <p ng-show="property_geocoding_columns_array.length">


### PR DESCRIPTION
#### Any background context you want to provide?
During file import, the property and tax lot matching criteria was presented in one list, which wasn't very clear for users.

#### What's this PR do?
Splits out the matching criteria by inventory type.

#### How should this be manually tested?
Visit the import mapping page and see that current matching criteria is displayed by inventory type.

#### What are the relevant tickets?
#2028 

#### Screenshots (if appropriate)
<img width="715" alt="Screen Shot 2019-12-05 at 3 03 31 PM" src="https://user-images.githubusercontent.com/30608004/70277906-81d1ae80-1770-11ea-9b1a-f8a32de0e754.png">