### PR TITLE
fix(buildingsync): defer creation of bsync models until last task

### DIFF
--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1212,7 +1212,7 @@ def finish_mapping_additional_models(result, import_file_id, progress_key):
                     merged_result[key] += value
                 else:
                     merged_result[key] = value
-        
+
         import_file.matching_results_data = merged_result
     else:
         raise Exception('Expected result to be a list of one or more items')

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -464,31 +464,17 @@ def map_xml_chunk(ids, file_pk, file_type, prog_key, **kwargs):
                 filename = raw_property_state.extra_data['_filename']
                 property_xml = raw_property_state.extra_data['_xml']
 
-                # get or create the buildingfile associated with this file
-                # this allows the task to be called multiple times while only creating
-                # a single building_file and property_state for the file
-                building_files = BuildingFile.objects.filter(
+                # create the buildingfile
+                the_file = SimpleUploadedFile(
+                    name=filename,
+                    content=property_xml.encode(),
+                    content_type="application/xml"
+                )
+                building_file = BuildingFile.objects.create(
+                    file=the_file,
                     filename=filename,
-                    property_state__data_state=DATA_STATE_MAPPING,
-                    property_state__import_file=import_file)
-                if building_files.count() == 0:
-                    # This buildingfile hasn't been created yet
-                    the_file = SimpleUploadedFile(
-                        name=filename,
-                        content=property_xml.encode(),
-                        content_type="application/xml"
-                    )
-                    building_file = BuildingFile.objects.create(
-                        file=the_file,
-                        filename=filename,
-                        file_type=file_type,
-                    )
-                elif building_files.count() == 1:
-                    # This buildingfile already exists
-                    building_file = building_files[0]
-                else:
-                    # Uh oh, apparently our requirements for "uniqueness" is insufficient
-                    raise Exception('Found more than one building file and expected 1 or 0')
+                    file_type=file_type,
+                )
 
                 # create or update the PropertyState linked to the building file
                 p_status, property_state, messages = building_file.process_property_state(org.id)

--- a/seed/data_importer/tests/integration/test_data_import.py
+++ b/seed/data_importer/tests/integration/test_data_import.py
@@ -39,7 +39,6 @@ from seed.models import (
     Cycle,
     Meter,
     Scenario,
-    DATA_STATE_MAPPING,
     BuildingFile,
 )
 from seed.tests.util import DataMappingBaseTestCase
@@ -256,7 +255,7 @@ class TestBuildingSyncImportXml(DataMappingBaseTestCase):
         ps = PropertyState.objects.filter(address_line_1='123 MAIN BLVD',
                                           import_file=self.import_file)
         self.assertEqual(len(ps), 1)
-    
+
     def test_map_data_xml_is_idempotent(self):
         # -- Setup
         with patch.object(ImportFile, 'cache_first_rows', return_value=None):
@@ -313,8 +312,6 @@ class TestBuildingSyncImportXml(DataMappingBaseTestCase):
 
         scenario = Scenario.objects.filter(property_state=ps)
         self.assertEqual(scenario.count(), 3)
-
-
 
 
 class TestBuildingSyncImportInvalid(DataMappingBaseTestCase):

--- a/seed/data_importer/tests/integration/test_data_import.py
+++ b/seed/data_importer/tests/integration/test_data_import.py
@@ -265,8 +265,8 @@ class TestBuildingSyncImportXml(DataMappingBaseTestCase):
         # -- Act
         # Call map data multiple times
         tasks.map_data(self.import_file.pk)
-        tasks.map_data(self.import_file.pk)
-        progress_info = tasks.map_data(self.import_file.pk)
+        tasks.map_data(self.import_file.pk, remap=True)
+        progress_info = tasks.map_data(self.import_file.pk, remap=True)
 
         # -- Assert
         self.assertEqual('success', progress_info['status'])

--- a/seed/data_importer/tests/integration/test_data_import.py
+++ b/seed/data_importer/tests/integration/test_data_import.py
@@ -18,6 +18,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
 from mock import patch
 
+from config.settings.common import BASE_DIR
 from seed.data_importer import tasks
 from seed.data_importer.models import ImportFile, ImportRecord
 from seed.data_importer.tasks import save_raw_data, map_data
@@ -36,6 +37,10 @@ from seed.models import (
     PropertyView,
     TaxLotState,
     Cycle,
+    Meter,
+    Scenario,
+    DATA_STATE_MAPPING,
+    BuildingFile,
 )
 from seed.tests.util import DataMappingBaseTestCase
 
@@ -193,10 +198,14 @@ class TestBuildingSyncImportZip(DataMappingBaseTestCase):
         self.assertEqual(PropertyState.objects.filter(import_file=self.import_file).count(), 1)
 
         # -- Act
-        tasks.map_data(self.import_file.pk)
+        progress_info = tasks.map_data(self.import_file.pk)
 
         # -- Assert
-        ps = PropertyState.objects.filter(address_line_1='123 Main St', import_file=self.import_file)
+        self.assertEqual('success', progress_info['status'])
+        # verify there were no errors with the files
+        self.assertEqual({}, progress_info.get('file_info', {}))
+        ps = PropertyState.objects.filter(address_line_1='123 Main St',
+                                          import_file=self.import_file)
         self.assertEqual(len(ps), 1)
 
 
@@ -204,8 +213,8 @@ class TestBuildingSyncImportXml(DataMappingBaseTestCase):
     def setUp(self):
         self.maxDiff = None
 
-        filename = 'example-bsync-v1.xml'
-        filepath = osp.join(osp.dirname(__file__), '..', 'data', filename)
+        filename = 'buildingsync_v2_0_bricr_workflow.xml'
+        filepath = osp.join(BASE_DIR, 'seed', 'building_sync', 'tests', 'data', filename)
 
         import_file_source_type = 'BuildingSync Raw'
         selfvars = self.set_up(import_file_source_type)
@@ -237,11 +246,75 @@ class TestBuildingSyncImportXml(DataMappingBaseTestCase):
         self.assertEqual(PropertyState.objects.filter(import_file=self.import_file).count(), 1)
 
         # -- Act
-        tasks.map_data(self.import_file.pk)
+        progress_info = tasks.map_data(self.import_file.pk)
 
         # -- Assert
-        ps = PropertyState.objects.filter(address_line_1='123 Main St', import_file=self.import_file)
+        self.assertEqual('success', progress_info['status'])
+        # verify there were no errors with the files
+        self.assertEqual({}, progress_info.get('file_info', {}))
+
+        ps = PropertyState.objects.filter(address_line_1='123 MAIN BLVD',
+                                          import_file=self.import_file)
         self.assertEqual(len(ps), 1)
+    
+    def test_map_data_xml_is_idempotent(self):
+        # -- Setup
+        with patch.object(ImportFile, 'cache_first_rows', return_value=None):
+            tasks.save_raw_data(self.import_file.pk)
+        self.assertEqual(PropertyState.objects.filter(import_file=self.import_file).count(), 1)
+
+        # -- Act
+        # Call map data multiple times
+        tasks.map_data(self.import_file.pk)
+        tasks.map_data(self.import_file.pk)
+        progress_info = tasks.map_data(self.import_file.pk)
+
+        # -- Assert
+        self.assertEqual('success', progress_info['status'])
+        # verify there were no errors with the files
+        self.assertEqual({}, progress_info.get('file_info', {}))
+
+        ps = PropertyState.objects.filter(address_line_1='123 MAIN BLVD',
+                                          import_file=self.import_file)
+        self.assertEqual(len(ps), 1)
+
+        building_file = BuildingFile.objects.filter(property_state=ps[0].id)
+        self.assertEqual(len(building_file), 1)
+
+    def test_map_all_models_xml(self):
+        # -- Setup
+        with patch.object(ImportFile, 'cache_first_rows', return_value=None):
+            tasks.save_raw_data(self.import_file.pk)
+        self.assertEqual(PropertyState.objects.filter(import_file=self.import_file).count(), 1)
+
+        progress_info = tasks.map_data(self.import_file.pk)
+        self.assertEqual('success', progress_info['status'])
+        # verify there were no errors with the files
+        self.assertEqual({}, progress_info.get('file_info', {}))
+
+        ps = PropertyState.objects.filter(address_line_1='123 MAIN BLVD',
+                                          import_file=self.import_file)
+        self.assertEqual(len(ps), 1)
+
+        # -- Act
+        tasks.map_additional_models(self.import_file.pk)
+
+        # -- Assert
+        ps = PropertyState.objects.filter(address_line_1='123 MAIN BLVD', import_file=self.import_file)
+
+        self.assertEqual(ps.count(), 1)
+
+        # verify the property view, scenario and meter data were created
+        pv = PropertyView.objects.filter(state=ps)
+        self.assertEqual(pv.count(), 1)
+
+        meters = Meter.objects.filter(property=pv[0].property)
+        self.assertEqual(meters.count(), 6)
+
+        scenario = Scenario.objects.filter(property_state=ps)
+        self.assertEqual(scenario.count(), 3)
+
+
 
 
 class TestBuildingSyncImportInvalid(DataMappingBaseTestCase):

--- a/seed/models/building_file.py
+++ b/seed/models/building_file.py
@@ -136,8 +136,7 @@ class BuildingFile(models.Model):
 
         # get or create the property state
         if self.property_state is None:
-            property_state = PropertyState.objects.create(**create_data)
-            property_state.extra_data = extra_data
+            property_state = PropertyState.objects.create(**create_data, extra_data=extra_data)
 
             PropertyAuditLog.objects.create(
                 organization_id=organization_id,

--- a/seed/models/building_file.py
+++ b/seed/models/building_file.py
@@ -83,9 +83,8 @@ class BuildingFile(models.Model):
             return None
 
     def process_property_state(self, organization_id):
-        """Parses only the property state from the file. If the building file is
-        already associated with a property state, it updates it. Else it creates
-        a new one. This is intended to be used with the data_importer tasks to allow
+        """Parses and creates the property state from the file.
+        This is intended to be used with the data_importer tasks to allow
         only the creation of the PropertyState at the mapping stage
 
         :param: organization_id: integer, ID of organization
@@ -112,7 +111,7 @@ class BuildingFile(models.Model):
         return True, self._create_property_state(organization_id, data), messages
 
     def _create_property_state(self, organization_id, data):
-        """given data parsed from a file, it updates or creates the property state
+        """given data parsed from a file, it creates the property state
         for this BuildingFile and returns it.
 
         :param organization_id: integer, ID of organization
@@ -134,22 +133,17 @@ class BuildingFile(models.Model):
             else:
                 extra_data[k] = v
 
-        # get or create the property state
-        if self.property_state is None:
-            property_state = PropertyState.objects.create(**create_data, extra_data=extra_data)
+        # create the property state
+        property_state = PropertyState.objects.create(**create_data, extra_data=extra_data)
 
-            PropertyAuditLog.objects.create(
-                organization_id=organization_id,
-                state_id=property_state.id,
-                name='Import Creation',
-                description='Creation from Import file.',
-                import_filename=self.file.path,
-                record_type=AUDIT_IMPORT
-            )
-        else:
-            property_state = self.property_state
-            property_state.__dict__.update(create_data)
-            property_state.extra_data = extra_data
+        PropertyAuditLog.objects.create(
+            organization_id=organization_id,
+            state_id=property_state.id,
+            name='Import Creation',
+            description='Creation from Import file.',
+            import_filename=self.file.path,
+            record_type=AUDIT_IMPORT
+        )
 
         property_state.save()
 

--- a/seed/models/building_file.py
+++ b/seed/models/building_file.py
@@ -144,9 +144,6 @@ class BuildingFile(models.Model):
             import_filename=self.file.path,
             record_type=AUDIT_IMPORT
         )
-
-        property_state.save()
-
         # set the property_state_id so that we can list the building files by properties
         self.property_state_id = property_state.id
         self.save()

--- a/seed/models/building_file.py
+++ b/seed/models/building_file.py
@@ -82,6 +82,86 @@ class BuildingFile(models.Model):
         else:
             return None
 
+    def process_property_state(self, organization_id):
+        """Parses only the property state from the file. If the building file is
+        already associated with a property state, it updates it. Else it creates
+        a new one. This is intended to be used with the data_importer tasks to allow
+        only the creation of the PropertyState at the mapping stage
+
+        :param: organization_id: integer, ID of organization
+        :return: list, [status, (PropertyState|None), messages]
+        """
+        Parser = self.BUILDING_FILE_PARSERS.get(self.file_type, None)
+        if not Parser:
+            acceptable_file_types = ', '.join(
+                map(dict(self.BUILDING_FILE_TYPES).get, list(self.BUILDING_FILE_PARSERS.keys()))
+            )
+            return False, None, "File format was not one of: {}".format(acceptable_file_types)
+
+        parser = Parser()
+        parser.import_file(self.file.path)
+        parser_args = []
+        parser_kwargs = {}
+        if self.file_type == self.BUILDINGSYNC:
+            parser_args.append(BuildingSync.BRICR_STRUCT)
+        data, messages = parser.process(*parser_args, **parser_kwargs)
+
+        if len(messages['errors']) > 0 or not data:
+            return False, None, messages
+
+        return True, self._create_property_state(organization_id, data), messages
+
+    def _create_property_state(self, organization_id, data):
+        """given data parsed from a file, it updates or creates the property state
+        for this BuildingFile and returns it.
+
+        :param organization_id: integer, ID of organization
+        :param data: dict, a dictionary that was returned from a parser
+        :return: PropertyState
+        """
+        # sub-select the data that are needed to create the PropertyState object
+        db_columns = Column.retrieve_db_field_table_and_names_from_db_tables()
+        create_data = {"organization_id": organization_id}
+        extra_data = {}
+        for k, v in data.items():
+            # Skip the keys that are for measures and reports and process later
+            if k in ['measures', 'reports', 'scenarios']:
+                continue
+
+            # Check if the column exists, if not, then create one.
+            if ('PropertyState', k) in db_columns:
+                create_data[k] = v
+            else:
+                extra_data[k] = v
+
+        # get or create the property state
+        if self.property_state is None:
+            property_state = PropertyState.objects.create(**create_data)
+            property_state.extra_data = extra_data
+
+            PropertyAuditLog.objects.create(
+                organization_id=organization_id,
+                state_id=property_state.id,
+                name='Import Creation',
+                description='Creation from Import file.',
+                import_filename=self.file.path,
+                record_type=AUDIT_IMPORT
+            )
+        else:
+            property_state = self.property_state
+            property_state.__dict__.update(create_data)
+            property_state.extra_data = extra_data
+
+        property_state.save()
+
+        # set the property_state_id so that we can list the building files by properties
+        self.property_state_id = property_state.id
+        self.save()
+
+        Column.save_column_names(property_state)
+
+        return property_state
+
     def process(self, organization_id, cycle, property_view=None):
         """
         Process the building file that was uploaded and create the correct models for the object
@@ -110,42 +190,11 @@ class BuildingFile(models.Model):
         if len(messages['errors']) > 0 or not data:
             return False, None, None, messages
 
-        # sub-select the data that are needed to create the PropertyState object
-        db_columns = Column.retrieve_db_field_table_and_names_from_db_tables()
-        create_data = {"organization_id": organization_id}
-        extra_data = {}
-        for k, v in data.items():
-            # Skip the keys that are for measures and reports and process later
-            if k in ['measures', 'reports', 'scenarios']:
-                continue
-
-            # Check if the column exists, if not, then create one.
-
-            if ('PropertyState', k) in db_columns:
-                create_data[k] = v
-            else:
-                extra_data[k] = v
-
-        # always create the new object, then decide if we need to merge it.
-        # create a new property_state for the object and promote to a new property_view
-        property_state = PropertyState.objects.create(**create_data)
-        property_state.extra_data = extra_data
-        property_state.save()
-
-        Column.save_column_names(property_state)
-
-        PropertyAuditLog.objects.create(
-            organization_id=organization_id,
-            state_id=property_state.id,
-            name='Import Creation',
-            description='Creation from Import file.',
-            import_filename=self.file.path,
-            record_type=AUDIT_IMPORT
-        )
-
-        # set the property_state_id so that we can list the building files by properties
-        self.property_state_id = property_state.id
-        self.save()
+        # Create the property state if none already exists for this file
+        if self.property_state is None:
+            property_state = self._create_property_state(organization_id, data)
+        else:
+            property_state = self.property_state
 
         # merge or create the property state's view
         if property_view:


### PR DESCRIPTION
#### Any background context you want to provide?
After moving BuildingSync import into the normal import/mapping flow, I realized there were a few issues:
1. the mapping task was not idempotent - multiple building files, property states, etc were duplicated each time
2. we created the Scenarios, Meters, and other models associated with the property too soon (during the mapping), and should defer until the user is done and wants to finish the import.
#### What's this PR do?
Addresses the issues above:
1. ensures mapping can get called multiple times
2. defers the creation of additional models by creating a new task that BuildingSync imports will take, rather than the property merging/matching step.

NOTE: as mentioned above, BuildingSync imports don't go through the merging step. This is how the import of BuildingSync files worked originally before moving it into the tasks backend, so we decided this was an ok option for now. However, we need to have discussions down the road about merging BuildingSync properties as there are a few small complications.
#### How should this be manually tested?
Use the data from the building_sync/tests/data directory and upload a couple different files (at a minimum the bricr_workflow file, the zip file). You should be directed through the mapping flow, and by the end scenarios and meters should be created for them (if they have them, which the bricr_workflow file does).

Since this change partially touches the code which "Update with BuildingSync" uses, it's worth additionally updating a property with a buildingsync file and verifying that it worked.

