### PR TITLE
2310 datasets v3 transition

### DIFF
--- a/seed/static/seed/js/services/dataset_service.js
+++ b/seed/static/seed/js/services/dataset_service.js
@@ -11,7 +11,7 @@ angular.module('BE.seed.service.dataset', []).factory('dataset_service', [
     var dataset_service = {total_datasets_for_user: 0};
 
     dataset_service.get_datasets_count = function () {
-      return $http.get('/api/v2/datasets/count/', {
+      return $http.get('/api/v3/datasets/count/', {
         params: {
           organization_id: user_service.get_organization().id
         }
@@ -22,7 +22,7 @@ angular.module('BE.seed.service.dataset', []).factory('dataset_service', [
     };
 
     dataset_service.get_datasets = function () {
-      return $http.get('/api/v2/datasets/', {
+      return $http.get('/api/v3/datasets/', {
         params: {
           organization_id: user_service.get_organization().id
         }
@@ -33,7 +33,7 @@ angular.module('BE.seed.service.dataset', []).factory('dataset_service', [
     };
 
     dataset_service.get_dataset = function (dataset_id) {
-      return $http.get('/api/v2/datasets/' + dataset_id + '/', {
+      return $http.get('/api/v3/datasets/' + dataset_id + '/', {
         params: {
           organization_id: user_service.get_organization().id
         }
@@ -56,7 +56,7 @@ angular.module('BE.seed.service.dataset', []).factory('dataset_service', [
     };
 
     dataset_service.delete_dataset = function (dataset_id) {
-      return $http.delete('/api/v2/datasets/' + dataset_id + '/', {
+      return $http.delete('/api/v3/datasets/' + dataset_id + '/', {
         params: {
           organization_id: user_service.get_organization().id
         }
@@ -66,7 +66,7 @@ angular.module('BE.seed.service.dataset', []).factory('dataset_service', [
     };
 
     dataset_service.update_dataset = function (dataset) {
-      return $http.put('/api/v2/datasets/' + dataset.id + '/', {
+      return $http.put('/api/v3/datasets/' + dataset.id + '/', {
         dataset: dataset.name
       }, {
         params: {

--- a/seed/static/seed/js/services/uploader_service.js
+++ b/seed/static/seed/js/services/uploader_service.js
@@ -28,7 +28,7 @@ angular.module('BE.seed.service.uploader', []).factory('uploader_service', [
      */
     uploader_factory.create_dataset = function (dataset_name) {
       // timeout here for testing
-      return $http.post('/api/v2/datasets/', {
+      return $http.post('/api/v3/datasets/', {
         name: dataset_name
       }, {
         params: {

--- a/seed/tests/api/test_modules.py
+++ b/seed/tests/api/test_modules.py
@@ -333,7 +333,7 @@ def delete_set(header, main_url, organization_id, dataset_id, log):
     print('API Function: delete_dataset\n'),
     partmsg = 'delete_dataset'
     result = requests.delete(
-        main_url + '/api/v2/datasets/{}/'.format(dataset_id),
+        main_url + '/api/v3/datasets/{}/'.format(dataset_id),
         headers=header,
         params={'organization_id': organization_id},
     )

--- a/seed/tests/api/test_seed_host_api.py
+++ b/seed/tests/api/test_seed_host_api.py
@@ -140,7 +140,7 @@ print('\n\n|-------Create Dataset-------|')
 partmsg = 'create_dataset'
 params = {'organization_id': organization_id}
 payload = {'name': 'API Test'}
-result = requests.post(main_url + '/api/v2/datasets/',
+result = requests.post(main_url + '/api/v3/datasets/',
                        headers=header,
                        params=params,
                        data=payload)

--- a/seed/tests/test_api.py
+++ b/seed/tests/test_api.py
@@ -330,7 +330,7 @@ class TestApi(TestCase):
         payload = {'name': 'API Test'}
 
         # create the data set
-        r = self.client.post('/api/v2/datasets/?organization_id=' + str(organization_id),
+        r = self.client.post('/api/v3/datasets/?organization_id=' + str(organization_id),
                              data=json.dumps(payload),
                              content_type='application/json',
                              **self.headers)

--- a/seed/tests/test_project_views.py
+++ b/seed/tests/test_project_views.py
@@ -690,7 +690,7 @@ class ProjectViewTests(DeleteModelsTestCase):
             owner=other_user,
         )
         resp = self.client.get(
-            reverse_lazy("api:v2:datasets-count") + '?organization_id=' + str(self.org.id),
+            reverse_lazy("api:v3:datasets-count") + '?organization_id=' + str(self.org.id),
             content_type='application/json',
         )
         self.assertDictEqual(
@@ -702,7 +702,7 @@ class ProjectViewTests(DeleteModelsTestCase):
         )
         # test case where user is not in org
         resp = self.client.get(
-            reverse_lazy("api:v2:datasets-count") + '?organization_id=' + str(other_org.id),
+            reverse_lazy("api:v3:datasets-count") + '?organization_id=' + str(other_org.id),
             content_type='application/json',
         )
         self.assertDictEqual(
@@ -714,7 +714,7 @@ class ProjectViewTests(DeleteModelsTestCase):
         )
         # test case where org does not exist
         resp = self.client.get(
-            reverse_lazy("api:v2:datasets-count") + '?organization_id=999',
+            reverse_lazy("api:v3:datasets-count") + '?organization_id=999',
             content_type='application/json',
         )
         self.assertDictEqual(

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -86,7 +86,7 @@ class GetDatasetsViewsTests(TestCase):
         import_record = ImportRecord.objects.create(owner=self.user)
         import_record.super_organization = self.org
         import_record.save()
-        response = self.client.get(reverse('api:v2:datasets-list'),
+        response = self.client.get(reverse('api:v3:datasets-list'),
                                    {'organization_id': self.org.pk})
         self.assertEqual(1, len(response.json()['datasets']))
 
@@ -94,7 +94,7 @@ class GetDatasetsViewsTests(TestCase):
         import_record = ImportRecord.objects.create(owner=self.user)
         import_record.super_organization = self.org
         import_record.save()
-        response = self.client.get(reverse('api:v2:datasets-count'),
+        response = self.client.get(reverse('api:v3:datasets-count'),
                                    {'organization_id': self.org.pk})
         self.assertEqual(200, response.status_code)
         j = response.json()
@@ -105,7 +105,7 @@ class GetDatasetsViewsTests(TestCase):
         import_record = ImportRecord.objects.create(owner=self.user)
         import_record.super_organization = self.org
         import_record.save()
-        response = self.client.get(reverse('api:v2:datasets-count'),
+        response = self.client.get(reverse('api:v3:datasets-count'),
                                    {'organization_id': 666})
         self.assertEqual(200, response.status_code)
         j = response.json()
@@ -117,7 +117,7 @@ class GetDatasetsViewsTests(TestCase):
         import_record.super_organization = self.org
         import_record.save()
         response = self.client.get(
-            reverse('api:v2:datasets-detail', args=[import_record.pk]) + '?organization_id=' + str(
+            reverse('api:v3:datasets-detail', args=[import_record.pk]) + '?organization_id=' + str(
                 self.org.pk)
         )
         self.assertEqual('success', response.json()['status'])
@@ -128,7 +128,7 @@ class GetDatasetsViewsTests(TestCase):
         import_record.save()
 
         response = self.client.delete(
-            reverse_lazy('api:v2:datasets-detail',
+            reverse_lazy('api:v3:datasets-detail',
                          args=[import_record.pk]) + '?organization_id=' + str(self.org.pk),
             content_type='application/json'
         )
@@ -146,7 +146,7 @@ class GetDatasetsViewsTests(TestCase):
         }
 
         response = self.client.put(
-            reverse_lazy('api:v2:datasets-detail',
+            reverse_lazy('api:v3:datasets-detail',
                          args=[import_record.pk]) + '?organization_id=' + str(self.org.pk),
             content_type='application/json',
             data=json.dumps(post_data)
@@ -433,7 +433,7 @@ class TestMCMViews(TestCase):
         DATASET_NAME_1 = 'test_name 1'
         DATASET_NAME_2 = 'city compliance dataset 2014'
         resp = self.client.post(
-            reverse_lazy('api:v2:datasets-list') + '?organization_id=' + str(self.org.pk),
+            reverse_lazy('api:v3:datasets-list') + '?organization_id=' + str(self.org.pk),
             data=json.dumps({
                 'name': DATASET_NAME_1,
             }),
@@ -443,7 +443,7 @@ class TestMCMViews(TestCase):
         self.assertEqual(data['name'], DATASET_NAME_1)
 
         resp = self.client.post(
-            reverse_lazy('api:v2:datasets-list') + '?organization_id=' + str(self.org.pk),
+            reverse_lazy('api:v3:datasets-list') + '?organization_id=' + str(self.org.pk),
             data=json.dumps({
                 'name': DATASET_NAME_2,
             }),
@@ -463,7 +463,7 @@ class TestMCMViews(TestCase):
 
         # test duplicate name
         resp = self.client.post(
-            reverse_lazy('api:v2:datasets-list') + '?organization_id=' + str(self.org.pk),
+            reverse_lazy('api:v3:datasets-list') + '?organization_id=' + str(self.org.pk),
             data=json.dumps({
                 'name': DATASET_NAME_1,
             }),


### PR DESCRIPTION
#### Any background context you want to provide?
Part of the effort to move FE and tests to v3 APIs

#### What's this PR do?
Update tests and frontend _services to use API v3 dataset endpoints

#### How should this be manually tested?
- On the dataset list page, CRUD datasets
- On the dataset detail page, CRD import_files
- On the inventory detail meter page, upload GreenButton data, see a list of datasets
- On any page, expand the left menu to view the count of datasets

#### What are the relevant tickets?
#2310 

