### PR TITLE
Col settings - "display_name" is only re-added before save

### DIFF
--- a/seed/static/seed/js/controllers/column_settings_controller.js
+++ b/seed/static/seed/js/controllers/column_settings_controller.js
@@ -371,6 +371,7 @@ angular.module('BE.seed.controller.column_settings', [])
             column_id = Number(column_id);
             var col = angular.copy(_.find($scope.columns, {id: column_id}));
             col.display_name = col.displayName;  // Add display_name for backend
+            delete col.displayName;
             promises.push(columns_service.update_column_for_org($scope.org.id, column_id, col));
           });
 

--- a/seed/static/seed/js/controllers/column_settings_controller.js
+++ b/seed/static/seed/js/controllers/column_settings_controller.js
@@ -215,11 +215,6 @@ angular.module('BE.seed.controller.column_settings', [])
               return _.isEqual(value, cleanColumns[index][key]) ? result : result.concat(key);
             }, []);
             diff[originalCol.id] = _.pick(cleanColumns[index], modifiedKeys);
-            if (_.includes(modifiedKeys, 'displayName')) {
-              // Rename to match backend
-              diff[originalCol.id].display_name = diff[originalCol.id].displayName;
-              delete diff[originalCol.id].displayName;
-            }
           }
         });
       };
@@ -375,6 +370,7 @@ angular.module('BE.seed.controller.column_settings', [])
           _.forOwn(diff, function (delta, column_id) {
             column_id = Number(column_id);
             var col = angular.copy(_.find($scope.columns, {id: column_id}));
+            col.display_name = col.displayName;  // Add display_name for backend
             promises.push(columns_service.update_column_for_org($scope.org.id, column_id, col));
           });
 

--- a/seed/static/seed/js/controllers/confirm_column_settings_modal_controller.js
+++ b/seed/static/seed/js/controllers/confirm_column_settings_modal_controller.js
@@ -78,7 +78,7 @@ angular.module('BE.seed.controller.confirm_column_settings_modal', [])
           field: 'column_name'
         },
         {
-          field: 'display_name',
+          field: 'displayName',
           displayName: 'Display Name Change'
         },
         {


### PR DESCRIPTION
#### Any background context you want to provide?
Could not save Column display_name since that particular key was being converted to `displayName` once columns were received from the backend. 

Previously, `displayName` was being converted to `display_name` when the `diffs` were built. This worked before since we were sending the `diffs` with PATCH requests. 

Now, we're sending PUT requests with all the model details, and diffs aren't being used directly. Instead, the diffs are being used to find the relevant objects.

#### What's this PR do?
Just before the PUT requests are sent, use the `displayName` to provide the `display_name` for each object.

#### How should this be manually tested?
Test that you can change `display_name` for Column objects. Also verify that the change is still shown in the column save confirmation window.

#### What are the relevant tickets?
#2324 

#### Screenshots (if appropriate)
