### PR TITLE
Enable and use created and updated for 2.7.0

### DIFF
--- a/seed/migrations/0111_rehash.py
+++ b/seed/migrations/0111_rehash.py
@@ -68,6 +68,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(forwards),
         migrations.RunPython(recalculate_hash_objects),
+        migrations.RunPython(forwards),
     ]

--- a/seed/migrations/0120_created_updated_col_objects.py
+++ b/seed/migrations/0120_created_updated_col_objects.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def forwards(apps, schema_editor):
+    Column = apps.get_model("seed", "Column")
+
+    Column.objects.filter(
+        column_name__in=['created', 'updated'],
+        table_name='TaxLot',
+        is_extra_data=False
+    ).update(table_name='TaxLotState')
+
+    Column.objects.filter(
+        column_name__in=['created', 'updated'],
+        table_name='Property',
+        is_extra_data=False
+    ).update(table_name='PropertyState')
+
+
+def backwards(apps, schema_editor):
+    Column = apps.get_model("seed", "Column")
+
+    Column.objects.filter(
+        column_name__in=['created', 'updated'],
+        table_name='TaxLotState',
+        is_extra_data=False
+    ).update(table_name='TaxLot')
+
+    Column.objects.filter(
+        column_name__in=['created', 'updated'],
+        table_name='PropertyState',
+        is_extra_data=False
+    ).update(table_name='Property')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('seed', '0119_column_recognize_empty'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, reverse_code=backwards),
+    ]

--- a/seed/migrations/0121_update_updated_timestamps.py
+++ b/seed/migrations/0121_update_updated_timestamps.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+from django.db import connection, migrations
+
+
+def forwards(apps, schema_editor):
+    property_sql = (
+        'UPDATE seed_propertystate '
+        'SET updated = (SELECT created '
+        '               FROM seed_propertyauditlog '
+        '               WHERE seed_propertystate.id = state_id '
+        '               ORDER BY created DESC '
+        '               LIMIT 1) '
+        'FROM seed_propertyauditlog '
+        'WHERE seed_propertystate.id = state_id;'
+    )
+
+    taxlot_sql = (
+        'UPDATE seed_taxlotstate '
+        'SET updated = (SELECT created '
+        '               FROM seed_taxlotauditlog '
+        '               WHERE seed_taxlotstate.id = state_id '
+        '               ORDER BY created DESC '
+        '               LIMIT 1) '
+        'FROM seed_taxlotauditlog '
+        'WHERE seed_taxlotstate.id = state_id;'
+    )
+
+    with connection.cursor() as cursor:
+        cursor.execute(property_sql)
+        cursor.execute(taxlot_sql)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('seed', '0120_created_updated_col_objects'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards),
+    ]

--- a/seed/models/columns.py
+++ b/seed/models/columns.py
@@ -53,10 +53,8 @@ class Column(models.Model):
     # Do not return these columns to the front end -- when using the tax_lot_properties
     # get_related method.
     EXCLUDED_COLUMN_RETURN_FIELDS = [
-        'created',
         'hash_object',
         'normalized_address',
-        'updated',
         # Records below are old and should not be used
         'source_eui_modeled_orig',
         'site_eui_orig',
@@ -332,28 +330,28 @@ class Column(models.Model):
             # 'type': 'boolean',
         }, {
             'column_name': 'updated',
-            'table_name': 'Property',
+            'table_name': 'PropertyState',
             'display_name': 'Updated',
             'data_type': 'datetime',
             # 'type': 'date',
             # 'cellFilter': 'date:\'yyyy-MM-dd h:mm a\'',
         }, {
             'column_name': 'created',
-            'table_name': 'Property',
+            'table_name': 'PropertyState',
             'display_name': 'Created',
             'data_type': 'datetime',
             # 'type': 'date',
             # 'cellFilter': 'date:\'yyyy-MM-dd h:mm a\'',
         }, {
             'column_name': 'updated',
-            'table_name': 'TaxLot',
+            'table_name': 'TaxLotState',
             'display_name': 'Updated',
             'data_type': 'datetime',
             # 'type': 'date',
             # 'cellFilter': 'date:\'yyyy-MM-dd h:mm a\'',
         }, {
             'column_name': 'created',
-            'table_name': 'TaxLot',
+            'table_name': 'TaxLotState',
             'display_name': 'Created',
             'data_type': 'datetime',
             # 'type': 'date',

--- a/seed/models/tax_lot_properties.py
+++ b/seed/models/tax_lot_properties.py
@@ -388,18 +388,15 @@ class TaxLotProperty(models.Model):
                 if 'campus' in filtered_fields:
                     obj_dict[obj_column_name_mapping['campus']] = obj.property.campus
                 # Do not make these timestamps naive. They persist correctly.
-                if 'created' in filtered_fields:
-                    obj_dict[obj_column_name_mapping['created']] = obj.property.created
-                if 'updated' in filtered_fields:
-                    obj_dict[obj_column_name_mapping['updated']] = obj.property.updated
                 if 'analysis_state' in filtered_fields:
                     obj_dict[obj_column_name_mapping['analysis_state']] = obj.state.get_analysis_state_display()
-            elif lookups['obj_class'] == 'TaxLotView':
-                # Do not make these timestamps naive. They persist correctly.
-                if 'updated' in filtered_fields:
-                    obj_dict[obj_column_name_mapping['updated']] = obj.taxlot.updated
-                if 'created' in filtered_fields:
-                    obj_dict[obj_column_name_mapping['created']] = obj.taxlot.created
+
+            # These are not added in model_to_dict_with_mapping as these fields are not 'editable'
+            # Also, do not make these timestamps naive. They persist correctly.
+            if 'updated' in filtered_fields:
+                obj_dict[obj_column_name_mapping['updated']] = obj.state.updated
+            if 'created' in filtered_fields:
+                obj_dict[obj_column_name_mapping['created']] = obj.state.created
 
             # All the related tax lot states.
             obj_dict['related'] = join_map.get(obj.pk, [])

--- a/seed/static/seed/partials/inventory_detail.html
+++ b/seed/static/seed/partials/inventory_detail.html
@@ -165,7 +165,7 @@
 
                             <!-- Show read-only current 'property / taxlot' fields -->
                             <td ng-if="edit_form_showing===false && !col.table_name.toLowerCase().includes('state')" ng-class="{highlight: col.changed}" class="ellipsis">
-                                <span class="sd-data-content" popover-placement="top-left" popover-animation="false" popover-trigger="outsideClick" uib-popover="{$ item_state[col.column_name] $}">
+                                <span class="sd-data-content" popover-placement="top-left" popover-animation="false" popover-trigger="outsideClick" uib-popover="{$ item_parent[col.column_name] $}">
                                     <span ng-if="::col.data_type !== 'datetime'">{$:: item_parent[col.column_name] $}</span>
                                     <span ng-if="::col.data_type === 'datetime'">{$:: item_parent[col.column_name] | date: 'yyyy-MM-dd h:mm a' $}</span>
                                 </span>
@@ -186,11 +186,11 @@
 
                             <!-- Show read-only historical field value -->
                             <td ng-repeat="historical_item in historical_items" ng-class="{highlight: col.changed}" class="ellipsis">
-                                <span ng-if="::!col.is_extra_data" class="sd-data-content" popover-placement="top-left" popover-trigger="outsideClick" popover-animation="false" uib-popover="{$:: historical_item.state[col.column_name] $}">
+                                <span ng-if="::!col.is_extra_data && col.table_name.toLowerCase().includes('state')" class="sd-data-content" popover-placement="top-left" popover-trigger="outsideClick" popover-animation="false" uib-popover="{$:: historical_item.state[col.column_name] $}">
                                     <span ng-if="col.data_type !== 'datetime'">{$:: historical_item.state[col.column_name] $}</span>
                                     <span ng-if="col.data_type === 'datetime'">{$:: historical_item.state[col.column_name] | date: 'yyyy-MM-dd h:mm a' $}</span>
                                 </span>
-                                <span ng-if="::col.is_extra_data" class="sd-data-content" popover-placement="top-left" popover-trigger="outsideClick" popover-animation="false" uib-popover="{$:: historical_item.state.extra_data[col.column_name] $}">
+                                <span ng-if="::col.is_extra_data && col.table_name.toLowerCase().includes('state')" class="sd-data-content" popover-placement="top-left" popover-trigger="outsideClick" popover-animation="false" uib-popover="{$:: historical_item.state.extra_data[col.column_name] $}">
                                     <span ng-if="col.data_type !== 'datetime'">{$:: historical_item.state.extra_data[col.column_name] $}</span>
                                     <span ng-if="col.data_type === 'datetime'">{$:: historical_item.state.extra_data[col.column_name] | date: 'yyyy-MM-dd h:mm a' $}</span>
                                 </span>


### PR DESCRIPTION
#### Any background context you want to provide?
-State created and updated values needed to be enabled/used on the FE.

See the associated PR below for more details.

#### What's this PR do?
This is a direct cherry-pick of the merge commit from https://github.com/SEED-platform/seed/pull/2149 with no modifications: 
`git cherry-pick -m 1 eb9a7ccd912cb70396eac7d5a7401455659cd378`

#### How should this be manually tested?
Ideally this would be run on a recent copy of the production database. The `created` and `updated` values produced for existing records should be relatively close to those on the production server. 

Spot checking should be conducted:
<img width="1293" alt="Screen Shot 2020-03-26 at 9 29 46 PM" src="https://user-images.githubusercontent.com/30608004/77718728-37876e00-6fa9-11ea-8f30-2a02c81bf6bb.png">

Also, historical -States should have created and updated values.
