### PR TITLE
PropertyViewViewSet - remove select_related slowing down swagger page

### DIFF
--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -199,7 +199,7 @@ class PropertyViewViewSet(SEEDOrgModelViewSet):
     filter_class = PropertyViewFilterSet
     orgfilter = 'property__organization_id'
     data_name = "property_views"
-    queryset = PropertyView.objects.all().select_related('state')
+    queryset = PropertyView.objects.all()
 
 
 class PropertyViewSet(GenericViewSet, ProfileIdMixin):


### PR DESCRIPTION
After merging and deploying to dev1, the current temporary fix of redirecting to maintenance page should be removed.

#### Any background context you want to provide?
Swagger page was slow. Lately, it's been enough to crash dev1.

#### What's this PR do?
Remove select_related slowing down swagger page.

This will slow down the actual endpoint for anyone that uses it. But it doesn't seem to be used on the frontend. Also, tests pass when the endpoint is disabled. As to whether this is old and should be deprecated, that conversation should be had in building API v3.

#### How should this be manually tested?
Load the swagger page and see it loads much faster. 

#### What are the relevant tickets?

#### Screenshots (if appropriate)
<img width="1383" alt="Screen Shot 2020-05-14 at 2 30 32 PM" src="https://user-images.githubusercontent.com/30608004/81982751-7f149880-95ef-11ea-938e-587ac5df9b49.png">