### PR TITLE
Import mapping - check for duplicates when applying profile

### DIFF
--- a/seed/static/seed/js/controllers/mapping_controller.js
+++ b/seed/static/seed/js/controllers/mapping_controller.js
@@ -113,6 +113,7 @@ angular.module('BE.seed.controller.mapping', [])
             $scope.current_preset = $scope.dropdown_selected_preset;
             $scope.initialize_mappings();
             analyze_chosen_inventory_types();
+            $scope.updateColDuplicateStatus();
           }).catch(function () {
             $scope.dropdown_selected_preset = $scope.current_preset;
             return;
@@ -122,6 +123,7 @@ angular.module('BE.seed.controller.mapping', [])
           $scope.current_preset = $scope.dropdown_selected_preset;
           $scope.initialize_mappings();
           analyze_chosen_inventory_types();
+          $scope.updateColDuplicateStatus();
         }
       };
 


### PR DESCRIPTION
#### Any background context you want to provide?
Cherry-picks changes made into `develop` into 2.7.2.1 (#2372)

The bug was the result of a lack of duplicate column mapping checking when applying a mapping profile.

See issue for more details on the bug.

#### What's this PR do?
Add dup check when applying a profile.

#### How should this be manually tested?
Test on 2.7.2 database.

1. Import a file. 
2. Map to the same column twice.
3. Save preset.
4. Refresh page.
5. Apply that previously saved preset.
6. See an error.

#### What are the relevant tickets?
#2371 

#### Screenshots (if appropriate)
