### PR TITLE
Update ESPM Endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ Closed Issues and Features:
 - Fixed [#1913]( https://github.com/SEED-platform/seed/issues/1913 ), Add Notes info to export
 - Fixed [#1713]( https://github.com/SEED-platform/seed/issues/1713 ), Return progress status immediately when uploading large files
 
+# SEED Version 2.6.1-Patch1
+
+- Fixed [#2076]( https://github.com/SEED-platform/seed/issues/2076 ), ESPM import no longer works due to ESPM website updates
+
 # SEED Version 2.6.1-Patch0
 
 - This includes the patches from 2.6.0-patch0 since the patches were not complete until after the release of 2.6.1.
@@ -89,6 +93,9 @@ This patch has address a couple issues including:
 - Update the deployment to automatically read the version of redis, postgres, and OEP from the docker-compose.build.yml file
 - Fix data comparisons when merging records
 - Use OEP Version 1.4
+- Fixed [#2039]( https://github.com/SEED-platform/seed/issues/2039 ), Portfolio Manager Login URL Changed
+- Fixed [#2058]( https://github.com/SEED-platform/seed/issues/2058 ), Portfolio Manager URL Changed (Flapping Issue)
+- Fixed [#2076]( https://github.com/SEED-platform/seed/issues/2076 ), ESPM import no longer works due to ESPM website updates
 
 # SEED Version 2.6.0
 

--- a/seed/views/portfoliomanager.py
+++ b/seed/views/portfoliomanager.py
@@ -125,10 +125,7 @@ class PortfolioManagerViewSet(GenericViewSet):
                 else:
                     content = pm.generate_and_download_template_report(template)
             except PMExcept as pme:
-                return JsonResponse(
-                    {'status': 'error', 'message': str(pme)},
-                    status=status.HTTP_400_BAD_REQUEST
-                )
+                return JsonResponse({'status': 'error', 'message': str(pme)}, status=status.HTTP_400_BAD_REQUEST)
             try:
                 content_object = xmltodict.parse(content, dict_constructor=dict)
             except Exception:  # catch all because xmltodict doesn't specify a class of Exceptions
@@ -158,8 +155,7 @@ class PortfolioManagerViewSet(GenericViewSet):
 
             return JsonResponse({'status': 'success', 'properties': properties})
         except Exception as e:
-            return JsonResponse({'status': 'error', 'message': e},
-                                status=status.HTTP_400_BAD_REQUEST)
+            return JsonResponse({'status': 'error', 'message': e}, status=status.HTTP_400_BAD_REQUEST)
 
 
 class PortfolioManagerImport(object):
@@ -199,7 +195,8 @@ class PortfolioManagerImport(object):
             raise PMExcept("SSL Error in Portfolio Manager Query; check VPN/Network/Proxy.")
 
         # This returns a 200 even if the credentials are bad, so I'm having to check some text in the response
-        if 'The username and/or password you entered is not correct. Please try again.' in response.content.decode('utf-8'):
+        if 'The username and/or password you entered is not correct. Please try again.' in response.content.decode(
+                'utf-8'):
             raise PMExcept('Unsuccessful response from login attempt; aborting.  Check credentials.')
 
         # Upon successful logging in, we should have received a cookie header that we can reuse later
@@ -218,36 +215,31 @@ class PortfolioManagerImport(object):
 
     def get_list_of_report_templates(self):
         """
-        This method calls out to the ESPM API to get the full list of template rows.  For each row, it checks to see if
-        it has children rows, and if so, it calls out to the API for the child rows and retrieves IDs and names for
-        those as well.
+        New method to support update to ESPM
 
-        :return: Returns a list of template objects.  All rows will have a z_seed_child_row key that is False for main
+        :return: Returns a list of template objects. All rows will have a z_seed_child_row key that is False for main
         rows and True for child rows
         """
-
         # login if needed
         if not self.authenticated_headers:
             self.login_and_set_cookie_header()
 
-        # Get the report templates
-        url = 'https://portfoliomanager.energystar.gov/pm/reports/templateTableRows'
+        # get the report data
+        url = 'https://portfoliomanager.energystar.gov/pm/reports/reportData'
         try:
             response = requests.get(url, headers=self.authenticated_headers)
+
         except requests.exceptions.SSLError:
             raise PMExcept('SSL Error in Portfolio Manager Query; check VPN/Network/Proxy.')
         if not response.status_code == status.HTTP_200_OK:
             raise PMExcept('Unsuccessful response from report template rows query; aborting.')
-        try:
-            template_object = json.loads(response.text)
-        except ValueError:
-            raise PMExcept('Malformed JSON response from report template rows query; aborting.')
-        _log.debug('Received the following JSON return: ' + json.dumps(template_object, indent=2))
+
+        template_object = self.parse_template_response(response.text)
 
         # We need to parse the list of report templates
-        if 'rows' not in template_object:
-            raise PMExcept('Could not find rows key in template response; aborting.')
-        templates = template_object['rows']
+        if 'customReportsData' not in template_object:
+            raise PMExcept('Could not find customReportsData key in template response; aborting.')
+        templates = template_object['customReportsData']
         template_response = []
         sorted_templates = sorted(templates, key=lambda x: x['name'])
         for t in sorted_templates:
@@ -260,16 +252,24 @@ class PortfolioManagerImport(object):
             _log.debug('Found template,\n id=' + str(t['id']) + '\n name=' + str(t['name']))
             if 'hasChildrenRows' in t and t['hasChildrenRows']:
                 _log.debug('Template row has children data request rows, trying to get them now')
-                children_url = \
-                    'https://portfoliomanager.energystar.gov/pm/reports/templateTableChildrenRows/TEMPLATE/{0}'.format(
-                        t['id']
-                    )
+                children_url = f'https://portfoliomanager.energystar.gov/pm/reports/templateChildrenRows/TEMPLATE/{t["id"]}'
+
                 # SSL errors would have been caught earlier in this function and raised, so this should be ok
                 children_response = requests.get(children_url, headers=self.authenticated_headers)
                 if not children_response.status_code == status.HTTP_200_OK:
                     raise PMExcept('Unsuccessful response from child row template lookup; aborting.')
                 try:
-                    child_object = json.loads(children_response.text)
+                    # the data are now in the string of the data key of the returned dictionary with an excessive amount of
+                    # escaped doublequotes.
+                    # e.g., response = {"data": "{"customReportsData":"..."}"}
+                    decoded = json.loads(children_response.text)  # .encode('utf-8').decode('unicode_escape')
+
+                    # the beginning and end of the string needs to be without the doublequote. Remove the escaped double quotes
+                    data_to_parse = decoded['data'].replace('"{', '{').replace('}"', '}').replace('"[{', '[{').replace(
+                        '}]"', '}]').replace('\\"', '"')
+
+                    # print(f'data to parse: {data_to_parse}')
+                    child_object = json.loads(data_to_parse)['childrenRows']
                 except ValueError:
                     raise PMExcept('Malformed JSON response from report template child row query; aborting.')
                 _log.debug('Received the following child JSON return: ' + json.dumps(child_object, indent=2))
@@ -295,6 +295,29 @@ class PortfolioManagerImport(object):
             raise PMExcept("Could not find a matching template for this name, try a different name")
         _log.debug("Desired report name found, template info: " + json.dumps(matched_template, indent=2))
         return matched_template
+
+    def parse_template_response(self, response_text):
+        """
+        This method is for the updated ESPM where the response is escaped JSON string in a JSON response.
+
+        :param response_text: str, repsonse to parse
+        :return: dict
+        """
+        try:
+            # the data are now in the string of the data key of the returned dictionary with an excessive amount of
+            # escaped doublequotes.
+            # e.g., response = {"data": "{"customReportsData":"..."}"}
+            decoded = json.loads(response_text)  # .encode('utf-8').decode('unicode_escape')
+
+            # the beginning and end of the string needs to be without the doublequote. Remove the escaped double quotes
+            data_to_parse = decoded['data'].replace('"[{', '[{').replace('}]"', '}]').replace('\\"', '"')
+
+            # print(f'data to parse: {data_to_parse}')
+            template_object = json.loads(data_to_parse)
+            _log.debug('Received the following JSON return: ' + json.dumps(template_object, indent=2))
+            return template_object
+        except ValueError:
+            raise PMExcept('Malformed JSON response from report template rows query; aborting.')
 
     def generate_and_download_template_report(self, matched_template):
         """
@@ -329,18 +352,21 @@ class PortfolioManagerImport(object):
             response.headers))
 
         # Now we need to wait while the report is being generated
-        url = 'https://portfoliomanager.energystar.gov/pm/reports/templateTableRows'
+        url = 'https://portfoliomanager.energystar.gov/pm/reports/reportData'
         attempt_count = 0
         report_generation_complete = False
         while attempt_count < 10:
             attempt_count += 1
+
+            # get the report data
             try:
                 response = requests.get(url, headers=self.authenticated_headers)
             except requests.exceptions.SSLError:
                 raise PMExcept('SSL Error in Portfolio Manager Query; check VPN/Network/Proxy.')
             if not response.status_code == status.HTTP_200_OK:
-                raise PMExcept('Unsuccessful response from GET trying to check status on generated report; aborting.')
-            template_objects = json.loads(response.text)['rows']
+                raise PMExcept('Unsuccessful response from report template rows query; aborting.')
+
+            template_objects = self.parse_template_response(response.text)['customReportsData']
             for t in template_objects:
                 if 'id' in t and t['id'] == matched_template['id']:
                     this_matched_template = t
@@ -355,6 +381,7 @@ class PortfolioManagerImport(object):
             else:
                 report_generation_complete = True
                 break
+
         if report_generation_complete:
             _log.debug('Report appears to have been generated successfully (attempt_count=' + str(attempt_count) + ')')
         else:
@@ -362,24 +389,26 @@ class PortfolioManagerImport(object):
 
         # Finally we can download the generated report
         template_report_name = quote(matched_template['name']) + '.xml'
-        sanitized_template_report_name = template_report_name.replace('/', '_')
-        d_url = 'https://portfoliomanager.energystar.gov/pm/reports/template/download/%s/XML/false/%s?testEnv=false' % (
-            str(template_report_id), sanitized_template_report_name
+        url = 'https://portfoliomanager.energystar.gov/pm/reports/template/download/{0}/XML/false/{1}?testEnv=false'
+        download_url = url.format(
+            str(template_report_id), template_report_name
         )
         try:
-            response = requests.get(d_url, headers=self.authenticated_headers)
+            response = requests.get(download_url, headers=self.authenticated_headers)
         except requests.exceptions.SSLError:
             raise PMExcept('SSL Error in Portfolio Manager Query; check VPN/Network/Proxy.')
         if not response.status_code == status.HTTP_200_OK:
             error_message = 'Unsuccessful response from GET trying to download generated report;'
             error_message += ' Generated report name: ' + template_report_name + ';'
-            error_message += ' Tried to download report from URL: ' + d_url + ';'
+            error_message += ' Tried to download report from URL: ' + download_url + ';'
             error_message += ' Returned with a status code = ' + response.status_code + ';'
             raise PMExcept(error_message)
         return response.content
 
     def generate_and_download_child_data_request_report(self, matched_data_request):
         """
+        Updated for recent update of ESPM
+
         This method calls out to ESPM to get the report data for a child template (a data request).  For child
         templates, the process simply requires calling out the download URL and getting the data in XML format.
 
@@ -408,9 +437,11 @@ class PortfolioManagerImport(object):
             str(template_report_id), sanitized_template_report_name
         )
         try:
-            response = requests.get(download_url, headers=self.authenticated_headers)
+            response = requests.get(download_url, headers=self.authenticated_headers, allow_redirects=True)
         except requests.exceptions.SSLError:
             raise PMExcept('SSL Error in Portfolio Manager Query; check VPN/Network/Proxy.')
+
         if not response.status_code == status.HTTP_200_OK:
             raise PMExcept('Unsuccessful response from GET trying to download generated report; aborting.')
+
         return response.content


### PR DESCRIPTION
#### Any background context you want to provide?
The latest round of ESPM updated broke the ESPM import for SEED.

#### What's this PR do?
* Use new endpoints for retrieving ESMP data
* Parse the new result of the unofficial API

#### How should this be manually tested?
* Click add data file
* Select import from Portfolio Manager
* Verify that both a normal report and a child report can successfully import

#### What are the relevant tickets?
#2076 

#### Screenshots (if appropriate)
