### PR TITLE
Ability to delete notes

### DIFF
--- a/seed/static/seed/js/controllers/inventory_detail_notes_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_notes_controller.js
@@ -105,4 +105,31 @@ angular.module('BE.seed.controller.inventory_detail_notes', [])
           refreshNotes();
         });
       };
+
+      $scope.open_delete_note_modal = function (note) {
+        var noteModalInstance = $uibModal.open({
+          templateUrl: urls.static_url + 'seed/partials/inventory_detail_notes_modal.html',
+          controller: 'inventory_detail_notes_modal_controller',
+          size: 'lg',
+          resolve: {
+            inventoryType: function () {
+              return $scope.inventory_type;
+            },
+            viewId: function () {
+              return $scope.inventory.view_id;
+            },
+            orgId: function () {
+              return $scope.org_id;
+            },
+            note: function () {
+              return note;
+            },
+            action: _.constant('delete'),
+          }
+        });
+
+        noteModalInstance.result.finally(function () {
+          refreshNotes();
+        });
+      };
     }]);

--- a/seed/static/seed/js/controllers/inventory_detail_notes_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_notes_controller.js
@@ -54,9 +54,6 @@ angular.module('BE.seed.controller.inventory_detail_notes', [])
         });
       };
 
-      /**
-       * open_data_quality_modal: modal to present data data_quality warnings and errors
-       */
       $scope.open_create_note_modal = function () {
         var newNoteModalInstance = $uibModal.open({
           templateUrl: urls.static_url + 'seed/partials/inventory_detail_notes_modal.html',
@@ -71,7 +68,9 @@ angular.module('BE.seed.controller.inventory_detail_notes', [])
             },
             orgId: function () {
               return $scope.org_id;
-            }
+            },
+            note: _.constant({text: ''}),
+            action: _.constant('new'),
           }
         });
 

--- a/seed/static/seed/js/controllers/inventory_detail_notes_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_notes_controller.js
@@ -78,4 +78,31 @@ angular.module('BE.seed.controller.inventory_detail_notes', [])
           refreshNotes();
         });
       };
+
+      $scope.open_edit_note_modal = function (note) {
+        var noteModalInstance = $uibModal.open({
+          templateUrl: urls.static_url + 'seed/partials/inventory_detail_notes_modal.html',
+          controller: 'inventory_detail_notes_modal_controller',
+          size: 'lg',
+          resolve: {
+            inventoryType: function () {
+              return $scope.inventory_type;
+            },
+            viewId: function () {
+              return $scope.inventory.view_id;
+            },
+            orgId: function () {
+              return $scope.org_id;
+            },
+            note: function () {
+              return note;
+            },
+            action: _.constant('update'),
+          }
+        });
+
+        noteModalInstance.result.finally(function () {
+          refreshNotes();
+        });
+      };
     }]);

--- a/seed/static/seed/js/controllers/inventory_detail_notes_modal_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_notes_modal_controller.js
@@ -6,37 +6,37 @@ angular.module('BE.seed.controller.inventory_detail_notes_modal', [])
   .controller('inventory_detail_notes_modal_controller', [
     '$scope',
     '$uibModalInstance',
+    'action',
     'note_service',
     'inventoryType',
     'viewId',
+    'note',
     'orgId',
     function (
       $scope,
       $uibModalInstance,
+      action,
       note_service,
       inventoryType,
       viewId,
+      note,
       orgId
     ) {
       $scope.inventoryType = inventoryType;
-      $scope.newNote = '';
       $scope.viewId = viewId;
       $scope.orgId = orgId;
-
-      $scope.isNoteEmpty = function () {
-        return _.isEmpty(_.trim($scope.newNote));
-      };
+      $scope.action = action;
+      $scope.note = note;
 
       $scope.close = function () {
         $uibModalInstance.dismiss();
       };
 
-      $scope.save = function () {
-        //note_factory.create_note = function (org_id, inventory_type, inventory_id, note_data) {
+      $scope.create = function () {
         var data = {
           name: 'Manually Created',
           note_type: 'Note',
-          text: $scope.newNote
+          text: note.text,
         };
         note_service.create_note($scope.orgId, $scope.inventoryType, $scope.viewId, data).then(function () {
           $uibModalInstance.close();

--- a/seed/static/seed/js/controllers/inventory_detail_notes_modal_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_notes_modal_controller.js
@@ -42,4 +42,15 @@ angular.module('BE.seed.controller.inventory_detail_notes_modal', [])
           $uibModalInstance.close();
         });
       };
+
+      $scope.update = function () {
+        var data = {
+          name: note.name,
+          note_type: note.note_type,
+          text: note.text,
+        };
+        note_service.update_note($scope.orgId, $scope.inventoryType, $scope.viewId, note.id, data).then(function () {
+          $uibModalInstance.close();
+        });
+      };
     }]);

--- a/seed/static/seed/js/controllers/inventory_detail_notes_modal_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_notes_modal_controller.js
@@ -53,4 +53,10 @@ angular.module('BE.seed.controller.inventory_detail_notes_modal', [])
           $uibModalInstance.close();
         });
       };
+
+      $scope.delete = function () {
+        note_service.delete_note($scope.inventoryType, $scope.viewId, note.id).then(function () {
+          $uibModalInstance.close();
+        });
+      };
     }]);

--- a/seed/static/seed/js/services/note_service.js
+++ b/seed/static/seed/js/services/note_service.js
@@ -35,8 +35,8 @@ angular.module('BE.seed.service.note', []).factory('note_service', [
       });
     };
 
-    note_factory.delete_note = function (inventory_type, view_id) {
-      return $http.delete('/api/v2.1/' + inventory_type + '/' + view_id + /notes/, {}).then(function (response) {
+    note_factory.delete_note = function (inventory_type, view_id, note_id) {
+      return $http.delete('/api/v2.1/' + inventory_type + '/' + view_id + /notes/ + note_id + '/', {}).then(function (response) {
         return response.data;
       });
     };

--- a/seed/static/seed/js/services/note_service.js
+++ b/seed/static/seed/js/services/note_service.js
@@ -60,6 +60,14 @@ angular.module('BE.seed.service.note', []).factory('note_service', [
       });
     };
 
+    note_factory.update_note = function (org_id, inventory_type, view_id, note_id, note_data) {
+      var payload = note_data;
+      payload.organization_id = org_id;
+      return $http.put('/api/v2.1/' + inventory_type + '/' + view_id + /notes/ + note_id + '/', payload).then(function (response) {
+        return response.data;
+      });
+    };
+
     return note_factory;
 
   }]);

--- a/seed/static/seed/partials/inventory_detail_notes.html
+++ b/seed/static/seed/partials/inventory_detail_notes.html
@@ -41,8 +41,8 @@
                 <th width="1%" class="ellipsis-resizable">Type</th>
                 <th width="1%" class="ellipsis-resizable">Name</th>
                 <th class="ellipsis-resizable">Text</th>
-                <th></th>
-                <th></th>
+                <th width="1%"></th>
+                <th width="1%"></th>
             </tr>
         </thead>
         <tbody>

--- a/seed/static/seed/partials/inventory_detail_notes.html
+++ b/seed/static/seed/partials/inventory_detail_notes.html
@@ -41,6 +41,7 @@
                 <th width="1%" class="ellipsis-resizable">Type</th>
                 <th width="1%" class="ellipsis-resizable">Name</th>
                 <th class="ellipsis-resizable">Text</th>
+                <th></th>
             </tr>
         </thead>
         <tbody>
@@ -49,6 +50,11 @@
                 <td style="white-space: nowrap;">{$:: note.note_type $}</td>
                 <td style="white-space: nowrap;">{$:: note.name $}</td>
                 <td>{$:: note.text $}</td>
+                <td>
+                    <button class="btn btn-primary" type="button" ng-click="open_edit_note_modal(note)" tooltip-placement="bottom" uib-tooltip="Edit">
+                        <span class="glyphicon glyphicon-erase" aria-hidden="true"></span>
+                    </button>
+                </td>
             </tr>
         </tbody>
     </table>

--- a/seed/static/seed/partials/inventory_detail_notes.html
+++ b/seed/static/seed/partials/inventory_detail_notes.html
@@ -42,6 +42,7 @@
                 <th width="1%" class="ellipsis-resizable">Name</th>
                 <th class="ellipsis-resizable">Text</th>
                 <th></th>
+                <th></th>
             </tr>
         </thead>
         <tbody>
@@ -53,6 +54,11 @@
                 <td>
                     <button class="btn btn-primary" type="button" ng-click="open_edit_note_modal(note)" tooltip-placement="bottom" uib-tooltip="Edit">
                         <span class="glyphicon glyphicon-erase" aria-hidden="true"></span>
+                    </button>
+                </td>
+                <td>
+                    <button class="btn btn-danger" type="button" ng-click="open_delete_note_modal(note)" tooltip-placement="bottom" uib-tooltip="Delete">
+                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
                     </button>
                 </td>
             </tr>

--- a/seed/static/seed/partials/inventory_detail_notes_modal.html
+++ b/seed/static/seed/partials/inventory_detail_notes_modal.html
@@ -1,6 +1,7 @@
 <div class="modal-header" ng-switch on="action">
     <h4 class="modal-title" ng-switch-when="new" translate>Add New Note</h4>
     <h4 class="modal-title" ng-switch-when="update">{$:: 'Update' | translate $} {$:: note.name $} ({$:: note.created | date: 'MM/dd/yyyy hh:mm:ss a' $})</h4>
+    <h4 class="modal-title" ng-switch-when="delete">{$:: 'Delete' | translate $} {$:: note.name $} ({$:: note.created | date: 'MM/dd/yyyy hh:mm:ss a' $})</h4>
 </div>
 
 <div class="modal-body no_bottom_padding">
@@ -8,7 +9,7 @@
         <div class="form-group" ng-class="{'has-error': data.alert, 'has-feedback': data.alert}">
             <label class="control-label col-lg-3 col-sm-3" for="noteText" translate>Note</label>
             <div class="col-lg-8 col-sm-8">
-                <textarea class="form-control" id="noteText" ng-model="note.text" rows="4" autofocus required></textarea>
+                <textarea class="form-control" ng-disabled="action === 'delete'" id="noteText" ng-model="note.text" rows="4" autofocus required></textarea>
             </div>
         </div>
     </div>
@@ -18,4 +19,5 @@
     <button type="button" class="btn btn-default" ng-click="close()" translate>Cancel</button>
     <button type="submit" class="btn btn-primary" ng-click="create()" ng-switch-when="new" ng-disabled="!note.text" translate>Add Note</button>
     <button type="submit" class="btn btn-primary" ng-click="update()" ng-switch-when="update" ng-disabled="!note.text" translate>Update</button>
+    <button type="button" class="btn btn-danger" ng-click="delete()" ng-switch-when="delete" translate>Delete</button>
 </div>

--- a/seed/static/seed/partials/inventory_detail_notes_modal.html
+++ b/seed/static/seed/partials/inventory_detail_notes_modal.html
@@ -1,18 +1,19 @@
-<div class="modal-header">
-    <h4 class="modal-title" translate>Add New Note</h4>
+<div class="modal-header" ng-switch on="action">
+    <h4 class="modal-title" ng-switch-when="new" translate>Add New Note</h4>
 </div>
+
 <div class="modal-body no_bottom_padding">
     <div class="data_upload_steps form-horizontal">
         <div class="form-group" ng-class="{'has-error': data.alert, 'has-feedback': data.alert}">
-            <label class="control-label col-lg-3 col-sm-3" for="createNote" translate>Note</label>
+            <label class="control-label col-lg-3 col-sm-3" for="noteText" translate>Note</label>
             <div class="col-lg-8 col-sm-8">
-                <textarea class="form-control" id="createNote" ng-model="newNote" rows="4" autofocus required></textarea>
+                <textarea class="form-control" id="noteText" ng-model="note.text" rows="4" autofocus required></textarea>
             </div>
         </div>
     </div>
 </div>
 
-<div class="modal-footer">
+<div class="modal-footer" ng-switch on="action">
     <button type="button" class="btn btn-default" ng-click="close()" translate>Cancel</button>
-    <button type="submit" class="btn btn-primary" ng-click="save()" ng-disabled="isNoteEmpty()" translate>Add Note</button>
+    <button type="submit" class="btn btn-primary" ng-click="create()" ng-switch-when="new" ng-disabled="!note.text" translate>Add Note</button>
 </div>

--- a/seed/static/seed/partials/inventory_detail_notes_modal.html
+++ b/seed/static/seed/partials/inventory_detail_notes_modal.html
@@ -1,5 +1,6 @@
 <div class="modal-header" ng-switch on="action">
     <h4 class="modal-title" ng-switch-when="new" translate>Add New Note</h4>
+    <h4 class="modal-title" ng-switch-when="update">{$:: 'Update' | translate $} {$:: note.name $} ({$:: note.created | date: 'MM/dd/yyyy hh:mm:ss a' $})</h4>
 </div>
 
 <div class="modal-body no_bottom_padding">
@@ -16,4 +17,5 @@
 <div class="modal-footer" ng-switch on="action">
     <button type="button" class="btn btn-default" ng-click="close()" translate>Cancel</button>
     <button type="submit" class="btn btn-primary" ng-click="create()" ng-switch-when="new" ng-disabled="!note.text" translate>Add Note</button>
+    <button type="submit" class="btn btn-primary" ng-click="update()" ng-switch-when="update" ng-disabled="!note.text" translate>Update</button>
 </div>


### PR DESCRIPTION
#### Any background context you want to provide?
See attached issue
#### What's this PR do?
Add update and delete buttons for notes, making use of the same modal to help users accept/use new functionality. See screenshots below.

#### How should this be manually tested?
Update and delete notes.

#### What are the relevant tickets?
#2013 

#### Screenshots (if appropriate)
Initial Buttons
![Screen Shot 2020-01-13 at 5 08 54 PM](https://user-images.githubusercontent.com/30608004/72303484-b3208280-362a-11ea-9c7c-db9ff24c83d9.png)

Update modal
![Screen Shot 2020-01-13 at 5 11 21 PM](https://user-images.githubusercontent.com/30608004/72303485-b3b91900-362a-11ea-8163-6c56fc5b55f2.png)

Delete modal
![Screen Shot 2020-01-13 at 5 11 28 PM](https://user-images.githubusercontent.com/30608004/72303486-b3b91900-362a-11ea-9520-f59804199122.png)

