### PR TITLE
Shift Swagger Schema Generator to drf-yasg

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -101,7 +101,6 @@ INSTALLED_APPS = (
     'raven.contrib.django.raven_compat',
     'django_filters',
     'rest_framework',
-    'rest_framework_swagger',
     'drf_yasg',
     'oauth2_provider',
     'oauth2_jwt_provider',

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -102,6 +102,7 @@ INSTALLED_APPS = (
     'django_filters',
     'rest_framework',
     'rest_framework_swagger',
+    'drf_yasg',
     'oauth2_provider',
     'oauth2_jwt_provider',
     'crispy_forms',  # needed to squash warnings around collectstatic with rest_framework
@@ -282,8 +283,22 @@ REST_FRAMEWORK = {
 }
 
 SWAGGER_SETTINGS = {
-    'exclude_namespaces': ['app'],  # List URL namespaces to ignore
-    'APIS_SORTER': 'alpha',
+    'TAGS_SORTER': 'alpha',
+    'DEFAULT_FIELD_INSPECTORS': [
+        'drf_yasg.inspectors.CamelCaseJSONFilter',
+        'drf_yasg.inspectors.InlineSerializerInspector',  # this disables models and is the only non-default entry
+        'drf_yasg.inspectors.RelatedFieldInspector',
+        'drf_yasg.inspectors.ChoiceFieldInspector',
+        'drf_yasg.inspectors.FileFieldInspector',
+        'drf_yasg.inspectors.DictFieldInspector',
+        'drf_yasg.inspectors.JSONFieldInspector',
+        'drf_yasg.inspectors.HiddenFieldInspector',
+        'drf_yasg.inspectors.RecursiveFieldInspector',
+        'drf_yasg.inspectors.SerializerMethodFieldInspector',
+        'drf_yasg.inspectors.SimpleFieldInspector',
+        'drf_yasg.inspectors.StringDefaultFieldInspector',
+    ],
+    'DOC_EXPANSION': 'none',
     'LOGOUT_URL': '/accounts/logout',
 }
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -8,15 +8,28 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from rest_framework_swagger.views import get_swagger_view
 
 from config.views import robots_txt
 from seed.api.base.urls import urlpatterns as api
 from seed.landing.views import password_reset_complete, password_reset_confirm, password_reset_done
 from seed.views.main import angular_js_tests
 
-from rest_framework.schemas import get_schema_view
-schema_view = get_schema_view(title='SEED API Schema')
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+   openapi.Info(
+      title="SEED API",
+      default_version='v3',
+      description="Test description",
+      # terms_of_service="https://www.google.com/policies/terms/",
+      # contact=openapi.Contact(email="contact@snippets.local"),
+      # license=openapi.License(name="BSD License"),
+   ),
+   public=False,
+   permission_classes=(permissions.AllowAny,),
+)
 
 urlpatterns = [
     url(r'^accounts/password/reset/done/$', password_reset_done, name='password_reset_done'),
@@ -42,8 +55,7 @@ urlpatterns = [
     url(r'^robots\.txt', robots_txt, name='robots_txt'),
 
     # API
-    url(r'^api/schema/$', schema_view),
-    url(r'^api/swagger/', get_swagger_view(title='SEED API'), name='swagger'),
+    url(r'^api/swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     url(r'^api/', include((api, "seed"), namespace='api')),
     url(r'^oauth/', include(('oauth2_jwt_provider.urls', 'oauth2_jwt_provider'), namespace='oauth2_provider'))
 ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,7 +33,6 @@ django-pint==0.4
 djangorestframework==3.10.3
 # simplejson dependency needs to be installed via github due to a pip segfault with Python 3.6.7
 -e git+https://github.com/simplejson/simplejson@v3.16.1#egg=simplejson
-django-rest-swagger==2.2.0
 drf-yasg==1.17.1
 django-filter==2.2.0
 drf-nested-routers==0.91

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,6 +34,7 @@ djangorestframework==3.10.3
 # simplejson dependency needs to be installed via github due to a pip segfault with Python 3.6.7
 -e git+https://github.com/simplejson/simplejson@v3.16.1#egg=simplejson
 django-rest-swagger==2.2.0
+drf-yasg==1.17.1
 django-filter==2.2.0
 drf-nested-routers==0.91
 docutils==0.16

--- a/seed/static/seed/js/controllers/api_controller.js
+++ b/seed/static/seed/js/controllers/api_controller.js
@@ -3,7 +3,7 @@
  * :author
  */
 angular.module('BE.seed.controller.api', []).controller('api_controller', [function () {
-  $('#swagger-frame').on('load', function () {
+  $('#swagger-ui').on('load', function () {
     $(this).contents().find('body').css('margin', 0);
   });
 }]);

--- a/seed/static/seed/partials/api_docs.html
+++ b/seed/static/seed/partials/api_docs.html
@@ -1,1 +1,1 @@
-<iframe id="swagger-frame" src="/api/swagger/" frameborder="0"></iframe>
+<iframe id="swagger-ui" src="/api/swagger/" frameborder="0"></iframe>

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -2811,7 +2811,7 @@ gs-input .tags .tag-item .remove-button {
   background-color: $highlighter;
 }
 
-#swagger-frame {
+#swagger-ui {
   height: calc(100vh - 60px);
   width: 100%;
 }

--- a/seed/utils/api_schema.py
+++ b/seed/utils/api_schema.py
@@ -36,11 +36,11 @@ class AutoSchemaHelper(SwaggerAutoSchema):
             type=openapi.TYPE_INTEGER
         )
 
-    def query_integer_field(self, name, description, required):
+    def query_integer_field(self, name, required, description):
         return openapi.Parameter(
             name,
             openapi.IN_QUERY,
-            description="Task ID created when DataQuality task is created.",
+            description=description,
             required=True,
             type=openapi.TYPE_INTEGER
         )

--- a/seed/utils/api_schema.py
+++ b/seed/utils/api_schema.py
@@ -1,90 +1,80 @@
 # !/usr/bin/env python
 # encoding: utf-8
-from rest_framework.schemas import AutoSchema
-import coreapi
+from drf_yasg.inspectors import SwaggerAutoSchema
+from drf_yasg import openapi
 
 
-class AutoSchemaHelper(AutoSchema):
-    def __init__(self):
-        super().__init__()
+class AutoSchemaHelper(SwaggerAutoSchema):
 
-    def base_field(self, name, location, required, type, description):
+    # Used to easily build out example values displayed on Swagger page.
+    body_parameter_formats = {
+        'interger_list': openapi.Schema(
+            type=openapi.TYPE_ARRAY,
+            items=openapi.Schema(type=openapi.TYPE_INTEGER)
+        )
+    }
+
+    def base_field(self, name, location_attr, description, required, type):
         """
-        Created to avoid needing to directly access coreapi within ViewSets.
+        Created to avoid needing to directly access openapi within ViewSets.
         Ideally, the cases below will be used instead of this one.
         """
-        return coreapi.Field(
+        return openapi.Parameter(
             name,
-            location=location,
+            getattr(openapi, location_attr),
+            description=description,
             required=required,
-            type=type,
-            description=description
+            type=type
         )
 
-    def org_id_field(self, location='query', required=True, type='integer', description='Organization ID'):
-        return coreapi.Field(
+    def org_id_field(self):
+        return openapi.Parameter(
             'organization_id',
-            location=location,
-            required=required,
-            type=type,
-            description=description
+            openapi.IN_QUERY,
+            description='Organization ID',
+            required=True,
+            type=openapi.TYPE_INTEGER
+        )
+
+    def query_integer_field(self, name, description, required):
+        return openapi.Parameter(
+            name,
+            openapi.IN_QUERY,
+            description="Task ID created when DataQuality task is created.",
+            required=True,
+            type=openapi.TYPE_INTEGER
         )
 
     def path_id_field(self, description):
-        return coreapi.Field(
-            "id",  # matches reference name in uri path
-            location='path',
+        return openapi.Parameter(
+            'id',
+            openapi.IN_PATH,
+            description=description,
             required=True,
-            type='integer',
-            description=description
+            type=openapi.TYPE_INTEGER
         )
 
-    def body_field(self, required, description):
-        return coreapi.Field(
-            'body',
-            location='body',
-            required=required,
-            type='object',
-            description=description
-        )
-
-    def form_field(self, name, required, description):
-        return coreapi.Field(
+    def body_field(self, required, description, name='body', params_to_formats={}):
+        return openapi.Parameter(
             name,
-            location='form',
+            openapi.IN_BODY,
+            description=description,
             required=required,
-            type='object',
-            description=description
+            schema=self._build_body_schema(params_to_formats)
         )
 
-    def test_field_options(self):
-        return [
-            coreapi.Field('remove_label_ids', location='form', required=False, type='array'),
-            coreapi.Field('inventory_ids', location='form', required=False, type='array', description="This is what the description looks like for an 'array'."),
-            coreapi.Field('string test', location='form', required=False, type='string'),
-            coreapi.Field('integer test', location='form', required=False, type='integer'),
-            coreapi.Field('boolean test', location='form', required=False, type='boolean'),
-            coreapi.Field('json test', location='form', required=False, type='json'),
-            coreapi.Field('list test', location='form', required=False, type='list'),
-            coreapi.Field('dict test', location='form', required=False, type='dict'),
-            coreapi.Field('object test', location='form', required=False, type='object'),
-            coreapi.Field('integers test', location='form', required=False, type='integers'),
-            coreapi.Field('strings test', location='form', required=False, type='strings'),
-            coreapi.Field('objects test', location='form', required=False, type='objects'),
-            coreapi.Field('organization_id', location='query', required=True, type='integer'),
-            coreapi.Field('string query test', location='query', required=True, type='string', description="Here's a query description"),
-            coreapi.Field('boolean query test', location='query', required=True, type='boolean'),
-            coreapi.Field('json query test', location='query', required=True, type='json'),
-            coreapi.Field('object query test', location='query', required=True, type='object'),
-            coreapi.Field('array query test', location='query', required=True, type='array'),
-        ]
+    def _build_body_schema(self, params_to_formats):
+        return openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                k: self.body_parameter_formats.get(format_name, "")
+                for k, format_name
+                in params_to_formats.items()
+            }
+        )
 
-    def get_path_fields(self, path, http_method):
-        default_fields = AutoSchema.get_path_fields(self, path, http_method)
+    def add_manual_parameters(self, parameters):
+        manual_params = self.manual_fields.get((self.method, self.view.action), [])
 
-        return self.path_fields.get((http_method, self.view.action), default_fields)
-
-    def get_manual_fields(self, path, http_method):
-        default_fields = AutoSchema.get_manual_fields(self, path, http_method)
-
-        return self.manual_fields.get((http_method, self.view.action), default_fields)
+        # I think this should add to existing parameters, but haven't been able to confirm.
+        return parameters + manual_params

--- a/seed/views/v3/data_quality.py
+++ b/seed/views/v3/data_quality.py
@@ -125,8 +125,8 @@ class DataQualitySchema(AutoSchemaHelper):
                 self.org_id_field(),
                 self.query_integer_field(
                     name='data_quality_id',
-                    description="Task ID created when DataQuality task is created.",
-                    required=True
+                    required=True,
+                    description="Task ID created when DataQuality task is created."
                 ),
             ],
             ('GET', 'csv'): [

--- a/seed/views/v3/data_quality.py
+++ b/seed/views/v3/data_quality.py
@@ -94,16 +94,20 @@ def _get_severity_from_js(severity):
 
 
 class DataQualitySchema(AutoSchemaHelper):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args):
+        super().__init__(*args)
 
         self.manual_fields = {
             ('POST', 'create'): [
                 self.org_id_field(),
-                self.form_field(
+                self.body_field(
                     name='data_quality_ids',
                     required=True,
-                    description="An object containing IDs of the records to perform data quality checks on. Should contain two keys- property_state_ids and taxlot_state_ids, each of which is an array of appropriate IDs."
+                    description="An object containing IDs of the records to perform data quality checks on. Should contain two keys- property_state_ids and taxlot_state_ids, each of which is an array of appropriate IDs.",
+                    params_to_formats={
+                        'property_state_ids': 'interger_list',
+                        'taxlot_state_ids': 'interger_list'
+                    }
                 ),
             ],
             ('GET', 'data_quality_rules'): [self.org_id_field()],
@@ -111,16 +115,24 @@ class DataQualitySchema(AutoSchemaHelper):
             ('PUT', 'reset_default_data_quality_rules'): [self.org_id_field()],
             ('POST', 'save_data_quality_rules'): [
                 self.org_id_field(),
-                self.body_field(required=True, description='Rules information')
+                self.body_field(
+                    name='data_quality_rules',
+                    required=True,
+                    description="Rules information"
+                )
             ],
-            ('GET', 'results'): [self.org_id_field()],
-            ('GET', 'testing_core_api'): self.test_field_options(),
-        }
-
-        self.path_fields = {
+            ('GET', 'results'): [
+                self.org_id_field(),
+                self.query_integer_field(
+                    name='data_quality_id',
+                    description="Task ID created when DataQuality task is created.",
+                    required=True
+                ),
+            ],
             ('GET', 'csv'): [
-                self.path_id_field(description='Import file ID or cache key'),
-            ]
+                # This will replace the auto-generated field - adds description.
+                self.path_id_field(description="Import file ID or cache key")
+            ],
         }
 
 
@@ -130,14 +142,7 @@ class DataQualityViews(viewsets.ViewSet):
     (1) Post, wait, get…
     (2) Respond with what changed
     """
-    schema = DataQualitySchema()
-
-    @action(detail=False, methods=['GET'])
-    def testing_core_api(self, request):
-        """
-        Testing/documenting coreapi.Field options
-        """
-        pass
+    swagger_schema = DataQualitySchema
 
     def create(self, request):
         """


### PR DESCRIPTION
#### Any background context you want to provide?
We needed to move away from the, now deprecated, django-rest-swagger as a schema generator/renderer. (Not to be confused with django-rest-**framework**, which is still being used 😄 .)

#### What's this PR do?
Swagger page now uses drf_yasg.

#### How should this be manually tested?
**Reminder to refresh installed packages.**

Check the Swagger page still renders. See that the v3 DQ endpoints are documented and "trying" each of the endpoints should work.

For code review, each commit can be used to break up and partition review. The last commit is a small clean up item.

For the https://github.com/SEED-platform/seed/pull/2188/commits/78fb1a849009978b549265b5076970d992b48e88 commit, it might be easier to review the resulting code as opposed to code diffs as the diffs shown by GH are not as readable in my opinion.

Also note that there are AssertionErrors being thrown across a number of ViewSets as there are some additional setup steps likely needed. Things seem to work to the extent they did before - v2 endpoints are still visible, so I think we can address those errors later.

#### What are the relevant tickets?

#### Screenshots (if appropriate)
![Screen Shot 2020-04-23 at 2 03 41 PM](https://user-images.githubusercontent.com/30608004/80144172-455dee00-856b-11ea-9cec-86b8c4eebe6d.png)

