### PR TITLE
#2238 Added data type to taxlots rule "Address line 1"

### DIFF
--- a/seed/models/data_quality.py
+++ b/seed/models/data_quality.py
@@ -161,6 +161,7 @@ class Rule(models.Model):
         }, {
             'table_name': 'TaxLotState',
             'field': 'address_line_1',
+            'data_type': TYPE_STRING,
             'not_null': True,
             'rule_type': RULE_TYPE_DEFAULT,
             'severity': SEVERITY_ERROR,


### PR DESCRIPTION
#### Any background context you want to provide?
#### What's this PR do?
To give rule "Address line 1" a default data type so that a text field is given to this specific rule instead of min/max values.

#### How should this be manually tested?
Go to dq taxlots view. Hit "Reset Rules" or "Restore default rules". Should expect to see rule "Address line 1" prompts with a text field for input.
 
#### What are the relevant tickets?
#2238 

#### Screenshots (if appropriate)
<img width="1288" alt="Screen Shot 2020-05-31 at 3 22 34 PM" src="https://user-images.githubusercontent.com/49968203/83362989-046bad00-a353-11ea-895d-14c301974735.png">

