### PR TITLE
fix(validation_client): fix default use case name

### DIFF
--- a/seed/building_sync/validation_client.py
+++ b/seed/building_sync/validation_client.py
@@ -5,7 +5,7 @@ import requests
 
 VALIDATION_API_URL = "https://selectiontool.buildingsync.net/api/validate"
 DEFAULT_SCHEMA_VERSION = '2.0.0'
-DEFAULT_USE_CASE = 'SEED'
+DEFAULT_USE_CASE = 'SEED v2.0.0'
 
 
 class ValidationClientException(Exception):


### PR DESCRIPTION
#### Any background context you want to provide?
A recent update to the BSync selection tool broke our client, specifically some use case names were appended with "v2.0.0"
#### What's this PR do?
Fixes the name of the use case we're looking for
#### How should this be manually tested?
upload a buildingsync file (e.g. ex1.xml). It should run validation and return with warnings/errors from use case tool.
#### What are the relevant tickets?
#### Screenshots (if appropriate)
