### PR TITLE
2263 api v3 add property views

### DIFF
--- a/seed/api/v3/urls.py
+++ b/seed/api/v3/urls.py
@@ -31,6 +31,7 @@ from seed.views.v3.portfolio_manager import PortfolioManagerViewSet
 from seed.views.v3.progress import ProgressViewSet
 from seed.views.v3.properties import PropertyViewSet
 from seed.views.v3.property_states import PropertyStateViewSet
+from seed.views.v3.property_views import PropertyViewViewSet
 from seed.views.v3.property_scenarios import PropertyScenarioViewSet
 from seed.views.v3.tax_lot_properties import TaxLotPropertyViewSet
 from seed.views.v3.taxlots import TaxlotViewSet
@@ -60,6 +61,7 @@ api_v3_router.register(r'portfolio_manager', PortfolioManagerViewSet, base_name=
 api_v3_router.register(r'progress', ProgressViewSet, base_name="progress")
 api_v3_router.register(r'properties', PropertyViewSet, base_name='properties')
 api_v3_router.register(r'property_states', PropertyStateViewSet, base_name="property_states")
+api_v3_router.register(r'property_views', PropertyViewViewSet, base_name="property_views")
 api_v3_router.register(r'tax_lot_properties', TaxLotPropertyViewSet, base_name="tax_lot_properties")
 api_v3_router.register(r'taxlots', TaxlotViewSet, base_name='taxlots')
 api_v3_router.register(r'ubid', UbidViewSet, base_name='ubid')

--- a/seed/serializers/properties.py
+++ b/seed/serializers/properties.py
@@ -230,11 +230,11 @@ class PropertyStateWritableSerializer(serializers.ModelSerializer):
 
     # support naive datetime objects
     # support naive datetime objects
-    generation_date = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True)
-    recent_sale_date = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True)
-    release_date = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True)
-    analysis_start_time = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True)
-    analysis_end_time = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True)
+    generation_date = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True, required=False)
+    recent_sale_date = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True, required=False)
+    release_date = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True, required=False)
+    analysis_start_time = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True, required=False)
+    analysis_end_time = serializers.DateTimeField('%Y-%m-%dT%H:%M:%S', allow_null=True, required=False)
 
     # support the pint objects
     conditioned_floor_area = PintQuantitySerializerField(allow_null=True, required=False)

--- a/seed/serializers/properties.py
+++ b/seed/serializers/properties.py
@@ -106,8 +106,8 @@ class PropertyListSerializer(serializers.ListSerializer):
 
 class PropertySerializer(serializers.ModelSerializer):
     # The created and updated fields are in UTC time and need to be casted accordingly in this format
-    created = serializers.DateTimeField("%Y-%m-%dT%H:%M:%S.%fZ", default_timezone=pytz.utc)
-    updated = serializers.DateTimeField("%Y-%m-%dT%H:%M:%S.%fZ", default_timezone=pytz.utc)
+    created = serializers.DateTimeField("%Y-%m-%dT%H:%M:%S.%fZ", default_timezone=pytz.utc, read_only=True)
+    updated = serializers.DateTimeField("%Y-%m-%dT%H:%M:%S.%fZ", default_timezone=pytz.utc, read_only=True)
 
     class Meta:
         model = Property

--- a/seed/views/v3/property_views.py
+++ b/seed/views/v3/property_views.py
@@ -1,0 +1,57 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2020, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Department of Energy) and contributors.
+All rights reserved.  # NOQA
+"""
+
+from seed.filtersets import PropertyViewFilterSet
+from seed.models import PropertyView
+from seed.serializers.properties import PropertyViewAsStateSerializer
+from seed.utils.viewsets import SEEDOrgModelViewSet
+
+
+class PropertyViewViewSet(SEEDOrgModelViewSet):
+    """PropertyViews API Endpoint
+
+        Returns::
+            {
+                'status': 'success',
+                'properties': [
+                    {
+                        'id': PropertyView primary key,
+                        'property_id': id of associated Property,
+                        'state': dict of associated PropertyState values (writeable),
+                        'cycle': dict of associated Cycle values,
+                        'certifications': dict of associated GreenAssessmentProperties values
+                    }
+                ]
+            }
+
+
+    retrieve:
+        Return a PropertyView instance by pk if it is within specified org.
+
+    list:
+        Return all PropertyViews available to user through specified org.
+
+    create:
+        Create a new PropertyView within user`s specified org.
+
+    delete:
+        Remove an existing PropertyView.
+
+    update:
+        Update a PropertyView record.
+
+    partial_update:
+        Update one or more fields on an existing PropertyView.
+    """
+    serializer_class = PropertyViewAsStateSerializer
+    model = PropertyView
+    filter_class = PropertyViewFilterSet
+    orgfilter = 'property__organization_id'
+    data_name = "property_views"
+    queryset = PropertyView.objects.all()


### PR DESCRIPTION
#### Any background context you want to provide?
See related Issue and PR.

#### What's this PR do?
Add property_views endpoints to API v3.

Also, fix a related serializer affecting write operations (essentially cherry-picked from linked PR) for these endpoints as well as another serializer affecting the write operation for canonical Property endpoints (gbr_properties).

#### How should this be manually tested?
Test the property_views endpoints on the Swagger page. For the /v3/property_views/ POST endpoint, remove the _data fields from the nested State object to be created (created by not providing the "id" key (from `"state": { "id"...`). 

Also test the /v3/gpr_properties/ POST endpoint while removing the "created" and "updated" fields.

#### What are the relevant tickets?
Issue #2263 
PR #2288 

#### Screenshots (if appropriate)
