### PR TITLE
Notes are added to record exports

### DIFF
--- a/seed/static/seed/js/controllers/export_inventory_modal_controller.js
+++ b/seed/static/seed/js/controllers/export_inventory_modal_controller.js
@@ -14,6 +14,7 @@ angular.module('BE.seed.controller.export_inventory_modal', []).controller('expo
   'profile_id',
   function ($http, $scope, $uibModalInstance, user_service, cycle_id, ids, columns, inventory_type, profile_id) {
     $scope.export_name = '';
+    $scope.inventory_type = inventory_type;
 
     $scope.export_selected = function (export_type) {
       var filename = $scope.export_name;

--- a/seed/static/seed/partials/export_inventory_modal.html
+++ b/seed/static/seed/partials/export_inventory_modal.html
@@ -11,7 +11,7 @@
 </div>
 <div class="modal-footer">
     <button type="button" class="btn btn-primary" ng-click="export_selected('csv')" ng-disabled="!export_name.length" translate>Export CSV</button>
-    <button type="button" class="btn btn-primary" ng-click="export_selected('xlsx')" ng-disabled="!export_name.length" translate>Export BuildingSync in Excel format</button>
+    <button type="button" class="btn btn-primary" ng-click="export_selected('xlsx')" ng-disabled="!export_name.length" ng-if="inventory_type === 'properties'" translate>Export BuildingSync in Excel format</button>
     <button type="button" class="btn btn-primary" ng-click="export_selected('geojson')" ng-disabled="!export_name.length" translate>Export GeoJSON</button>
 
 </div>


### PR DESCRIPTION
#### Any background context you want to provide?
See attached issue
#### What's this PR do?
Appends Notes to records when exporting records.

**Issue/Caveat:** Since the file exports are generated in the backend, the "created" time for each note is always provided in the app's default timezone, 'America/Los_Angeles'. I've spent some time trying to prevent this, but was not successful. Since the users requesting this are from San Jose (within that timezone), I'll just be creating an issue for this.

Extra details regarding this: When a note is created via the browser, the DB entry for this note seems to use the machine's current local timezone. When that note is read from the DB into Django (and subsequently, into the export file), it's automatically converted to 'America/Los_Angeles' regardless of my own actual timezone.

**Also**, this hides the tax lot excel export button for now since conversations are ongoing surrounding tax lots and BuildingSync.

#### How should this be manually tested?
Add notes to records, export them, and see that notes are added

#### What are the relevant tickets?
#1913 - add notes to exports
#2057 - hide tax lot excel export button for now

#### Screenshots (if appropriate)
