### PR TITLE
set updated and created to read_only to unbreak write actions

### DIFF
--- a/seed/serializers/properties.py
+++ b/seed/serializers/properties.py
@@ -230,11 +230,11 @@ class PropertyStateWritableSerializer(serializers.ModelSerializer):
 
     # support naive datetime objects
     # support naive datetime objects
-    generation_date = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True)
-    recent_sale_date = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True)
-    release_date = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True)
-    analysis_start_time = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True)
-    analysis_end_time = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True)
+    generation_date = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True, required=False)
+    recent_sale_date = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True, required=False)
+    release_date = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True, required=False)
+    analysis_start_time = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True, required=False)
+    analysis_end_time = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True, required=False)
 
     # support the pint objects
     conditioned_floor_area = PintQuantitySerializerField(allow_null=True, required=False)

--- a/seed/serializers/properties.py
+++ b/seed/serializers/properties.py
@@ -106,8 +106,8 @@ class PropertyListSerializer(serializers.ListSerializer):
 
 class PropertySerializer(serializers.ModelSerializer):
     # The created and updated fields are in UTC time and need to be casted accordingly in this format
-    created = serializers.DateTimeField("%Y-%m-%dT%H:%M:%S.%fZ", default_timezone=pytz.utc)
-    updated = serializers.DateTimeField("%Y-%m-%dT%H:%M:%S.%fZ", default_timezone=pytz.utc)
+    created = serializers.DateTimeField("%Y-%m-%dT%H:%M:%S.%fZ", default_timezone=pytz.utc, read_only=True)
+    updated = serializers.DateTimeField("%Y-%m-%dT%H:%M:%S.%fZ", default_timezone=pytz.utc, read_only=True)
 
     class Meta:
         model = Property


### PR DESCRIPTION
#### Any background context you want to provide?
The addition of 'created' and 'updated' to the PropertySerializer makes those fields required on write operations even though they are auto fields in the model.  Also in PropertyStateWritableSerializer, allow_null=True still leaves the fields required even though they are not.
#### What's this PR do?
Changes 'created' and 'updated' to read_only fields in the PropertySerializer.  Adds required=False to PropertyStateWritableSerializer non-required date and time fields.
#### How should this be manually tested?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
