### PR TITLE
Applied Labels show up in DQ checks results and results export

### DIFF
--- a/seed/models/data_quality.py
+++ b/seed/models/data_quality.py
@@ -704,18 +704,18 @@ class DataQualityCheck(models.Model):
                     # field that wasn't mapped
                     if rule.required:
                         self.add_result_missing_req(row.id, rule, display_name, value)
-                        label_applied = self.update_status_label(label, rule, linked_id)
+                        label_applied = self.update_status_label(label, rule, linked_id, row.id)
                 elif value is None or value == '':
                     # Empty fields
                     if rule.required:
                         self.add_result_missing_and_none(row.id, rule, display_name, value)
-                        label_applied = self.update_status_label(label, rule, linked_id)
+                        label_applied = self.update_status_label(label, rule, linked_id, row.id)
                     elif rule.not_null:
                         self.add_result_is_null(row.id, rule, display_name, value)
-                        label_applied = self.update_status_label(label, rule, linked_id)
+                        label_applied = self.update_status_label(label, rule, linked_id, row.id)
                 elif not rule.valid_text(value):
                     self.add_result_string_error(row.id, rule, display_name, value)
-                    label_applied = self.update_status_label(label, rule, linked_id)
+                    label_applied = self.update_status_label(label, rule, linked_id, row.id)
                 else:
                     # check the min and max values
                     try:
@@ -723,7 +723,7 @@ class DataQualityCheck(models.Model):
                             if rule.severity == Rule.SEVERITY_ERROR or rule.severity == Rule.SEVERITY_WARNING:
                                 s_min, s_max, s_value = rule.format_strings(value)
                                 self.add_result_min_error(row.id, rule, display_name, s_value, s_min)
-                                label_applied = self.update_status_label(label, rule, linked_id)
+                                label_applied = self.update_status_label(label, rule, linked_id, row.id)
                     except ComparisonError:
                         s_min, s_max, s_value = rule.format_strings(value)
                         self.add_result_comparison_error(row.id, rule, display_name, s_value, s_min)
@@ -741,7 +741,7 @@ class DataQualityCheck(models.Model):
                             if rule.severity == Rule.SEVERITY_ERROR or rule.severity == Rule.SEVERITY_WARNING:
                                 s_min, s_max, s_value = rule.format_strings(value)
                                 self.add_result_max_error(row.id, rule, display_name, s_value, s_max)
-                                label_applied = self.update_status_label(label, rule, linked_id)
+                                label_applied = self.update_status_label(label, rule, linked_id, row.id)
                     except ComparisonError:
                         s_min, s_max, s_value = rule.format_strings(value)
                         self.add_result_comparison_error(row.id, rule, display_name, s_value, s_max)
@@ -772,7 +772,7 @@ class DataQualityCheck(models.Model):
                                     }
                                 )
                                 '''
-                                label_applied = self.update_status_label(label, rule, linked_id)
+                                label_applied = self.update_status_label(label, rule, linked_id, row.id)
                     except MissingLabelError:
                         self.add_result_missing_label(row.id, rule, display_name, value)
                         continue
@@ -1009,7 +1009,7 @@ class DataQualityCheck(models.Model):
             'severity': rule.get_severity_display(),
         })
 
-    def update_status_label(self, label_class, rule, linked_id):
+    def update_status_label(self, label_class, rule, linked_id, row_id):
         """
 
         :param label_class: statuslabel object, either propertyview label or taxlotview label
@@ -1046,6 +1046,9 @@ class DataQualityCheck(models.Model):
                             taxlot_parent_org_id
                         )
                     )
+
+            self.results[row_id]['data_quality_results'][-1]['label'] = rule.status_label.name
+
             return True
 
     def remove_status_label(self, label_class, rule, linked_id):

--- a/seed/static/seed/js/controllers/data_quality_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_modal_controller.js
@@ -60,6 +60,10 @@ angular.module('BE.seed.controller.data_quality_modal', [])
         sortable: false,
         title: 'Field'
       }, {
+        sort_column: 'label',
+        sortable: false,
+        title: 'Applied Label'
+      }, {
         sort_column: 'detailed_message',
         sortable: false,
         title: 'Error Message'

--- a/seed/static/seed/partials/data_quality_modal.html
+++ b/seed/static/seed/partials/data_quality_modal.html
@@ -41,7 +41,7 @@
                             <tbody ng-repeat="row in dataQualityResults | filter: {visible: true}">
                                 <tr ng-repeat="result in row.data_quality_results | filter: {visible: true}" ng-class="::{'data-quality-error': result.severity === 'error', 'data-quality-warning': result.severity === 'warning'}">
                                     <td ng-repeat="c in ::columns" ng-class="{sorted: search.sort_column === c.sort_column}">
-                                        {$:: (_.includes(['detailed_message', 'formatted_field', 'table_name'], c.sort_column) ? result[c.sort_column] : row[c.sort_column]) || '--' $}
+                                        {$:: (_.includes(['detailed_message', 'formatted_field', 'table_name', 'label'], c.sort_column) ? result[c.sort_column] : row[c.sort_column]) || '--' $}
                                     </td>
                                 </tr>
                             </tbody>

--- a/seed/tests/test_labels.py
+++ b/seed/tests/test_labels.py
@@ -88,6 +88,7 @@ class TestLabelIntegrityChecks(DataMappingBaseTestCase):
                     self.PropertyViewLabels,
                     Rule.objects.get(pk=org_1_ps_rule.id),
                     org_1_propertyview.id,
+                    org_1_propertystate.id
                 )
 
         self.assertFalse(PropertyView.objects.get(pk=org_1_propertyview.id).labels.all().exists())
@@ -128,6 +129,7 @@ class TestLabelIntegrityChecks(DataMappingBaseTestCase):
                     self.TaxlotViewLabels,
                     Rule.objects.get(pk=org_1_tls_rule.id),
                     org_1_taxlot.id,
+                    org_1_taxlotstate.id
                 )
 
         self.assertFalse(TaxLotView.objects.get(pk=org_1_taxlotview.id).labels.all().exists())

--- a/seed/views/data_quality.py
+++ b/seed/views/data_quality.py
@@ -169,7 +169,7 @@ class DataQualityViews(viewsets.ViewSet):
 
         writer.writerow(
             ['Table', 'Address Line 1', 'PM Property ID', 'Tax Lot ID', 'Custom ID', 'Field',
-             'Error Message', 'Severity'])
+             'Applied Label', 'Error Message', 'Severity'])
 
         for row in data_quality_results:
             for result in row['data_quality_results']:
@@ -180,6 +180,7 @@ class DataQualityViews(viewsets.ViewSet):
                     row['jurisdiction_tax_lot_id'] if 'jurisdiction_tax_lot_id' in row else None,
                     row['custom_id_1'],
                     result['formatted_field'],
+                    result.get('label', None),
                     # the detailed_message field can have units which has superscripts/subscripts, so unidecode it!
                     unidecode(result['detailed_message']),
                     result['severity']


### PR DESCRIPTION
#### Any background context you want to provide?
See attached issue

#### What's this PR do?
During Inventory List DQ check, show the labels that were applied to records (added to -Views) in the results and the export.

#### How should this be manually tested?
For each inventory, add a label to a DQ check/rule. Trigger that check with a record(s) via Inventory List DQ check. See the label in the modal, then export the results to see the label in the export.

#### What are the relevant tickets?
#1819 

#### Screenshots (if appropriate)
![Screen Shot 2020-01-10 at 1 16 51 PM](https://user-images.githubusercontent.com/30608004/72226769-0541a500-3552-11ea-8c6f-13c55224f2c0.png)

