### PR TITLE
ESPM single property report for upload and test

### DIFF
--- a/seed/tests/test_portfoliomanager.py
+++ b/seed/tests/test_portfoliomanager.py
@@ -381,7 +381,7 @@ class PortfolioManagerReportSinglePropertyUploadTest(TestCase):
         self.client.login(**user_details)
 
         # create a dataset
-        dataset_name = 'test_name 1'
+        dataset_name = 'test_dataset'
         response = self.client.post(
             reverse_lazy('api:v3:datasets-list') + '?organization_id=' + str(self.org.pk),
             data=json.dumps({'name': dataset_name}),

--- a/seed/tests/test_portfoliomanager.py
+++ b/seed/tests/test_portfoliomanager.py
@@ -395,6 +395,7 @@ class PortfolioManagerReportSinglePropertyUploadTest(TestCase):
         if not self.pm_un or not self.pm_pw:
             self.fail('Somehow PM test was initiated without %s or %s in the environment' % (PM_UN, PM_PW))
 
+    @pm_skip_test_check
     def test_single_property_template_for_upload(self):
 
         # create a single property report with template

--- a/seed/views/v3/portfolio_manager.py
+++ b/seed/views/v3/portfolio_manager.py
@@ -184,6 +184,8 @@ class PortfolioManagerViewSet(GenericViewSet):
                 possible_properties = content_object['report']['informationAndMetrics']['row']
                 if isinstance(possible_properties, list):
                     properties = possible_properties
+                elif isinstance(possible_properties, dict):
+                    properties = [possible_properties]
                 else:  # OrderedDict hints that a 'preview' report was generated, anything else is an unhandled case
                     return JsonResponse(
                         {


### PR DESCRIPTION
#### Any background context you want to provide?
When an espm template has only one property, it is returned as a dictionary object as SEED expected a list of records. Import espm with single property failed to proceed to data mapping.

#### What's this PR do?
Append single property espm template/record to a list object for upload.

#### How should this be manually tested?
Create an espm with 1 property. Import a espm template with one property and expect it to be successfully imported for mapping.

#### What are the relevant tickets?
#2384 

#### Screenshots (if appropriate)
Create an espm with 1 property:
![image](https://user-images.githubusercontent.com/49968203/92255756-fec0be80-ee8f-11ea-933e-a7e659afd95b.png)

From SEED, import espm:
<img width="706" alt="Screen Shot 2020-07-29 at 8 11 46 PM" src="https://user-images.githubusercontent.com/49968203/92256057-6d9e1780-ee90-11ea-8d90-7bdc8668cfae.png">

Expect to see report successfully added:
![image](https://user-images.githubusercontent.com/49968203/92255860-244dc800-ee90-11ea-8114-6b95b501e86b.png)
