### PR TITLE
Espm and tests 270

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,19 +41,19 @@ install:
   - npm --version
   - nvm install stable
 before_script:
-  - psql -c "DROP DATABASE IF EXISTS seeddb;" -U postgres
-  - psql -c "DROP DATABASE IF EXISTS test_seeddb;" -U postgres
+  - psql -p 5433 -c "DROP DATABASE IF EXISTS seeddb;" -U postgres
+  - psql -p 5433 -c "DROP DATABASE IF EXISTS test_seeddb;" -U postgres
   - mv config/settings/test_local_untracked.py config/settings/local_untracked.py
   - sudo add-apt-repository ppa:timescale/timescaledb-ppa -y
   - sudo apt-get update -q
   - sudo apt-get install -y timescaledb-postgresql-11 timescaledb-tools
   - sudo timescaledb-tune -yes
   - sudo service postgresql restart
-  - psql -c "CREATE DATABASE seeddb;" -U postgres
-  - psql -d seeddb -c "CREATE EXTENSION postgis;" -U postgres
+  - psql -p 5433 -c "CREATE DATABASE seeddb;" -U postgres
+  - psql -p 5433 -d seeddb -c "CREATE EXTENSION postgis;" -U postgres
 env:
   global:
-    - DOCKER_COMPOSE_VERSION=1.16.0
+    - DOCKER_COMPOSE_VERSION=1.23.1
     - DJANGO_SETTINGS_MODULE=config.settings.travis
     - DISPLAY=:99.0
     - COVERALLS_REPO_TOKEN=y8UqJm8Bri5ZP8hr3YZM3guBaUKpsfoCv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ Closed Issues and Features:
 - Fixed [#1913]( https://github.com/SEED-platform/seed/issues/1913 ), Add Notes info to export
 - Fixed [#1713]( https://github.com/SEED-platform/seed/issues/1713 ), Return progress status immediately when uploading large files
 
+# SEED Version 2.6.1-Patch1
+
+- Fixed [#2076]( https://github.com/SEED-platform/seed/issues/2076 ), ESPM import no longer works due to ESPM website updates
+
 # SEED Version 2.6.1-Patch0
 
 - This includes the patches from 2.6.0-patch0 since the patches were not complete until after the release of 2.6.1.
@@ -88,6 +92,9 @@ This patch has address a couple issues including:
 - Update the deployment to automatically read the version of redis, postgres, and OEP from the docker-compose.build.yml file
 - Fix data comparisons when merging records
 - Use OEP Version 1.4
+- Fixed [#2039]( https://github.com/SEED-platform/seed/issues/2039 ), Portfolio Manager Login URL Changed
+- Fixed [#2058]( https://github.com/SEED-platform/seed/issues/2058 ), Portfolio Manager URL Changed (Flapping Issue)
+- Fixed [#2076]( https://github.com/SEED-platform/seed/issues/2076 ), ESPM import no longer works due to ESPM website updates
 
 # SEED Version 2.6.0
 

--- a/config/settings/travis.py
+++ b/config/settings/travis.py
@@ -15,7 +15,7 @@ DATABASES = {
         'USER': 'postgres',
         'PASSWORD': '',
         'HOST': 'localhost',
-        'PORT': '5432',
+        'PORT': '5433',
     }
 }
 

--- a/seed/tests/test_api.py
+++ b/seed/tests/test_api.py
@@ -11,6 +11,8 @@ import os
 import time
 from unittest import skip
 
+from datetime import date
+
 from django.core.urlresolvers import reverse_lazy, reverse
 from django.test import TestCase
 from django.utils import timezone
@@ -169,7 +171,7 @@ class TestApi(TestCase):
         self.assertEqual(r['organizations'][0]['owners'][0]['first_name'], 'Jaqen')
         self.assertEqual(r['organizations'][0]['cycles'], [
             {
-                'name': '2018 Calendar Year',
+                'name': str(date.today().year - 1) + ' Calendar Year',
                 'num_properties': 0,
                 'num_taxlots': 0,
                 'cycle_id': self.default_cycle.pk,

--- a/seed/views/portfoliomanager.py
+++ b/seed/views/portfoliomanager.py
@@ -125,10 +125,7 @@ class PortfolioManagerViewSet(GenericViewSet):
                 else:
                     content = pm.generate_and_download_template_report(template)
             except PMExcept as pme:
-                return JsonResponse(
-                    {'status': 'error', 'message': str(pme)},
-                    status=status.HTTP_400_BAD_REQUEST
-                )
+                return JsonResponse({'status': 'error', 'message': str(pme)}, status=status.HTTP_400_BAD_REQUEST)
             try:
                 content_object = xmltodict.parse(content, dict_constructor=dict)
             except Exception:  # catch all because xmltodict doesn't specify a class of Exceptions
@@ -158,8 +155,7 @@ class PortfolioManagerViewSet(GenericViewSet):
 
             return JsonResponse({'status': 'success', 'properties': properties})
         except Exception as e:
-            return JsonResponse({'status': 'error', 'message': e},
-                                status=status.HTTP_400_BAD_REQUEST)
+            return JsonResponse({'status': 'error', 'message': e}, status=status.HTTP_400_BAD_REQUEST)
 
 
 class PortfolioManagerImport(object):
@@ -199,7 +195,8 @@ class PortfolioManagerImport(object):
             raise PMExcept("SSL Error in Portfolio Manager Query; check VPN/Network/Proxy.")
 
         # This returns a 200 even if the credentials are bad, so I'm having to check some text in the response
-        if 'The username and/or password you entered is not correct. Please try again.' in response.content.decode('utf-8'):
+        if 'The username and/or password you entered is not correct. Please try again.' in response.content.decode(
+                'utf-8'):
             raise PMExcept('Unsuccessful response from login attempt; aborting.  Check credentials.')
 
         # Upon successful logging in, we should have received a cookie header that we can reuse later
@@ -218,36 +215,31 @@ class PortfolioManagerImport(object):
 
     def get_list_of_report_templates(self):
         """
-        This method calls out to the ESPM API to get the full list of template rows.  For each row, it checks to see if
-        it has children rows, and if so, it calls out to the API for the child rows and retrieves IDs and names for
-        those as well.
+        New method to support update to ESPM
 
-        :return: Returns a list of template objects.  All rows will have a z_seed_child_row key that is False for main
+        :return: Returns a list of template objects. All rows will have a z_seed_child_row key that is False for main
         rows and True for child rows
         """
-
         # login if needed
         if not self.authenticated_headers:
             self.login_and_set_cookie_header()
 
-        # Get the report templates
-        url = 'https://portfoliomanager.energystar.gov/pm/reports/templateTableRows'
+        # get the report data
+        url = 'https://portfoliomanager.energystar.gov/pm/reports/reportData'
         try:
             response = requests.get(url, headers=self.authenticated_headers)
+
         except requests.exceptions.SSLError:
             raise PMExcept('SSL Error in Portfolio Manager Query; check VPN/Network/Proxy.')
         if not response.status_code == status.HTTP_200_OK:
             raise PMExcept('Unsuccessful response from report template rows query; aborting.')
-        try:
-            template_object = json.loads(response.text)
-        except ValueError:
-            raise PMExcept('Malformed JSON response from report template rows query; aborting.')
-        _log.debug('Received the following JSON return: ' + json.dumps(template_object, indent=2))
+
+        template_object = self.parse_template_response(response.text)
 
         # We need to parse the list of report templates
-        if 'rows' not in template_object:
-            raise PMExcept('Could not find rows key in template response; aborting.')
-        templates = template_object['rows']
+        if 'customReportsData' not in template_object:
+            raise PMExcept('Could not find customReportsData key in template response; aborting.')
+        templates = template_object['customReportsData']
         template_response = []
         sorted_templates = sorted(templates, key=lambda x: x['name'])
         for t in sorted_templates:
@@ -260,16 +252,24 @@ class PortfolioManagerImport(object):
             _log.debug('Found template,\n id=' + str(t['id']) + '\n name=' + str(t['name']))
             if 'hasChildrenRows' in t and t['hasChildrenRows']:
                 _log.debug('Template row has children data request rows, trying to get them now')
-                children_url = \
-                    'https://portfoliomanager.energystar.gov/pm/reports/templateTableChildrenRows/TEMPLATE/{0}'.format(
-                        t['id']
-                    )
+                children_url = f'https://portfoliomanager.energystar.gov/pm/reports/templateChildrenRows/TEMPLATE/{t["id"]}'
+
                 # SSL errors would have been caught earlier in this function and raised, so this should be ok
                 children_response = requests.get(children_url, headers=self.authenticated_headers)
                 if not children_response.status_code == status.HTTP_200_OK:
                     raise PMExcept('Unsuccessful response from child row template lookup; aborting.')
                 try:
-                    child_object = json.loads(children_response.text)
+                    # the data are now in the string of the data key of the returned dictionary with an excessive amount of
+                    # escaped doublequotes.
+                    # e.g., response = {"data": "{"customReportsData":"..."}"}
+                    decoded = json.loads(children_response.text)  # .encode('utf-8').decode('unicode_escape')
+
+                    # the beginning and end of the string needs to be without the doublequote. Remove the escaped double quotes
+                    data_to_parse = decoded['data'].replace('"{', '{').replace('}"', '}').replace('"[{', '[{').replace(
+                        '}]"', '}]').replace('\\"', '"')
+
+                    # print(f'data to parse: {data_to_parse}')
+                    child_object = json.loads(data_to_parse)['childrenRows']
                 except ValueError:
                     raise PMExcept('Malformed JSON response from report template child row query; aborting.')
                 _log.debug('Received the following child JSON return: ' + json.dumps(child_object, indent=2))
@@ -295,6 +295,29 @@ class PortfolioManagerImport(object):
             raise PMExcept("Could not find a matching template for this name, try a different name")
         _log.debug("Desired report name found, template info: " + json.dumps(matched_template, indent=2))
         return matched_template
+
+    def parse_template_response(self, response_text):
+        """
+        This method is for the updated ESPM where the response is escaped JSON string in a JSON response.
+
+        :param response_text: str, repsonse to parse
+        :return: dict
+        """
+        try:
+            # the data are now in the string of the data key of the returned dictionary with an excessive amount of
+            # escaped doublequotes.
+            # e.g., response = {"data": "{"customReportsData":"..."}"}
+            decoded = json.loads(response_text)  # .encode('utf-8').decode('unicode_escape')
+
+            # the beginning and end of the string needs to be without the doublequote. Remove the escaped double quotes
+            data_to_parse = decoded['data'].replace('"[{', '[{').replace('}]"', '}]').replace('\\"', '"')
+
+            # print(f'data to parse: {data_to_parse}')
+            template_object = json.loads(data_to_parse)
+            _log.debug('Received the following JSON return: ' + json.dumps(template_object, indent=2))
+            return template_object
+        except ValueError:
+            raise PMExcept('Malformed JSON response from report template rows query; aborting.')
 
     def generate_and_download_template_report(self, matched_template):
         """
@@ -329,18 +352,21 @@ class PortfolioManagerImport(object):
             response.headers))
 
         # Now we need to wait while the report is being generated
-        url = 'https://portfoliomanager.energystar.gov/pm/reports/templateTableRows'
+        url = 'https://portfoliomanager.energystar.gov/pm/reports/reportData'
         attempt_count = 0
         report_generation_complete = False
         while attempt_count < 10:
             attempt_count += 1
+
+            # get the report data
             try:
                 response = requests.get(url, headers=self.authenticated_headers)
             except requests.exceptions.SSLError:
                 raise PMExcept('SSL Error in Portfolio Manager Query; check VPN/Network/Proxy.')
             if not response.status_code == status.HTTP_200_OK:
-                raise PMExcept('Unsuccessful response from GET trying to check status on generated report; aborting.')
-            template_objects = json.loads(response.text)['rows']
+                raise PMExcept('Unsuccessful response from report template rows query; aborting.')
+
+            template_objects = self.parse_template_response(response.text)['customReportsData']
             for t in template_objects:
                 if 'id' in t and t['id'] == matched_template['id']:
                     this_matched_template = t
@@ -355,6 +381,7 @@ class PortfolioManagerImport(object):
             else:
                 report_generation_complete = True
                 break
+
         if report_generation_complete:
             _log.debug('Report appears to have been generated successfully (attempt_count=' + str(attempt_count) + ')')
         else:
@@ -362,24 +389,26 @@ class PortfolioManagerImport(object):
 
         # Finally we can download the generated report
         template_report_name = quote(matched_template['name']) + '.xml'
-        sanitized_template_report_name = template_report_name.replace('/', '_')
-        d_url = 'https://portfoliomanager.energystar.gov/pm/reports/template/download/%s/XML/false/%s?testEnv=false' % (
-            str(template_report_id), sanitized_template_report_name
+        url = 'https://portfoliomanager.energystar.gov/pm/reports/template/download/{0}/XML/false/{1}?testEnv=false'
+        download_url = url.format(
+            str(template_report_id), template_report_name
         )
         try:
-            response = requests.get(d_url, headers=self.authenticated_headers)
+            response = requests.get(download_url, headers=self.authenticated_headers)
         except requests.exceptions.SSLError:
             raise PMExcept('SSL Error in Portfolio Manager Query; check VPN/Network/Proxy.')
         if not response.status_code == status.HTTP_200_OK:
             error_message = 'Unsuccessful response from GET trying to download generated report;'
             error_message += ' Generated report name: ' + template_report_name + ';'
-            error_message += ' Tried to download report from URL: ' + d_url + ';'
+            error_message += ' Tried to download report from URL: ' + download_url + ';'
             error_message += ' Returned with a status code = ' + response.status_code + ';'
             raise PMExcept(error_message)
         return response.content
 
     def generate_and_download_child_data_request_report(self, matched_data_request):
         """
+        Updated for recent update of ESPM
+
         This method calls out to ESPM to get the report data for a child template (a data request).  For child
         templates, the process simply requires calling out the download URL and getting the data in XML format.
 
@@ -408,9 +437,11 @@ class PortfolioManagerImport(object):
             str(template_report_id), sanitized_template_report_name
         )
         try:
-            response = requests.get(download_url, headers=self.authenticated_headers)
+            response = requests.get(download_url, headers=self.authenticated_headers, allow_redirects=True)
         except requests.exceptions.SSLError:
             raise PMExcept('SSL Error in Portfolio Manager Query; check VPN/Network/Proxy.')
+
         if not response.status_code == status.HTTP_200_OK:
             raise PMExcept('Unsuccessful response from GET trying to download generated report; aborting.')
+
         return response.content

--- a/seed/views/portfoliomanager.py
+++ b/seed/views/portfoliomanager.py
@@ -1,7 +1,7 @@
 # !/usr/bin/env python
 # encoding: utf-8
 """
-:copyright (c) 2014 - 2019, The Regents of the University of California,
+:copyright (c) 2014 - 2020, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of any
 required approvals from the U.S. Department of Energy) and contributors.
 All rights reserved.  # NOQA
@@ -46,7 +46,6 @@ class PortfolioManagerViewSet(GenericViewSet):
         """
         This API view makes a request to ESPM for the list of available report templates, including root templates and
         child data requests.
-
         :param request: A request with a POST body containing the ESPM credentials (username and password)
         :return: This API responds with a JSON object with two keys: status, which will be a string -
         either error or success.  If successful, a second key, templates, will hold the list of templates from ESPM. If
@@ -83,7 +82,6 @@ class PortfolioManagerViewSet(GenericViewSet):
     def report(self, request):
         """
         This API view makes a request to ESPM to generate and download a report based on a specific template.
-
         :param request: A request with a POST body containing the ESPM credentials (username and password) as well as
         a template key that contains one of the template objects retrieved using the /template_list/ endpoint
         :return: This API responds with a JSON object with two keys: status, which will be a string -
@@ -167,7 +165,6 @@ class PortfolioManagerImport(object):
         """
         To instantiate this class, provide ESPM username and password.  Currently, this constructor doesn't do anything
         except store the credentials.
-
         :param m_username: The ESPM username
         :param m_password: The ESPM password
         """
@@ -182,13 +179,12 @@ class PortfolioManagerImport(object):
         """
         This method calls out to ESPM to perform a login operation and get a session authentication token.  This token
         is then stored in the proper form to allow authenticated calls into ESPM.
-
         :return: None
         """
 
         # First we need to log in to Portfolio Manager
-        login_url = "https://portfoliomanager.energystar.gov/pm/login"
-        payload = {"username": self.username, "password": self.password}
+        login_url = "https://portfoliomanager.energystar.gov/pm/j_spring_security_check"
+        payload = {"j_username": self.username, "j_password": self.password}
         try:
             response = requests.post(login_url, data=payload)
         except requests.exceptions.SSLError:
@@ -216,7 +212,6 @@ class PortfolioManagerImport(object):
     def get_list_of_report_templates(self):
         """
         New method to support update to ESPM
-
         :return: Returns a list of template objects. All rows will have a z_seed_child_row key that is False for main
         rows and True for child rows
         """
@@ -283,7 +278,6 @@ class PortfolioManagerImport(object):
     def get_template_by_name(templates, template_name):
         """
         This method searches through a list of templates for a template that matches the specific template name
-
         :param templates: A list of template objects, each of which will have a name key
         :param template_name: A string name to match in the list of templates
         :return: Returns a single template object that matches the name, raises a PMExcept if no match
@@ -299,7 +293,6 @@ class PortfolioManagerImport(object):
     def parse_template_response(self, response_text):
         """
         This method is for the updated ESPM where the response is escaped JSON string in a JSON response.
-
         :param response_text: str, repsonse to parse
         :return: dict
         """
@@ -324,12 +317,10 @@ class PortfolioManagerImport(object):
         This method calls out to ESPM to trigger generation of a report for the supplied template.  The process requires
         calling out to the generateData/ endpoint on ESPM, followed by a waiting period for the template status to be
         updated to complete.  Once complete, a download URL allows download of the report in XML format.
-
         This response content can be enormous, so ...
         TODO: Evaluate whether we should just download this XML to file here.  It would require re-reading the file
         TODO: afterwards, but it would 1) be downloaded and available for inspection/debugging, and 2) reduce the size
         TODO: of data coming through in memory during these calls, which seems to have been problematic at times
-
         :param matched_template: A template object down-selected from the full list found using the /template_list/ API
         :return: Full XML data report from ESPM report generation and download process
         """
@@ -408,13 +399,10 @@ class PortfolioManagerImport(object):
     def generate_and_download_child_data_request_report(self, matched_data_request):
         """
         Updated for recent update of ESPM
-
         This method calls out to ESPM to get the report data for a child template (a data request).  For child
         templates, the process simply requires calling out the download URL and getting the data in XML format.
-
         This response content can be enormous, so the same message applies here as with the main report download method
         where we should consider downloading the file itself instead of passing the XML data around in memory.
-
         :param matched_data_request: A child template object (template where z_seed_child_row is True)
         :return: Full XML data report from ESPM report generation and download process
         """


### PR DESCRIPTION
#### Any background context you want to provide?
While SEED 2.6.1 was deployed to `prod`, there were several, loosely related code changes involving fixing broken tests. The most meaningful of those was a patch to update the ESPM login view within SEED. The other two changes involved the calendar year change from 2019 to 2020 as well as TravisCI expecting Postgres to use port 5433 (vs 5432).

#### What's this PR do?
For 2.7. 0, cherry-picks 3 commits for each of the 3 required changes listed above.
Here's the source of each of the 3 commits:

- [add changelog entry](https://github.com/SEED-platform/seed/pull/2077/commits/c1b51b943036f8e47450262a39c8332dba9b3dd0)
- [Update hardcoded date within test](https://github.com/SEED-platform/seed/commit/9204fcd504d52e6424a8de17fac4b98542f6568c)
- [Update TravisCI config for Postgres to use port 5433](https://github.com/SEED-platform/seed/commit/916fb6be9974f6e747071db80ae41d0653259ff4)

Additionally, the `add changelog entry` cherry-pick didn't quite get what was in commit c1b51b9. So another commit was added to this PR to fix that.

#### How should this be manually tested?
Log in to ESPM via Portfolio Manager Import. **Note that the 2.7.0 is using Django 1.11.**
<img width="817" alt="Screen Shot 2020-03-26 at 3 01 33 PM" src="https://user-images.githubusercontent.com/30608004/77696267-b6ad7f80-6f72-11ea-945d-45f8ed25dc80.png">

Verify that TravisCI tests passed.

#### What are the relevant tickets?
#### Screenshots (if appropriate)
