### PR TITLE
2333 - Hand edit QuantityField bug

### DIFF
--- a/seed/serializers/pint.py
+++ b/seed/serializers/pint.py
@@ -142,6 +142,16 @@ class PintQuantitySerializerField(serializers.Field):
         field = self.root.Meta.model._meta.get_field(self.field_name)
 
         try:
+            org = self.root.instance.organization
+
+            if field.base_units == 'kBtu/ft**2/year':
+                data = float(data) * ureg(org.display_units_eui)
+            elif field.base_units == 'ft**2':
+                data = float(data) * ureg(org.display_units_area)
+            else:
+                # This shouldn't happen unless we're supporting a new pints_unit QuantityField.
+                data = float(data) * ureg(field.base_units)
+        except AttributeError:
             data = float(data) * ureg(field.base_units)
         except ValueError:
             data = None

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -656,6 +656,31 @@ class InventoryViewTests(DeleteModelsTestCase):
         self.assertEqual(result['state']['gross_floor_area'], 11235.00)
         self.assertEqual(result['state']['site_eui'], 90.10)
 
+    def test_update_pint_fields_with_modified_display_settings(self):
+        self.org.display_units_area = 'm**2'
+        self.org.display_units_eui = 'kWh/m**2/year'
+        self.org.save()
+
+        state = self.property_state_factory.get_property_state(self.org)
+        prprty = self.property_factory.get_property()
+        pv = PropertyView.objects.create(
+            property=prprty, cycle=self.cycle, state=state
+        )
+
+        url = reverse(
+            'api:v2:properties-detail', args=[pv.id]
+        ) + '?cycle_id=%s&organization_id=%s' % (self.cycle.id, self.org.id)
+        params = {
+            'state': {
+                'gross_floor_area': 11235,
+                'site_eui': 90.1,
+            }
+        }
+        response = self.client.put(url, data=json.dumps(params), content_type='application/json')
+        result = response.json()
+        self.assertEqual(result['state']['gross_floor_area'], 11235.00)
+        self.assertEqual(result['state']['site_eui'], 90.10)
+
     def test_get_properties_with_taxlots(self):
         property_state = self.property_state_factory.get_property_state()
         property_property = self.property_factory.get_property(campus=True)


### PR DESCRIPTION
#### Any background context you want to provide?
Non-default display settings for an organization can cause issues when hand editing and updating affected fields. See the attached issue for more details.

#### What's this PR do?
When updating a record, the values provided from the frontend are considered to be in the appropriate units. For example, if the area display setting is meters squared, the value entered for gross_floor_area is taken as meters squared.

#### How should this be manually tested?
On the organization settings page, use a non-default display unit for either areas or EUIs.
Hand-edit any record to change an area or EUI field value and see that the value is saved and displays as expected (i.e. if you input "100", you see "100").

#### What are the relevant tickets?
#2333 

#### Screenshots (if appropriate)
