### PR TITLE
DQ button sequence #786

### DIFF
--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -119,9 +119,11 @@ angular.module('BE.seed.controller.data_quality_admin', [])
       $scope.restore_defaults = function () {
         spinner_utility.show();
         $scope.defaults_restored = false;
+        $scope.rules_reset = false;
         data_quality_service.reset_default_data_quality_rules($scope.org.org_id).then(function (rules) {
           loadRules(rules);
           $scope.defaults_restored = true;
+          $scope.rules_updated = false;
         }, function (data) {
           $scope.$emit('app_error', data);
         }).finally(function () {
@@ -133,6 +135,8 @@ angular.module('BE.seed.controller.data_quality_admin', [])
       $scope.reset_all_rules = function () {
         spinner_utility.show();
         $scope.rules_reset = false;
+        $scope.defaults_restored = false;
+        $scope.rules_updated = false;
         data_quality_service.reset_all_data_quality_rules($scope.org.org_id).then(function (rules) {
           loadRules(rules);
           $scope.rules_reset = true;
@@ -146,6 +150,8 @@ angular.module('BE.seed.controller.data_quality_admin', [])
       // Saves the configured rules
       $scope.save_settings = function () {
         $scope.rules_updated = false;
+        $scope.defaults_restored = false;
+        $scope.rules_reset = false;
         var rules = {
           properties: [],
           taxlots: []


### PR DESCRIPTION
1. Both 'Restore rules' and 'Reset rules' automatically save changes (without clicking on 'Save');
2. Clicking on 'Save' should uncheck both 'Restore' and 'Reset' because only rules other than those made by 'Restore' or 'Reset' need to be saved. However, clicking on 'Save' should not affect previously saved setting (restore or rest);
3. Clicking on either 'Restore' or 'Reset' should uncheck 'Save' so checkmark indicates which button has been previously clicked on ('Restore' or 'Reset');
4. Clicking on 'Restore' should uncheck 'Reset' and vice versa:

Make a change (error -> warning) and save changes:
![Screen Shot 2019-12-10 at 11 09 20 AM](https://user-images.githubusercontent.com/49968203/70556196-9b427400-1b3d-11ea-9c14-557e8b2bfee6.png)

Reset rules. Reset button automatically saves changes. Previously made change is back from 'Warning' to 'Error'. And check mark on 'Save' button disappears:
![Screen Shot 2019-12-10 at 11 10 56 AM](https://user-images.githubusercontent.com/49968203/70556441-21f75100-1b3e-11ea-8dad-04163724e4f2.png)

Do another change rules (first 2 rules changed, error -> warning) and save changes:
![Screen Shot 2019-12-10 at 11 15 49 AM](https://user-images.githubusercontent.com/49968203/70556722-ae097880-1b3e-11ea-8934-80a6d472d245.png)

Now click on 'Restore rule', Check marks on 'Save changes' buttons disappears. Rule restored:
![Screen Shot 2019-12-10 at 11 14 33 AM](https://user-images.githubusercontent.com/49968203/70556862-edd06000-1b3e-11ea-9eaa-54ae6a239bbb.png)
