### PR TITLE
1998 lat long initial edit

### DIFF
--- a/seed/tests/test_property_views.py
+++ b/seed/tests/test_property_views.py
@@ -135,6 +135,33 @@ class PropertyViewTests(DataMappingBaseTestCase):
         self.assertGreater(datetime.strptime(data['property']['updated'], "%Y-%m-%dT%H:%M:%S.%fZ"),
                            datetime.strptime(db_updated_time, "%Y-%m-%dT%H:%M:%S.%fZ"))
 
+    def test_first_lat_long_edit(self):
+        state = self.property_state_factory.get_property_state()
+        prprty = self.property_factory.get_property()
+        view = PropertyView.objects.create(
+            property=prprty, cycle=self.cycle, state=state
+        )
+
+        # update the address
+        new_data = {
+            "state": {
+                "latitude": 39.765251,
+                "longitude": -104.986138,
+            }
+        }
+        url = reverse('api:v2:properties-detail', args=[view.id]) + '?organization_id={}'.format(self.org.pk)
+        response = self.client.put(url, json.dumps(new_data), content_type='application/json')
+        data = json.loads(response.content)
+        self.assertEqual(data['status'], 'success')
+
+        response = self.client.get(url, content_type='application/json')
+        data = json.loads(response.content)
+
+        self.assertEqual(data['status'], 'success')
+
+        self.assertIsNotNone(data['state']['long_lat'])
+        self.assertIsNotNone(data['state']['geocoding_confidence'])
+
     def test_merged_indicators_provided_on_filter_endpoint(self):
         _import_record, import_file_1 = self.create_import_file(self.user, self.org, self.cycle)
 

--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -1001,8 +1001,7 @@ class PropertyViewSet(GenericViewSet, ProfileIdMixin):
                     state=property_view.state
                 ).order_by('-id').first()
 
-                if log.name in ['Manual Edit', 'Manual Match', 'System Match',
-                                  'Merge current state in migration']:
+                if log.name in ['Manual Edit', 'Manual Match', 'System Match', 'Merge current state in migration']:
                     # Convert this to using the serializer to save the data. This will override the previous values
                     # in the state object.
 

--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -940,11 +940,7 @@ class PropertyViewSet(GenericViewSet, ProfileIdMixin):
                     state=property_view.state
                 ).order_by('-id').first()
 
-                if 'extra_data' in new_property_state_data:
-                    property_state_data['extra_data'].update(
-                        new_property_state_data.pop('extra_data'))
-                property_state_data.update(new_property_state_data)
-
+                # if checks above pass, create an exact copy of the current state for historical purposes
                 if log.name == 'Import Creation':
                     # Add new state by removing the existing ID.
                     property_state_data.pop('id')
@@ -984,17 +980,6 @@ class PropertyViewSet(GenericViewSet, ProfileIdMixin):
 
                         # save the property view so that the datetime gets updated on the property.
                         property_view.save()
-
-                        count, view_id = match_merge_in_cycle(property_view.id, 'PropertyState')
-
-                        if view_id is not None:
-                            result.update({
-                                'view_id': view_id,
-                                'match_merged_count': count,
-                            })
-
-                        return JsonResponse(result, encoder=PintJSONEncoder,
-                                            status=status.HTTP_200_OK)
                     else:
                         result.update({
                             'status': 'error',
@@ -1003,7 +988,20 @@ class PropertyViewSet(GenericViewSet, ProfileIdMixin):
                         )
                         return JsonResponse(result, encoder=PintJSONEncoder,
                                             status=status.HTTP_422_UNPROCESSABLE_ENTITY)
-                elif log.name in ['Manual Edit', 'Manual Match', 'System Match',
+
+                # redo assignment of this variable in case this was an initial edit
+                property_state_data = PropertyStateSerializer(property_view.state).data
+
+                if 'extra_data' in new_property_state_data:
+                    property_state_data['extra_data'].update(
+                        new_property_state_data.pop('extra_data'))
+                property_state_data.update(new_property_state_data)
+
+                log = PropertyAuditLog.objects.select_related().filter(
+                    state=property_view.state
+                ).order_by('-id').first()
+
+                if log.name in ['Manual Edit', 'Manual Match', 'System Match',
                                   'Merge current state in migration']:
                     # Convert this to using the serializer to save the data. This will override the previous values
                     # in the state object.


### PR DESCRIPTION
#### Any background context you want to provide?
See issue linked below.

#### What's this PR do?
This PR adjusts the initial edit process for records (both properties and tax lots).

Just like before, for an initial edit, a copy of the record is created and used to preserve the initial import history. Now, this copy is created as the very first step, without the "initial edit" changes **first**, as opposed to creating the copy with the changes included. The new copy is then run through the normal (non-initial) edit flow.

This allows the presave hook to trigger.

#### How should this be manually tested?
For "new" (just imported) records that were geocoded on import, edit them while removing latitude and longitude. See that the `geocoding_confidence` and `long_lat` are no longer populated.

For "new" records that were not geocoded on import, edit them while changing a latitude and longitude. See that the `geocoding_confidence` and `long_lat` are populated.

#### What are the relevant tickets?
#1998 

#### Screenshots (if appropriate)
