### PR TITLE
Fixed unnecessary URL params

### DIFF
--- a/seed/static/seed/js/controllers/menu_controller.js
+++ b/seed/static/seed/js/controllers/menu_controller.js
@@ -67,17 +67,7 @@ angular.module('BE.seed.controller.menu', [])
       });
 
       $scope.is_active = function (menu_item) {
-        if ($state.current.url.split('/').length > 1) {
-          $location.search('', $state.current.url);
-        }
-        if($rootScope.stay_on_page && menu_item === '/' + $state.current.url.split('/')[1]) {
-          return true;
-        } else if (menu_item === $location.path()) {
-          if ($rootScope.stay_on_page) {
-            return false;
-          } else if (!$rootScope.stay_on_page && menu_item === ('/' + $state.current.url.split('/')[1])) {
-            return true;
-          }
+        if (menu_item === $location.path()) {
           return true;
         } else if (menu_item !== '/' && _.startsWith($location.path(), menu_item)) {
           return true;
@@ -99,7 +89,7 @@ angular.module('BE.seed.controller.menu', [])
       };
 
       //Sets initial expanded/collapse state of sidebar menu
-      function init_menu () {
+      function init_menu() {
         //Default to false but use cookie value if one has been set
         var isNavExpanded = $cookies.seed_nav_is_expanded === 'true';
         $scope.expanded_controller = isNavExpanded;

--- a/seed/static/seed/js/controllers/modified_modal_controller.js
+++ b/seed/static/seed/js/controllers/modified_modal_controller.js
@@ -4,17 +4,14 @@
  */
 angular.module('BE.seed.controller.modified_modal', [])
   .controller('modified_modal_controller', [
-    '$rootScope',
     '$scope',
     '$uibModalInstance',
-    function ($rootScope, $scope, $uibModalInstance) {
+    function ($scope, $uibModalInstance) {
       $scope.leave = function () {
-        $rootScope.stay_on_page = false;
         $uibModalInstance.close();
       };
 
       $scope.stay = function () {
-        $rootScope.stay_on_page = true;
         $uibModalInstance.dismiss();
       };
     }]);

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -236,6 +236,15 @@ SEED_app.run([
           $rootScope.load_error_message = '' || message || error;
         }
       }
+
+      // Revert the url when the transition was triggered by a sidebar link (options.source === 'url')
+      if (transition.options().source === 'url') {
+        var $state = transition.router.stateService;
+        var $urlRouter = transition.router.urlRouter;
+
+        $urlRouter.push($state.$current.navigable.url, $state.params, {replace: true});
+        $urlRouter.update(true);
+      }
     });
 
     $state.defaultErrorHandler(function (error) {
@@ -847,12 +856,12 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
         templateUrl: static_url + 'seed/partials/column_mappings.html',
         controller: 'column_mappings_controller',
         resolve: {
-          mappable_property_columns_payload: ['inventory_service' , function (inventory_service) {
+          mappable_property_columns_payload: ['inventory_service', function (inventory_service) {
             return inventory_service.get_mappable_property_columns().then(function (result) {
               return result;
             });
           }],
-          mappable_taxlot_columns_payload: ['inventory_service' , function (inventory_service) {
+          mappable_taxlot_columns_payload: ['inventory_service', function (inventory_service) {
             return inventory_service.get_mappable_taxlot_columns().then(function (result) {
               return result;
             });


### PR DESCRIPTION
#### Any background context you want to provide?
Since late February URLs have had a ton of unnecessary params added on:
`https://dev1.seed-platform.org/app/#/properties?=%2F%7Binventory_type:properties%7Ctaxlots%7D`
instead of
`https://dev1.seed-platform.org/app/#/properties`

#### What's this PR do?
Fixes it.  The main issue was calling $location.search.

Related bug: https://github.com/angular-ui/ui-router/issues/3416

#### How should this be manually tested?
Look at the address bar

