### PR TITLE
DQ Admin page - doesn't guess condition when field changes

### DIFF
--- a/seed/static/seed/js/controllers/column_settings_controller.js
+++ b/seed/static/seed/js/controllers/column_settings_controller.js
@@ -182,6 +182,7 @@ angular.module('BE.seed.controller.column_settings', [])
         // Remove any potential duplicates
         if (column.comstock_mapping !== null) {
           _.forEach($scope.columns, function (col) {
+            // eslint-disable-next-line lodash/prefer-matches
             if (col.id !== column.id && col.comstock_mapping === column.comstock_mapping) {
               col.comstock_mapping = null;
             }

--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -295,7 +295,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
 
       $scope.validate_conditions = function (group, group_name) {
         var conditions = _.map(group, 'condition');
-        if (conditions.includes("range") && (conditions.includes("include") || conditions.includes("exclude"))) {
+        if (conditions.includes('range') && (conditions.includes('include') || conditions.includes('exclude'))) {
           $scope.invalid_conditions = _.union($scope.invalid_conditions, [group_name]);
         } else if ($scope.invalid_conditions.includes(group_name)) {
           _.pull($scope.invalid_conditions, group_name);
@@ -323,7 +323,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
       };
 
       // perform checks on load
-      _.forEach($scope.ruleGroups[$scope.inventory_type], function(group, group_name) {
+      _.forEach($scope.ruleGroups[$scope.inventory_type], function (group, group_name) {
         $scope.validate_data_types(group, group_name);
         $scope.validate_conditions(group, group_name);
       });

--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -334,7 +334,10 @@ angular.module('BE.seed.controller.data_quality_admin', [])
         $scope.rules_reset = false;
         if (rule.condition === 'include' || rule.condition === 'exclude' && rule.data_type !== 'string') rule.data_type = 'string';
         if (_.isMatch(rule, {condition: 'range', data_type: 'string'})) rule.data_type = null;
-        if (_.isMatch(rule, {condition: 'not_null', data_type: 'string'}) || _.isMatch(rule, {condition: 'required', data_type: 'string'})) rule.text_match = null;
+        if (_.isMatch(rule, {condition: 'not_null', data_type: 'string'}) || _.isMatch(rule, {
+          condition: 'required',
+          data_type: 'string'
+        })) rule.text_match = null;
         if (rule.condition !== 'range') {
           rule.units = '';
           rule.min = null;
@@ -375,8 +378,9 @@ angular.module('BE.seed.controller.data_quality_admin', [])
         rule.data_type = newDataType;
 
         // move rule to appropriate spot in ruleGroups.
-        if (!_.has($scope.ruleGroups[$scope.inventory_type], rule.field)) $scope.ruleGroups[$scope.inventory_type][rule.field] = [];
-        else {
+        if (!_.has($scope.ruleGroups[$scope.inventory_type], rule.field)) {
+          $scope.ruleGroups[$scope.inventory_type][rule.field] = [];
+        } else {
           // Rules already exist for the new field name, so match the data_type, required, and not_null columns
           var existingRule = _.first($scope.ruleGroups[$scope.inventory_type][rule.field]);
           rule.data_type = existingRule.data_type;
@@ -393,6 +397,9 @@ angular.module('BE.seed.controller.data_quality_admin', [])
         var group = $scope.ruleGroups[$scope.inventory_type][group_name];
         $scope.validate_data_types(group, group_name);
         $scope.validate_conditions(group, group_name);
+
+        $scope.validate_data_types($scope.ruleGroups[$scope.inventory_type][oldField], oldField);
+        $scope.validate_conditions($scope.ruleGroups[$scope.inventory_type][oldField], oldField);
       };
       // Keep field types consistent for identical fields
       $scope.change_data_type = function (rule, oldValue) {

--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -329,9 +329,6 @@ angular.module('BE.seed.controller.data_quality_admin', [])
         }
 
         rule.data_type = newDataType;
-        if (rule.data_type === 'None' || rule.data_type === null) rule.condition = '';
-        else if (rule.data_type === 'string') rule.condition = 'include';
-        else rule.condition = 'range';
 
         // move rule to appropriate spot in ruleGroups.
         if (!_.has($scope.ruleGroups[$scope.inventory_type], rule.field)) $scope.ruleGroups[$scope.inventory_type][rule.field] = [];

--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -289,6 +289,45 @@ angular.module('BE.seed.controller.data_quality_admin', [])
           spinner_utility.hide();
         });
       };
+
+      // check that contradictory conditions aren't being used in any Rule Group
+      $scope.invalid_conditions = [];
+
+      $scope.validate_conditions = function (group, group_name) {
+        var conditions = _.map(group, 'condition');
+        if (conditions.includes("range") && (conditions.includes("include") || conditions.includes("exclude"))) {
+          $scope.invalid_conditions = _.union($scope.invalid_conditions, [group_name]);
+        } else if ($scope.invalid_conditions.includes(group_name)) {
+          _.pull($scope.invalid_conditions, group_name);
+        }
+      };
+
+      // check that data_types are aligned in any Rule Group
+      $scope.invalid_data_types = [];
+
+      $scope.validate_data_types = function (group, group_name) {
+        var data_types = _.uniq(_.map(group, 'data_type'));
+        var conditions = _.map(group, 'condition');
+
+        var range_has_text = conditions.includes('range') && data_types.includes('string');
+        var numeric_types = _.map($scope.data_types[1], 'id');
+        var include_has_numeric = conditions.includes('include') && _.intersection(data_types, numeric_types).length > 0;
+        var exclude_has_numeric = conditions.includes('exclude') && _.intersection(data_types, numeric_types).length > 0;
+        var invalid_condition_data_type_combinations = range_has_text || include_has_numeric || exclude_has_numeric;
+
+        if (data_types.length > 1 || invalid_condition_data_type_combinations) {
+          $scope.invalid_data_types = _.uniq(_.concat($scope.invalid_data_types, group_name));
+        } else if ($scope.invalid_data_types.includes(group_name)) {
+          _.pull($scope.invalid_data_types, group_name);
+        }
+      };
+
+      // perform checks on load
+      _.forEach($scope.ruleGroups[$scope.inventory_type], function(group, group_name) {
+        $scope.validate_data_types(group, group_name);
+        $scope.validate_conditions(group, group_name);
+      });
+
       $scope.change_condition = function (rule) {
         $scope.rules_updated = false;
         $scope.defaults_restored = false;
@@ -301,6 +340,11 @@ angular.module('BE.seed.controller.data_quality_admin', [])
           rule.min = null;
           rule.max = null;
         }
+
+        var group_name = rule.field;
+        var group = $scope.ruleGroups[$scope.inventory_type][group_name];
+        $scope.validate_conditions(group, group_name);
+        $scope.validate_data_types(group, group_name);
       };
 
       $scope.check_null = false;
@@ -344,11 +388,18 @@ angular.module('BE.seed.controller.data_quality_admin', [])
         if ($scope.ruleGroups[$scope.inventory_type][oldField].length === 1) delete $scope.ruleGroups[$scope.inventory_type][oldField];
         else $scope.ruleGroups[$scope.inventory_type][oldField].splice(index, 1);
         rule.autofocus = true;
+
+        var group_name = rule.field;
+        var group = $scope.ruleGroups[$scope.inventory_type][group_name];
+        $scope.validate_data_types(group, group_name);
+        $scope.validate_conditions(group, group_name);
       };
       // Keep field types consistent for identical fields
       $scope.change_data_type = function (rule, oldValue) {
         var data_type = rule.data_type;
-        _.forEach($scope.ruleGroups[$scope.inventory_type][rule.field], function (currentRule) {
+        var rule_group = $scope.ruleGroups[$scope.inventory_type][rule.field];
+
+        _.forEach(rule_group, function (currentRule) {
           currentRule.text_match = null;
 
           if (!_.includes(['', 'number'], oldValue) || !_.includes([null, 'number'], data_type)) {
@@ -358,6 +409,8 @@ angular.module('BE.seed.controller.data_quality_admin', [])
           }
           currentRule.data_type = data_type;
         });
+
+        $scope.validate_data_types(rule_group, rule.field);
       };
 
       $scope.remove_label = function (rule) {

--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -347,10 +347,10 @@ angular.module('BE.seed.controller.data_upload_modal', [])
               // Assessed Data; upload is step 2; PM import is currently treated as such, and is step 13
               if (current_step === 2 || current_step === 13) {
                 // if importing BuildingSync, validate then save, otherwise just save
-                if (file.source_type === "BuildingSync Raw") {
-                  validate_use_cases_then_save(file.file_id, file.cycle_id)
+                if (file.source_type === 'BuildingSync Raw') {
+                  validate_use_cases_then_save(file.file_id, file.cycle_id);
                 } else {
-                  save_raw_assessed_data(file.file_id, file.cycle_id, false)
+                  save_raw_assessed_data(file.file_id, file.cycle_id, false);
                 }
               }
               // Portfolio Data
@@ -497,45 +497,45 @@ angular.module('BE.seed.controller.data_upload_modal', [])
         $scope.uploader.status_message = 'validating data';
         $scope.uploader.progress = 0;
 
-        const successHandler = (progress_data) => {
-          $scope.uploader.complete = false
-          $scope.uploader.in_progress = true
+        var successHandler = function (progress_data) {
+          $scope.uploader.complete = false;
+          $scope.uploader.in_progress = true;
           $scope.uploader.status_message = 'validation complete; starting to save data';
           $scope.uploader.progress = 100;
 
-          const result = JSON.parse(progress_data.message)
-          $scope.buildingsync_valid = result.valid
-          $scope.buildingsync_issues = result.issues
-          
+          var result = JSON.parse(progress_data.message);
+          $scope.buildingsync_valid = result.valid;
+          $scope.buildingsync_issues = result.issues;
+
           // if validation failed, end the import flow here; otherwise continue
           if ($scope.buildingsync_valid !== true) {
-            $scope.step_12_error_message = 'Failed to validate uploaded BuildingSync file(s)'
-            $scope.step_12_buildingsync_validation_error = true
-            $scope.step.number = 12
+            $scope.step_12_error_message = 'Failed to validate uploaded BuildingSync file(s)';
+            $scope.step_12_buildingsync_validation_error = true;
+            $scope.step.number = 12;
           } else {
             // successfully passed validation, save the data
-            save_raw_assessed_data(file_id, cycle_id, false)
+            save_raw_assessed_data(file_id, cycle_id, false);
           }
-        }
+        };
 
-        const errorHandler = (data) => {
+        var errorHandler = function (data) {
           $log.error(data.message);
-          if (data.hasOwnProperty('stacktrace')) $log.error(data.stacktrace);
+          if (data.stacktrace) $log.error(data.stacktrace);
           $scope.step_12_error_message = data.data ? data.data.message : data.message;
           $scope.step.number = 12;
-        }
+        };
 
         uploader_service.validate_use_cases(file_id)
-          .then(data => {
-            const progress = _.clamp(data.progress, 0, 100);
+          .then(function (data) {
+            var progress = _.clamp(data.progress, 0, 100);
             uploader_service.check_progress_loop(
               data.progress_key,
               progress, 1 - (progress / 100),
               successHandler,
               errorHandler,
-              $scope.uploader,
-            )
-          })
+              $scope.uploader
+            );
+          });
       };
 
       /**

--- a/seed/static/seed/js/controllers/inventory_detail_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_controller.js
@@ -115,7 +115,7 @@ angular.module('BE.seed.controller.inventory_detail', [])
         }
       };
 
-      function populated_columns_modal() {
+      function populated_columns_modal () {
         $uibModal.open({
           backdrop: 'static',
           templateUrl: urls.static_url + 'seed/partials/show_populated_columns_modal.html',

--- a/seed/static/seed/js/controllers/inventory_settings_controller.js
+++ b/seed/static/seed/js/controllers/inventory_settings_controller.js
@@ -155,7 +155,7 @@ angular.module('BE.seed.controller.inventory_settings', [])
         }
       });
 
-      function switchProfile(newProfile) {
+      function switchProfile (newProfile) {
         ignoreNextChange = true;
         if (newProfile) {
           $scope.currentProfile = _.find($scope.profiles, {id: newProfile.id});

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -503,7 +503,8 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       return inventory_service.get_property_columns_for_org(user_service.get_organization().id);
     };
 
-    inventory_service.get_property_columns_for_org = function (org_id, only_used=false) {
+    inventory_service.get_property_columns_for_org = function (org_id, only_used) {
+      if (only_used === undefined) only_used = false;
       return $http.get('/api/v2/properties/columns/', {
         params: {
           organization_id: org_id,
@@ -582,7 +583,8 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       return inventory_service.get_taxlot_columns_for_org(user_service.get_organization().id);
     };
 
-    inventory_service.get_taxlot_columns_for_org = function (org_id, only_used=false) {
+    inventory_service.get_taxlot_columns_for_org = function (org_id, only_used) {
+      if (only_used === undefined) only_used = false;
       return $http.get('/api/v2/taxlots/columns/', {
         params: {
           organization_id: org_id,

--- a/seed/static/seed/js/services/label_service.js
+++ b/seed/static/seed/js/services/label_service.js
@@ -61,7 +61,7 @@ angular.module('BE.seed.service.label', [])
         return get_labels_for_org(user_service.get_organization().id, inventory_type, filter_ids);
       }
 
-      function get_labels_for_org(org_id, inventory_type, filter_ids) {
+      function get_labels_for_org (org_id, inventory_type, filter_ids) {
         var params = {
           organization_id: org_id
         };

--- a/seed/static/seed/js/services/uploader_service.js
+++ b/seed/static/seed/js/services/uploader_service.js
@@ -46,18 +46,18 @@ angular.module('BE.seed.service.uploader', []).factory('uploader_service', [
      * @param file_id: the pk of a ImportFile object we're going to save raw.
      */
     uploader_factory.validate_use_cases = function (file_id) {
-      const org_id = user_service.get_organization().id
+      var org_id = user_service.get_organization().id;
       return $http.post('/api/v2/import_files/' + file_id + '/validate_use_cases/?organization_id=' + org_id.toString())
-        .then(response => {
-          return response.data
+        .then(function (response) {
+          return response.data;
         })
-        .catch(err => {
+        .catch(function (err) {
           if (err.data.status === 'error') {
-            return err.data
+            return err.data;
           }
           // something unexpected happened... throw it
-          throw err
-        })
+          throw err;
+        });
     };
 
     /**

--- a/seed/static/seed/partials/data_quality_admin.html
+++ b/seed/static/seed/partials/data_quality_admin.html
@@ -25,7 +25,7 @@
                 <button type="button" class="btn btn-danger" ng-click="reset_all_rules()">{$:: 'Reset All Rules' | translate $}
                     <i class="fa fa-check" ng-show="rules_reset"></i>
                 </button>
-                <button type="button" class="btn btn-primary" ng-click="save_settings()" ng-disabled="!isModified()">{$:: 'Save Changes' | translate $}
+                <button type="button" class="btn btn-primary" ng-click="save_settings()" ng-disabled="!isModified() || invalid_conditions.length > 0 || invalid_data_types.length > 0">{$:: 'Save Changes' | translate $}
                     <i class="fa fa-check" ng-show="rules_updated && !error_string"></i>
                 </button>
             </div>
@@ -38,6 +38,14 @@
             Restore Default Rules: reset only default rules.<br>
             Reset All Rules: delete all rules and reinitialize the default set of rules.</p>
             <button class="btn btn-info btn-sm" style="margin-bottom: 15px;" ng-click="create_new_rule()" translate>Create a new rule</button>
+
+            <div class="alert alert-danger" ng-show="invalid_conditions.length > 0" translate>
+                Fields that have a "Must Contain" or "Must Not Contain" Condition Check rule cannot have a "Range" Condition Check rule.
+            </div>
+            <div class="alert alert-danger" ng-show="invalid_data_types.length > 0" translate>
+                Rules for a single field must have the same Data Type. Note that some Data Types are not available to certain Condition Checks.
+            </div>
+
             <div class="data-quality-tab-container">
                 <ul class="nav nav-tabs" style="margin-bottom:1px;">
                     <li ui-sref-active="active" heading="{$:: 'View by Property' | translate $}">
@@ -72,17 +80,39 @@
                                 <input type="checkbox" ng-model="rule.enabled" class="no-click">
                             </td>
                             <td>
-                                <select class="form-control input-sm" ng-model="rule.condition" ng-options="condition.id as condition.label for condition in ::conditions" ng-change="rule.rule_type = 1; change_condition(rule)"></select>
+                                <select class="form-control input-sm" ng-model="rule.condition"
+                                        ng-options="condition.id as condition.label for condition in ::conditions"
+                                        ng-change="rule.rule_type = 1; change_condition(rule, ruleGroups[inventory_type][field], field);"
+                                        ng-class="{'border-red red': invalid_conditions.includes(field)}"></select>
                             </td>
                             <td>
-                                <select class="form-control input-sm" ng-model="rule.field" ng-options="col.column_name as col.displayName for col in ::columns" ng-change="rule.rule_type = 1; change_field(rule, '{$ rule.field $}', $index)" title="{$ rule.field $}" focus-if="{$ rule.autofocus || 'false' $}"></select>
+                                <select class="form-control input-sm"
+                                        ng-model="rule.field"
+                                        ng-options="col.column_name as col.displayName for col in ::columns"
+                                        ng-change="rule.rule_type = 1; change_field(rule, '{$ rule.field $}', $index)"
+                                        title="{$ rule.field $}"
+                                        focus-if="{$ rule.autofocus || 'false' $}"></select>
                             </td>
                             <td ng-if="rule.condition === 'range'">
-                                <select class="form-control input-sm" ng-model="rule.data_type" ng-options="type.id as type.label for type in ::data_types[1]" ng-change="rule.rule_type = 1; change_data_type(rule, '{$ rule.data_type $}')"></select>
+                                <select class="form-control input-sm"
+                                        ng-model="rule.data_type"
+                                        ng-options="type.id as type.label for type in ::data_types[1]"
+                                        ng-change="rule.rule_type = 1; change_data_type(rule, '{$ rule.data_type $}')"
+                                        ng-class="{'border-red red': invalid_data_types.includes(field)}"></select>
                             </td>
                             <td ng-if="rule.condition !== 'range'" >
-                                <select class="form-control input-sm" ng-model="rule.data_type" ng-if="_.includes(['include', 'exclude'], rule.condition)" ng-options="type.id as type.label for type in ::data_types[0]" ng-change="rule.rule_type = 1; change_data_type(rule, '{$ rule.data_type $}')"></select>
-                                <select class="form-control input-sm" ng-model="rule.data_type" ng-if="_.includes(['required', 'not_null', '', null, 'None'], rule.condition)" ng-options="type.id as type.label for type in ::data_types[2]" ng-change="rule.rule_type = 1; change_data_type(rule, '{$ rule.data_type $}')"></select>
+                                <select class="form-control input-sm"
+                                        ng-model="rule.data_type"
+                                        ng-if="_.includes(['include', 'exclude'], rule.condition)"
+                                        ng-options="type.id as type.label for type in ::data_types[0]"
+                                        ng-change="rule.rule_type = 1; change_data_type(rule, '{$ rule.data_type $}')"
+                                        ng-class="{'border-red red': invalid_data_types.includes(field)}"></select>
+                                <select class="form-control input-sm"
+                                        ng-model="rule.data_type"
+                                        ng-if="_.includes(['required', 'not_null', '', null, 'None'], rule.condition)"
+                                        ng-options="type.id as type.label for type in ::data_types[2]"
+                                        ng-change="rule.rule_type = 1; change_data_type(rule, '{$ rule.data_type $}')"
+                                        ng-class="{'border-red red': invalid_data_types.includes(field)}"></select>
                             </td>
                             <td ng-if="rule.data_type === 'string'" colspan="2">
                                 <input class="form-control input-sm" type="text" maxlength="200" ng-model="rule.text_match" ng-if="_.includes(['include', 'exclude', 'required', 'not_null', '', null, 'None'], rule.condition)" ng-change="rule.rule_type = 1"
@@ -144,7 +174,8 @@
                 <button type="button" class="btn btn-danger" ng-click="reset_all_rules()">{$:: 'Reset All Rules' | translate $}
                     <i class="fa fa-check" ng-show="rules_reset"></i>
                 </button>
-                <button type="button" class="btn btn-primary" ng-click="save_settings()" ng-disabled="!isModified()">{$:: 'Save Changes' | translate $}
+                <!-- <button type="button" class="btn btn-primary" ng-click="save_settings()" ng-disabled="!isModified() || invalid_conditions.length > 0 || invalid_data_types.length > 0">{$:: 'Save Changes' | translate $} -->
+                <button type="button" class="btn btn-primary" ng-click="save_settings()" ng-disabled="false">{$:: 'Save Changes' | translate $}
                     <i class="fa fa-check" ng-show="rules_updated && !error_string"></i>
                 </button>
             </div>

--- a/seed/static/seed/partials/data_quality_admin.html
+++ b/seed/static/seed/partials/data_quality_admin.html
@@ -174,8 +174,7 @@
                 <button type="button" class="btn btn-danger" ng-click="reset_all_rules()">{$:: 'Reset All Rules' | translate $}
                     <i class="fa fa-check" ng-show="rules_reset"></i>
                 </button>
-                <!-- <button type="button" class="btn btn-primary" ng-click="save_settings()" ng-disabled="!isModified() || invalid_conditions.length > 0 || invalid_data_types.length > 0">{$:: 'Save Changes' | translate $} -->
-                <button type="button" class="btn btn-primary" ng-click="save_settings()" ng-disabled="false">{$:: 'Save Changes' | translate $}
+                <button type="button" class="btn btn-primary" ng-click="save_settings()" ng-disabled="!isModified() || invalid_conditions.length > 0 || invalid_data_types.length > 0">{$:: 'Save Changes' | translate $}
                     <i class="fa fa-check" ng-show="rules_updated && !error_string"></i>
                 </button>
             </div>

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -79,6 +79,10 @@ $pairingCellWidth: 200px;
   color: $red;
 }
 
+.border-red {
+  border-color: $red;
+}
+
 .green {
   color: $green;
 }


### PR DESCRIPTION
#### Any background context you want to provide?
See issue

#### What's this PR do?
The DQ Admin page doesn't guess condition when Field values is changed for one of the rules.

In addition, validations have been added to `condition` and `data_type`. These are triggered whenever `condition`, `field`, and `data_type` values are changed. Warning messages are provided to help users "fix" any invalid rules.

#### How should this be manually tested?
Visit DQ admin page, and change the Field value for one of the rules. See that the Condition doesn't change.

In addition, monkey test changing the `condition`, `field`, and `data_type` values for rules.

#### What are the relevant tickets?
#2281 

#### Screenshots (if appropriate)
