### PR TITLE
chore(buildingsync): parse conditioned floors above grade and prem ID

### DIFF
--- a/seed/building_sync/building_sync.py
+++ b/seed/building_sync/building_sync.py
@@ -262,6 +262,8 @@ class BuildingSync(object):
             'year_built': property_['year_built'],
             'floors_above_grade': property_['floors_above_grade'],
             'floors_below_grade': property_['floors_below_grade'],
+            'conditioned_floors_above_grade': property_['conditioned_floors_above_grade'],
+            'conditioned_floors_below_grade': property_['conditioned_floors_below_grade'],
             'premise_identifier': property_['premise_identifier'],
             'custom_id_1': property_['custom_id_1'],
             'gross_floor_area': property_['gross_floor_area'],

--- a/seed/building_sync/mappings.py
+++ b/seed/building_sync/mappings.py
@@ -502,8 +502,22 @@ BASE_MAPPING_V2_0 = {
                 'formatter': to_int,
                 'required': False
             },
+            'conditioned_floors_above_grade': {
+                'xpath': './auc:Buildings/auc:Building/auc:ConditionedFloorsAboveGrade',
+                'type': 'value',
+                'value': 'text',
+                'formatter': to_int,
+                'required': False
+            },
+            'conditioned_floors_below_grade': {
+                'xpath': './auc:Buildings/auc:Building/auc:ConditionedFloorsBelowGrade',
+                'type': 'value',
+                'value': 'text',
+                'formatter': to_int,
+                'required': False
+            },
             'premise_identifier': {
-                'xpath': './auc:Buildings/auc:Building/auc:PremisesIdentifiers/auc:PremisesIdentifier[auc:IdentifierLabel="Assessor parcel number"]/auc:IdentifierValue',
+                'xpath': './auc:Buildings/auc:Building/auc:PremisesIdentifiers/auc:PremisesIdentifier[auc:IdentifierCustomName="Custom ID 2"]/auc:IdentifierValue',
                 'type': 'value',
                 'value': 'text',
                 'required': False

--- a/seed/building_sync/tests/data/buildingsync_v2_0_bricr_workflow.xml
+++ b/seed/building_sync/tests/data/buildingsync_v2_0_bricr_workflow.xml
@@ -21,7 +21,8 @@
               <auc:PremisesNotes/>
               <auc:PremisesIdentifiers>
                 <auc:PremisesIdentifier>
-                  <auc:IdentifierLabel>Assessor parcel number</auc:IdentifierLabel>
+                  <auc:IdentifierLabel>Custom</auc:IdentifierLabel>
+                  <auc:IdentifierCustomName>Custom ID 2</auc:IdentifierCustomName>
                   <auc:IdentifierValue>SF000011</auc:IdentifierValue>
                 </auc:PremisesIdentifier>
                 <auc:PremisesIdentifier>
@@ -54,6 +55,8 @@
               <auc:Latitude>37.74391054330132</auc:Latitude>
               <auc:FloorsAboveGrade>1</auc:FloorsAboveGrade>
               <auc:FloorsBelowGrade>0</auc:FloorsBelowGrade>
+              <auc:ConditionedFloorsAboveGrade>1</auc:ConditionedFloorsAboveGrade>
+              <auc:ConditionedFloorsBelowGrade>0</auc:ConditionedFloorsBelowGrade>
               <auc:FloorAreas>
                 <auc:FloorArea>
                   <auc:FloorAreaType>Gross</auc:FloorAreaType>

--- a/seed/building_sync/tests/test_buildingsync.py
+++ b/seed/building_sync/tests/test_buildingsync.py
@@ -18,7 +18,7 @@ from seed.models import (
     User
 )
 from seed.utils.organizations import create_organization
-
+# REMOVE ME
 
 class TestImport(TestCase):
     def test_import_v2_0_ok(self):

--- a/seed/building_sync/tests/test_buildingsync.py
+++ b/seed/building_sync/tests/test_buildingsync.py
@@ -18,7 +18,7 @@ from seed.models import (
     User
 )
 from seed.utils.organizations import create_organization
-# REMOVE ME
+
 
 class TestImport(TestCase):
     def test_import_v2_0_ok(self):

--- a/seed/building_sync/tests/test_buildingsync.py
+++ b/seed/building_sync/tests/test_buildingsync.py
@@ -78,6 +78,8 @@ class TestProcess(TestCase):
             'year_built': 2010,
             'floors_above_grade': 1,
             'floors_below_grade': 0,
+            'conditioned_floors_above_grade': 1,
+            'conditioned_floors_below_grade': 0,
             'premise_identifier': 'SF000011',
             'custom_id_1': '1',
             'gross_floor_area': 77579.0,


### PR DESCRIPTION
#### Any background context you want to provide?
BRICR files are being tweaked for ATT support, tweaking the parser accordingly
#### What's this PR do?
- parse premise_identifier from Custom ID 2
- parse conditioned_floors[above|below]_grade
#### How should this be manually tested?
None needed
