### PR TITLE
API v3 - Append ComStock list profile after serialization

### DIFF
--- a/seed/views/v3/column_list_profiles.py
+++ b/seed/views/v3/column_list_profiles.py
@@ -138,19 +138,18 @@ class ColumnListProfileViewSet(OrgValidateMixin, SEEDOrgNoPatchOrOrgCreateModelV
             return self.get_paginated_response(serializer.data)
 
         results = list(queryset)
-        results.append({
-            "id": None,
-            "name": "ComStock",
-            "profile_location": 0,
-            "inventory_type": 0
-        })
-
-        serializer = self.get_serializer(results, many=True)
+        base_profiles = self.get_serializer(results, many=True).data
 
         # Add ComStock columns
-        serializer.data[len(serializer.data) - 1]['columns'] = self.list_comstock_columns(org_id)
+        base_profiles.append({
+            "id": None,
+            "name": "ComStock",
+            "profile_location": profile_location,
+            "inventory_type": inventory_type,
+            "columns": self.list_comstock_columns(org_id)
+        })
 
-        return Response(serializer.data)
+        return Response(base_profiles)
 
     @staticmethod
     def list_comstock_columns(org_id):


### PR DESCRIPTION
#### Any background context you want to provide?
Before, when the ComStock list profile feature was built, it originally injected data before serialization of response data.

Since then, the serializer was updated to expect data in a different format.

#### What's this PR do?
As a quick fix, the "fake" ComStock list profile is injected after serialization.

#### How should this be manually tested?
Enable ComStock in org settings.
Navigate to Column Settings and set some ComStock Mappings
Visit the property inventory list page and see that the ComStock profile works
Visit the column list profile page and see the ComStock profile is uneditable.

#### What are the relevant tickets?

#### Screenshots (if appropriate)
