### PR TITLE
chore(mappings.py): get premise id from city custom building id

### DIFF
--- a/seed/building_sync/mappings.py
+++ b/seed/building_sync/mappings.py
@@ -517,7 +517,7 @@ BASE_MAPPING_V2_0 = {
                 'required': False
             },
             'premise_identifier': {
-                'xpath': './auc:Buildings/auc:Building/auc:PremisesIdentifiers/auc:PremisesIdentifier[auc:IdentifierCustomName="Custom ID 2"]/auc:IdentifierValue',
+                'xpath': './auc:Buildings/auc:Building/auc:PremisesIdentifiers/auc:PremisesIdentifier[auc:IdentifierCustomName="City Custom Building ID"]/auc:IdentifierValue',
                 'type': 'value',
                 'value': 'text',
                 'required': False

--- a/seed/building_sync/tests/data/buildingsync_v2_0_bricr_workflow.xml
+++ b/seed/building_sync/tests/data/buildingsync_v2_0_bricr_workflow.xml
@@ -22,11 +22,6 @@
               <auc:PremisesIdentifiers>
                 <auc:PremisesIdentifier>
                   <auc:IdentifierLabel>Custom</auc:IdentifierLabel>
-                  <auc:IdentifierCustomName>Custom ID 2</auc:IdentifierCustomName>
-                  <auc:IdentifierValue>SF000011</auc:IdentifierValue>
-                </auc:PremisesIdentifier>
-                <auc:PremisesIdentifier>
-                  <auc:IdentifierLabel>Custom</auc:IdentifierLabel>
                   <auc:IdentifierCustomName>Custom ID</auc:IdentifierCustomName>
                   <auc:IdentifierValue>1</auc:IdentifierValue>
                 </auc:PremisesIdentifier>
@@ -38,7 +33,7 @@
                 <auc:PremisesIdentifier>
                   <auc:IdentifierLabel>Custom</auc:IdentifierLabel>
                   <auc:IdentifierCustomName>City Custom Building ID</auc:IdentifierCustomName>
-                  <auc:IdentifierValue>1</auc:IdentifierValue>
+                  <auc:IdentifierValue>SF000011</auc:IdentifierValue>
                 </auc:PremisesIdentifier>
               </auc:PremisesIdentifiers>
               <auc:Address>

--- a/seed/management/commands/create_geojson_test_data.py
+++ b/seed/management/commands/create_geojson_test_data.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         :return:
         """
         if geom['type'] == "Polygon":
-            coords = [f"{l[0]} {l[1]}" for l in geom['coordinates'][0]]
+            coords = [f"{coord[0]} {coord[1]}" for coord in geom['coordinates'][0]]
             return f"POLYGON (( {', '.join(coords)} ))"
         else:
             raise Exception(f"Unknown type of Geomoetry in GeoJSON of {geom['type']}")

--- a/seed/models/column_list_settings_columns.py
+++ b/seed/models/column_list_settings_columns.py
@@ -22,4 +22,4 @@ class ColumnListSettingColumn(models.Model):
     pinned = models.BooleanField(default=False)
 
     def __str__(self):
-        return self.column_list_setting.name + " %s %s".format(self.order, self.pinned)
+        return f"{self.column_list_setting.name} {self.order} {self.pinned}"


### PR DESCRIPTION
#### Any background context you want to provide?
ATT added parsing of Assessor parcel number from City Custom Building ID.
#### What's this PR do?
Parses premise_id from City Custom Building ID
#### How should this be manually tested?
Upload bricr workflow xml, verify that the premise_id contains the SF parcel number (should be SF000011).
