### PR TITLE
2290 dq valid label results fix

### DIFF
--- a/seed/models/data_quality.py
+++ b/seed/models/data_quality.py
@@ -787,7 +787,6 @@ class DataQualityCheck(models.Model):
                         if rule.severity == Rule.SEVERITY_VALID:
                             label_applied = self.update_status_label(label, rule, linked_id, row.id, False)
 
-
                 if not label_applied and rule.status_label_id in model_labels['label_ids']:
                     self.remove_status_label(label, rule, linked_id)
 

--- a/seed/models/data_quality.py
+++ b/seed/models/data_quality.py
@@ -786,11 +786,11 @@ class DataQualityCheck(models.Model):
                         self.add_result_dimension_error(row.id, rule, display_name, value)
                         continue
 
-                    # Check for mandatory label for valid data:
+                    # Check min and max values for valid data:
                     try:
                         if rule.minimum_valid(value) and rule.maximum_valid(value):
                             if rule.severity == Rule.SEVERITY_VALID:
-                                label_applied = self.update_status_label(label, rule, linked_id, row.id)
+                                label_applied = self.update_status_label(label, rule, linked_id, row.id, False)
                     except MissingLabelError:
                         self.add_result_missing_label(row.id, rule, display_name, value)
                         continue
@@ -1044,7 +1044,7 @@ class DataQualityCheck(models.Model):
             'condition': rule.condition,
         })
 
-    def update_status_label(self, label_class, rule, linked_id, row_id):
+    def update_status_label(self, label_class, rule, linked_id, row_id, add_to_results=True):
         """
 
         :param label_class: statuslabel object, either propertyview label or taxlotview label
@@ -1082,7 +1082,8 @@ class DataQualityCheck(models.Model):
                         )
                     )
 
-            self.results[row_id]['data_quality_results'][-1]['label'] = rule.status_label.name
+            if add_to_results:
+                self.results[row_id]['data_quality_results'][-1]['label'] = rule.status_label.name
 
             return True
 

--- a/seed/models/data_quality.py
+++ b/seed/models/data_quality.py
@@ -48,10 +48,6 @@ class UnitMismatchError(Exception):
     pass
 
 
-class MissingLabelError(Exception):
-    pass
-
-
 def format_pint_violation(rule, source_value):
     """
     Format a pint min, max violation for human readability.
@@ -787,13 +783,10 @@ class DataQualityCheck(models.Model):
                         continue
 
                     # Check min and max values for valid data:
-                    try:
-                        if rule.minimum_valid(value) and rule.maximum_valid(value):
-                            if rule.severity == Rule.SEVERITY_VALID:
-                                label_applied = self.update_status_label(label, rule, linked_id, row.id, False)
-                    except MissingLabelError:
-                        self.add_result_missing_label(row.id, rule, display_name, value)
-                        continue
+                    if rule.minimum_valid(value) and rule.maximum_valid(value):
+                        if rule.severity == Rule.SEVERITY_VALID:
+                            label_applied = self.update_status_label(label, rule, linked_id, row.id, False)
+
 
                 if not label_applied and rule.status_label_id in model_labels['label_ids']:
                     self.remove_status_label(label, rule, linked_id)
@@ -988,19 +981,6 @@ class DataQualityCheck(models.Model):
             'severity': rule.get_severity_display(),
             'condition': rule.condition,
         })
-
-    def add_result_missing_label(self, row_id, rule, display_name, value):
-        if rule.severity == Rule.SEVERITY_VALID:
-            self.results[row_id]['data_quality_results'].append({
-                'field': rule.field,
-                'formatted_field': rule.field,
-                'value': value,
-                'table_name': rule.table_name,
-                'message': rule.status_label + ' is missing',
-                'detailed_message': rule.status_label + ' is required and missing',
-                'severity': rule.get_severity_display(),
-                'condition': rule.condition,
-            })
 
     def add_result_missing_and_none(self, row_id, rule, display_name, value):
         self.results[row_id]['data_quality_results'].append({

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -95,7 +95,6 @@ angular.module('BE.seed.controller.inventory_list', [])
 
       // Reduce labels to only records found in the current cycle
       $scope.selected_labels = [];
-      updateApplicableLabels();
 
       var localStorageKey = 'grid.' + $scope.inventory_type;
       var localStorageLabelKey = 'grid.' + $scope.inventory_type + '.labels';

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -203,12 +203,10 @@ angular.module('BE.seed.controller.inventory_list', [])
           });
         });
         // Ensure that no previously-applied labels remain
-        var new_labels = _.filter($scope.selected_labels, function (label) {
-          return _.includes($scope.labels, label.id);
+        // Filter on $scope.labels to refresh is_applied
+        $scope.selected_labels = _.filter($scope.labels, function (label) {
+          return _.find($scope.selected_labels, ['id', label.id]);
         });
-        if ($scope.selected_labels.length !== new_labels.length) {
-          $scope.selected_labels = new_labels;
-        }
       }
 
       var filterUsingLabels = function () {

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -647,6 +647,7 @@ angular.module('BE.seed.controller.inventory_list', [])
       var get_labels = function () {
         label_service.get_labels($scope.inventory_type).then(function (current_labels) {
           updateApplicableLabels(current_labels);
+          filterUsingLabels();
         });
       };
 


### PR DESCRIPTION
#### Any background context you want to provide?
In cases that a Rule with "valid" severity and a "range" condition is triggered, a line is **not** included in the DQ Check results. Because of this, it's possible for SEED to hang when trying to display the label that is accompanied with that triggered rule.

See the attached issue to see how this was discovered.

#### What's this PR do?
This PR implements a flag to allow for the application of the label to the record while avoiding the attempt to display the applied label in the result.

In addition, the following inventory list label clean ups are included here as well:
With labels applied, the following actions would remove selected and valid (is_applied) labels.
- Run DQ check - Now selected labels should remain.
- Switch cycles - Now, only no-longer-applicable labels are filtered out.
- Remove selected label from some records - Now, selected labels can remain only if they're applied to records. Also, the filtered records are refreshed.

#### How should this be manually tested?
Run DQ checks from the inventory list page while forcing valid data rules to trigger. Check that any of these valid data rules had their labels applied to **only** the records that should have triggered these rules. 

Also, specifically test that a single Rule can successfully be triggered on a single record without "hanging".

Lastly, monkey test labels, and specifically test that with labels applied, the following actions have a reasonable UX (see changes above):
- Run DQ check
- Switch cycles
- Remove selected label from records

#### What are the relevant tickets?
#2290 

#### Screenshots (if appropriate)
