### PR TITLE
API v3 properties - queryset attr set as empty QS for swagger

### DIFF
--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -127,6 +127,9 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
     serializer_class = PropertySerializer
     _organization = None
 
+    # For the Swagger page, GenericAPIView asserts a value exists for `queryset`
+    queryset = PropertyView.objects.none()
+
     @action(detail=False, filter_backends=[PropertyViewFilterBackend])
     def search(self, request):
         """


### PR DESCRIPTION
#### Any background context you want to provide?
There were errors on the Swagger page that were cleaned up. A new one was introduced when a -ViewSet began inheriting from DRF's GenericViewSet. This inheritance required that a `queryset` attr be set or the `get_queryset()` method be defined for that ViewSet class.

#### What's this PR do?
Fixes that most recent issue.

#### How should this be manually tested?
Load the Swagger page and see that no errors are shown.

#### What are the relevant tickets?
#2232 - original ticket to clean up Swagger page errors
and
#2279 - PR that inadvertently introduced these errors


