### PR TITLE
2286 dq indicate mapped fields

### DIFF
--- a/seed/static/seed/js/controllers/column_settings_controller.js
+++ b/seed/static/seed/js/controllers/column_settings_controller.js
@@ -423,6 +423,9 @@ angular.module('BE.seed.controller.column_settings', [])
             },
             all_column_names: function () {
               return _.map($scope.columns, 'column_name');
+            },
+            org_id: function () {
+              return $scope.org.id;
             }
           }
         });

--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -9,6 +9,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
     '$state',
     '$stateParams',
     'columns',
+    'used_columns',
     'organization_payload',
     'data_quality_rules_payload',
     'auth_payload',
@@ -29,6 +30,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
       $state,
       $stateParams,
       columns,
+      used_columns,
       organization_payload,
       data_quality_rules_payload,
       auth_payload,
@@ -97,6 +99,16 @@ angular.module('BE.seed.controller.data_quality_admin', [])
       ];
 
       $scope.columns = columns;
+
+      $scope.check_if_column_used = function (col) {
+        var display = col.displayName;
+
+        if (!_.find(used_columns, ['id', col.id])) {
+          display += " **";
+        }
+
+        return display;
+      }
 
       // if (flippers.is_active('release:orig_columns')) {
       //   // db may return _orig columns; don't suggest them in the select

--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -98,17 +98,14 @@ angular.module('BE.seed.controller.data_quality_admin', [])
         {id: 'kBtu/m**2/year', label: 'kBtu/m²/year'}
       ];
 
-      $scope.columns = columns;
-
-      $scope.check_if_column_used = function (col) {
-        var display = col.displayName;
-
+      $scope.columns = _.map(angular.copy(columns), function (col) {
         if (!_.find(used_columns, ['id', col.id])) {
-          display += " **";
+          col.group = 'Unused Fields';
+        } else {
+          col.group = 'Mapped Fields';
         }
-
-        return display;
-      }
+        return col;
+      });
 
       // if (flippers.is_active('release:orig_columns')) {
       //   // db may return _orig columns; don't suggest them in the select

--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -100,7 +100,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
 
       $scope.columns = _.map(angular.copy(columns), function (col) {
         if (!_.find(used_columns, ['id', col.id])) {
-          col.group = 'Unused Fields';
+          col.group = 'Not Mapped';
         } else {
           col.group = 'Mapped Fields';
         }

--- a/seed/static/seed/js/controllers/rename_column_modal_controller.js
+++ b/seed/static/seed/js/controllers/rename_column_modal_controller.js
@@ -12,6 +12,7 @@ angular.module('BE.seed.controller.rename_column_modal', [])
     'column_name',
     'columns_service',
     'spinner_utility',
+    'org_id',
     function (
       $scope,
       $state,
@@ -20,7 +21,8 @@ angular.module('BE.seed.controller.rename_column_modal', [])
       column_id,
       column_name,
       columns_service,
-      spinner_utility
+      spinner_utility,
+      org_id
     ) {
       $scope.step = {
         number: 1
@@ -48,7 +50,7 @@ angular.module('BE.seed.controller.rename_column_modal', [])
 
       $scope.accept_rename = function () {
         spinner_utility.show();
-        columns_service.rename_column($scope.column.id, $scope.column.name, $scope.settings.overwrite_preference)
+        columns_service.rename_column_for_org(org_id, $scope.column.id, $scope.column.name, $scope.settings.overwrite_preference)
           .then(function (response) {
             $scope.results = {
               success: response.data.success,

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -941,6 +941,26 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
               });
             }
           }],
+          used_columns: ['$stateParams', 'inventory_service', function ($stateParams, inventory_service) {
+            var organization_id = $stateParams.organization_id;
+            if ($stateParams.inventory_type === 'properties') {
+              return inventory_service.get_property_columns_for_org(organization_id, true).then(function (columns) {
+                columns = _.reject(columns, 'related');
+                columns = _.map(columns, function (col) {
+                  return _.omit(col, ['pinnedLeft', 'related']);
+                });
+                return columns;
+              });
+            } else if ($stateParams.inventory_type === 'taxlots') {
+              return inventory_service.get_taxlot_columns_for_org(organization_id, true).then(function (columns) {
+                columns = _.reject(columns, 'related');
+                columns = _.map(columns, function (col) {
+                  return _.omit(col, ['pinnedLeft', 'related']);
+                });
+                return columns;
+              });
+            }
+          }],
           organization_payload: ['organization_service', '$stateParams', function (organization_service, $stateParams) {
             var organization_id = $stateParams.organization_id;
             return organization_service.get_organization(organization_id);

--- a/seed/static/seed/js/services/columns_service.js
+++ b/seed/static/seed/js/services/columns_service.js
@@ -24,8 +24,12 @@ angular.module('BE.seed.service.columns', []).factory('columns_service', [
     };
 
     columns_service.rename_column = function (column_id, column_name, overwrite_preference) {
+      return columns_service.rename_column_for_org(user_service.get_organization().id, column_id, column_name, overwrite_preference);
+    };
+
+    columns_service.rename_column_for_org = function (org_id, column_id, column_name, overwrite_preference) {
       return $http.post('/api/v2/columns/' + column_id + '/rename/', {
-        organization_id: user_service.get_organization().id,
+        organization_id: org_id,
         new_column_name: column_name,
         overwrite: overwrite_preference
       }).then(function (response) {

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -503,10 +503,11 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       return inventory_service.get_property_columns_for_org(user_service.get_organization().id);
     };
 
-    inventory_service.get_property_columns_for_org = function (org_id) {
+    inventory_service.get_property_columns_for_org = function (org_id, only_used=false) {
       return $http.get('/api/v2/properties/columns/', {
         params: {
-          organization_id: org_id
+          organization_id: org_id,
+          only_used: only_used
         }
       }).then(function (response) {
         // Remove empty columns
@@ -581,10 +582,11 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       return inventory_service.get_taxlot_columns_for_org(user_service.get_organization().id);
     };
 
-    inventory_service.get_taxlot_columns_for_org = function (org_id) {
+    inventory_service.get_taxlot_columns_for_org = function (org_id, only_used=false) {
       return $http.get('/api/v2/taxlots/columns/', {
         params: {
-          organization_id: org_id
+          organization_id: org_id,
+          only_used: only_used
         }
       }).then(function (response) {
         // Remove empty columns

--- a/seed/static/seed/partials/data_quality_admin.html
+++ b/seed/static/seed/partials/data_quality_admin.html
@@ -34,10 +34,9 @@
     <div class="section_content_container">
         <div class="section_content with_padding" style="margin-bottom:15px;">
             <h3 translate>Modifying Data Quality Rules</h3>
-            <p ng-bind-html-unsafe>From the table below, select the rules that you want to: 1) enable/disable within your organization, 2) modify the minimum/maximum values to validate against on file upload, and 3) optionally assign or remove a label if the condition is not met.<br>
+            <p>From the table below, select the rules that you want to: 1) enable/disable within your organization, 2) modify the minimum/maximum values to validate against on file upload, and 3) optionally assign or remove a label if the condition is not met.<br>
             Restore Default Rules: reset only default rules.<br>
             Reset All Rules: delete all rules and reinitialize the default set of rules.</p>
-            <p>** Indicates that a field has not yet been explicitly mapped during file import.</p>
             <button class="btn btn-info btn-sm" style="margin-bottom: 15px;" ng-click="create_new_rule()" translate>Create a new rule</button>
             <div class="data-quality-tab-container">
                 <ul class="nav nav-tabs" style="margin-bottom:1px;">
@@ -76,7 +75,7 @@
                                 <select class="form-control input-sm" ng-model="rule.condition" ng-options="condition.id as condition.label for condition in ::conditions" ng-change="rule.rule_type = 1; change_condition(rule)"></select>
                             </td>
                             <td>
-                                <select class="form-control input-sm" ng-model="rule.field" ng-options="col.column_name as check_if_column_used(col) for col in ::columns" ng-change="rule.rule_type = 1; change_field(rule, '{$ rule.field $}', $index)" title="{$ rule.field $}" focus-if="{$ rule.autofocus || 'false' $}"></select>
+                                <select class="form-control input-sm" ng-model="rule.field" ng-options="col.column_name as col.displayName group by col.group for col in ::columns | orderBy: 'group'" ng-change="rule.rule_type = 1; change_field(rule, '{$ rule.field $}', $index)" title="{$ rule.field $}" focus-if="{$ rule.autofocus || 'false' $}"></select>
                             </td>
                             <td ng-if="rule.condition === 'range'">
                                 <select class="form-control input-sm" ng-model="rule.data_type" ng-options="type.id as type.label for type in ::data_types[1]" ng-change="rule.rule_type = 1; change_data_type(rule, '{$ rule.data_type $}')"></select>

--- a/seed/static/seed/partials/data_quality_admin.html
+++ b/seed/static/seed/partials/data_quality_admin.html
@@ -61,7 +61,7 @@
                             <th translate>Minimum</th>
                             <th translate>Maximum</th>
                             <th translate>Units</th>
-                            <th style="min-width: 100px; width: 100px;" translate>Severity Level</th>
+                            <th style="min-width: 110px; width: 110px;" translate>Severity Level</th>
                             <th translate>Label</th>
                             <th style="min-width: 54px; width: 54px;" translate>Delete</th>
                         </tr>

--- a/seed/static/seed/partials/data_quality_admin.html
+++ b/seed/static/seed/partials/data_quality_admin.html
@@ -37,6 +37,7 @@
             <p ng-bind-html-unsafe>From the table below, select the rules that you want to: 1) enable/disable within your organization, 2) modify the minimum/maximum values to validate against on file upload, and 3) optionally assign or remove a label if the condition is not met.<br>
             Restore Default Rules: reset only default rules.<br>
             Reset All Rules: delete all rules and reinitialize the default set of rules.</p>
+            <p>** Indicates that a field has not yet been explicitly mapped during file import.</p>
             <button class="btn btn-info btn-sm" style="margin-bottom: 15px;" ng-click="create_new_rule()" translate>Create a new rule</button>
             <div class="data-quality-tab-container">
                 <ul class="nav nav-tabs" style="margin-bottom:1px;">
@@ -75,7 +76,7 @@
                                 <select class="form-control input-sm" ng-model="rule.condition" ng-options="condition.id as condition.label for condition in ::conditions" ng-change="rule.rule_type = 1; change_condition(rule)"></select>
                             </td>
                             <td>
-                                <select class="form-control input-sm" ng-model="rule.field" ng-options="col.column_name as col.displayName for col in ::columns" ng-change="rule.rule_type = 1; change_field(rule, '{$ rule.field $}', $index)" title="{$ rule.field $}" focus-if="{$ rule.autofocus || 'false' $}"></select>
+                                <select class="form-control input-sm" ng-model="rule.field" ng-options="col.column_name as check_if_column_used(col) for col in ::columns" ng-change="rule.rule_type = 1; change_field(rule, '{$ rule.field $}', $index)" title="{$ rule.field $}" focus-if="{$ rule.autofocus || 'false' $}"></select>
                             </td>
                             <td ng-if="rule.condition === 'range'">
                                 <select class="form-control input-sm" ng-model="rule.data_type" ng-options="type.id as type.label for type in ::data_types[1]" ng-change="rule.rule_type = 1; change_data_type(rule, '{$ rule.data_type $}')"></select>

--- a/seed/static/seed/tests/data_quality_admin_controller.spec.js
+++ b/seed/static/seed/tests/data_quality_admin_controller.spec.js
@@ -35,6 +35,7 @@ describe('controller: data_quality_admin_controller', function () {
     controller('data_quality_admin_controller', {
       $scope: data_quality_admin_controller_scope,
       columns: col_payload,
+      used_columns: col_payload,
       organization_payload: {},
       data_quality_rules_payload: {},
       auth_payload: {},

--- a/seed/views/properties.py
+++ b/seed/views/properties.py
@@ -8,6 +8,8 @@ All rights reserved.  # NOQA
 :author
 """
 
+import json
+
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import JsonResponse
 from rest_framework import status
@@ -814,7 +816,7 @@ class PropertyViewSet(ViewSet, ProfileIdMixin):
               paramType: query
         """
         organization_id = int(request.query_params.get('organization_id'))
-        only_used = request.query_params.get('only_used', False)
+        only_used = json.loads(request.query_params.get('only_used', 'false'))
         columns = Column.retrieve_all(organization_id, 'property', only_used)
         organization = Organization.objects.get(pk=organization_id)
         unitted_columns = [add_pint_unit_suffix(organization, x) for x in columns]

--- a/seed/views/taxlots.py
+++ b/seed/views/taxlots.py
@@ -8,6 +8,8 @@ All rights reserved.  # NOQA
 :author
 """
 
+import json
+
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import JsonResponse
 from rest_framework import status
@@ -624,7 +626,7 @@ class TaxLotViewSet(ViewSet, ProfileIdMixin):
         organization_id = int(request.query_params.get('organization_id'))
         organization = Organization.objects.get(pk=organization_id)
 
-        only_used = request.query_params.get('only_used', False)
+        only_used = json.loads(request.query_params.get('only_used', 'false'))
         columns = Column.retrieve_all(organization_id, 'taxlot', only_used)
         unitted_columns = [add_pint_unit_suffix(organization, x) for x in columns]
 


### PR DESCRIPTION
#### Any background context you want to provide?
When defining DQ Rules, we realized it would be helpful to flag fields that were not mapped by an organization. 

See attached issue for more details.

#### What's this PR do?
This PR introduces an indicator on the DQ admin page that shows which fields have been mapped to during file imports. In the backend, the mapped, or "used", columns are flagged by checking if `ColumnMapping.objects.filter(column_mapped=[col_object]).exists()`. [This check existed already and didn't need to be written.](https://github.com/SEED-platform/seed/blob/4baeb3441f92a4e886d2d28c515dde39289f05c7/seed/models/columns.py#L1321-L1323)

Note that no checks are performed on the actual inventory records as that operation could potentially be very expensive.

#### How should this be manually tested?
Visit the DQ admin page, and see that a ** is added to indicate fields that have not been mapped. Spot check to confirm fields are correctly flagged.

#### What are the relevant tickets?
#2286 

#### Screenshots (if appropriate)
<img width="936" alt="Screen Shot 2020-07-15 at 1 21 30 PM" src="https://user-images.githubusercontent.com/30608004/87593349-8e27cd80-c6a8-11ea-8a52-defd140e928b.png">
