### PR TITLE
500 errors for /api/v2/properties/columns/

### DIFF
--- a/seed/api/v2_1/views.py
+++ b/seed/api/v2_1/views.py
@@ -128,7 +128,7 @@ class PropertyViewSetV21(SEEDOrgReadOnlyModelViewSet):
         Return a property view based on the property id and cycle
         :param pk: ID of property (not property view)
         :param cycle_pk: ID of the cycle
-        :return: dict, propety view and status
+        :return: dict, property view and status
         """
         try:
             property_view = PropertyView.objects.select_related(


### PR DESCRIPTION
#### Any background context you want to provide?
Leaving out the `organization_id` parameter or providing an invalid one would result in a 500 error for `/api/v2/properties/columns/`

#### What's this PR do?
Returns proper 400 and 404 errors

#### How should this be manually tested?
Test the following URLs with valid and invalid org ids, make sure json is always returned:
/api/v2/properties/columns/?only_used=false&organization_id=1
/api/v2/properties/columns/?only_used=false&organization_id=9999
/api/v2/properties/columns/?only_used=false
