### PR TITLE
patch(meters.py): handle mistyping

### DIFF
--- a/seed/utils/meters.py
+++ b/seed/utils/meters.py
@@ -41,6 +41,7 @@ class PropertyMeterReadingsExporter():
         self._cache_factors = None
         self._cache_org_country = None
 
+        scenario_ids = scenario_ids if scenario_ids is not None else []
         self.meters = Meter.objects.filter(
             Q(property_id=property_id) | Q(scenario_id__in=scenario_ids)
         ).exclude(pk__in=excluded_meter_ids)


### PR DESCRIPTION
Small patch for mistyped query parameter. This isn't a current issue (ie it should not actually cause runtime exceptions) but is an error nonetheless.