### PR TITLE
#1904 - extra_data columns can now be deleted

### DIFF
--- a/seed/migrations/0130_auto_20200924_1337.py
+++ b/seed/migrations/0130_auto_20200924_1337.py
@@ -1,0 +1,15 @@
+# Manually generated on 2020-09-24 13:10
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('seed', '0129_auto_20200828_0610'),
+    ]
+
+    operations = [
+        migrations.RunSQL('ALTER TABLE "seed_taxlotstate" ALTER COLUMN "extra_data" TYPE jsonb;'),
+        migrations.RunSQL('ALTER TABLE "seed_propertystate" ALTER COLUMN "extra_data" TYPE jsonb;'),
+    ]

--- a/seed/models/column_mappings.py
+++ b/seed/models/column_mappings.py
@@ -69,9 +69,10 @@ def get_column_mapping(raw_column, organization, attr_name='column_mapped'):
         # list. Eventually delete this code.
         raise Exception("I am a LIST! Which makes no sense!")
 
-    # Should only return one column
+    # Should return zero when importing a column name the first time
+    # Should return one column if previously imported (table_name is blank to search only raw column names)
     cols = Column.objects.filter(
-        organization=organization, column_name__in=column_raw
+        organization=organization, column_name__in=column_raw, table_name=''
     )
 
     try:

--- a/seed/static/seed/js/controllers/column_settings_controller.js
+++ b/seed/static/seed/js/controllers/column_settings_controller.js
@@ -370,7 +370,7 @@ angular.module('BE.seed.controller.column_settings', [])
           _.forOwn(diff, function (delta, column_id) {
             column_id = Number(column_id);
             var col = angular.copy(_.find($scope.columns, {id: column_id}));
-            col.display_name = col.displayName;  // Add display_name for backend
+            col.display_name = col.displayName; // Add display_name for backend
             delete col.displayName;
             promises.push(columns_service.update_column_for_org($scope.org.id, column_id, col));
           });
@@ -424,6 +424,22 @@ angular.module('BE.seed.controller.column_settings', [])
             },
             org_id: function () {
               return $scope.org.id;
+            }
+          }
+        });
+      };
+
+      $scope.delete_column = function (column) {
+        $uibModal.open({
+          backdrop: 'static',
+          templateUrl: urls.static_url + 'seed/partials/delete_column_modal.html',
+          controller: 'delete_column_modal_controller',
+          resolve: {
+            organization_id: function () {
+              return $scope.org.id;
+            },
+            column: function () {
+              return column;
             }
           }
         });

--- a/seed/static/seed/js/controllers/delete_column_modal_controller.js
+++ b/seed/static/seed/js/controllers/delete_column_modal_controller.js
@@ -1,0 +1,38 @@
+/**
+ * :copyright (c) 2014 - 2020, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.
+ * :author
+ */
+angular.module('BE.seed.controller.delete_column_modal', [])
+  .controller('delete_column_modal_controller', [
+    '$scope',
+    '$window',
+    '$log',
+    '$uibModalInstance',
+    'spinner_utility',
+    'columns_service',
+    'organization_id',
+    'column',
+    function ($scope, $window, $log, $uibModalInstance, spinner_utility, columns_service, organization_id, column) {
+      $scope.column_name = column.column_name;
+
+      $scope.delete = function () {
+        $scope.state = 'running';
+        columns_service.delete_column_for_org(organization_id, column.id).then(function (result) {
+          $scope.result = result.data.message;
+          $scope.state = 'done';
+        }).catch(function (err) {
+          $log.error(err);
+          $scope.result = 'Failed to delete column';
+          $scope.state = 'done';
+        });
+      };
+
+      $scope.refresh = function () {
+        spinner_utility.show();
+        $window.location.reload();
+      };
+
+      $scope.cancel = function () {
+        $uibModalInstance.dismiss();
+      };
+    }]);

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -50,6 +50,7 @@ angular.module('BE.seed.controllers', [
   'BE.seed.controller.data_upload_modal',
   'BE.seed.controller.dataset',
   'BE.seed.controller.dataset_detail',
+  'BE.seed.controller.delete_column_modal',
   'BE.seed.controller.delete_dataset_modal',
   'BE.seed.controller.delete_file_modal',
   'BE.seed.controller.delete_modal',

--- a/seed/static/seed/js/services/columns_service.js
+++ b/seed/static/seed/js/services/columns_service.js
@@ -44,6 +44,16 @@ angular.module('BE.seed.service.columns', []).factory('columns_service', [
       });
     };
 
+    columns_service.delete_column = function (column_id) {
+      return columns_service.delete_column_for_org(user_service.get_organization().id, column_id);
+    };
+
+    columns_service.delete_column_for_org = function (org_id, column_id) {
+      return $http.delete('/api/v3/columns/' + column_id + '/', {
+        organization_id: org_id
+      });
+    };
+
     return columns_service;
 
   }]);

--- a/seed/static/seed/js/services/columns_service.js
+++ b/seed/static/seed/js/services/columns_service.js
@@ -50,7 +50,7 @@ angular.module('BE.seed.service.columns', []).factory('columns_service', [
 
     columns_service.delete_column_for_org = function (org_id, column_id) {
       return $http.delete('/api/v3/columns/' + column_id + '/', {
-        organization_id: org_id
+        params: {organization_id: org_id},
       });
     };
 

--- a/seed/static/seed/partials/column_settings.html
+++ b/seed/static/seed/partials/column_settings.html
@@ -109,6 +109,14 @@
                         </ul>
                     </td>
                 </tr>
+                <tr>
+                    <td translate>Delete</td>
+                    <td>
+                        <ul>
+                            <li translate>Permanently delete extra_data columns and all associated data</li>
+                        </ul>
+                    </td>
+                </tr>
             </table>
         </div>
         <div class="section_content with_padding" style="margin-bottom:15px;">
@@ -145,6 +153,7 @@
                                 <span>Match Criteria</span> <i class="glyphicon glyphicon-sort"></i>
                             </th>
                             <th class="text-center" style="min-width: 80px" ng-if="::org.comstock_enabled" translate>ComStock Mapping</th>
+                            <th class="text-center" style="min-width: 65px; width: 65px;" translate>Delete</th>
                         </tr>
                         <tr class="sub_head">
                             <th class="sub_head">
@@ -168,6 +177,7 @@
                             <th class="sub_head"></th>
                             <th class="sub_head"></th>
                             <th class="sub_head" ng-if="::org.comstock_enabled"></th>
+                            <th class="sub_head"></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -206,11 +216,16 @@
                             <td class="text-center" ng-if="!column.is_extra_data" ng-click="change_is_matching_criteria(column)">
                                 <input type="checkbox" ng-checked="column.is_matching_criteria" class="no-click">
                             </td>
-                            <td class="text-center" ng-if="column.is_extra_data">
+                            <td class="text-center" ng-if="::column.is_extra_data">
                                 <span ng-if="column.is_extra_data" translate>Ineligible</span>
                             </td>
                             <td class="text-center" ng-if="::org.comstock_enabled">
                                 <select class="form-control input-sm" ng-model="column.comstock_mapping" ng-options="type.id as type.label for type in ::comstock_types" ng-change="comstockModified(column)"></select>
+                            </td>
+                            <td class="text-center">
+                                <button ng-if="::column.is_extra_data" class="btn btn-danger" type="button" ng-click="delete_column(column)">
+                                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                                </button>
                             </td>
                         </tr>
                     </tbody>

--- a/seed/static/seed/partials/delete_column_modal.html
+++ b/seed/static/seed/partials/delete_column_modal.html
@@ -1,0 +1,21 @@
+<div class="modal-header" ng-switch="state">
+    <h4 class="modal-title" ng-switch-default>Delete Column '{$ column_name $}'</h4>
+    <h4 class="modal-title" ng-switch-when="running">Deleting Column '{$ column_name $}'</h4>
+    <h4 class="modal-title" ng-switch-when="done" translate>Column Deleted</h4>
+</div>
+<div class="modal-body row" ng-switch="state">
+    <div class="col-sm-12">
+        <div ng-switch-default>
+            This will delete the extra_data column '{$ column_name $}' and all associated data. Are you sure you want to continue?
+        </div>
+        <div ng-switch-when="running">
+            <uib-progressbar class="progress-striped active" animate="false" value="100" type="success"></uib-progressbar>
+        </div>
+        <div ng-switch-when="done">{$ result $}</div>
+    </div>
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-default" ng-click="cancel()" ng-if="state !== 'done'" ng-disabled="state === 'running'">Cancel</button>
+    <button type="button" class="btn btn-info" ng-click="delete()" ng-if="state !== 'done'" ng-disabled="state === 'running'" autofocus>Delete</button>
+    <button type="button" class="btn btn-info" ng-click="refresh()" ng-if="state === 'done'" autofocus>Refresh</button>
+</div>

--- a/seed/templates/seed/_scripts.html
+++ b/seed/templates/seed/_scripts.html
@@ -40,6 +40,7 @@
         <script src="{{STATIC_URL}}seed/js/controllers/data_upload_modal_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/dataset_detail_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/dataset_list_controller.js"></script>
+        <script src="{{STATIC_URL}}seed/js/controllers/delete_column_modal_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/delete_dataset_modal_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/delete_file_modal_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/delete_modal_controller.js"></script>


### PR DESCRIPTION
#### What's this PR do?
- Limits `DELETE /api/v3/columns/XXX/` to only extra_data columns
- Adds a delete button to extra_data columns on the org's column_settings page

#### How should this be manually tested?
- Import a file with columns mapped to extra_data fields (new or existing)
- Go to the column_settings page for the org and click the delete button next to extra_data fields
- Monkey test with deleting columns, reimporting data and recreating the column, attempting to delete non-extra_data columns, etc
#### What are the relevant tickets?
#1904

## CAVEATS
When a column is deleted the column mapping with the raw column_name also has to be deleted.  If you go back to the Data Mapping for an imported record from the dataset the original data will still appear in the preview, but if you click the button to review the mapping the deleted column will no longer appear (which is expected once the column mapping has been deleted)

It takes 6 seconds to update 512 records, and this comes entirely from recalculating the state hash_objects.  It would be advisable to move this logic to a celery task as a next step