### PR TITLE
docs: restore site settings

### DIFF
--- a/docs/source/developer_resources.rst
+++ b/docs/source/developer_resources.rst
@@ -278,6 +278,16 @@ Restoring a Database Dump
         --organization=testorg
 
 
+    # if restoring a seedv2 backup to a different deployment update the site settings for password reset emails
+    ./manage.py shell
+
+    from django.contrib.sites.models import Site
+    site = Site.objects.first()
+    site.domain = 'dev1.seed-platform.org'
+    site.name = 'SEED Dev1'
+    site.save()
+
+
 Migrating the Database
 ----------------------
 


### PR DESCRIPTION
#### Any background context you want to provide?
When restoring a dump to a different deployment the site's URL and name will likely no longer match (e.g. SEED v2 ->Dev1).  If this URL is incorrect then password reset emails will link to the wrong site (and won't function).

#### What's this PR do?
Adds instructions to `developer_resources.rst` with the steps to update the site name and URL.