### PR TITLE
2289 dq admin save button fix

### DIFF
--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -153,23 +153,12 @@ angular.module('BE.seed.controller.data_quality_admin', [])
       $scope.isModified = function () {
         return modified_service.isModified();
       };
-      var originalRules = angular.copy(data_quality_rules_payload.rules);
-      $scope.original = originalRules;
+
       $scope.change_rules = function () {
         $scope.defaults_restored = false;
         $scope.rules_reset = false;
         $scope.rules_updated = false;
-        $scope.setModified();
-      };
-      $scope.setModified = function () {
-        var cleanRules = angular.copy($scope.ruleGroups);
-        _.each(originalRules, function (rules, index) {
-          Object.keys(rules).forEach(function (key) {
-            _.reduce(cleanRules[index][rules[key].field], function (result, value) {
-              return !_.isEqual(value, rules[key]) && modified_service.setModified();
-            }, []);
-          });
-        });
+        modified_service.setModified();
       };
 
       // Restores the default rules
@@ -447,10 +436,8 @@ angular.module('BE.seed.controller.data_quality_admin', [])
       };
 
       $scope.selectAll = function () {
-        $scope.rules_updated = false;
-        $scope.rules_reset = false;
-        $scope.defaults_restored = false;
-        $scope.setModified();
+        $scope.change_rules();
+
         var allEnabled = $scope.allEnabled();
         _.forEach($scope.ruleGroups[$scope.inventory_type], function (ruleGroup) {
           _.forEach(ruleGroup, function (rule) {

--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -154,7 +154,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
         return modified_service.isModified();
       };
 
-      $scope.change_rules = function () {
+      $scope.rules_changed = function () {
         $scope.defaults_restored = false;
         $scope.rules_reset = false;
         $scope.rules_updated = false;
@@ -381,7 +381,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
           'new': true,
           autofocus: true
         });
-        $scope.change_rules();
+        $scope.rules_changed();
         if ($scope.inventory_type === 'properties') $scope.rule_count_property += 1;
         else $scope.rule_count_taxlot += 1;
       };
@@ -412,7 +412,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
         if ($scope.ruleGroups[$scope.inventory_type][rule.field].length === 1) {
           delete $scope.ruleGroups[$scope.inventory_type][rule.field];
         } else $scope.ruleGroups[$scope.inventory_type][rule.field].splice(index, 1);
-        $scope.change_rules();
+        $scope.rules_changed();
         if ($scope.inventory_type === 'properties') $scope.rule_count_property -= 1;
         else $scope.rule_count_taxlot -= 1;
       };
@@ -436,7 +436,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
       };
 
       $scope.selectAll = function () {
-        $scope.change_rules();
+        $scope.rules_changed();
 
         var allEnabled = $scope.allEnabled();
         _.forEach($scope.ruleGroups[$scope.inventory_type], function (ruleGroup) {

--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -163,7 +163,9 @@ angular.module('BE.seed.controller.data_quality_admin', [])
         return modified_service.isModified();
       };
 
-      $scope.rules_changed = function () {
+      $scope.rules_changed = function (rule) {
+        if (rule) rule.rule_type = 1;
+
         $scope.defaults_restored = false;
         $scope.rules_reset = false;
         $scope.rules_updated = false;

--- a/seed/static/seed/partials/data_quality_admin.html
+++ b/seed/static/seed/partials/data_quality_admin.html
@@ -67,7 +67,7 @@
                         </tr>
                     </thead>
                     <tbody ng-repeat="field in sortedRuleGroups()">
-                        <tr ng-repeat="rule in ruleGroups[inventory_type][field]" ng-class="{ 'warning' : rule.new, 'disabled' : !rule.enabled }" ng-click="change_rules()">
+                        <tr ng-repeat="rule in ruleGroups[inventory_type][field]" ng-class="{ 'warning' : rule.new, 'disabled' : !rule.enabled }" ng-click="rules_changed()">
                             <td class="check is_aligned_center" ng-click="rule.rule_type = 1; rule.enabled = !rule.enabled">
                                 <input type="checkbox" ng-model="rule.enabled" class="no-click">
                             </td>

--- a/seed/static/seed/partials/data_quality_admin.html
+++ b/seed/static/seed/partials/data_quality_admin.html
@@ -67,42 +67,42 @@
                         </tr>
                     </thead>
                     <tbody ng-repeat="field in sortedRuleGroups()">
-                        <tr ng-repeat="rule in ruleGroups[inventory_type][field]" ng-class="{ 'warning' : rule.new, 'disabled' : !rule.enabled }" ng-click="rules_changed()">
-                            <td class="check is_aligned_center" ng-click="rule.rule_type = 1; rule.enabled = !rule.enabled">
+                        <tr ng-repeat="rule in ruleGroups[inventory_type][field]" ng-class="{ 'warning' : rule.new, 'disabled' : !rule.enabled }">
+                            <td class="check is_aligned_center" ng-click="rules_changed(rule); rule.enabled = !rule.enabled">
                                 <input type="checkbox" ng-model="rule.enabled" class="no-click">
                             </td>
                             <td>
-                                <select class="form-control input-sm" ng-model="rule.condition" ng-options="condition.id as condition.label for condition in ::conditions" ng-change="rule.rule_type = 1; change_condition(rule)"></select>
+                                <select class="form-control input-sm" ng-model="rule.condition" ng-options="condition.id as condition.label for condition in ::conditions" ng-change="rules_changed(rule); change_condition(rule)"></select>
                             </td>
                             <td>
-                                <select class="form-control input-sm" ng-model="rule.field" ng-options="col.column_name as col.displayName group by col.group for col in ::columns | orderBy: 'group'" ng-change="rule.rule_type = 1; change_field(rule, '{$ rule.field $}', $index)" title="{$ rule.field $}" focus-if="{$ rule.autofocus || 'false' $}"></select>
+                                <select class="form-control input-sm" ng-model="rule.field" ng-options="col.column_name as col.displayName group by col.group for col in ::columns | orderBy: 'group'" ng-change="rules_changed(rule); change_field(rule, '{$ rule.field $}', $index)" title="{$ rule.field $}" focus-if="{$ rule.autofocus || 'false' $}"></select>
                             </td>
                             <td ng-if="rule.condition === 'range'">
-                                <select class="form-control input-sm" ng-model="rule.data_type" ng-options="type.id as type.label for type in ::data_types[1]" ng-change="rule.rule_type = 1; change_data_type(rule, '{$ rule.data_type $}')"></select>
+                                <select class="form-control input-sm" ng-model="rule.data_type" ng-options="type.id as type.label for type in ::data_types[1]" ng-change="rules_changed(rule); change_data_type(rule, '{$ rule.data_type $}')"></select>
                             </td>
                             <td ng-if="rule.condition !== 'range'" >
-                                <select class="form-control input-sm" ng-model="rule.data_type" ng-if="_.includes(['include', 'exclude'], rule.condition)" ng-options="type.id as type.label for type in ::data_types[0]" ng-change="rule.rule_type = 1; change_data_type(rule, '{$ rule.data_type $}')"></select>
-                                <select class="form-control input-sm" ng-model="rule.data_type" ng-if="_.includes(['required', 'not_null', '', null, 'None'], rule.condition)" ng-options="type.id as type.label for type in ::data_types[2]" ng-change="rule.rule_type = 1; change_data_type(rule, '{$ rule.data_type $}')"></select>
+                                <select class="form-control input-sm" ng-model="rule.data_type" ng-if="_.includes(['include', 'exclude'], rule.condition)" ng-options="type.id as type.label for type in ::data_types[0]" ng-change="rules_changed(rule); change_data_type(rule, '{$ rule.data_type $}')"></select>
+                                <select class="form-control input-sm" ng-model="rule.data_type" ng-if="_.includes(['required', 'not_null', '', null, 'None'], rule.condition)" ng-options="type.id as type.label for type in ::data_types[2]" ng-change="rules_changed(rule); change_data_type(rule, '{$ rule.data_type $}')"></select>
                             </td>
                             <td ng-if="rule.data_type === 'string'" colspan="2">
-                                <input class="form-control input-sm" type="text" maxlength="200" ng-model="rule.text_match" ng-if="_.includes(['include', 'exclude', 'required', 'not_null', '', null, 'None'], rule.condition)" ng-change="rule.rule_type = 1"
+                                <input class="form-control input-sm" type="text" maxlength="200" ng-model="rule.text_match" ng-if="_.includes(['include', 'exclude', 'required', 'not_null', '', null, 'None'], rule.condition)" ng-change="rules_changed(rule)"
                                        placeholder="{$ rule.condition == 'include' && 'field must contain this text' || (rule.condition == 'exclude' && 'field must not contain this text' || '' | translate) $}"
                                        ng-disabled="filter_null(rule)"
                                        ng-style="{'border-color' : rules_updated && !rule.text_match && rule.condition != 'not_null' && rule.condition != 'required' && rule.condition != '' && '#ff4d4d'}">
                             </td>
                             <td ng-if="rule.data_type !== 'string'">
-                                <input class="form-control input-sm" type="number" ng-model="rule.min" ng-change="rule.rule_type = 1" ng-if="_.includes([null, 'None', 'number', 'year', 'area', 'eui'], rule.data_type)" placeholder="{$:: '(no minimum)' | translate $}" ng-disabled="filter_null(rule)">
-                                <input class="form-control input-sm" type="date" ng-model="rule.min" ng-change="rule.rule_type = 1" ng-if="rule.data_type === 'date'" ng-disabled="filter_null(rule)">
+                                <input class="form-control input-sm" type="number" ng-model="rule.min" ng-change="rules_changed(rule)" ng-if="_.includes([null, 'None', 'number', 'year', 'area', 'eui'], rule.data_type)" placeholder="{$:: '(no minimum)' | translate $}" ng-disabled="filter_null(rule)">
+                                <input class="form-control input-sm" type="date" ng-model="rule.min" ng-change="rules_changed(rule)" ng-if="rule.data_type === 'date'" ng-disabled="filter_null(rule)">
                             </td>
                             <td ng-if="rule.data_type !== 'string'">
-                                <input class="form-control input-sm" type="number" ng-model="rule.max" ng-change="rule.rule_type = 1" ng-if="rule.data_type !== 'date'" placeholder="{$:: '(no maximum)' | translate $}" ng-disabled="filter_null(rule)">
-                                <input class="form-control input-sm" type="date" ng-model="rule.max" ng-change="rule.rule_type = 1" ng-if="rule.data_type === 'date'" ng-disabled="filter_null(rule)">
+                                <input class="form-control input-sm" type="number" ng-model="rule.max" ng-change="rules_changed(rule)" ng-if="rule.data_type !== 'date'" placeholder="{$:: '(no maximum)' | translate $}" ng-disabled="filter_null(rule)">
+                                <input class="form-control input-sm" type="date" ng-model="rule.max" ng-change="rules_changed(rule)" ng-if="rule.data_type === 'date'" ng-disabled="filter_null(rule)">
                             </td>
                             <td>
-                                <select class="form-control input-sm" ng-options="unit.id as unit.label for unit in units" ng-model="rule.units" ng-change="rule.rule_type = 1" ng-disabled="filter_null(rule)"></select>
+                                <select class="form-control input-sm" ng-options="unit.id as unit.label for unit in units" ng-model="rule.units" ng-change="rules_changed(rule)" ng-disabled="filter_null(rule)"></select>
                             </td>
                             <td>
-                                <select class="form-control input-sm" ng-model="rule.severity" ng-change="rule.rule_type = 1" ng-class="{'valid-bg': rule.severity === 'valid', 'error-bg': rule.severity === 'error', 'warning-bg': rule.severity === 'warning'}">
+                                <select class="form-control input-sm" ng-model="rule.severity" ng-change="rules_changed(rule)" ng-class="{'valid-bg': rule.severity === 'valid', 'error-bg': rule.severity === 'error', 'warning-bg': rule.severity === 'warning'}">
                                     <option value="error" translate>Error</option>
                                     <option value="valid" translate>Valid Data</option>
                                     <option value="warning" translate>Warning</option>
@@ -112,19 +112,19 @@
                                 <div class="input-group input-group-sm" ng-if="rule.label">
                                     <span class="form-control label label-{$ rule.label.label $}" style="border: 0 none;">{$ rule.label.name | translate $}</span>
                                     <span class="input-group-btn">
-                                        <button class="btn btn-danger" type="button" ng-click="remove_label(rule)">
+                                        <button class="btn btn-danger" type="button" ng-click="rules_changed(rule); remove_label(rule)">
                                             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
                                         </button>
                                     </span>
                                 </div>
-                                <button class="btn btn-xs btn-info btn-rowform" ng-click="create_label(rule, $index)" ng-if="!rule.label">
+                                <button class="btn btn-xs btn-info btn-rowform" ng-click="rules_changed(rule); create_label(rule, $index)" ng-if="!rule.label">
                                     <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
                                 </button>
                                 <!-- code for multiple labels -->
                                 <!-- <span ng-repeat="label in rule.label" class="label label-{$ label.label $}" style="display: block; margin-top: 7px; padding: 4.6px 7px;">{$ label.name $}</span> -->
 
                                 <!-- old code -->
-                                <!-- <select class="form-control input-sm" ng-model="rule.label" ng-change="rule.rule_type = 1" ng-options="label.id as label.name for label in all_labels"></select> -->
+                                <!-- <select class="form-control input-sm" ng-model="rule.label" ng-change="rules_changed(rule)" ng-options="label.id as label.name for label in all_labels"></select> -->
                             </td>
                             <td class="check is_aligned_center">
                                 <button class="btn btn-xs btn-danger btn-rowform" ng-click="delete_rule(rule, $index)">

--- a/seed/static/seed/tests/data_quality_admin_controller.spec.js
+++ b/seed/static/seed/tests/data_quality_admin_controller.spec.js
@@ -14,6 +14,7 @@ describe('controller: data_quality_admin_controller', function () {
     inject(function (_$httpBackend_) {
       $httpBackend = _$httpBackend_;
       $httpBackend.whenGET(/^\/static\/seed\/locales\/.*\.json/).respond(200, {});
+      $httpBackend.whenGET(/^\/static\/seed\/partials\/modified_modal\.html/).respond(200, {});
     });
     inject(function ($controller, $rootScope/*, $q*/) {
       controller = $controller;


### PR DESCRIPTION
#### Any background context you want to provide?
On the DQ admin page, it was possible for the the "Save Changes" button to not be re-enabled when expected.

See attached issue for a specific case.

#### What's this PR do?
Removes extra logic around deciding whether a rule change has happened on the DQ admin page and clean up relevant methods (rename and delete no longer used variables).

#### How should this be manually tested?
Make changes on the DQ admin page, see that the Save Changes button is enabled.

Also, take the steps detailed in the attached issue to ensure that the original "steps" taken to discover this bug no longer yields this bug.

#### What are the relevant tickets?
#2289 
Should also address #1848 

#### Screenshots (if appropriate)
