### PR TITLE
Remove created and updated from EXCLUDED_COLUMN_RETURN_FIELDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# SEED Version 2.6.1-Patch2
+
+- Fixed [#2119]( https://github.com/SEED-platform/seed/issues/2119 ), Re-enable created and updated fields for master records on the front end
 # SEED Version 2.6.1-Patch1
 
 - Fixed [#2076]( https://github.com/SEED-platform/seed/issues/2076 ), ESPM import no longer works due to ESPM website updates

--- a/seed/models/columns.py
+++ b/seed/models/columns.py
@@ -53,10 +53,8 @@ class Column(models.Model):
     # Do not return these columns to the front end -- when using the tax_lot_properties
     # get_related method.
     EXCLUDED_COLUMN_RETURN_FIELDS = [
-        'created',
         'hash_object',
         'normalized_address',
-        'updated',
         # Records below are old and should not be used
         'source_eui_modeled_orig',
         'site_eui_orig',

--- a/seed/static/seed/partials/inventory_detail.html
+++ b/seed/static/seed/partials/inventory_detail.html
@@ -167,11 +167,11 @@
 
                             <!-- Show read-only historical field value -->
                             <td ng-repeat="historical_item in historical_items" ng-class="(!col.is_extra_data && historical_item.changed_fields.extra_data_fields.indexOf(col.column_name)>=0) || historical_item.changed_fields.regular_fields.indexOf(col.column_name)>=0 ? 'highlight' : ''" class="ellipsis">
-                                <span ng-if="::!col.is_extra_data" class="sd-data-content" popover-placement="top-left" popover-trigger="outsideClick" popover-animation="false" uib-popover="{$:: historical_item.state[col.column_name] $}">
+                                <span ng-if="::!col.is_extra_data && col.table_name.toLowerCase().includes('state')" class="sd-data-content" popover-placement="top-left" popover-trigger="outsideClick" popover-animation="false" uib-popover="{$:: historical_item.state[col.column_name] $}">
                                     <span ng-if="col.data_type !== 'datetime'">{$:: historical_item.state[col.column_name] $}</span>
                                     <span ng-if="col.data_type === 'datetime'">{$:: historical_item.state[col.column_name] | date: 'yyyy-MM-dd h:mm a' $}</span>
                                 </span>
-                                <span ng-if="::col.is_extra_data" class="sd-data-content" popover-placement="top-left" popover-trigger="outsideClick" popover-animation="false" uib-popover="{$:: historical_item.state.extra_data[col.column_name] $}">
+                                <span ng-if="::col.is_extra_data && col.table_name.toLowerCase().includes('state')" class="sd-data-content" popover-placement="top-left" popover-trigger="outsideClick" popover-animation="false" uib-popover="{$:: historical_item.state.extra_data[col.column_name] $}">
                                     <span ng-if="col.data_type !== 'datetime'">{$:: historical_item.state.extra_data[col.column_name] $}</span>
                                     <span ng-if="col.data_type === 'datetime'">{$:: historical_item.state.extra_data[col.column_name] | date: 'yyyy-MM-dd h:mm a' $}</span>
                                 </span>


### PR DESCRIPTION
#### Any background context you want to provide?
Within SEED, users were presented with `created` and `updated` datetime stamps for property and tax lot records.

During the matching revamp work, it was discovered that the datetime stamp was actually coming from the canonical Property and canonical Tax Lot respectively. Ideally, these would be coming from the respective -States models since that is what actually holds the record information that users are seeing. Since linking was not in place, canonical records and connected -State records were 1-to-1, and it wasn't actually an issue.

In preparation for linking, where canonical records might be 1-to-many with -State records, there was an attempt to present users with the `created` and `updated` from the -State models instead. To do that, those two fields were both initially created for the -State models, and the canonical versions were disabled. In doing so, the **any** fields named `created` and `updated` were inadvertently prevented from appearing to users.

#### What's this PR do?
This change re-enables the canonical versions of the `created` and `updated` versions of each record. 

Also, this currently hides the -State values in the UI so the inventory detail pages look more like how they looked previously.

Before linking is introduced, more work is needed to actually get users using the -State versions.
1. update the -State versions with the values within the canonical versions
2. Actually display the -State versions within the relevant API endpoints. 
The second point is likely a larger effort. It's possible that the Column model objects for the “canonical” `created` and `updated` fields would need to be replaced by Column model objects for the -State versions.

#### How should this be manually tested?
For previously imported records, see created and updated values across different views.

#### What are the relevant tickets?
#2119 
#### Screenshots (if appropriate)
