### PR TITLE
Update hardcoded date within test

### DIFF
--- a/seed/tests/test_api.py
+++ b/seed/tests/test_api.py
@@ -11,6 +11,8 @@ import os
 import time
 from unittest import skip
 
+from datetime import date
+
 from django.core.urlresolvers import reverse_lazy, reverse
 from django.test import TestCase
 from django.utils import timezone
@@ -169,7 +171,7 @@ class TestApi(TestCase):
         self.assertEqual(r['organizations'][0]['owners'][0]['first_name'], 'Jaqen')
         self.assertEqual(r['organizations'][0]['cycles'], [
             {
-                'name': '2018 Calendar Year',
+                'name': str(date.today().year - 1) + ' Calendar Year',
                 'num_properties': 0,
                 'num_taxlots': 0,
                 'cycle_id': self.default_cycle.pk,


### PR DESCRIPTION
#### Any background context you want to provide?
A hardcoded year within a test was referencing a value generated by the current calendar year. 

The value is generated here: https://github.com/SEED-platform/seed/blob/develop/seed/models/cycles.py#L34

#### What's this PR do?
Update the value in the test to also be generated by current calendar year.

#### How should this be manually tested?
- See that test suite passed

#### What are the relevant tickets?
#### Screenshots (if appropriate)
