### PR TITLE
#1369 - Add badges to each dq admin tab to indicate number of rules

### DIFF
--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -113,7 +113,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
             ruleGroups[index][rule.field].push(row);
           });
         });
-        data_quality_service.data_quality_rules($scope.org.org_id).then(function (data) {
+        data_quality_service.data_quality_rules($stateParams.organization_id).then(function (data) {
           $scope.rule_count = data.rules;
         });
         $scope.ruleGroups = ruleGroups;

--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -113,7 +113,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
             ruleGroups[index][rule.field].push(row);
           });
         });
-        data_quality_service.data_quality_rules($stateParams.organization_id).then(function (data) {
+        data_quality_service.data_quality_rules($scope.org.org_id).then(function (data) {
           $scope.rule_count = data.rules;
         });
         $scope.ruleGroups = ruleGroups;

--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -51,6 +51,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
 
       $scope.state = $state.current;
 
+      $scope.rule_count = 0;
       $scope.data_types = [
         {id: null, label: ''},
         {id: 'number', label: $translate.instant('Number')},
@@ -112,7 +113,9 @@ angular.module('BE.seed.controller.data_quality_admin', [])
             ruleGroups[index][rule.field].push(row);
           });
         });
-
+        data_quality_service.data_quality_rules($scope.org.org_id).then(function (data) {
+          $scope.rule_count = data.rules;
+        });
         $scope.ruleGroups = ruleGroups;
       };
       loadRules(data_quality_rules_payload);
@@ -341,6 +344,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
           autofocus: true
         });
         $scope.change_rules();
+        $scope.rule_count[$scope.inventory_type].length += 1;
       };
 
       // create label and assign to that rule
@@ -371,6 +375,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
         }
         else $scope.ruleGroups[$scope.inventory_type][rule.field].splice(index, 1);
         $scope.change_rules();
+        $scope.rule_count[$scope.inventory_type].length -= 1;
       };
 
       var displayNames = {};

--- a/seed/static/seed/partials/data_quality_admin.html
+++ b/seed/static/seed/partials/data_quality_admin.html
@@ -41,10 +41,10 @@
             <div class="data-quality-tab-container">
                 <ul class="nav nav-tabs" style="margin-bottom:1px;">
                     <li ui-sref-active="active" heading="{$:: 'View by Property' | translate $}">
-                        <a ui-sref="organization_data_quality(::{organization_id: org.id, inventory_type: 'properties'})" translate>View by Property</a>
+                        <a ui-sref="organization_data_quality(::{organization_id: org.id, inventory_type: 'properties'})">View by Property <span class="badge badge_menu">{$ rule_count['properties'].length | number:0 $}</span></a>
                     </li>
                     <li ui-sref-active="active" heading="{$:: 'View by Tax Lot' | translate $}">
-                        <a ui-sref="organization_data_quality(::{organization_id: org.id, inventory_type: 'taxlots'})" translate>View by Tax Lot</a>
+                        <a ui-sref="organization_data_quality(::{organization_id: org.id, inventory_type: 'taxlots'})">View by Tax Lot <span class="badge badge_menu">{$ rule_count['taxlots'].length | number:0 $}</span></a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
#### Any background context you want to provide?
#### What's this PR do?
Added badges to property and taxlots dq tabs to indicate number of rules on page.

#### How should this be manually tested?
1. Go to data quality admin page and should see a badge indicating the number of rules shown;
2. Create a new rule, badge number should increase by 1;
3. Delete a rule, badge number should decrease by 1.

#### What are the relevant tickets?
#1369 

#### Screenshots (if appropriate)
<img width="1352" alt="Screen Shot 2020-04-30 at 7 19 49 PM" src="https://user-images.githubusercontent.com/49968203/80773599-99427700-8b17-11ea-9e0e-d65b095363d5.png">
<img width="1353" alt="Screen Shot 2020-04-30 at 7 19 29 PM" src="https://user-images.githubusercontent.com/49968203/80773602-9a73a400-8b17-11ea-97e0-efaa5ea6bfaa.png">

