### PR TITLE
1715 inv detail pop cols only

### DIFF
--- a/seed/static/seed/js/controllers/inventory_detail_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_controller.js
@@ -133,8 +133,21 @@ angular.module('BE.seed.controller.inventory_detail', [])
             inventory_type: function () {
               return $stateParams.inventory_type;
             },
-            single_record: function () {
-              return $scope.item_state;
+            provided_inventory: function () {
+              var provided_inventory = [];
+
+              // Add historical items
+              _.each($scope.historical_items, function (item) {
+                var item_state_copy = angular.copy(item.state);
+                _.defaults(item_state_copy, item.state.extra_data);
+                provided_inventory.push(item_state_copy);
+              })
+
+              // add "master" copy
+              item_copy = angular.copy($scope.item_state);
+              _.defaults(item_copy, $scope.item_state.extra_data);
+
+              return provided_inventory;
             },
           }
         });

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -172,6 +172,9 @@ angular.module('BE.seed.controller.inventory_list', [])
             },
             inventory_type: function () {
               return $stateParams.inventory_type;
+            },
+            single_record: function () {
+              return null;
             }
           }
         });

--- a/seed/static/seed/js/controllers/show_populated_columns_modal_controller.js
+++ b/seed/static/seed/js/controllers/show_populated_columns_modal_controller.js
@@ -14,8 +14,9 @@ angular.module('BE.seed.controller.show_populated_columns_modal', [])
     'columns',
     'currentProfile',
     'cycle',
+    'single_record',
     'inventory_type',
-    function ($scope, $window, $uibModalInstance, Notification, inventory_service, modified_service, spinner_utility, columns, currentProfile, cycle, inventory_type) {
+    function ($scope, $window, $uibModalInstance, Notification, inventory_service, modified_service, spinner_utility, columns, currentProfile, cycle, single_record, inventory_type) {
       $scope.columns = columns;
       $scope.currentProfile = currentProfile;
       $scope.cycle = cycle;
@@ -48,80 +49,88 @@ angular.module('BE.seed.controller.show_populated_columns_modal', [])
         });
       };
 
+      var update_profile_with_populated_columns = function (inventory) {
+        $scope.status = 'Processing ' + $scope.columns.length + ' columns in ' + inventory.length + ' records';
+
+        var cols = _.reject($scope.columns, 'related');
+        // console.log('cols', cols);
+
+        var relatedCols = _.filter($scope.columns, 'related');
+        // console.log('relatedCols', relatedCols);
+
+        var col_key = single_record ? "column_name" : "name";
+
+        _.forEach(inventory, function (record, index) {
+          // console.log(cols.length + ' remaining cols to check');
+          _.forEachRight(cols, function (col, colIndex) {
+            if (notEmpty(record[col[col_key]])) {
+              // console.log('Removing ' + col[col_key] + ' from cols');
+              cols.splice(colIndex, 1);
+            }
+          });
+
+          _.forEach(record.related, function (relatedRecord) {
+            // console.log(relatedCols.length + ' remaining related cols to check');
+            _.forEachRight(relatedCols, function (col, colIndex) {
+              if (notEmpty(relatedRecord[col[col_key]])) {
+                // console.log('Removing ' + col[col_key] + ' from relatedCols');
+                relatedCols.splice(colIndex, 1);
+              }
+            });
+          });
+
+          $scope.progress = index / inventory.length * 50 + 50;
+        });
+
+        // determine hidden columns
+        var visible = _.reject($scope.columns, function (col) {
+          if (!col.related) {
+            return _.find(cols, {id: col.id});
+          }
+          return _.find(relatedCols, {id: col.id});
+        });
+
+        var hidden = _.reject($scope.columns, function (col) {
+          return _.find(visible, {id: col.id});
+        });
+
+        _.forEach(hidden, function (col) {
+          col.visible = false;
+        });
+
+        var columns = [];
+        _.forEach(visible, function (col) {
+          columns.push({
+            column_name: col.column_name,
+            id: col.id,
+            order: columns.length + 1,
+            pinned: col.pinnedLeft,
+            table_name: col.table_name
+          });
+        });
+
+        var id = $scope.currentProfile.id;
+        var profile = _.omit($scope.currentProfile, 'id');
+        profile.columns = columns;
+        inventory_service.update_settings_profile(id, profile).then(function (/*updatedProfile*/) {
+          modified_service.resetModified();
+          $scope.progress = 100;
+          $scope.state = 'done';
+          $scope.status = 'Found ' + visible.length + ' populated columns';
+        });
+      };
+
       $scope.start = function () {
         $scope.state = 'running';
         $scope.status = 'Fetching Inventory';
 
-        var page = 1;
-        var chunk = 5000;
-        fetch(page, chunk).then(function (inventory) {
-          $scope.status = 'Processing ' + $scope.columns.length + ' columns in ' + inventory.length + ' records';
-
-          var cols = _.reject($scope.columns, 'related');
-          // console.log('cols', cols);
-
-          var relatedCols = _.filter($scope.columns, 'related');
-          // console.log('relatedCols', relatedCols);
-
-          _.forEach(inventory, function (record, index) {
-            // console.log(cols.length + ' remaining cols to check');
-            _.forEachRight(cols, function (col, colIndex) {
-              if (notEmpty(record[col.name])) {
-                // console.log('Removing ' + col.name + ' from cols');
-                cols.splice(colIndex, 1);
-              }
-            });
-
-            _.forEach(record.related, function (relatedRecord) {
-              // console.log(relatedCols.length + ' remaining related cols to check');
-              _.forEachRight(relatedCols, function (col, colIndex) {
-                if (notEmpty(relatedRecord[col.name])) {
-                  // console.log('Removing ' + col.name + ' from relatedCols');
-                  relatedCols.splice(colIndex, 1);
-                }
-              });
-            });
-
-            $scope.progress = index / inventory.length * 50 + 50;
-          });
-
-          // determine hidden columns
-          var visible = _.reject($scope.columns, function (col) {
-            if (!col.related) {
-              return _.find(cols, {id: col.id});
-            }
-            return _.find(relatedCols, {id: col.id});
-          });
-
-          var hidden = _.reject($scope.columns, function (col) {
-            return _.find(visible, {id: col.id});
-          });
-
-          _.forEach(hidden, function (col) {
-            col.visible = false;
-          });
-
-          var columns = [];
-          _.forEach(visible, function (col) {
-            columns.push({
-              column_name: col.column_name,
-              id: col.id,
-              order: columns.length + 1,
-              pinned: col.pinnedLeft,
-              table_name: col.table_name
-            });
-          });
-
-          var id = $scope.currentProfile.id;
-          var profile = _.omit($scope.currentProfile, 'id');
-          profile.columns = columns;
-          inventory_service.update_settings_profile(id, profile).then(function (/*updatedProfile*/) {
-            modified_service.resetModified();
-            $scope.progress = 100;
-            $scope.state = 'done';
-            $scope.status = 'Found ' + visible.length + ' populated columns';
-          });
-        });
+        if (single_record) {
+          update_profile_with_populated_columns([single_record]);
+        } else {
+          var page = 1;
+          var chunk = 5000;
+          fetch(page, chunk).then(update_profile_with_populated_columns);
+        }
       };
 
       $scope.refresh = function () {

--- a/seed/static/seed/js/controllers/show_populated_columns_modal_controller.js
+++ b/seed/static/seed/js/controllers/show_populated_columns_modal_controller.js
@@ -14,9 +14,9 @@ angular.module('BE.seed.controller.show_populated_columns_modal', [])
     'columns',
     'currentProfile',
     'cycle',
-    'single_record',
+    'provided_inventory',
     'inventory_type',
-    function ($scope, $window, $uibModalInstance, Notification, inventory_service, modified_service, spinner_utility, columns, currentProfile, cycle, single_record, inventory_type) {
+    function ($scope, $window, $uibModalInstance, Notification, inventory_service, modified_service, spinner_utility, columns, currentProfile, cycle, provided_inventory, inventory_type) {
       $scope.columns = columns;
       $scope.currentProfile = currentProfile;
       $scope.cycle = cycle;
@@ -58,7 +58,7 @@ angular.module('BE.seed.controller.show_populated_columns_modal', [])
         var relatedCols = _.filter($scope.columns, 'related');
         // console.log('relatedCols', relatedCols);
 
-        var col_key = single_record ? "column_name" : "name";
+        var col_key = provided_inventory ? "column_name" : "name";
 
         _.forEach(inventory, function (record, index) {
           // console.log(cols.length + ' remaining cols to check');
@@ -124,8 +124,8 @@ angular.module('BE.seed.controller.show_populated_columns_modal', [])
         $scope.state = 'running';
         $scope.status = 'Fetching Inventory';
 
-        if (single_record) {
-          update_profile_with_populated_columns([single_record]);
+        if (provided_inventory) {
+          update_profile_with_populated_columns(provided_inventory);
         } else {
           var page = 1;
           var chunk = 5000;

--- a/seed/static/seed/partials/inventory_detail.html
+++ b/seed/static/seed/partials/inventory_detail.html
@@ -50,7 +50,7 @@
                             class="btn btn-default btn-sm">
                         {$:: 'Actions' | translate $} <span class="caret"></span>
                     </button>
-                    <ul id="inventory-detail-actions-dropdown" uib-dropdown-menu class="dropdown-menu" role="menu" aria-labelledby="btnInventoryActions">
+                    <ul id="#inventory-actions-dropdown" uib-dropdown-menu class="dropdown-menu" role="menu" aria-labelledby="btnInventoryActions">
                         <li role="menuitem" ng-if="::inventory_type === 'properties'" class="upload-list-item">
                             <div sd-uploader sourcetype="BuildingSyncUpdate" sourceprog="" sourcever="" importrecord="item_parent.id" organization-id="organization.id" cycle-id="cycle.id" eventfunc="uploaderfunc(message, file, progress)">{$:: 'Update with BuildingSync' | translate $}</div>
                         </li>
@@ -70,7 +70,10 @@
                         <li role="menuitem" ng-if="::historical_items.length > 1">
                             <a ng-click="unmerge()" class="yellow-bg">{$:: 'Unmerge Last' | translate $}</a>
                         </li>
-
+                        <li class="divider"></li>
+                        <li role="menuitem">
+                            <a ng-click="open_show_populated_columns_modal()" translate>Only Show Populated Columns</a>
+                        </li>
                     </ul>
                     <div ng-if="::inventory_type === 'properties'" style="margin: 50px 25px 0;">
                         <div class="alert alert-danger" ng-show="uploader.invalid_xml_extension_alert" translate="INVALID_XML_EXTENSION_ALERT"></div>

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -2824,11 +2824,7 @@ gs-input .tags .tag-item .remove-button {
   }
 }
 
-#inventory-actions-dropdown, #inventory-detail-actions-dropdown, #inventory-detail-edit {
-  &#inventory-detail-actions-dropdown {
-    width: 200px;
-  }
-
+#inventory-actions-dropdown, #inventory-detail-edit {
   li {
     cursor: default;
   }


### PR DESCRIPTION
#### Any background context you want to provide?
See attached issue

#### What's this PR do?
Adds "Only Show Populated Columns" to inventory detail page. 

**NOTE**: The current and historical states of a record are considered when looking for populated fields (as well as the extra data for each).

#### How should this be manually tested?
Test the new button works just like the one in the inventory list page.
 
#### What are the relevant tickets?
#1715 

#### Screenshots (if appropriate)
