### PR TITLE
Persistant drop down cycle choice

### DIFF
--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -64,12 +64,9 @@ angular.module('BE.seed.controller.data_upload_modal', [])
       organization
     ) {
       $scope.cycles = cycles.cycles;
-      var cached_cycle = inventory_service.get_last_selected_cycle();
-      if ($scope.cycles.length && cached_cycle == null){
-        $scope.selectedCycle = cycles.cycles[0];
-      } else {
-        $scope.selectedCycle = cached_cycle;
-      }
+      var cached_cycle = inventory_service.get_last_cycle();
+      $scope.selectedCycle = _.find(cycles.cycles, {id: cached_cycle}) || _.first(cycles.cycles);
+
       $scope.step_10_style = 'info';
       $scope.step_10_title = 'load more data';
       $scope.step = {
@@ -147,7 +144,7 @@ angular.module('BE.seed.controller.data_upload_modal', [])
 
       $scope.cycleChanged = function (selected) {
         $scope.selectedCycle = selected;
-        inventory_service.save_last_selected_cycle(selected);
+        inventory_service.save_last_cycle(selected.id);
       };
 
       /**

--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -64,7 +64,7 @@ angular.module('BE.seed.controller.data_upload_modal', [])
       organization
     ) {
       $scope.cycles = cycles.cycles;
-      if ($scope.cycles.length) $scope.selectedCycle = $scope.cycles[0];
+      if ($scope.cycles.length) $scope.selectedCycle = inventory_service.get_last_selected_cycle();
       $scope.step_10_style = 'info';
       $scope.step_10_title = 'load more data';
       $scope.step = {
@@ -142,6 +142,7 @@ angular.module('BE.seed.controller.data_upload_modal', [])
 
       $scope.cycleChanged = function (selected) {
         $scope.selectedCycle = selected;
+        inventory_service.save_last_selected_cycle(selected);
       };
 
       /**

--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -64,7 +64,12 @@ angular.module('BE.seed.controller.data_upload_modal', [])
       organization
     ) {
       $scope.cycles = cycles.cycles;
-      if ($scope.cycles.length) $scope.selectedCycle = inventory_service.get_last_selected_cycle();
+      var cached_cycle = inventory_service.get_last_selected_cycle();
+      if ($scope.cycles.length && cached_cycle == null){
+        $scope.selectedCycle = cycles.cycles[0];
+      } else {
+        $scope.selectedCycle = cached_cycle;
+      }
       $scope.step_10_style = 'info';
       $scope.step_10_title = 'load more data';
       $scope.step = {

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -460,14 +460,6 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       localStorage.setItem('cycles', JSON.stringify(cycles));
     };
 
-    inventory_service.get_last_selected_cycle = function () {
-      return (JSON.parse(localStorage.getItem('selected')));
-    };
-
-    inventory_service.save_last_selected_cycle = function (selected) {
-      localStorage.setItem('selected', JSON.stringify(selected));
-    };
-
     inventory_service.get_last_selected_cycles = function () {
       var organization_id = user_service.get_organization().id;
       return (JSON.parse(localStorage.getItem('selected_cycles')) || {})[organization_id];

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -460,6 +460,14 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       localStorage.setItem('cycles', JSON.stringify(cycles));
     };
 
+    inventory_service.get_last_selected_cycle = function () {
+      return (JSON.parse(localStorage.getItem('selected')));
+    };
+
+    inventory_service.save_last_selected_cycle = function (selected) {
+      localStorage.setItem('selected', JSON.stringify(selected));
+    };
+
     inventory_service.get_last_selected_cycles = function () {
       var organization_id = user_service.get_organization().id;
       return (JSON.parse(localStorage.getItem('selected_cycles')) || {})[organization_id];


### PR DESCRIPTION
#### What's this PR do?
Stores the choice of an item from the cycles dropdown menu in local storage.  
#### How should this be manually tested?
`Data` > `Add Data to Files` > `Select` > `Dismiss` Repeat to find your selection is cached
#### What are the relevant tickets?
Addressing #2023 
#### Screenshots (if appropriate)
