### PR TITLE
Issue #2114 - Reactivate save button after deleting a rule and save changes.

### DIFF
--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -368,9 +368,9 @@ angular.module('BE.seed.controller.data_quality_admin', [])
       $scope.delete_rule = function (rule, index) {
         if ($scope.ruleGroups[$scope.inventory_type][rule.field].length === 1) {
           delete $scope.ruleGroups[$scope.inventory_type][rule.field];
-          $scope.change_rules();
         }
         else $scope.ruleGroups[$scope.inventory_type][rule.field].splice(index, 1);
+        $scope.change_rules();
       };
 
       var displayNames = {};


### PR DESCRIPTION
#### Any background context you want to provide?
Save changes button inconsistency: if a user delete a rule for the first time, save button activate for saving the change. Upon clicking on "save" button and if user deletes another rule right after, "save" button stays gray and inactivate.

#### What's this PR do?
Reactivate "save" button after user delete a rule/rules and save changes.

#### How should this be manually tested?
1. Delete a rule, hit "save";
2. Right away, delete another rule;
3. Should see "save" button is reactivated.

#### What are the relevant tickets?
#2114 

#### Screenshots (if appropriate)
1. Before deleting a rule (address line 1):
![Screen Shot 2020-02-19 at 9 19 26 AM](https://user-images.githubusercontent.com/49968203/74851806-fb515580-52f8-11ea-96b1-6ea9a73e7f31.png)

2. Delete address line 1, save button lit up for click;
![Screen Shot 2020-02-19 at 9 17 38 AM](https://user-images.githubusercontent.com/49968203/74851893-18862400-52f9-11ea-803c-94506ee70610.png)

3. Save changes after deleting address line 1:
![Screen Shot 2020-02-19 at 9 17 59 AM](https://user-images.githubusercontent.com/49968203/74851930-26d44000-52f9-11ea-8f8e-8667363b7497.png)

4. Immediately, delete another rule (conditioned floor area), save button is reactivated:
![Screen Shot 2020-02-19 at 9 18 10 AM](https://user-images.githubusercontent.com/49968203/74852069-57b47500-52f9-11ea-9ead-b29de02e58af.png)



