### PR TITLE
2164 label is applied

### DIFF
--- a/seed/serializers/labels.py
+++ b/seed/serializers/labels.py
@@ -47,6 +47,15 @@ class LabelSerializer(serializers.ModelSerializer):
         }
         model = Label
 
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+
+        # Avoid the impression that no records "is_applied" if inventory isn't provided and a search never occurred
+        if not self.inventory:
+            del ret['is_applied']
+
+        return ret
+
     def get_is_applied(self, obj):
         filtered_result = []
         if self.inventory:

--- a/seed/tests/test_labels_api_views.py
+++ b/seed/tests/test_labels_api_views.py
@@ -6,6 +6,9 @@
 
 Unit tests for seed/views/labels.py
 """
+
+import json
+
 from collections import defaultdict
 
 from datetime import datetime
@@ -25,6 +28,8 @@ from seed.test_helpers.fake import (
     mock_queryset_factory,
     FakeCycleFactory,
     FakePropertyStateFactory,
+    FakePropertyViewFactory,
+    FakeTaxLotViewFactory,
 )
 from seed.tests.util import DeleteModelsTestCase
 from seed.utils.organizations import create_organization
@@ -114,6 +119,73 @@ class TestLabelsViewSet(DeleteModelsTestCase):
 
         assert results_a == {organization_a.pk}
         assert results_b == {organization_b.pk}
+
+    def test_labels_list_endpoint_doesnt_include_is_applied(self):
+        user = User.objects.create_superuser(
+            email='test_user@demo.com',
+            username='test_user@demo.com',
+            password='secret',
+        )
+        organization_a, _, _ = create_organization(user, "test-organization-a")
+
+        # Ensures that at least a single label exists to ensure that we are not
+        # relying on auto-creation of labels for this test to pass.
+        Label.objects.create(
+            color="red",
+            name="test_label-a",
+            super_organization=organization_a,
+        )
+
+        client = APIClient()
+        client.login(username=user.username, password='secret')
+
+        url = reverse('api:v2:labels-list')
+
+        response_a = client.get(url)
+
+        for label in response_a.data:
+            self.assertNotIn('is_applied', label)
+
+    def test_labels_inventory_specific_filter_endpoint_provides_IDs_for_records_where_label_is_applied(self):
+        user = User.objects.create_superuser(
+            email='test_user@demo.com',
+            username='test_user@demo.com',
+            password='secret',
+        )
+        organization_a, _, _ = create_organization(user, "test-organization-a")
+
+        # Ensures that at least a single label exists to ensure that we are not
+        # relying on auto-creation of labels for this test to pass.
+        new_label = Label.objects.create(
+            color="red",
+            name="test_label-a",
+            super_organization=organization_a,
+        )
+
+        # Create 2 properties and 2 tax lots. Then, apply that label to one of each
+        property_view_factory = FakePropertyViewFactory(organization=organization_a, user=user)
+        p_view_1 = property_view_factory.get_property_view()
+        p_view_1.labels.add(new_label)
+        property_view_factory.get_property_view()
+
+        taxlot_view_factory = FakeTaxLotViewFactory(organization=organization_a, user=user)
+        tl_view_1 = taxlot_view_factory.get_taxlot_view()
+        tl_view_1.labels.add(new_label)
+        taxlot_view_factory.get_taxlot_view()
+
+        client = APIClient()
+        client.login(username=user.username, password='secret')
+
+        # TODO: change these to POST /properties/labels and /taxlots/labels
+        url = reverse('api:v2:labels-filter')
+        response_a = client.post(url + '?organization_id={}&inventory_type={}'.format(organization_a.pk, 'property_view'))
+        data = json.loads(response_a.content)
+
+        for label in data:
+            if label.get('name') != 'test_label-a':
+                self.assertCountEqual(label.get('is_applied'), [])
+            else:
+                self.assertCountEqual(label.get('is_applied'), [p_view_1.id])
 
 
 class TestUpdateInventoryLabelsAPIView(DeleteModelsTestCase):


### PR DESCRIPTION
#### Any background context you want to provide?
For label read endpoints, we were missing some tests to ensure a vital aspect of these endpoints worked. That is, the addition of an "is_applied" key to serialized label records.

As a followup point, it was decided that the "is_applied" key should only really be present when the search for records actually happened. When the search did not happen, SEED would still provide the key without any record IDs, giving the impression that a search did actually happen, but no record IDs were found.

#### What's this PR do?
Add testing for the is_applied field.

Also, make updates to the serializer to remove the "is_applied" key when the search for is_applied records did not occur. 

#### How should this be manually tested?
Ensure that the API v3 label read endpoints still work on the Swagger page.

Test that the inventory list page still can fetch labels that are applied to records, and the label admin page still works.

#### What are the relevant tickets?
#2164 

#### Screenshots (if appropriate)
