### PR TITLE
1759 column mapping presets bug fix

### DIFF
--- a/seed/static/seed/js/controllers/column_mappings_controller.js
+++ b/seed/static/seed/js/controllers/column_mappings_controller.js
@@ -182,16 +182,16 @@ angular.module('BE.seed.controller.column_mappings', [])
 
       $scope.save_preset = function () {
         // If applicable, convert display names to db names for saving
-        var preset_id = $scope.current_preset.id;
-        var preset_index = _.findIndex($scope.presets, ['id', preset_id]);
+        _.forEach($scope.current_preset.mappings, mapping_display_to_db);
+        var updated_data = {mappings: $scope.current_preset.mappings};
 
-        _.forEach($scope.presets[preset_index].mappings, mapping_display_to_db);
-        var updated_data = {mappings: $scope.presets[preset_index].mappings};
-
-        column_mappings_service.update_column_mapping_preset($scope.org.id, preset_id, updated_data).then(function (result) {
+        column_mappings_service.update_column_mapping_preset($scope.org.id, $scope.current_preset.id, updated_data).then(function (result) {
           // If applicable, convert db names back to display names for rendering
-          _.forEach($scope.presets[preset_index].mappings, mapping_db_to_display);
-          $scope.presets[preset_index].updated = result.data.updated;
+          _.forEach($scope.current_preset.mappings, mapping_db_to_display);
+          $scope.current_preset.updated = result.data.updated;
+
+          var preset_id = $scope.current_preset.id;
+          _.find($scope.presets, ['id', preset_id]).mappings = $scope.current_preset.mappings;
 
           $scope.changes_possible = false;
           Notification.primary('Saved ' + $scope.current_preset.name);

--- a/seed/static/seed/js/controllers/mapping_controller.js
+++ b/seed/static/seed/js/controllers/mapping_controller.js
@@ -520,10 +520,20 @@ angular.module('BE.seed.controller.mapping', [])
       };
 
       /**
+       * empty_fields_present: used to disable or enable the 'show & review
+       *   mappings' button. No warning associated as users "aren't done" listing their mapping settings.
+       */
+      var suggestions_not_provided_yet = function () {
+        var no_suggestion_value = Boolean(_.find($scope.mappings, {suggestion: undefined}));
+        var no_suggestion_table_name = Boolean(_.find($scope.mappings, {suggestion_table_name: undefined}));
+        return no_suggestion_value || no_suggestion_table_name;
+      };
+
+      /**
        * check_fields: called by ng-disabled for "Map Your Data" button.  Checks for duplicates and for required fields.
        */
       $scope.check_fields = function () {
-        return $scope.duplicates_present || $scope.empty_fields_present() || !$scope.required_property_fields_present() || !$scope.required_taxlot_fields_present();
+        return $scope.duplicates_present || $scope.empty_fields_present() || !$scope.required_property_fields_present() || !$scope.required_taxlot_fields_present() || suggestions_not_provided_yet();
       };
 
       /**


### PR DESCRIPTION
#### Any background context you want to provide?
Within the organization presets page, a bug was preventing presets from being saved after switching between presets via the dropdown.

To provide more technical detail, the issue related to an assumption I made that I was passing the POST request a collection of mappings using a variable with a _reference_ vs a value.

#### What's this PR do?
Fixes the bug mentioned above.

AND also, includes a small clean up that disables the "Map your data" button the import mapping page on initial load. This wasn't needed before since the page previous loads with suggestions preloaded.

#### How should this be manually tested?
Edit and save mapping presets.

I'd also suggest monkey testing all aspects of CRUDing mapping presets.

#### What are the relevant tickets?
This is a clean up for #1759 
