### PR TITLE
Mapping preset creation during import has correct initial snapshot

### DIFF
--- a/seed/static/seed/js/controllers/mapping_controller.js
+++ b/seed/static/seed/js/controllers/mapping_controller.js
@@ -115,7 +115,7 @@ angular.module('BE.seed.controller.mapping', [])
           preset_mapping_data.push({
             from_field: mapping.name,
             from_units: mapping.from_units,
-            to_field: mapping.suggestion_column_name || mapping.name,
+            to_field: mapping.suggestion_column_name || mapping.suggestion || '',
             to_table_name: mapping.suggestion_table_name,
           });
 


### PR DESCRIPTION
#### Any background context you want to provide?
See attached issue

#### What's this PR do?
When a new preset created within the import mapping process, it's now given defaults for each raw_column as follows:
- DB-aware column
- string provided by user (not in DB yet)
- empty string

#### How should this be manually tested?
See attached issue

#### What are the relevant tickets?
#2060 

#### Screenshots (if appropriate)
