### PR TITLE
2370 fix/bsync excel export

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -816,10 +816,11 @@ angular.module('BE.seed.controller.inventory_list', [])
               return $scope.cycle.selected_cycle.id;
             },
             ids: function () {
-              var visibleRowIds = _.map($scope.gridApi.core.getVisibleRows($scope.gridApi.grid), function (row) {
-                return row.entity.id;
+              var viewId = $scope.inventory_type === 'properties' ? 'property_view_id' : 'taxlot_view_id';
+              var visibleRowIds = _.map($scope.gridApi.core.getVisibleRows($scope.gridApi.grid), function(row) {
+                return row.entity[viewId]
               });
-              var selectedRowIds = _.map($scope.gridApi.selection.getSelectedRows(), 'id');
+              var selectedRowIds = _.map($scope.gridApi.selection.getSelectedRows(), viewId);
               return _.filter(visibleRowIds, function (id) {
                 return _.includes(selectedRowIds, id);
               });

--- a/seed/tests/api/test_modules.py
+++ b/seed/tests/api/test_modules.py
@@ -557,7 +557,7 @@ def export_data(header, main_url, organization_id, cycle_id, log):
     result = requests.post(main_url + '/api/v3/properties/filter/',
                            headers=header,
                            params=params)
-    prop_ids = [prop['id'] for prop in result.json()['results']]
+    prop_ids = [prop['property_view_id'] for prop in result.json()['results']]
     prop_ids = prop_ids[:num_props]
 
     print('API Function: export_properties\n')
@@ -590,7 +590,7 @@ def export_data(header, main_url, organization_id, cycle_id, log):
     result = requests.post(main_url + '/api/v3/taxlots/filter/',
                            headers=header,
                            params=params)
-    lot_ids = [lot['id'] for lot in result.json()['results']]
+    lot_ids = [lot['taxlot_view_id'] for lot in result.json()['results']]
     lot_ids = lot_ids[:num_lots]
 
     print('API Function: export_taxlots\n')

--- a/seed/views/v3/tax_lot_properties.py
+++ b/seed/views/v3/tax_lot_properties.py
@@ -120,7 +120,7 @@ class TaxLotPropertyViewSet(GenericViewSet):
             prefetch_related = ['labels']
             filter_str = {'property__organization_id': org_id}
             if ids:
-                filter_str['property__id__in'] = ids
+                filter_str['id__in'] = ids
             # always export the labels and notes
             column_name_mappings['property_notes'] = 'Property Notes'
             column_name_mappings['property_labels'] = 'Property Labels'
@@ -130,7 +130,7 @@ class TaxLotPropertyViewSet(GenericViewSet):
             prefetch_related = ['labels']
             filter_str = {'taxlot__organization_id': org_id}
             if ids:
-                filter_str['taxlot__id__in'] = ids
+                filter_str['id__in'] = ids
             # always export the labels and notes
             column_name_mappings['taxlot_notes'] = 'Tax Lot Notes'
             column_name_mappings['taxlot_labels'] = 'Tax Lot Labels'
@@ -163,7 +163,11 @@ class TaxLotPropertyViewSet(GenericViewSet):
         # force the data into the same order as the IDs
         if ids:
             order_dict = {obj_id: index for index, obj_id in enumerate(ids)}
-            data.sort(key=lambda x: order_dict[x['id']])  # x is the property/taxlot object
+            if view_klass_str == 'properties':
+                view_id_str = 'property_view_id'
+            else:
+                view_id_str = 'taxlot_view_id'
+            data.sort(key=lambda inventory_obj: order_dict[inventory_obj[view_id_str]])
 
         export_type = request.data.get('export_type', 'csv')
 


### PR DESCRIPTION
#### What's this PR do? 
Fixes problem where exporting from the property detail page resulted in empty files. This was fixed by refactoring the `taxlot_properties/export` endpoint to accept View IDs rather than canonical IDs. This change required updating the frontend for the list view, as it was using canonical IDs.

#### How should this be manually tested?
1. Upload properties and taxlots
1. From inventory list page, select multiple properties and choose the "export selected" action. Verify that:
  - all selected properties were exported
  - the properties are in the same order as they appeared in the table
1. On a property details page, select "export buildingsync (excel)". Verify it exported correctly
1. Verify other export options still work as expected (CSV, geojson, etc)
1. Repeat for Taxlots (note you can't export excel for taxlots, and cant export individual taxlots from detail page)

#### What are the relevant tickets?
#2370 
