### PR TITLE
2371 dup mapping develop

### DIFF
--- a/seed/static/seed/js/controllers/mapping_controller.js
+++ b/seed/static/seed/js/controllers/mapping_controller.js
@@ -113,6 +113,7 @@ angular.module('BE.seed.controller.mapping', [])
             $scope.current_preset = $scope.dropdown_selected_preset;
             $scope.initialize_mappings();
             analyze_chosen_inventory_types();
+            $scope.updateColDuplicateStatus();
           }).catch(function () {
             $scope.dropdown_selected_preset = $scope.current_preset;
             return;
@@ -122,6 +123,7 @@ angular.module('BE.seed.controller.mapping', [])
           $scope.current_preset = $scope.dropdown_selected_preset;
           $scope.initialize_mappings();
           analyze_chosen_inventory_types();
+          $scope.updateColDuplicateStatus();
         }
       };
 

--- a/seed/static/seed/js/controllers/mapping_controller.js
+++ b/seed/static/seed/js/controllers/mapping_controller.js
@@ -92,17 +92,6 @@ angular.module('BE.seed.controller.mapping', [])
           || $scope.mappings_change_possible;
       };
 
-      var analyze_chosen_inventory_types = function () {
-        var chosenTypes = _.uniq(_.map($scope.mappings, 'suggestion_table_name'));
-        var all_cols_have_table_name = !_.find($scope.mappings, {suggestion_table_name: undefined});
-
-        if (chosenTypes.length === 1 && all_cols_have_table_name) {
-          $scope.setAllFields = _.find($scope.setAllFieldsOptions, {value: chosenTypes[0]});
-        } else {
-          $scope.setAllFields = '';
-        }
-      };
-
       $scope.apply_preset = function () {
         if ($scope.mappings_change_possible) {
           $uibModal.open({
@@ -112,7 +101,7 @@ angular.module('BE.seed.controller.mapping', [])
             $scope.mappings_change_possible = false;
             $scope.current_preset = $scope.dropdown_selected_preset;
             $scope.initialize_mappings();
-            analyze_chosen_inventory_types();
+            $scope.updateInventoryTypeDropdown();
             $scope.updateColDuplicateStatus();
           }).catch(function () {
             $scope.dropdown_selected_preset = $scope.current_preset;
@@ -122,7 +111,7 @@ angular.module('BE.seed.controller.mapping', [])
           $scope.preset_change_possible = false;
           $scope.current_preset = $scope.dropdown_selected_preset;
           $scope.initialize_mappings();
-          analyze_chosen_inventory_types();
+          $scope.updateInventoryTypeDropdown();
           $scope.updateColDuplicateStatus();
         }
       };


### PR DESCRIPTION
#### Any background context you want to provide?
See tagged issue.

#### What's this PR do?
On the import mapping page, when applying a preset, checks are now performed.

Also, clean up the inventory type dropdown check on that page.

#### How should this be manually tested?
Make sure these work as expected when importing a file:
- apply a preset that would trigger duplicate mappings to happen for different raw fields.
- apply a preset with a mix of tax lot and property fields.

#### What are the relevant tickets?
#2371 


Note that https://github.com/SEED-platform/seed/pull/2372/commits/e2c4a49a1c5091d68f5a8616c5985f4d2e9641c3 needs to be cherry-picked into 2.7.2.1
