### PR TITLE
2202 deleted dq rules

### DIFF
--- a/seed/tests/test_data_quality_rules.py
+++ b/seed/tests/test_data_quality_rules.py
@@ -1,0 +1,91 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2020, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+import json
+
+from copy import deepcopy
+
+from django.core.urlresolvers import reverse
+
+from seed.models.data_quality import (
+    DataQualityCheck,
+    Rule,
+)
+from seed.models.models import ASSESSED_RAW
+
+from seed.tests.util import DataMappingBaseTestCase
+
+
+class RuleViewTests(DataMappingBaseTestCase):
+    def setUp(self):
+        selfvars = self.set_up(ASSESSED_RAW)
+
+        self.user, self.org, self.import_file, self.import_record, self.cycle = selfvars
+
+        self.client.login(
+            username='test_user@demo.com',
+            password='test_pass',
+            email='test_user@demo.com'
+        )
+
+    def test_valid_data_rule_without_label_does_not_actually_update_or_delete_any_rules(self):
+        # Start with 3 Rules
+        dq = DataQualityCheck.retrieve(self.org.id)
+        dq.remove_all_rules()
+        base_rule_info = {
+            'field': 'address_line_1',
+            'table_name': 'PropertyState',
+            'enabled': True,
+            'data_type': Rule.TYPE_STRING,
+            'rule_type': Rule.RULE_TYPE_DEFAULT,
+            'required': False,
+            'not_null': False,
+            'min': None,
+            'max': None,
+            'text_match': 'Test Rule 1',
+            'severity': Rule.SEVERITY_ERROR,
+            'units': "",
+            'status_label_id': None
+        }
+        dq.add_rule(base_rule_info)
+
+        rule_2_info = deepcopy(base_rule_info)
+        rule_2_info['text_match'] = 'Test Rule 2'
+        dq.add_rule(rule_2_info)
+
+        rule_3_info = deepcopy(base_rule_info)
+        rule_3_info['text_match'] = 'Test Rule 3'
+        dq.add_rule(rule_3_info)
+
+        self.assertEqual(dq.rules.count(), 3)
+
+        property_rules = [base_rule_info, rule_2_info, rule_3_info]
+
+        # Make some adjustments to mimic how data is expected in API endpoint
+        rule_3_info['severity'] = dict(Rule.SEVERITY).get(Rule.SEVERITY_ERROR)
+        for rule in property_rules:
+            rule['data_type'] = dict(Rule.DATA_TYPES).get(rule['data_type'])
+            rule['label'] = None
+
+        # Make 2 rules trigger the "valid without label" failure
+        base_rule_info['severity'] = dict(Rule.SEVERITY).get(Rule.SEVERITY_VALID)
+        rule_2_info['severity'] = dict(Rule.SEVERITY).get(Rule.SEVERITY_VALID)
+
+        url = reverse('api:v2:data_quality_checks-save-data-quality-rules') + '?organization_id=' + str(self.org.pk)
+        post_data = {
+            "data_quality_rules": {
+                "properties": property_rules,
+                "taxlots": [],
+            },
+        }
+        res = self.client.post(url, content_type='application/json', data=json.dumps(post_data))
+
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(json.loads(res.content)['message'], 'Label must be assigned when using Valid Data Severity.')
+
+        # Count 3 total rules. None of them were updated
+        self.assertEqual(dq.rules.count(), 3)
+        self.assertEqual(dq.rules.filter(severity=Rule.SEVERITY_VALID).count(), 0)

--- a/seed/tests/test_data_quality_rules.py
+++ b/seed/tests/test_data_quality_rules.py
@@ -91,7 +91,7 @@ class RuleViewTests(DataMappingBaseTestCase):
         self.assertEqual(dq.rules.count(), 3)
         self.assertEqual(dq.rules.filter(severity=Rule.SEVERITY_VALID).count(), 0)
 
-    def test_include_exclude_without_text_mamtch_does_not_actually_update_or_delete_any_rules(self):
+    def test_include_exclude_without_text_match_does_not_actually_update_or_delete_any_rules(self):
         # Start with 3 Rules
         dq = DataQualityCheck.retrieve(self.org.id)
         dq.remove_all_rules()
@@ -202,3 +202,62 @@ class RuleViewTests(DataMappingBaseTestCase):
         # Count 2 total rules - the first and second rules
         self.assertEqual(dq.rules.count(), 2)
         self.assertEqual(dq.rules.filter(text_match__in=['Test Rule 1', 'Test Rule 3']).count(), 2)
+
+    def test_multiple_unique_errors_get_reported(self):
+        # Start with 3 Rules
+        dq = DataQualityCheck.retrieve(self.org.id)
+        dq.remove_all_rules()
+        base_rule_info = {
+            'field': 'address_line_1',
+            'table_name': 'PropertyState',
+            'enabled': True,
+            'data_type': Rule.TYPE_STRING,
+            'rule_type': Rule.RULE_TYPE_DEFAULT,
+            'condition': Rule.RULE_INCLUDE,
+            'required': False,
+            'not_null': False,
+            'min': None,
+            'max': None,
+            'text_match': 'Test Rule 1',
+            'severity': Rule.SEVERITY_ERROR,
+            'units': "",
+            'status_label_id': None
+        }
+        dq.add_rule(base_rule_info)
+
+        rule_2_info = deepcopy(base_rule_info)
+        rule_2_info['text_match'] = 'Test Rule 2'
+        dq.add_rule(rule_2_info)
+
+        rule_3_info = deepcopy(base_rule_info)
+        rule_3_info['text_match'] = 'Test Rule 3'
+        dq.add_rule(rule_3_info)
+
+        self.assertEqual(dq.rules.count(), 3)
+
+        property_rules = [base_rule_info, rule_2_info, rule_3_info]
+
+        # Make some adjustments to mimic how data is expected in API endpoint
+        rule_3_info['severity'] = dict(Rule.SEVERITY).get(Rule.SEVERITY_ERROR)
+        for rule in property_rules:
+            rule['data_type'] = dict(Rule.DATA_TYPES).get(rule['data_type'])
+            rule['label'] = None
+
+        # Make 1 rule trigger the include without text_match failure
+        base_rule_info['text_match'] = ''
+
+        # Make 1 rule trigger the "valid without label" failure
+        rule_2_info['severity'] = dict(Rule.SEVERITY).get(Rule.SEVERITY_VALID)
+
+        url = reverse('api:v2:data_quality_checks-save-data-quality-rules') + '?organization_id=' + str(self.org.pk)
+        post_data = {
+            "data_quality_rules": {
+                "properties": property_rules,
+                "taxlots": [],
+            },
+        }
+        res = self.client.post(url, content_type='application/json', data=json.dumps(post_data))
+
+        self.assertEqual(res.status_code, 400)
+        self.assertTrue('Rule must not include or exclude an empty string.' in json.loads(res.content)['message'])
+        self.assertTrue('Label must be assigned when using Valid Data Severity.' in json.loads(res.content)['message'])

--- a/seed/views/data_quality.py
+++ b/seed/views/data_quality.py
@@ -366,6 +366,17 @@ class DataQualityViews(viewsets.ViewSet):
         posted_rules = body['data_quality_rules']
         updated_rules = []
         for rule in posted_rules['properties']:
+            if _get_severity_from_js(rule['severity']) == Rule.SEVERITY_VALID and rule['label'] is None:
+                return JsonResponse({
+                    'status': 'error',
+                    'message': 'Label must be assigned when using Valid Data Severity.'
+                }, status=status.HTTP_400_BAD_REQUEST)
+            if rule['condition'] == Rule.RULE_INCLUDE or rule['condition'] == Rule.RULE_EXCLUDE:
+                if rule['text_match'] is None or rule['text_match'] == '':
+                    return JsonResponse({
+                        'status': 'error',
+                        'message': 'Rule must not include or exclude an empty string.',
+                    }, status=status.HTTP_400_BAD_REQUEST)
             updated_rules.append(
                 {
                     'field': rule['field'],
@@ -386,6 +397,17 @@ class DataQualityViews(viewsets.ViewSet):
             )
 
         for rule in posted_rules['taxlots']:
+            if _get_severity_from_js(rule['severity']) == Rule.SEVERITY_VALID and rule['label'] is None:
+                return JsonResponse({
+                    'status': 'error',
+                    'message': 'Label must be assigned when using Valid Data Severity.'
+                }, status=status.HTTP_400_BAD_REQUEST)
+            if rule['condition'] == Rule.RULE_INCLUDE or rule['condition'] == Rule.RULE_EXCLUDE:
+                if rule['text_match'] is None or rule['text_match'] == '':
+                    return JsonResponse({
+                        'status': 'error',
+                        'message': 'Rule must not include or exclude an empty string.',
+                    }, status=status.HTTP_400_BAD_REQUEST)
             updated_rules.append(
                 {
                     'field': rule['field'],
@@ -408,17 +430,6 @@ class DataQualityViews(viewsets.ViewSet):
         dq = DataQualityCheck.retrieve(organization.id)
         dq.remove_all_rules()
         for rule in updated_rules:
-            if rule['severity'] == Rule.SEVERITY_VALID and rule['status_label_id'] is None:
-                return JsonResponse({
-                    'status': 'error',
-                    'message': 'Label must be assigned when using Valid Data Severity.',
-                }, status=status.HTTP_400_BAD_REQUEST)
-            if rule['condition'] == Rule.RULE_INCLUDE or rule['condition'] == Rule.RULE_EXCLUDE:
-                if rule['text_match'] is None or rule['text_match'] == '':
-                    return JsonResponse({
-                        'status': 'error',
-                        'message': 'Rule must not include or exclude an empty string.',
-                    }, status=status.HTTP_400_BAD_REQUEST)
             try:
                 dq.add_rule(rule)
             except TypeError as e:


### PR DESCRIPTION
#### Any background context you want to provide?
DQ Rules could inadvertently be deleted. See tagged issue for more details.

#### What's this PR do?
Cherry-pick changes from 2.7.0-patch1.
- Performs validity checks on incoming DQ Rule updates _before_ the teardown and rebuild of DQ Rules (a pattern that is slated to be removed).
- Skips over DQ Rules that could not be recreated instead of stopping the recreation process entirely.

#### How should this be manually tested?
Try to save a "Valid Data" Rule without a label. See that nothing gets saved, and we get the same 400 we got from before. Refresh the page and see that nothing was lost either.

Try to save a Rule as Must Contain or Must Not Contain while keeping the text field blank. See that nothing gets saved, and we get the same 400 we got from before. Refresh the page and see that nothing was lost either.

For code review, commits can be reviewed in the order shown.

#### What are the relevant tickets?
#2202 

#### Screenshots (if appropriate)
