### PR TITLE
Using selection tool for bsync validation

### DIFF
--- a/seed/building_sync/tests/data/buildingsync_v2_0_bricr_workflow.xml
+++ b/seed/building_sync/tests/data/buildingsync_v2_0_bricr_workflow.xml
@@ -1915,6 +1915,7 @@
                     </auc:Modeled>
                   </auc:CalculationMethod>
                   <auc:AnnualSavingsSiteEnergy>0.0</auc:AnnualSavingsSiteEnergy>
+                  <auc:AnnualSavingsSourceEnergy>0.0</auc:AnnualSavingsSourceEnergy>
                   <auc:AnnualSavingsCost>0</auc:AnnualSavingsCost>
                   <auc:AnnualSavingsByFuels>
                     <auc:AnnualSavingsByFuel>
@@ -1936,6 +1937,7 @@
                   <auc:ResourceUnits>kBtu</auc:ResourceUnits>
                   <auc:AnnualFuelUseNativeUnits>2235075.9859244428</auc:AnnualFuelUseNativeUnits>
                   <auc:AnnualFuelUseConsistentUnits>2235.076</auc:AnnualFuelUseConsistentUnits>
+                  <auc:AnnualPeakConsistentUnits>110.75706</auc:AnnualPeakConsistentUnits>
                 </auc:ResourceUse>
                 <auc:ResourceUse ID="Baseline-Resource2">
                   <auc:EnergyResource>Natural gas</auc:EnergyResource>
@@ -2166,6 +2168,9 @@
                 <auc:AllResourceTotal>
                   <auc:EndUse>All end uses</auc:EndUse>
                   <auc:SiteEnergyUse>3902.655949232491</auc:SiteEnergyUse>
+                  <auc:SiteEnergyUseIntensity>52.8533358512101</auc:SiteEnergyUseIntensity>
+                  <auc:SourceEnergyUse>2051986.1527934822</auc:SourceEnergyUse>
+                  <auc:SourceEnergyUseIntensity>132.24988549512202</auc:SourceEnergyUseIntensity>
                 </auc:AllResourceTotal>
               </auc:AllResourceTotals>
             </auc:Scenario>
@@ -2183,6 +2188,7 @@
                     </auc:Modeled>
                   </auc:CalculationMethod>
                   <auc:AnnualSavingsSiteEnergy>758.5569977291548</auc:AnnualSavingsSiteEnergy>
+                  <auc:AnnualSavingsSourceEnergy>1772.1336698497769</auc:AnnualSavingsSourceEnergy>
                   <auc:AnnualSavingsCost>15183</auc:AnnualSavingsCost>
                   <auc:AnnualSavingsByFuels>
                     <auc:AnnualSavingsByFuel>
@@ -2204,6 +2210,7 @@
                   <auc:ResourceUnits>kBtu</auc:ResourceUnits>
                   <auc:AnnualFuelUseNativeUnits>3206417.9271639367</auc:AnnualFuelUseNativeUnits>
                   <auc:AnnualFuelUseConsistentUnits>2064.179</auc:AnnualFuelUseConsistentUnits>
+                  <auc:AnnualPeakConsistentUnits>110.75706</auc:AnnualPeakConsistentUnits>
                 </auc:ResourceUse>
                 <auc:ResourceUse ID="LED_Only-Resource2">
                   <auc:EnergyResource>Natural gas</auc:EnergyResource>
@@ -2434,6 +2441,9 @@
                 <auc:AllResourceTotal>
                   <auc:EndUse>All end uses</auc:EndUse>
                   <auc:SiteEnergyUse>3144.098951503336</auc:SiteEnergyUse>
+                  <auc:SiteEnergyUseIntensity>52.8533358512101</auc:SiteEnergyUseIntensity>
+                  <auc:SourceEnergyUse>2051986.1527934822</auc:SourceEnergyUse>
+                  <auc:SourceEnergyUseIntensity>132.24988549512202</auc:SourceEnergyUseIntensity>
                 </auc:AllResourceTotal>
               </auc:AllResourceTotals>
               <auc:LinkedPremises>
@@ -2456,6 +2466,7 @@
                     </auc:Modeled>
                   </auc:CalculationMethod>
                   <auc:AnnualSavingsSiteEnergy>284.11765998512055</auc:AnnualSavingsSiteEnergy>
+                  <auc:AnnualSavingsSourceEnergy>1772.1336698497769</auc:AnnualSavingsSourceEnergy>
                   <auc:AnnualSavingsCost>5194</auc:AnnualSavingsCost>
                   <auc:AnnualSavingsByFuels>
                     <auc:AnnualSavingsByFuel>
@@ -2477,6 +2488,7 @@
                   <auc:ResourceUnits>kBtu</auc:ResourceUnits>
                   <auc:AnnualFuelUseNativeUnits>2913836.260294419</auc:AnnualFuelUseNativeUnits>
                   <auc:AnnualFuelUseConsistentUnits>2913.836</auc:AnnualFuelUseConsistentUnits>
+                  <auc:AnnualPeakConsistentUnits>110.75706</auc:AnnualPeakConsistentUnits>
                 </auc:ResourceUse>
                 <auc:ResourceUse ID="Electric_Appliance_30pct_Reduction-Resource2">
                   <auc:EnergyResource>Natural gas</auc:EnergyResource>
@@ -2707,6 +2719,9 @@
                 <auc:AllResourceTotal>
                   <auc:EndUse>All end uses</auc:EndUse>
                   <auc:SiteEnergyUse>3618.5382892473704</auc:SiteEnergyUse>
+                  <auc:SiteEnergyUseIntensity>52.8533358512101</auc:SiteEnergyUseIntensity>
+                  <auc:SourceEnergyUse>2051986.1527934822</auc:SourceEnergyUse>
+                  <auc:SourceEnergyUseIntensity>132.24988549512202</auc:SourceEnergyUseIntensity>
                 </auc:AllResourceTotal>
               </auc:AllResourceTotals>
               <auc:LinkedPremises>

--- a/seed/building_sync/tests/test_validation_client.py
+++ b/seed/building_sync/tests/test_validation_client.py
@@ -1,0 +1,226 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2019, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+import os
+from unittest.mock import patch
+
+from django.test import TestCase
+from requests.models import Response
+import json
+
+from config.settings.common import BASE_DIR
+from seed.building_sync.validation_client import validate_use_case, DEFAULT_USE_CASE
+
+
+def responseFactory(status_code, body_dict):
+    the_response = Response()
+    the_response.status_code = status_code
+    the_response._content = json.dumps(body_dict).encode()
+    return the_response
+
+
+class TestValidationClient(TestCase):
+    def setUp(self):
+        # NOTE: the contents of these files are not actually used, it's just convenient
+        # to use these files so we don't have to create tmp ones and clean them up
+        self.single_file = open(os.path.join(BASE_DIR, 'seed', 'building_sync', 'tests', 'data', 'buildingsync_v2_0_bricr_workflow.xml'))
+        self.zip_file = open(os.path.join(BASE_DIR, 'seed', 'building_sync', 'tests', 'data', 'ex_1_and_buildingsync_ex01_measures.zip'))
+
+    def test_validation_single_file_ok(self):
+        good_body = {
+            'success': True,
+            'validation_results': {
+                'schema': {
+                    'valid': True
+                },
+                'use_cases': {
+                    DEFAULT_USE_CASE: {
+                        'errors': [],
+                        'warnings': [],
+                    }
+                }
+            }
+        }
+
+        with patch('seed.building_sync.validation_client._validation_api_post', return_value=responseFactory(200, good_body)):
+            all_files_valid, file_summaries = validate_use_case(self.single_file)
+
+        self.assertTrue(all_files_valid)
+        self.assertEqual([], file_summaries)
+
+    def test_validation_zip_file_ok(self):
+        good_body = {
+            'success': True,
+            'validation_results': [
+                {
+                    'file': 'file1.xml',
+                    'results': {
+                        'schema': {
+                            'valid': True
+                        },
+                        'use_cases': {
+                            DEFAULT_USE_CASE: {
+                                'errors': [],
+                                'warnings': [],
+                            }
+                        }
+                    }
+                }, {
+                    'file': 'file2.xml',
+                    'results': {
+                        'schema': {
+                            'valid': True
+                        },
+                        'use_cases': {
+                            DEFAULT_USE_CASE: {
+                                'errors': [],
+                                'warnings': [],
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+
+        with patch('seed.building_sync.validation_client._validation_api_post', return_value=responseFactory(200, good_body)):
+            all_files_valid, file_summaries = validate_use_case(self.zip_file)
+
+        self.assertTrue(all_files_valid)
+        self.assertEqual([], file_summaries)
+
+    def test_validation_fails_when_one_file_has_bad_schema(self):
+        bad_file_result = {
+            'file': 'bad.xml',
+            'results': {
+                'schema': {
+                    # Set the schema as NOT valid
+                    'valid': False,
+                    'errors': ['schema was bad']
+                },
+                'use_cases': {
+                    DEFAULT_USE_CASE: {
+                        'errors': [],
+                        'warnings': [],
+                    }
+                }
+            }
+        }
+
+        body = {
+            'success': True,
+            'validation_results': [
+                {
+                    'file': 'file1.xml',
+                    'results': {
+                        'schema': {
+                            'valid': True
+                        },
+                        'use_cases': {
+                            DEFAULT_USE_CASE: {
+                                'errors': [],
+                                'warnings': [],
+                            }
+                        }
+                    }
+                },
+                bad_file_result,
+            ]
+        }
+
+        with patch('seed.building_sync.validation_client._validation_api_post', return_value=responseFactory(200, body)):
+            all_files_valid, file_summaries = validate_use_case(self.zip_file)
+
+        self.assertFalse(all_files_valid)
+        bad_file_names = [f['file'] for f in file_summaries]
+        self.assertEqual([bad_file_result['file']], bad_file_names)
+
+    def test_validation_fails_when_one_file_fails_use_case(self):
+        bad_file_result = {
+            'file': 'bad.xml',
+            'results': {
+                'schema': {
+                    'valid': True,
+                },
+                'use_cases': {
+                    DEFAULT_USE_CASE: {
+                        # Include a use case error
+                        'errors': ['something was wrong'],
+                        'warnings': [],
+                    }
+                }
+            }
+        }
+
+        body = {
+            'success': True,
+            'validation_results': [
+                {
+                    'file': 'file1.xml',
+                    'results': {
+                        'schema': {
+                            'valid': True
+                        },
+                        'use_cases': {
+                            DEFAULT_USE_CASE: {
+                                'errors': [],
+                                'warnings': [],
+                            }
+                        }
+                    }
+                },
+                bad_file_result,
+            ]
+        }
+
+        with patch('seed.building_sync.validation_client._validation_api_post', return_value=responseFactory(200, body)):
+            all_files_valid, file_summaries = validate_use_case(self.zip_file)
+
+        self.assertFalse(all_files_valid)
+        bad_file_names = [f['file'] for f in file_summaries]
+        self.assertEqual([bad_file_result['file']], bad_file_names)
+
+    def test_validation_zip_file_ok_when_warnings(self):
+        good_body = {
+            'success': True,
+            'validation_results': [
+                {
+                    'file': 'file1.xml',
+                    'results': {
+                        'schema': {
+                            'valid': True
+                        },
+                        'use_cases': {
+                            DEFAULT_USE_CASE: {
+                                'errors': [],
+                                # Include a warning
+                                'warnings': ['This is a warning!'],
+                            }
+                        }
+                    }
+                }, {
+                    'file': 'file2.xml',
+                    'results': {
+                        'schema': {
+                            'valid': True
+                        },
+                        'use_cases': {
+                            DEFAULT_USE_CASE: {
+                                'errors': [],
+                                # Include a warning
+                                'warnings': ['This is another warning!'],
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+
+        with patch('seed.building_sync.validation_client._validation_api_post', return_value=responseFactory(200, good_body)):
+            all_files_valid, file_summaries = validate_use_case(self.zip_file)
+
+        self.assertTrue(all_files_valid)
+        file_names = [f['file'] for f in file_summaries]
+        self.assertEqual(['file1.xml', 'file2.xml'], file_names)

--- a/seed/building_sync/validation_client.py
+++ b/seed/building_sync/validation_client.py
@@ -5,7 +5,7 @@ import requests
 
 VALIDATION_API_URL = "https://selectiontool.buildingsync.net/api/validate"
 DEFAULT_SCHEMA_VERSION = '2.0.0'
-DEFAULT_USE_CASE = 'BRICR_SEED'
+DEFAULT_USE_CASE = 'SEED'
 
 
 class ValidationClientException(Exception):

--- a/seed/building_sync/validation_client.py
+++ b/seed/building_sync/validation_client.py
@@ -5,7 +5,7 @@ import requests
 
 VALIDATION_API_URL = "https://selectiontool.buildingsync.net/api/validate"
 DEFAULT_SCHEMA_VERSION = '2.0.0'
-DEFAULT_USE_CASE = 'L000 OpenStudio Simulation'
+DEFAULT_USE_CASE = 'BRICR_SEED'
 
 
 class ValidationClientException(Exception):
@@ -27,10 +27,11 @@ def _validation_api_post(file_, schema_version, use_case_name):
     )
 
 
-def validate_use_case(file_, schema_version=DEFAULT_SCHEMA_VERSION, use_case_name=DEFAULT_USE_CASE):
+def validate_use_case(file_, filename=None, schema_version=DEFAULT_SCHEMA_VERSION, use_case_name=DEFAULT_USE_CASE):
     """calls Selection Tool's validation API
 
     :param file_: File, the file to validate; can be single xml or zip
+    :param filename: string, (optional) name of the file, useful if file_.name is not user friendly (e.g. a Django SimpleUploadedFile). Not used if file_ is a zip
     :param schema_version: string
     :param use_case_name: string
     :return: tuple, (bool, list), bool indicates if the file passes validation,
@@ -41,7 +42,7 @@ def validate_use_case(file_, schema_version=DEFAULT_SCHEMA_VERSION, use_case_nam
         response = _validation_api_post(file_, schema_version, use_case_name)
     except requests.exceptions.Timeout:
         raise ValidationClientException(
-            f"Request to Selection Tool timed out. SEED may need to increase the timeout",
+            "Request to Selection Tool timed out. SEED may need to increase the timeout",
         )
     except Exception as e:
         raise ValidationClientException(
@@ -85,8 +86,10 @@ def validate_use_case(file_, schema_version=DEFAULT_SCHEMA_VERSION, use_case_nam
                 f"Expected response validation_results to be dict for single xml file: {response.text}",
             )
         # turn the single file result into the same structure as zip file result
+        if filename is None:
+            filename = os.path.basename(file_.name)
         validation_results = [{
-            'file': os.path.basename(file_.name),
+            'file': filename,
             'results': validation_results,
         }]
 

--- a/seed/building_sync/validation_client.py
+++ b/seed/building_sync/validation_client.py
@@ -1,0 +1,131 @@
+import os
+
+import requests
+
+
+VALIDATION_API_URL = "https://selectiontool.buildingsync.net/api/validate"
+DEFAULT_SCHEMA_VERSION = '2.0.0'
+DEFAULT_USE_CASE = 'L000 OpenStudio Simulation'
+
+
+class ValidationClientException(Exception):
+    pass
+
+
+def _validation_api_post(file_, schema_version, use_case_name):
+    payload = {'schema_version': schema_version}
+    files = [
+        ('file', file_)
+    ]
+
+    return requests.request(
+        "POST",
+        VALIDATION_API_URL,
+        data=payload,
+        files=files,
+        timeout=60 * 2,  # timeout after two minutes (it can take a long time for zips)
+    )
+
+
+def validate_use_case(file_, schema_version=DEFAULT_SCHEMA_VERSION, use_case_name=DEFAULT_USE_CASE):
+    """calls Selection Tool's validation API
+
+    :param file_: File, the file to validate; can be single xml or zip
+    :param schema_version: string
+    :param use_case_name: string
+    :return: tuple, (bool, list), bool indicates if the file passes validation,
+             the list is a collection of files and their errors, warnings, and infos
+    """
+
+    try:
+        response = _validation_api_post(file_, schema_version, use_case_name)
+    except requests.exceptions.Timeout:
+        raise ValidationClientException(
+            f"Request to Selection Tool timed out. SEED may need to increase the timeout",
+        )
+    except Exception as e:
+        raise ValidationClientException(
+            f"Failed to make request to selection tool: {e}",
+        )
+
+    if response.status_code != 200:
+        raise ValidationClientException(
+            f"Received bad response from Selection Tool: {response.text}",
+        )
+
+    try:
+        response_body = response.json()
+    except ValueError:
+        raise ValidationClientException(
+            f"Expected JSON response from Selection Tool: {response.text}",
+        )
+
+    if response_body.get('success', False) is not True:
+        ValidationClientException(
+            f"Selection Tool request was not successful: {response.text}",
+        )
+
+    response_schema_version = response_body.get('schema_version')
+    if response_schema_version != schema_version:
+        ValidationClientException(
+            f"Expected schema_version to be '{schema_version}' but it was '{response_schema_version}'",
+        )
+
+    _, file_extension = os.path.splitext(file_.name)
+    validation_results = response_body.get('validation_results')
+    # check the returned type and make validation_results a list if it's not already
+    if file_extension == '.zip':
+        if type(validation_results) is not list:
+            raise ValidationClientException(
+                f"Expected response validation_results to be list for zip file: {response.text}",
+            )
+    else:
+        if type(validation_results) is not dict:
+            raise ValidationClientException(
+                f"Expected response validation_results to be dict for single xml file: {response.text}",
+            )
+        # turn the single file result into the same structure as zip file result
+        validation_results = [{
+            'file': os.path.basename(file_.name),
+            'results': validation_results,
+        }]
+
+    # check that the schema and use case is valid for every file
+    file_summaries = []
+    all_files_valid = True
+    for validation_result in validation_results:
+        results = validation_result['results']
+        filename = validation_result['file']
+
+        # it's possible there's no use_cases key - occurs when schema validation fails
+        if results['schema']['valid'] is False:
+            use_case_result = {}
+        else:
+            if use_case_name not in results.get('use_cases', []):
+                raise ValidationClientException(
+                    f'Expected use case "{use_case_name}" to exist in result\'s uses cases.',
+                )
+            use_case_result = results['use_cases'][use_case_name]
+
+        file_summary = {
+            'file': filename,
+            'schema_errors': results['schema'].get('errors', []),
+            'use_case_errors': use_case_result.get('errors', []),
+            'use_case_warnings': use_case_result.get('warnings', []),
+        }
+
+        file_has_errors = (
+            len(file_summary['schema_errors']) > 0
+            or len(file_summary['use_case_errors']) > 0
+        )
+        if file_has_errors:
+            all_files_valid = False
+
+        file_has_errors_or_warnings = (
+            file_has_errors
+            or len(file_summary['use_case_warnings']) > 0
+        )
+        if file_has_errors_or_warnings:
+            file_summaries.append(file_summary)
+
+    return all_files_valid, file_summaries

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -33,6 +33,7 @@ from django.utils.timezone import make_naive
 from past.builtins import basestring
 from unidecode import unidecode
 
+from seed.building_sync import validation_client
 from seed.data_importer.equivalence_partitioner import EquivalencePartitioner
 from seed.data_importer.match import (
     match_and_link_incoming_properties_and_taxlots,
@@ -1527,3 +1528,44 @@ def pair_new_states(merged_property_views, merged_taxlot_views):
         m2m_join.save()
 
     return
+
+
+@shared_task
+def _validate_use_cases(file_pk, progress_key):
+    import_file = ImportFile.objects.get(pk=file_pk)
+    progress_data = ProgressData.from_key(progress_key)
+
+    try:
+        all_files_valid, file_summaries = validation_client.validate_use_case(import_file.file)
+        if all_files_valid is False:
+            import_file.delete()
+        progress_data.finish_with_success(
+            message=json.dumps({
+                'valid': all_files_valid,
+                'issues': file_summaries,
+            }),
+        )
+    except validation_client.ValidationClientException as e:
+        _log.debug(f'ValidationClientException while validating import_file `{file_pk}`: {e}')
+        progress_data.finish_with_error(message=str(e))
+        progress_data.save()
+        import_file.delete()
+    except Exception as e:
+        _log.debug(f'Unexpected Exception while validating import_file `{file_pk}`: {e}')
+        progress_data.finish_with_error(message=str(e))
+        progress_data.save()
+        import_file.delete()
+
+
+def validate_use_cases(file_pk):
+    """
+    Kicks off task for validating BuildingSync files for use cases
+
+    :param file_pk: ImportFile Primary Key
+    :return:
+    """
+    progress_data = ProgressData(func_name='validate_use_cases', unique_id=file_pk)
+
+    _validate_use_cases.s(file_pk, progress_data.key).apply_async()
+    _log.debug(progress_data.result())
+    return progress_data.result()

--- a/seed/data_importer/views.py
+++ b/seed/data_importer/views.py
@@ -34,6 +34,7 @@ from seed.data_importer.tasks import (
     map_additional_models as task_map_additional_models,
     match_buildings as task_match_buildings,
     save_raw_data as task_save_raw,
+    validate_use_cases as task_validate_use_cases,
 )
 from seed.decorators import ajax_request, ajax_request_class
 from seed.decorators import get_prog_key
@@ -905,6 +906,44 @@ class ImportFileViewSet(viewsets.ViewSet):
     @ajax_request_class
     @has_perm_class('can_modify_data')
     @action(detail=True, methods=['POST'])
+    @detail_route(methods=['POST'])
+    def validate_use_cases(self, request, pk=None):
+        """
+        Starts a background task to call BuildingSync's use case validation
+        tool.
+        ---
+        type:
+            status:
+                required: true
+                type: string
+                description: either success or error
+            message:
+                required: false
+                type: string
+                description: error message, if any
+            progress_key:
+                type: integer
+                description: ID of background job, for retrieving job progress
+        parameter_strategy: replace
+        parameters:
+            - name: pk
+              description: Import file ID
+              required: true
+              paramType: path
+        """
+        import_file_id = pk
+        if not import_file_id:
+            return JsonResponse({
+                'status': 'error',
+                'message': 'must include pk of import_file to validate'
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        return task_validate_use_cases(import_file_id)
+
+    @api_endpoint_class
+    @ajax_request_class
+    @has_perm_class('can_modify_data')
+    @detail_route(methods=['POST'])
     def save_raw_data(self, request, pk=None):
         """
         Starts a background task to import raw data from an ImportFile

--- a/seed/data_importer/views.py
+++ b/seed/data_importer/views.py
@@ -906,7 +906,6 @@ class ImportFileViewSet(viewsets.ViewSet):
     @ajax_request_class
     @has_perm_class('can_modify_data')
     @action(detail=True, methods=['POST'])
-    @detail_route(methods=['POST'])
     def validate_use_cases(self, request, pk=None):
         """
         Starts a background task to call BuildingSync's use case validation
@@ -943,7 +942,7 @@ class ImportFileViewSet(viewsets.ViewSet):
     @api_endpoint_class
     @ajax_request_class
     @has_perm_class('can_modify_data')
-    @detail_route(methods=['POST'])
+    @action(detail=True, methods=['POST'])
     def save_raw_data(self, request, pk=None):
         """
         Starts a background task to import raw data from an ImportFile

--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -21,7 +21,6 @@
  * ng-switch-when="11" == Confirm Save Mappings?
  * ng-switch-when="12" == Error Processing Data
  * ng-switch-when="13" == Portfolio Manager Import
- * ng-switch-when="14" == Successful upload! [BuildingSync]
  */
 angular.module('BE.seed.controller.data_upload_modal', [])
   .controller('data_upload_modal_controller', [
@@ -318,34 +317,20 @@ angular.module('BE.seed.controller.data_upload_modal', [])
           case 'upload_error':
             $scope.step_12_error_message = file.error;
             $scope.step.number = 12;
-            // add variables to identify buildingsync bulk uploads
-            $scope.building_sync_files = (file.source_type === 'BuildingSync');
-            $scope.bulk_upload = (_.last(file.filename.split('.')) === 'zip');
             break;
 
           case 'upload_in_progress':
             $scope.uploader.in_progress = true;
-            if (file.source_type === 'BuildingSync') {
-              $scope.uploader.progress = 100 * progress.loaded / progress.total;
-            } else {
-              $scope.uploader.progress = 25 * progress.loaded / progress.total;
-            }
+            $scope.uploader.progress = 25 * progress.loaded / progress.total;
             break;
 
           case 'upload_complete':
             var current_step = $scope.step.number;
             $scope.uploader.status_message = 'upload complete';
             $scope.dataset.filename = file.filename;
-            $scope.step_14_message = null;
             $scope.source_type = file.source_type;
 
-            if (file.source_type === 'BuildingSync') {
-              $scope.uploader.complete = true;
-              $scope.uploader.in_progress = false;
-              $scope.uploader.progress = 100;
-              $scope.step.number = 14;
-              $scope.step_14_message = (_.size(file.message.warnings) > 0) ? file.message.warnings : null;
-            } else if (file.source_type === 'PM Meter Usage') {
+            if (file.source_type === 'PM Meter Usage') {
               $scope.cycle_id = file.cycle_id;
               $scope.file_id = file.file_id;
 
@@ -361,7 +346,12 @@ angular.module('BE.seed.controller.data_upload_modal', [])
 
               // Assessed Data; upload is step 2; PM import is currently treated as such, and is step 13
               if (current_step === 2 || current_step === 13) {
-                save_raw_assessed_data(file.file_id, file.cycle_id, false);
+                // if importing BuildingSync, validate then save, otherwise just save
+                if (file.source_type === "BuildingSync Raw") {
+                  validate_use_cases_then_save(file.file_id, file.cycle_id)
+                } else {
+                  save_raw_assessed_data(file.file_id, file.cycle_id, false)
+                }
               }
               // Portfolio Data
               if (current_step === 4) {
@@ -494,6 +484,58 @@ angular.module('BE.seed.controller.data_upload_modal', [])
           enableVerticalScrollbar: results.length <= 5 ? uiGridConstants.scrollbars.NEVER : uiGridConstants.scrollbars.WHEN_NEEDED,
           minRowsToShow: grid_rows_to_display(results)
         };
+      };
+
+      /**
+       * validate_use_cases_then_save: validates BuildingSync files for use cases
+       * before saving the data
+       *
+       * @param {string} file_id: the id of the import file
+       * @param cycle_id
+       */
+      var validate_use_cases_then_save = function (file_id, cycle_id) {
+        $scope.uploader.status_message = 'validating data';
+        $scope.uploader.progress = 0;
+
+        const successHandler = (progress_data) => {
+          $scope.uploader.complete = false
+          $scope.uploader.in_progress = true
+          $scope.uploader.status_message = 'validation complete; starting to save data';
+          $scope.uploader.progress = 100;
+
+          const result = JSON.parse(progress_data.message)
+          $scope.buildingsync_valid = result.valid
+          $scope.buildingsync_issues = result.issues
+          
+          // if validation failed, end the import flow here; otherwise continue
+          if ($scope.buildingsync_valid !== true) {
+            $scope.step_12_error_message = 'Failed to validate uploaded BuildingSync file(s)'
+            $scope.step_12_buildingsync_validation_error = true
+            $scope.step.number = 12
+          } else {
+            // successfully passed validation, save the data
+            save_raw_assessed_data(file_id, cycle_id, false)
+          }
+        }
+
+        const errorHandler = (data) => {
+          $log.error(data.message);
+          if (data.hasOwnProperty('stacktrace')) $log.error(data.stacktrace);
+          $scope.step_12_error_message = data.data ? data.data.message : data.message;
+          $scope.step.number = 12;
+        }
+
+        uploader_service.validate_use_cases(file_id)
+          .then(data => {
+            const progress = _.clamp(data.progress, 0, 100);
+            uploader_service.check_progress_loop(
+              data.progress_key,
+              progress, 1 - (progress / 100),
+              successHandler,
+              errorHandler,
+              $scope.uploader,
+            )
+          })
       };
 
       /**

--- a/seed/static/seed/js/services/uploader_service.js
+++ b/seed/static/seed/js/services/uploader_service.js
@@ -40,6 +40,26 @@ angular.module('BE.seed.service.uploader', []).factory('uploader_service', [
     };
 
     /**
+     * validate_use_cases
+     * This service call will simply call a view on the backend to validate
+     * BuildingSync files with use cases
+     * @param file_id: the pk of a ImportFile object we're going to save raw.
+     */
+    uploader_factory.validate_use_cases = function (file_id) {
+      return $http.post('/api/v2/import_files/' + file_id + '/validate_use_cases/')
+        .then(response => {
+          return response.data
+        })
+        .catch(err => {
+          if (err.data.status === 'error') {
+            return err.data
+          }
+          // something unexpected happened... throw it
+          throw err
+        })
+    };
+
+    /**
      * save_raw_data
      * This service call will simply call a view on the backend to save raw
      * data into BuildingSnapshot instances.

--- a/seed/static/seed/partials/data_upload_modal.html
+++ b/seed/static/seed/partials/data_upload_modal.html
@@ -99,6 +99,18 @@
             translate="DATASET_FILENAME_UPLOADED_TO"
             translate-values="{ dataset_name: dataset.name , dataset_filename: dataset.filename }"></div>
         </div>
+        <div class="row" ng-if="buildingsync_issues != null && buildingsync_issues.length > 0">
+            <div>
+                <p>There were one or more warnings for the file(s) uploaded.</p>
+                <div ng-repeat="file_issues in buildingsync_issues">
+                    <em>{$ file_issues.file $}</em>
+                    <div class="alert alert-warning" ng-if="file_issues.use_case_warnings.length > 0">
+                        <h5>Use Case Warnings</h5>
+                        <div ng-repeat="warn in file_issues.use_case_warnings">{$ warn $}</div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
     <!-- Step 4: load Portfolio Manager report data -->
     <div class="data_upload_steps" ng-switch-when="4">

--- a/seed/static/seed/partials/data_upload_modal.html
+++ b/seed/static/seed/partials/data_upload_modal.html
@@ -100,11 +100,11 @@
             translate-values="{ dataset_name: dataset.name , dataset_filename: dataset.filename }"></div>
         </div>
         <div class="row" ng-if="buildingsync_issues != null && buildingsync_issues.length > 0">
-            <div>
+            <div class="col-sm-12">
                 <p>There were one or more warnings for the file(s) uploaded.</p>
                 <div ng-repeat="file_issues in buildingsync_issues">
                     <em>{$ file_issues.file $}</em>
-                    <div class="alert alert-warning" ng-if="file_issues.use_case_warnings.length > 0">
+                    <div class="alert alert-warning" ng-if="file_issues.use_case_warnings.length > 0" style="word-wrap: break-word;">
                         <h5>Use Case Warnings</h5>
                         <div ng-repeat="warn in file_issues.use_case_warnings">{$ warn $}</div>
                     </div>
@@ -267,15 +267,15 @@
                         <p>BuildingSync file(s) failed to validate. No files were imported. Please fix the errors and re-upload the corrected file(s).</p> 
                         <div ng-repeat="file_issues in buildingsync_issues">
                             <em>{$ file_issues.file $}</em>
-                            <div class="alert alert-danger" ng-if="file_issues.schema_errors.length > 0">
+                            <div class="alert alert-danger" ng-if="file_issues.schema_errors.length > 0" style="word-wrap: break-word;">
                                 <h5>Schema Errors</h5>
                                 <div ng-repeat="err in file_issues.schema_errors">{$ err.path $}: {$ err.message $}</div>
                             </div>
-                            <div class="alert alert-danger" ng-if="file_issues.use_case_errors.length > 0">
+                            <div class="alert alert-danger" ng-if="file_issues.use_case_errors.length > 0" style="word-wrap: break-word;">
                                 <h5>Use Case Errors</h5>
                                 <div ng-repeat="err in file_issues.use_case_errors">{$ err $}</div>
                             </div>
-                            <div class="alert alert-warning" ng-if="file_issues.use_case_warnings.length > 0">
+                            <div class="alert alert-warning" ng-if="file_issues.use_case_warnings.length > 0" style="word-wrap: break-word;">
                                 <h5>Use Case Warnings</h5>
                                 <div ng-repeat="warn in file_issues.use_case_warnings">{$ warn $}</div>
                             </div>

--- a/seed/static/seed/partials/data_upload_modal.html
+++ b/seed/static/seed/partials/data_upload_modal.html
@@ -12,7 +12,6 @@
     <h4 class="modal-title" ng-switch-when="11" translate>Confirm Save Mappings?</h4>
     <h4 class="modal-title" ng-switch-when="12" translate>Error Processing Data</h4>
     <h4 class="modal-title" ng-switch-when="13" translate>Portfolio Manager Import</h4>
-    <h4 class="modal-title" ng-switch-when="14" translate>Successful upload!</h4>
     <h4 class="modal-title" ng-switch-when="15" translate>UPLOAD_PM_READINGS_MODAL_TITLE</h4>
     <h4 class="modal-title" ng-switch-when="16" translate>PM_METER_IMPORT_RESULTS</h4>
 
@@ -250,10 +249,26 @@
             <div class="col-sm-12">
                 <div>
 
-                    <p ng-if="!building_sync_files" translate>An error occurred while processing the file. Please ensure that your file meets the required specifications.</p>
-                    <p ng-if="building_sync_files && bulk_upload" translate>Error(s) occurred while processing the BuildingSync data bulk upload, potentially resulting in a partial import.  Fix the errors and re-upload the corrected files.</p>
-                    <p ng-if="building_sync_files && !bulk_upload" translate>An error occurred while processing the BuildingSync xml file. Please ensure that your file meets the required specifications.</p>
-                    <pre class="text-wrap" ng-class="{'pre-scrollable': step_12_error_message.length >= 300}" ng-show="step_12_error_message">{$ step_12_error_message | json $}</pre>
+                    <p ng-if="!step_12_buildingsync_validation_error" translate>An error occurred while processing the file. Please ensure that your file meets the required specifications.</p>
+                    <pre class="text-wrap" ng-class="{'pre-scrollable': step_12_error_message.length >= 300}" ng-show="step_12_error_message && !step_12_buildingsync_validation_error">{$ step_12_error_message | json $}</pre>
+                    <span ng-if="step_12_buildingsync_validation_error">
+                        <p>BuildingSync file(s) failed to validate. No files were imported. Please fix the errors and re-upload the corrected file(s).</p> 
+                        <div ng-repeat="file_issues in buildingsync_issues">
+                            <em>{$ file_issues.file $}</em>
+                            <div class="alert alert-danger" ng-if="file_issues.schema_errors.length > 0">
+                                <h5>Schema Errors</h5>
+                                <div ng-repeat="err in file_issues.schema_errors">{$ err.path $}: {$ err.message $}</div>
+                            </div>
+                            <div class="alert alert-danger" ng-if="file_issues.use_case_errors.length > 0">
+                                <h5>Use Case Errors</h5>
+                                <div ng-repeat="err in file_issues.use_case_errors">{$ err $}</div>
+                            </div>
+                            <div class="alert alert-warning" ng-if="file_issues.use_case_warnings.length > 0">
+                                <h5>Use Case Warnings</h5>
+                                <div ng-repeat="warn in file_issues.use_case_warnings">{$ warn $}</div>
+                            </div>
+                        </div>
+                    </span>
                 </div>
             </div>
         </div>
@@ -290,21 +305,6 @@
             <div class="col-lg-8 col-sm-8">
                 <div class="btn btn-primary" style="display: block; font-weight: bold;" ng-disabled="!pm_buttons_enabled || !pm_template" ng-click="get_pm_report(pm_username, pm_password, pm_template);">Submit</div>
             </div>
-        </div>
-    </div>
-    <!-- Step 14: Successful BuildingSync upload -->
-    <div class="data_upload_steps" ng-switch-when="14">
-        <div class="row">
-            <div class="alert alert-success"
-            translate="DATASET_FILENAME_UPLOADED_TO"
-            translate-values="{ dataset_name: dataset.name, dataset_filename: dataset.filename }"></div>
-             <div class="col-sm-12">
-                <div ng-if="step_14_message.length > 0">
-                    <p translate>Warnings:</p>
-                    <pre class="text-wrap" ng-class="{'pre-scrollable': step_14_message.length >= 300}" ng-show="step_14_message">{$ step_14_message | json $}</pre>
-                </div>
-            </div>
-
         </div>
     </div>
     <!-- Step 15:  Upload PM Meter Readings -->
@@ -400,14 +400,6 @@
     <div ng-switch-when="11">
         <div class="row text-center">
             <button type="button" id="confirm-mapping" class="btn btn-primary col-sm-6 center-block" ng-click="save_mappings()" translate>CONFIRM_AND_START_MATCHING</button>
-        </div>
-    </div>
-    <div ng-switch-when="14">
-        <div class="row text-center">
-            <button type="button" class="btn btn-primary col-sm-6 center-block" ng-click="goto_step(2)" translate>Add another file</button>
-        </div>
-        <div class="row text-center">
-            <button type="button" class="btn btn-primary col-sm-6 center-block" ng-click="view_my_properties()" translate>View my properties</button>
         </div>
     </div>
     <div ng-switch-when="15">


### PR DESCRIPTION
### Any background context?
This is the sister-pr to https://github.com/SEED-platform/seed/pull/2234

#### What's this PR do?
Adds an extra step to validate schema and use case when importing BuildingSync files
Also removes some vestigial front-end code for the old buildingsync import flow.

#### How should this be manually tested?
These tests should probably be run with and without celery workers, ie in local config include/exclude these lines
```bash
CELERY_TASK_ALWAYS_EAGER = True
CELERY_TASK_EAGER_PROPAGATES = True
```
When testing celery workers, it might be worth setting the log level to debug so messages can be seen: `celery ... -l debug`. Note that you WON'T see any messages when not running workers

Files for testing:
[use_case_data2.zip](https://github.com/SEED-platform/seed/files/4718996/use_case_data2.zip)

##### single valid file
- navigate to the data upload modal, click upload buildingsync
- select the file `buildingsync_v2_0_bricr_workflow_GOOD.xml`
- if looking at the network tab of debug tools, it hits `/validate_use_cases`
- eventually it should succeed and you should be allowed to go to the mapping page and continue like normal

##### single valid file with warnings
- navigate to the data upload modal, click upload buildingsync
- select this file: `buildingsync_v2_0_bricr_workflow_WARNINGS.xml`
- eventually it should SUCCEED and you should be allowed to go to the mapping page and continue like normal. You should ALSO see the warnings listed for the file

##### single file bad use case
- first, note the number of imported files for the data set you're going to upload to
- navigate to the data upload modal, click upload buildingsync
- select the file `ex_1_missing_required.xml`
- eventually it should say it failed to pass validation, and list use case errors and use case warnings, but no schema errors
- you should only be allowed to dismiss the dialog (not continue to mapping) and if you refresh the data page you should NOT see the number of files increase.

##### sing file bad schema
- first, note the number of imported files for the data set you're going to upload to
- navigate to the data upload modal, click upload buildingsync
- select the file `ex_1_bad_schema.xml`
- eventually it should say it failed to pass validation, and only show schema errors
- you should only be allowed to dismiss the dialog (not continue to mapping) and if you refresh the data page you should NOT see the number of files increase.

##### sing file that can't be parsed
- first, note the number of imported files for the data set you're going to upload to
- navigate to the data upload modal, click upload buildingsync
- select the file `ex_1_malformed.xml`
- eventually it should say it error out saying the request was unsuccessful (the file isn't parsable)
- you should only be allowed to dismiss the dialog (not continue to mapping) and if you refresh the data page you should NOT see the number of files increase.

##### zip file all good
- navigate to the data upload modal, click upload buildingsync
- select the file `many_all_good.zip`
- eventually it should succeed and you should be allowed to go to the mapping page and continue like normal

##### zip file one bad
- first, note the number of imported files for the data set you're going to upload to
- navigate to the data upload modal, click upload buildingsync
- select the file `many_one_bad.zip`
- eventually it should say it failed to pass validation, and only show use case warnings and errors for the bad file
- you should only be allowed to dismiss the dialog (not continue to mapping) and if you refresh the data page you should NOT see the number of files increase.

##### random api issues
These are some things to test if the validation api is down or we get an unexpected response.
1. test timeout by editing the timeout in `building_sync/validation_client.py` where the request is being made. Changing it to something like `1` should be sufficient (make sure you restart celery!). When uploading a buildingsync file it should fail saying it timed out
1. again in `validation_client.py` test a bad request by tweaking the API url, the default schema version or use case name (again remember to restart celery). These should all result in some sort of failure, and should be reported when trying to upload a buildingsync file

#### Screenshots (if appropriate)
Example failure
<img width="614" alt="Screen Shot 2020-05-29 at 4 50 41 PM" src="https://user-images.githubusercontent.com/18518728/83305821-71563a00-a1cf-11ea-858e-be37f1380b49.png">

Example success
<img width="612" alt="Screen Shot 2020-05-29 at 5 11 12 PM" src="https://user-images.githubusercontent.com/18518728/83305848-7a470b80-a1cf-11ea-83b4-d1773bf3b062.png">
