### PR TITLE
2252 refactor/api v3 meters

### DIFF
--- a/seed/api/v3/urls.py
+++ b/seed/api/v3/urls.py
@@ -12,6 +12,7 @@ from seed.views.v3.data_quality_check_rules import DataQualityCheckRuleViewSet
 from seed.views.v3.datasets import DatasetViewSet
 from seed.views.v3.labels import LabelViewSet
 from seed.views.v3.import_files import ImportFileViewSet
+from seed.views.v3.meters import MeterViewSet
 from seed.views.v3.organizations import OrganizationViewSet
 from seed.views.v3.properties import PropertyViewSet
 from seed.views.v3.taxlots import TaxlotViewSet
@@ -24,6 +25,7 @@ api_v3_router.register(r'datasets', DatasetViewSet, base_name='datasets')
 api_v3_router.register(r'labels', LabelViewSet, base_name='labels')
 api_v3_router.register(r'data_quality_checks', DataQualityCheckViewSet, base_name='data_quality_checks')
 api_v3_router.register(r'import_files', ImportFileViewSet, base_name='import_files')
+api_v3_router.register(r'meters', MeterViewSet, base_name='meters')
 api_v3_router.register(r'organizations', OrganizationViewSet, base_name='organizations')
 api_v3_router.register(r'properties', PropertyViewSet, base_name='properties')
 api_v3_router.register(r'taxlots', TaxlotViewSet, base_name='taxlots')

--- a/seed/views/v3/import_files.py
+++ b/seed/views/v3/import_files.py
@@ -10,56 +10,35 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.http import JsonResponse
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers, status, viewsets
-from rest_framework.decorators import (
-    action,
-    permission_classes,
-)
-
-from seed.data_importer.models import (
-    ImportFile,
-    ImportRecord
-)
-from seed.data_importer.models import ROW_DELIMITER
+from rest_framework.decorators import action, permission_classes
+from seed.data_importer.meters_parser import MetersParser
+from seed.data_importer.models import ROW_DELIMITER, ImportRecord
 from seed.data_importer.tasks import do_checks
-from seed.data_importer.tasks import (
-    map_data,
-    geocode_buildings_task as task_geocode_buildings,
-    map_additional_models as task_map_additional_models,
-    match_buildings as task_match_buildings,
-    save_raw_data as task_save_raw,
-    validate_use_cases as task_validate_use_cases,
-)
+from seed.data_importer.tasks import \
+    geocode_buildings_task as task_geocode_buildings
+from seed.data_importer.tasks import \
+    map_additional_models as task_map_additional_models
+from seed.data_importer.tasks import map_data
+from seed.data_importer.tasks import match_buildings as task_match_buildings
+from seed.data_importer.tasks import save_raw_data as task_save_raw
+from seed.data_importer.tasks import \
+    validate_use_cases as task_validate_use_cases
 from seed.decorators import ajax_request_class
 from seed.lib.mappings import mapper as simple_mapper
-from seed.lib.mcm import mapper
-from seed.lib.xml_mapping import mapper as xml_mapper
+from seed.lib.mcm import mapper, reader
 from seed.lib.superperms.orgs.decorators import has_perm_class
-from seed.lib.superperms.orgs.models import (
-    Organization,
-)
-from seed.lib.superperms.orgs.models import OrganizationUser
+from seed.lib.superperms.orgs.models import Organization, OrganizationUser
 from seed.lib.superperms.orgs.permissions import SEEDOrgPermissions
-from seed.models import (
-    get_column_mapping,
-)
-from seed.models import (
-    obj_to_dict,
-    PropertyState,
-    TaxLotState,
-    DATA_STATE_MAPPING,
-    DATA_STATE_MATCHING,
-    MERGE_STATE_UNKNOWN,
-    MERGE_STATE_NEW,
-    MERGE_STATE_MERGED,
-    Cycle,
-    Column,
-    PropertyAuditLog,
-    TaxLotAuditLog,
-    AUDIT_USER_EDIT,
-    TaxLotProperty,
-)
+from seed.lib.xml_mapping import mapper as xml_mapper
+from seed.models import (AUDIT_USER_EDIT, DATA_STATE_MAPPING,
+                         DATA_STATE_MATCHING, MERGE_STATE_MERGED,
+                         MERGE_STATE_NEW, MERGE_STATE_UNKNOWN, Column, Cycle,
+                         ImportFile, Meter, PropertyAuditLog, PropertyState,
+                         PropertyView, TaxLotAuditLog, TaxLotProperty,
+                         TaxLotState, get_column_mapping, obj_to_dict)
 from seed.utils.api import api_endpoint_class
-from seed.utils.api_schema import AutoSchemaHelper, swagger_auto_schema_org_query_param
+from seed.utils.api_schema import (AutoSchemaHelper,
+                                   swagger_auto_schema_org_query_param)
 from seed.utils.geocode import MapQuestAPIKeyError
 
 _log = logging.getLogger(__name__)
@@ -806,3 +785,39 @@ class ImportFileViewSet(viewsets.ViewSet):
         # This does not actually delete the object because it is a NonDeletableModel
         import_file.delete()
         return JsonResponse({'status': 'success'})
+
+    @swagger_auto_schema(
+        manual_parameters=[
+            AutoSchemaHelper.query_org_id_field(),
+            AutoSchemaHelper.query_integer_field(
+                'view_id',
+                required=True,
+                description='ID for property view'
+            )
+        ]
+    )
+    @ajax_request_class
+    @action(detail=True, methods=['GET'])
+    def greenbutton_meters_preview(self, request, pk):
+        """
+        Returns validated type units and proposed imports
+        """
+        org_id = request.query_params.get('organization_id')
+        view_id = request.query_params.get('view_id')
+
+        import_file = ImportFile.objects.get(pk=pk)
+        parser = reader.GreenButtonParser(import_file.local_file)
+        raw_meter_data = list(parser.data)
+
+        property_id = PropertyView.objects.get(pk=view_id).property_id
+        meters_parser = MetersParser(org_id, raw_meter_data, source_type=Meter.GREENBUTTON, property_id=property_id)
+
+        result = {}
+
+        result["validated_type_units"] = meters_parser.validated_type_units()
+        result["proposed_imports"] = meters_parser.proposed_imports
+
+        import_file.matching_results_data['property_id'] = property_id
+        import_file.save()
+
+        return result

--- a/seed/views/v3/import_files.py
+++ b/seed/views/v3/import_files.py
@@ -797,6 +797,7 @@ class ImportFileViewSet(viewsets.ViewSet):
         ]
     )
     @ajax_request_class
+    @has_perm_class('requires_member')
     @action(detail=True, methods=['GET'])
     def greenbutton_meters_preview(self, request, pk):
         """
@@ -826,6 +827,7 @@ class ImportFileViewSet(viewsets.ViewSet):
         manual_parameters=[AutoSchemaHelper.query_org_id_field()]
     )
     @ajax_request_class
+    @has_perm_class('requires_member')
     @action(detail=True, methods=['GET'])
     def pm_meters_preview(self, request, pk):
         """

--- a/seed/views/v3/meters.py
+++ b/seed/views/v3/meters.py
@@ -1,0 +1,129 @@
+# !/usr/bin/env python
+# encoding: utf-8
+
+from django.db.models import Q
+
+from rest_framework import viewsets
+from rest_framework.decorators import action
+
+from seed.data_importer.meters_parser import MetersParser
+from seed.data_importer.utils import (
+    kbtu_thermal_conversion_factors,
+    usage_point_id,
+)
+from seed.decorators import ajax_request_class
+from seed.lib.mcm import reader
+from seed.models import (
+    Meter,
+    ImportFile,
+    PropertyView,
+)
+from seed.utils.meters import PropertyMeterReadingsExporter
+
+
+class MeterViewSet(viewsets.ViewSet):
+
+    @ajax_request_class
+    @action(detail=False, methods=['POST'])
+    def parsed_meters_confirmation(self, request):
+        body = dict(request.data)
+        file_id = body['file_id']
+        org_id = body['organization_id']
+
+        import_file = ImportFile.objects.get(pk=file_id)
+        parser = reader.MCMParser(import_file.local_file, sheet_name='Meter Entries')
+        raw_meter_data = list(parser.data)
+
+        meters_parser = MetersParser(org_id, raw_meter_data)
+
+        result = {}
+
+        result["validated_type_units"] = meters_parser.validated_type_units()
+        result["proposed_imports"] = meters_parser.proposed_imports
+        result["unlinkable_pm_ids"] = meters_parser.unlinkable_pm_ids
+
+        return result
+
+    @ajax_request_class
+    @action(detail=False, methods=['POST'])
+    def greenbutton_parsed_meters_confirmation(self, request):
+        body = dict(request.data)
+        file_id = body['file_id']
+        org_id = body['organization_id']
+        view_id = body['view_id']
+
+        import_file = ImportFile.objects.get(pk=file_id)
+        parser = reader.GreenButtonParser(import_file.local_file)
+        raw_meter_data = list(parser.data)
+
+        property_id = PropertyView.objects.get(pk=view_id).property_id
+        meters_parser = MetersParser(org_id, raw_meter_data, source_type=Meter.GREENBUTTON, property_id=property_id)
+
+        result = {}
+
+        result["validated_type_units"] = meters_parser.validated_type_units()
+        result["proposed_imports"] = meters_parser.proposed_imports
+
+        import_file.matching_results_data['property_id'] = property_id
+        import_file.save()
+
+        return result
+
+    @ajax_request_class
+    @action(detail=False, methods=['POST'])
+    def property_meters(self, request):
+        body = dict(request.data)
+        property_view_id = body['property_view_id']
+        property_view = PropertyView.objects.get(pk=property_view_id)
+        property_id = property_view.property.id
+        scenario_ids = [s.id for s in property_view.state.scenarios.all()]
+        energy_types = dict(Meter.ENERGY_TYPES)
+
+        res = []
+        for meter in Meter.objects.filter(Q(property_id=property_id) | Q(scenario_id__in=scenario_ids)):
+            if meter.source == meter.GREENBUTTON:
+                source = 'GB'
+                source_id = usage_point_id(meter.source_id)
+            elif meter.source == meter.BUILDINGSYNC:
+                source = 'BS'
+                source_id = meter.source_id
+            else:
+                source = 'PM'
+                source_id = meter.source_id
+
+            res.append({
+                'id': meter.id,
+                'type': energy_types[meter.type],
+                'source': source,
+                'source_id': source_id,
+                'scenario_id': meter.scenario.id if meter.scenario is not None else None,
+                'scenario_name': meter.scenario.name if meter.scenario is not None else None
+            })
+
+        return res
+
+    @ajax_request_class
+    @action(detail=False, methods=['POST'])
+    def property_meter_usage(self, request):
+        body = dict(request.data)
+        property_view_id = body['property_view_id']
+        interval = body['interval']
+        excluded_meter_ids = body['excluded_meter_ids']
+
+        property_view = PropertyView.objects.get(pk=property_view_id)
+        property_id = property_view.property.id
+        org_id = property_view.cycle.organization_id
+        scenario_ids = [s.id for s in property_view.state.scenarios.all()]
+
+        exporter = PropertyMeterReadingsExporter(property_id, org_id, excluded_meter_ids, scenario_ids=scenario_ids)
+
+        return exporter.readings_and_column_defs(interval)
+
+    @ajax_request_class
+    @action(detail=False, methods=['GET'])
+    def valid_types_units(self, request):
+        return {
+            type: list(units.keys())
+            for type, units
+            in kbtu_thermal_conversion_factors("US").items()
+        }

--- a/seed/views/v3/meters.py
+++ b/seed/views/v3/meters.py
@@ -46,31 +46,6 @@ class MeterViewSet(viewsets.ViewSet):
 
     @ajax_request_class
     @action(detail=False, methods=['POST'])
-    def greenbutton_parsed_meters_confirmation(self, request):
-        body = dict(request.data)
-        file_id = body['file_id']
-        org_id = body['organization_id']
-        view_id = body['view_id']
-
-        import_file = ImportFile.objects.get(pk=file_id)
-        parser = reader.GreenButtonParser(import_file.local_file)
-        raw_meter_data = list(parser.data)
-
-        property_id = PropertyView.objects.get(pk=view_id).property_id
-        meters_parser = MetersParser(org_id, raw_meter_data, source_type=Meter.GREENBUTTON, property_id=property_id)
-
-        result = {}
-
-        result["validated_type_units"] = meters_parser.validated_type_units()
-        result["proposed_imports"] = meters_parser.proposed_imports
-
-        import_file.matching_results_data['property_id'] = property_id
-        import_file.save()
-
-        return result
-
-    @ajax_request_class
-    @action(detail=False, methods=['POST'])
     def property_meters(self, request):
         body = dict(request.data)
         property_view_id = body['property_view_id']

--- a/seed/views/v3/meters.py
+++ b/seed/views/v3/meters.py
@@ -6,43 +6,19 @@ from django.db.models import Q
 from rest_framework import viewsets
 from rest_framework.decorators import action
 
-from seed.data_importer.meters_parser import MetersParser
 from seed.data_importer.utils import (
     kbtu_thermal_conversion_factors,
     usage_point_id,
 )
 from seed.decorators import ajax_request_class
-from seed.lib.mcm import reader
 from seed.models import (
     Meter,
-    ImportFile,
     PropertyView,
 )
 from seed.utils.meters import PropertyMeterReadingsExporter
 
 
 class MeterViewSet(viewsets.ViewSet):
-
-    @ajax_request_class
-    @action(detail=False, methods=['POST'])
-    def parsed_meters_confirmation(self, request):
-        body = dict(request.data)
-        file_id = body['file_id']
-        org_id = body['organization_id']
-
-        import_file = ImportFile.objects.get(pk=file_id)
-        parser = reader.MCMParser(import_file.local_file, sheet_name='Meter Entries')
-        raw_meter_data = list(parser.data)
-
-        meters_parser = MetersParser(org_id, raw_meter_data)
-
-        result = {}
-
-        result["validated_type_units"] = meters_parser.validated_type_units()
-        result["proposed_imports"] = meters_parser.proposed_imports
-        result["unlinkable_pm_ids"] = meters_parser.unlinkable_pm_ids
-
-        return result
 
     @ajax_request_class
     @action(detail=False, methods=['POST'])

--- a/seed/views/v3/meters.py
+++ b/seed/views/v3/meters.py
@@ -15,6 +15,15 @@ class MeterViewSet(viewsets.ViewSet):
     @ajax_request_class
     @action(detail=False, methods=['GET'])
     def valid_types_units(self, request):
+        """
+        Returns the valid type for units.
+
+        The valid type and unit combinations are built from US Thermal Conversion
+        values. As of this writing, the valid combinations are the same as for
+        Canadian conversions, even though the actual factors may differ between
+        the two.
+        (https://portfoliomanager.energystar.gov/pdf/reference/Thermal%20Conversions.pdf)
+        """
         return {
             type: list(units.keys())
             for type, units

--- a/seed/views/v3/meters.py
+++ b/seed/views/v3/meters.py
@@ -15,7 +15,6 @@ from seed.models import (
     Meter,
     PropertyView,
 )
-from seed.utils.meters import PropertyMeterReadingsExporter
 
 
 class MeterViewSet(viewsets.ViewSet):
@@ -52,23 +51,6 @@ class MeterViewSet(viewsets.ViewSet):
             })
 
         return res
-
-    @ajax_request_class
-    @action(detail=False, methods=['POST'])
-    def property_meter_usage(self, request):
-        body = dict(request.data)
-        property_view_id = body['property_view_id']
-        interval = body['interval']
-        excluded_meter_ids = body['excluded_meter_ids']
-
-        property_view = PropertyView.objects.get(pk=property_view_id)
-        property_id = property_view.property.id
-        org_id = property_view.cycle.organization_id
-        scenario_ids = [s.id for s in property_view.state.scenarios.all()]
-
-        exporter = PropertyMeterReadingsExporter(property_id, org_id, excluded_meter_ids, scenario_ids=scenario_ids)
-
-        return exporter.readings_and_column_defs(interval)
 
     @ajax_request_class
     @action(detail=False, methods=['GET'])

--- a/seed/views/v3/meters.py
+++ b/seed/views/v3/meters.py
@@ -1,56 +1,16 @@
 # !/usr/bin/env python
 # encoding: utf-8
 
-from django.db.models import Q
-
 from rest_framework import viewsets
 from rest_framework.decorators import action
 
 from seed.data_importer.utils import (
     kbtu_thermal_conversion_factors,
-    usage_point_id,
 )
 from seed.decorators import ajax_request_class
-from seed.models import (
-    Meter,
-    PropertyView,
-)
 
 
 class MeterViewSet(viewsets.ViewSet):
-
-    @ajax_request_class
-    @action(detail=False, methods=['POST'])
-    def property_meters(self, request):
-        body = dict(request.data)
-        property_view_id = body['property_view_id']
-        property_view = PropertyView.objects.get(pk=property_view_id)
-        property_id = property_view.property.id
-        scenario_ids = [s.id for s in property_view.state.scenarios.all()]
-        energy_types = dict(Meter.ENERGY_TYPES)
-
-        res = []
-        for meter in Meter.objects.filter(Q(property_id=property_id) | Q(scenario_id__in=scenario_ids)):
-            if meter.source == meter.GREENBUTTON:
-                source = 'GB'
-                source_id = usage_point_id(meter.source_id)
-            elif meter.source == meter.BUILDINGSYNC:
-                source = 'BS'
-                source_id = meter.source_id
-            else:
-                source = 'PM'
-                source_id = meter.source_id
-
-            res.append({
-                'id': meter.id,
-                'type': energy_types[meter.type],
-                'source': source,
-                'source_id': source_id,
-                'scenario_id': meter.scenario.id if meter.scenario is not None else None,
-                'scenario_name': meter.scenario.name if meter.scenario is not None else None
-            })
-
-        return res
 
     @ajax_request_class
     @action(detail=False, methods=['GET'])

--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -68,6 +68,9 @@ class PropertyViewSet(viewsets.ViewSet, OrgMixin):
     @ajax_request_class
     @action(detail=True, methods=['POST'])
     def meter_usage(self, request, pk):
+        """
+        Retrieves meter usage information
+        """
         body = dict(request.data)
         interval = body['interval']
         excluded_meter_ids = body['excluded_meter_ids']
@@ -84,6 +87,9 @@ class PropertyViewSet(viewsets.ViewSet, OrgMixin):
     @ajax_request_class
     @action(detail=True, methods=['GET'])
     def meters(self, request, pk):
+        """
+        Retrieves meters for the property
+        """
         property_view = PropertyView.objects.get(pk=pk)
         property_id = property_view.property.id
         scenario_ids = [s.id for s in property_view.state.scenarios.all()]

--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -12,6 +12,7 @@ from rest_framework.parsers import JSONParser
 from rest_framework.renderers import JSONRenderer
 from seed.data_importer.utils import usage_point_id
 from seed.decorators import ajax_request_class
+from seed.lib.superperms.orgs.decorators import has_perm_class
 from seed.models import (
     Meter,
     PropertyView,
@@ -40,6 +41,7 @@ class PropertyViewSet(viewsets.ViewSet, OrgMixin):
             description='IDs for properties to be checked for which labels are applied.'
         )
     )
+    @has_perm_class('can_modify_data')
     @action(detail=False, methods=['POST'])
     def labels(self, request):
         """
@@ -66,6 +68,7 @@ class PropertyViewSet(viewsets.ViewSet, OrgMixin):
         )
     )
     @ajax_request_class
+    @has_perm_class('requires_member')
     @action(detail=True, methods=['POST'])
     def meter_usage(self, request, pk):
         """
@@ -85,6 +88,7 @@ class PropertyViewSet(viewsets.ViewSet, OrgMixin):
         return exporter.readings_and_column_defs(interval)
 
     @ajax_request_class
+    @has_perm_class('requires_member')
     @action(detail=True, methods=['GET'])
     def meters(self, request, pk):
         """

--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -9,12 +9,16 @@ from collections import namedtuple
 from rest_framework.decorators import action
 from rest_framework.parsers import JSONParser
 from rest_framework.renderers import JSONRenderer
+from seed.decorators import ajax_request_class
 from seed.models import (
+    PropertyView,
     StatusLabel as Label,
 )
 from seed.utils.api import OrgMixin
 from seed.utils.api_schema import AutoSchemaHelper
 from seed.utils.labels import get_labels
+from seed.utils.meters import PropertyMeterReadingsExporter
+
 
 ErrorState = namedtuple('ErrorState', ['status_code', 'message'])
 
@@ -45,3 +49,31 @@ class PropertyViewSet(viewsets.ViewSet, OrgMixin):
         super_organization = self.get_organization(request)
         # TODO: refactor to avoid passing request here
         return get_labels(request, labels, super_organization, 'property_view')
+
+    @swagger_auto_schema(
+        request_body=AutoSchemaHelper.schema_factory(
+            {
+                'interval': 'string',
+                'excluded_meter_ids': ['integer'],
+            },
+            required=['property_view_id', 'interval', 'excluded_meter_ids'],
+            description='Properties:\n'
+                        '- interval: one of "Exact", "Month", or "Year"\n'
+                        '- excluded_meter_ids: array of meter IDs to exclude'
+        )
+    )
+    @ajax_request_class
+    @action(detail=True, methods=['POST'])
+    def meter_usage(self, request, pk):
+        body = dict(request.data)
+        interval = body['interval']
+        excluded_meter_ids = body['excluded_meter_ids']
+
+        property_view = PropertyView.objects.get(pk=pk)
+        property_id = property_view.property.id
+        org_id = property_view.cycle.organization_id
+        scenario_ids = [s.id for s in property_view.state.scenarios.all()]
+
+        exporter = PropertyMeterReadingsExporter(property_id, org_id, excluded_meter_ids, scenario_ids=scenario_ids)
+
+        return exporter.readings_and_column_defs(interval)


### PR DESCRIPTION
#### What's this PR do? 
Moves and refactors v2 meters endpoints into v3
#### How should this be manually tested?
Test the endpoints on the swagger page:
- `api/v3/meters/valid_types_units`
- `api/v3/import_files/{id}/greenbutton_meters_preview`
- `api/v3/import_files/{id}/pm_meters_preview`
- `api/v3/properties/{id}/meter_usage`
- `api/v3/properties/{id}/meters`
#### What are the relevant tickets?
#2252 
