### PR TITLE
2.7.0 patch1 - for review only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# SEED Version 2.7.0-patch1
+
+- Fixed [#2202]( https://github.com/SEED-platform/seed/issues/2202 ), Organization's DQ Rules can be inadvertently deleted
+
 # SEED Version 2.7.0
 
 SEED Version 2.7.0 includes several significant updates that need to be thoroughly tested on production data
@@ -61,11 +65,6 @@ Closed Issues and Features:
 - Fixed [#1913]( https://github.com/SEED-platform/seed/issues/1913 ), Add Notes info to export
 - Fixed [#1713]( https://github.com/SEED-platform/seed/issues/1713 ), Return progress status immediately when uploading large files
 
-The item(s) below are patched applied to 2.7.0-Beta
-- Feature [#2134]( https://github.com/SEED-platform/seed/issues/2134 ), Add new column setting to allow blank/'Not Available' values to overwrite other values
-- Update ESPM connection to support latest update.
-- Fixed [#2119]( https://github.com/SEED-platform/seed/issues/2119 ), Re-enable created and updated fields for master records on the front end
-
 # SEED Version 2.6.1-Patch1
 
 - Fixed [#2076]( https://github.com/SEED-platform/seed/issues/2076 ), ESPM import no longer works due to ESPM website updates
@@ -74,6 +73,7 @@ The item(s) below are patched applied to 2.7.0-Beta
 
 - This includes the patches from 2.6.0-patch0 since the patches were not complete until after the release of 2.6.1.
 - Fixed [#2039]( https://github.com/SEED-platform/seed/issues/2039 ), Portfolio Manager Login URL Changed
+- Fixed [#2058]( https://github.com/SEED-platform/seed/issues/2058 ), Portfolio Manager URL Changed (Flapping Issue)
 
 # SEED Version 2.6.1
 

--- a/seed/management/commands/create_geojson_test_data.py
+++ b/seed/management/commands/create_geojson_test_data.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         :return:
         """
         if geom['type'] == "Polygon":
-            coords = [f"{l[0]} {l[1]}" for l in geom['coordinates'][0]]
+            coords = [f"{coord[0]} {coord[1]}" for coord in geom['coordinates'][0]]
             return f"POLYGON (( {', '.join(coords)} ))"
         else:
             raise Exception(f"Unknown type of Geomoetry in GeoJSON of {geom['type']}")

--- a/seed/models/column_list_settings_columns.py
+++ b/seed/models/column_list_settings_columns.py
@@ -22,4 +22,4 @@ class ColumnListSettingColumn(models.Model):
     pinned = models.BooleanField(default=False)
 
     def __str__(self):
-        return self.column_list_setting.name + " %s %s".format(self.order, self.pinned)
+        return f"{self.column_list_setting.name} {self.order} {self.pinned}"

--- a/seed/tests/test_data_quality_rules.py
+++ b/seed/tests/test_data_quality_rules.py
@@ -1,0 +1,91 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2020, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+import json
+
+from copy import deepcopy
+
+from django.core.urlresolvers import reverse
+
+from seed.models.data_quality import (
+    DataQualityCheck,
+    Rule,
+)
+from seed.models.models import ASSESSED_RAW
+
+from seed.tests.util import DataMappingBaseTestCase
+
+
+class RuleViewTests(DataMappingBaseTestCase):
+    def setUp(self):
+        selfvars = self.set_up(ASSESSED_RAW)
+
+        self.user, self.org, self.import_file, self.import_record, self.cycle = selfvars
+
+        self.client.login(
+            username='test_user@demo.com',
+            password='test_pass',
+            email='test_user@demo.com'
+        )
+
+    def test_valid_data_rule_without_label_does_not_actually_update_or_delete_any_rules(self):
+        # Start with 3 Rules
+        dq = DataQualityCheck.retrieve(self.org.id)
+        dq.remove_all_rules()
+        base_rule_info = {
+            'field': 'address_line_1',
+            'table_name': 'PropertyState',
+            'enabled': True,
+            'data_type': Rule.TYPE_STRING,
+            'rule_type': Rule.RULE_TYPE_DEFAULT,
+            'required': False,
+            'not_null': False,
+            'min': None,
+            'max': None,
+            'text_match': 'Test Rule 1',
+            'severity': Rule.SEVERITY_ERROR,
+            'units': "",
+            'status_label_id': None
+        }
+        dq.add_rule(base_rule_info)
+
+        rule_2_info = deepcopy(base_rule_info)
+        rule_2_info['text_match'] = 'Test Rule 2'
+        dq.add_rule(rule_2_info)
+
+        rule_3_info = deepcopy(base_rule_info)
+        rule_3_info['text_match'] = 'Test Rule 3'
+        dq.add_rule(rule_3_info)
+
+        self.assertEqual(dq.rules.count(), 3)
+
+        property_rules = [base_rule_info, rule_2_info, rule_3_info]
+
+        # Make some adjustments to mimic how data is expected in API endpoint
+        rule_3_info['severity'] = dict(Rule.SEVERITY).get(Rule.SEVERITY_ERROR)
+        for rule in property_rules:
+            rule['data_type'] = dict(Rule.DATA_TYPES).get(rule['data_type'])
+            rule['label'] = None
+
+        # Make 2 rules trigger the "valid without label" failure
+        base_rule_info['severity'] = dict(Rule.SEVERITY).get(Rule.SEVERITY_VALID)
+        rule_2_info['severity'] = dict(Rule.SEVERITY).get(Rule.SEVERITY_VALID)
+
+        url = reverse('api:v2:data_quality_checks-save-data-quality-rules') + '?organization_id=' + str(self.org.pk)
+        post_data = {
+            "data_quality_rules": {
+                "properties": property_rules,
+                "taxlots": [],
+            },
+        }
+        res = self.client.post(url, content_type='application/json', data=json.dumps(post_data))
+
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(json.loads(res.content)['message'], 'Label must be assigned when using Valid Data Severity.')
+
+        # Count 3 total rules. None of them were updated
+        self.assertEqual(dq.rules.count(), 3)
+        self.assertEqual(dq.rules.filter(severity=Rule.SEVERITY_VALID).count(), 0)

--- a/seed/views/data_quality.py
+++ b/seed/views/data_quality.py
@@ -8,6 +8,7 @@
 import csv
 
 from celery.utils.log import get_task_logger
+from django.db import transaction
 from django.http import JsonResponse, HttpResponse
 from rest_framework import viewsets, serializers, status
 from rest_framework.decorators import list_route, detail_route
@@ -411,18 +412,27 @@ class DataQualityViews(viewsets.ViewSet):
                 }
             )
 
+        # This pattern of deleting and recreating Rules is slated to be deprecated
+        bad_rule_creation = False
+        error_messages = set()
         dq = DataQualityCheck.retrieve(organization.id)
         dq.remove_all_rules()
         for rule in updated_rules:
-            try:
-                dq.add_rule(rule)
-            except TypeError as e:
-                return JsonResponse({
-                    'status': 'error',
-                    'message': e,
-                }, status=status.HTTP_400_BAD_REQUEST)
+            with transaction.atomic():
+                try:
+                    dq.add_rule(rule)
+                except Exception as e:
+                    error_messages.add('Rule could not be recreated: ' + str(e))
+                    bad_rule_creation = True
+                    continue
 
-        return self.data_quality_rules(request)
+        if bad_rule_creation:
+            return JsonResponse({
+                'status': 'error',
+                'message': '\n'.join(error_messages),
+            }, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            return self.data_quality_rules(request)
 
     @api_endpoint_class
     @ajax_request_class

--- a/seed/views/data_quality.py
+++ b/seed/views/data_quality.py
@@ -362,6 +362,12 @@ class DataQualityViews(viewsets.ViewSet):
         posted_rules = body['data_quality_rules']
         updated_rules = []
         for rule in posted_rules['properties']:
+            if _get_severity_from_js(rule['severity']) == Rule.SEVERITY_VALID and rule['label'] is None:
+                return JsonResponse({
+                    'status': 'error',
+                    'message': 'Label must be assigned when using Valid Data Severity.'
+                }, status=status.HTTP_400_BAD_REQUEST)
+
             updated_rules.append(
                 {
                     'field': rule['field'],
@@ -381,6 +387,12 @@ class DataQualityViews(viewsets.ViewSet):
             )
 
         for rule in posted_rules['taxlots']:
+            if _get_severity_from_js(rule['severity']) == Rule.SEVERITY_VALID and rule['label'] is None:
+                return JsonResponse({
+                    'status': 'error',
+                    'message': 'Label must be assigned when using Valid Data Severity.'
+                }, status=status.HTTP_400_BAD_REQUEST)
+
             updated_rules.append(
                 {
                     'field': rule['field'],
@@ -402,12 +414,6 @@ class DataQualityViews(viewsets.ViewSet):
         dq = DataQualityCheck.retrieve(organization.id)
         dq.remove_all_rules()
         for rule in updated_rules:
-            if rule['severity'] == Rule.SEVERITY_VALID and rule['status_label_id'] is None:
-                return JsonResponse({
-                    'status': 'error',
-                    'message': 'Label must be assigned when using Valid Data Severity.'
-                }, status=status.HTTP_400_BAD_REQUEST)
-
             try:
                 dq.add_rule(rule)
             except TypeError as e:


### PR DESCRIPTION
#### Any background context you want to provide?
DQ Rules were being inadvertently deleted.

See attached issue for more details.

#### What's this PR do?
In the save_data_quality_rules POST endpoint, move any "checks" that trigger a 400 to before the records are deleted. Also, for that same endpoint, update the try-except logic to "...except and continue rebuilding Rules", returning a JSON response at the end that includes a message that Rules were lost/deleted.

#### How should this be manually tested?
Try to save a "Valid Data" Rule without a label. See that nothing gets saved, and we get the same 400 we got from before. Refresh the page and see that nothing was lost either.

For code review, commits can be reviewed in the order shown.

#### What are the relevant tickets?
#2202 

#### Screenshots (if appropriate)
The error message still appears as before.
<img width="1383" alt="Screen Shot 2020-05-13 at 2 45 43 AM" src="https://user-images.githubusercontent.com/30608004/81836223-69747580-9500-11ea-8c5c-6664afb7d4be.png">
