### PR TITLE
2.7.1 patch1 - for review only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# SEED Version 2.7.1-patch1
+
+- Fixed [#2202]( https://github.com/SEED-platform/seed/issues/2202 ), Organization's DQ Rules can be inadvertently deleted
+
 # SEED Version 2.7.1
 
 Date Range: 12/21/19 - 03/27/20
@@ -53,17 +57,19 @@ Date Range: 12/21/19 - 03/27/20
 - Fixed [#2134]( https://github.com/SEED-platform/seed/issues/2134 ), Add new column setting to allow blank/'Not Available' values to overwrite other values
 - Fixed [#2139]( https://github.com/SEED-platform/seed/issues/2139 ), Missing reverse match for password reset
 
+# SEED Version 2.7.0-patch1
 
+- Fixed [#2202]( https://github.com/SEED-platform/seed/issues/2202 ), Organization's DQ Rules can be inadvertently deleted
 
-# SEED Version 2.7.0-Beta
+# SEED Version 2.7.0
 
-SEED Version 2.7.0-Beta includes several significant updates that need to be thoroughly tested on production data
+SEED Version 2.7.0 includes several significant updates that need to be thoroughly tested on production data
 before being deployed. The most notable changes:
 
 - User can define which fields to match/merge/pair/link
-- Properties and Tax Lots are not linked across multiple years or compliance cycles
+- Properties and Tax Lots are now linked across multiple years or compliance cycles
 - Users can define mapping profiles to save/recall mappings easier
-- 55 closed issues/new features
+- 57 closed issues/new features
 
 Date Range: 09/30/19 - 12/20/19
 

--- a/seed/management/commands/create_geojson_test_data.py
+++ b/seed/management/commands/create_geojson_test_data.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         :return:
         """
         if geom['type'] == "Polygon":
-            coords = [f"{l[0]} {l[1]}" for l in geom['coordinates'][0]]
+            coords = [f"{coord[0]} {coord[1]}" for coord in geom['coordinates'][0]]
             return f"POLYGON (( {', '.join(coords)} ))"
         else:
             raise Exception(f"Unknown type of Geomoetry in GeoJSON of {geom['type']}")

--- a/seed/models/column_list_settings_columns.py
+++ b/seed/models/column_list_settings_columns.py
@@ -22,4 +22,4 @@ class ColumnListSettingColumn(models.Model):
     pinned = models.BooleanField(default=False)
 
     def __str__(self):
-        return self.column_list_setting.name + " %s %s".format(self.order, self.pinned)
+        return f"{self.column_list_setting.name} {self.order} {self.pinned}"

--- a/seed/tests/test_data_quality_rules.py
+++ b/seed/tests/test_data_quality_rules.py
@@ -1,0 +1,91 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2020, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+import json
+
+from copy import deepcopy
+
+from django.core.urlresolvers import reverse
+
+from seed.models.data_quality import (
+    DataQualityCheck,
+    Rule,
+)
+from seed.models.models import ASSESSED_RAW
+
+from seed.tests.util import DataMappingBaseTestCase
+
+
+class RuleViewTests(DataMappingBaseTestCase):
+    def setUp(self):
+        selfvars = self.set_up(ASSESSED_RAW)
+
+        self.user, self.org, self.import_file, self.import_record, self.cycle = selfvars
+
+        self.client.login(
+            username='test_user@demo.com',
+            password='test_pass',
+            email='test_user@demo.com'
+        )
+
+    def test_valid_data_rule_without_label_does_not_actually_update_or_delete_any_rules(self):
+        # Start with 3 Rules
+        dq = DataQualityCheck.retrieve(self.org.id)
+        dq.remove_all_rules()
+        base_rule_info = {
+            'field': 'address_line_1',
+            'table_name': 'PropertyState',
+            'enabled': True,
+            'data_type': Rule.TYPE_STRING,
+            'rule_type': Rule.RULE_TYPE_DEFAULT,
+            'required': False,
+            'not_null': False,
+            'min': None,
+            'max': None,
+            'text_match': 'Test Rule 1',
+            'severity': Rule.SEVERITY_ERROR,
+            'units': "",
+            'status_label_id': None
+        }
+        dq.add_rule(base_rule_info)
+
+        rule_2_info = deepcopy(base_rule_info)
+        rule_2_info['text_match'] = 'Test Rule 2'
+        dq.add_rule(rule_2_info)
+
+        rule_3_info = deepcopy(base_rule_info)
+        rule_3_info['text_match'] = 'Test Rule 3'
+        dq.add_rule(rule_3_info)
+
+        self.assertEqual(dq.rules.count(), 3)
+
+        property_rules = [base_rule_info, rule_2_info, rule_3_info]
+
+        # Make some adjustments to mimic how data is expected in API endpoint
+        rule_3_info['severity'] = dict(Rule.SEVERITY).get(Rule.SEVERITY_ERROR)
+        for rule in property_rules:
+            rule['data_type'] = dict(Rule.DATA_TYPES).get(rule['data_type'])
+            rule['label'] = None
+
+        # Make 2 rules trigger the "valid without label" failure
+        base_rule_info['severity'] = dict(Rule.SEVERITY).get(Rule.SEVERITY_VALID)
+        rule_2_info['severity'] = dict(Rule.SEVERITY).get(Rule.SEVERITY_VALID)
+
+        url = reverse('api:v2:data_quality_checks-save-data-quality-rules') + '?organization_id=' + str(self.org.pk)
+        post_data = {
+            "data_quality_rules": {
+                "properties": property_rules,
+                "taxlots": [],
+            },
+        }
+        res = self.client.post(url, content_type='application/json', data=json.dumps(post_data))
+
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(json.loads(res.content)['message'], 'Label must be assigned when using Valid Data Severity.')
+
+        # Count 3 total rules. None of them were updated
+        self.assertEqual(dq.rules.count(), 3)
+        self.assertEqual(dq.rules.filter(severity=Rule.SEVERITY_VALID).count(), 0)

--- a/seed/tests/test_data_quality_rules.py
+++ b/seed/tests/test_data_quality_rules.py
@@ -8,7 +8,7 @@ import json
 
 from copy import deepcopy
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from seed.models.data_quality import (
     DataQualityCheck,

--- a/seed/views/data_quality.py
+++ b/seed/views/data_quality.py
@@ -8,6 +8,7 @@
 import csv
 
 from celery.utils.log import get_task_logger
+from django.db import transaction
 from django.http import JsonResponse, HttpResponse
 from rest_framework import viewsets, serializers, status
 from rest_framework.decorators import action
@@ -412,18 +413,27 @@ class DataQualityViews(viewsets.ViewSet):
                 }
             )
 
+        # This pattern of deleting and recreating Rules is slated to be deprecated
+        bad_rule_creation = False
+        error_messages = set()
         dq = DataQualityCheck.retrieve(organization.id)
         dq.remove_all_rules()
         for rule in updated_rules:
-            try:
-                dq.add_rule(rule)
-            except TypeError as e:
-                return JsonResponse({
-                    'status': 'error',
-                    'message': e,
-                }, status=status.HTTP_400_BAD_REQUEST)
+            with transaction.atomic():
+                try:
+                    dq.add_rule(rule)
+                except Exception as e:
+                    error_messages.add('Rule could not be recreated: ' + str(e))
+                    bad_rule_creation = True
+                    continue
 
-        return self.data_quality_rules(request)
+        if bad_rule_creation:
+            return JsonResponse({
+                'status': 'error',
+                'message': '\n'.join(error_messages),
+            }, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            return self.data_quality_rules(request)
 
     @api_endpoint_class
     @ajax_request_class

--- a/seed/views/data_quality.py
+++ b/seed/views/data_quality.py
@@ -363,6 +363,12 @@ class DataQualityViews(viewsets.ViewSet):
         posted_rules = body['data_quality_rules']
         updated_rules = []
         for rule in posted_rules['properties']:
+            if _get_severity_from_js(rule['severity']) == Rule.SEVERITY_VALID and rule['label'] is None:
+                return JsonResponse({
+                    'status': 'error',
+                    'message': 'Label must be assigned when using Valid Data Severity.'
+                }, status=status.HTTP_400_BAD_REQUEST)
+
             updated_rules.append(
                 {
                     'field': rule['field'],
@@ -382,6 +388,12 @@ class DataQualityViews(viewsets.ViewSet):
             )
 
         for rule in posted_rules['taxlots']:
+            if _get_severity_from_js(rule['severity']) == Rule.SEVERITY_VALID and rule['label'] is None:
+                return JsonResponse({
+                    'status': 'error',
+                    'message': 'Label must be assigned when using Valid Data Severity.'
+                }, status=status.HTTP_400_BAD_REQUEST)
+
             updated_rules.append(
                 {
                     'field': rule['field'],
@@ -403,12 +415,6 @@ class DataQualityViews(viewsets.ViewSet):
         dq = DataQualityCheck.retrieve(organization.id)
         dq.remove_all_rules()
         for rule in updated_rules:
-            if rule['severity'] == Rule.SEVERITY_VALID and rule['status_label_id'] is None:
-                return JsonResponse({
-                    'status': 'error',
-                    'message': 'Label must be assigned when using Valid Data Severity.'
-                }, status=status.HTTP_400_BAD_REQUEST)
-
             try:
                 dq.add_rule(rule)
             except TypeError as e:


### PR DESCRIPTION
Cherry-picked from the 2.7.0-patch1 with 1 additional commit related to the Django version difference between the two versions.

The details below was copied from that branch's PR.

#### Any background context you want to provide?
DQ Rules were being inadvertently deleted.

See attached issue for more details.

#### What's this PR do?
In the save_data_quality_rules POST endpoint, move any "checks" that trigger a 400 to before the records are deleted. Also, for that same endpoint, update the try-except logic to "...except and continue rebuilding Rules", returning a JSON response at the end that includes a message that Rules were lost/deleted.

#### How should this be manually tested?
Try to save a "Valid Data" Rule without a label. See that nothing gets saved, and we get the same 400 we got from before. Refresh the page and see that nothing was lost either.

For code review, commits can be reviewed in the order shown.

#### What are the relevant tickets?
#2202 

#### Screenshots (if appropriate)
