### PR TITLE
fix: updated scripts to use lokalise2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ docs/scripts/.python-version
 docs/scripts/seed_issues.csv
 
 lokalise.cfg
+lokalise.yml
 
 # Docker-based files
 docker-compose.*.yml

--- a/lokalise.cfg.example
+++ b/lokalise.cfg.example
@@ -1,2 +1,0 @@
-Token = "MY_API_TOKEN"
-Project = "3537487659ca9b1dce98a7.36378626"

--- a/lokalise.yml.example
+++ b/lokalise.yml.example
@@ -1,0 +1,30 @@
+# Lokalise CLI v2 example config
+# Copy it to config.yml and modify to use
+
+# API token
+# You can create token at Personal profile page at https://lokalise.com/profile
+token: MY_API_TOKEN
+
+# Default Project ID
+# If set, used for all endpoints requiring project-id flag.
+#project-id: 3537487659ca9b1dce98a7.36378626
+
+# Number of retries for API requests.
+# Default is 3.
+#retry-count: 5
+
+# Sleep time before retrying a request.
+# Default is 100 milliseconds.
+#retry-timeout: 500ms
+
+# Connection timeout for API requests.
+# Default is 1 min.
+#connection-timeout: 5s
+
+# Items to return per page.
+# Default is 5000 (max available in API).
+#page-limit: 1000
+
+# Debug API requests.
+# Default is false.
+#debug: true

--- a/script/get_angular_translations
+++ b/script/get_angular_translations
@@ -7,11 +7,8 @@
 # Then, as shown in the code below, move the unzipped .json files into the
 # seed/static/seed/locales directory.
 
-# Note this script assumes you're not using the v2 CLI
-# Install the tool here: https://docs.lokalise.com/en/articles/1400697-lokalise-cli-v1
-
-if [[ ! -f lokalise.cfg ]]; then
-  echo "Missing lokalise.cfg. Copy from lokalise.cfg.example"
+if [[ ! -f lokalise.yml ]]; then
+  echo "Missing lokalise.yml. Copy from lokalise.yml.example"
   exit 1
 fi
 
@@ -20,17 +17,17 @@ dest=seed/static/seed/locales
 
 mkdir -p $tmp
 
-lokalise                \
-  --config lokalise.cfg \
-    export              \
-  --langs fr_CA,en_US   \
-  --type json           \
-  --include_comments 1  \
-  --export_sort a_z     \
-  --export_empty base   \
-  --dest $tmp
+lokalise2                    \
+  --config=lokalise.yml      \
+    file download            \
+  --filter-langs=fr_CA,en_US \
+  --format=json              \
+  --include-comments=true    \
+  --export-sort=a_z          \
+  --export-empty-as=base     \
+  --unzip-to=$tmp            \
+  --original-filenames=false
 
-unzip $tmp/SEED_Platform-locale.zip -d $tmp
 mv $tmp/locale/fr_CA.json $dest
 mv $tmp/locale/en_US.json $dest
 rm -rf $tmp

--- a/script/get_python_translations
+++ b/script/get_python_translations
@@ -12,22 +12,26 @@
 # Then, assuming msgfmt is installed, run the `msgfmt` command
 # with the -o option referencing each of these django.po files.
 
+if [[ ! -f lokalise.yml ]]; then
+  echo "Missing lokalise.yml. Copy from lokalise.yml.example"
+  exit 1
+fi
+
 tmp=tmp/python_locales
 dest=locale
 
 mkdir -p $tmp
 
-lokalise                \
-  --config lokalise.cfg \
-    export              \
-  --langs fr_CA,en_US   \
-  --type po             \
-  --include_comments 1  \
-  --export_sort a_z     \
-  --export_empty base   \
-  --dest $tmp
-
-unzip $tmp/SEED_Platform-locale.zip -d $tmp
+lokalise2                    \
+  --config=lokalise.yml      \
+    file download            \
+  --filter-langs=fr_CA,en_US \
+  --format=po              \
+  --include-comments=true    \
+  --export-sort=a_z          \
+  --export-empty-as=base     \
+  --unzip-to=$tmp            \
+  --original-filenames=false
 
 mv $tmp/locale/fr_CA.po $dest/fr_CA/LC_MESSAGES/django.po
 msgfmt -o $dest/fr_CA/LC_MESSAGES/django.{mo,po}


### PR DESCRIPTION
#### Any background context you want to provide?
Regarding lokalise v1:
"This version of CLI tool is depreciated. We will stop supporting requests sent using this version of CLI at November 1st 2020. Use Lokalise CLI v2 instead."
From:
https://docs.lokalise.com/en/articles/1400697-lokalise-cli-v1
#### What's this PR do?
Updates scripts and related files to use v2 instead of v1
#### How should this be manually tested?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
