### PR TITLE
feat(ci): use github actions for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  tests:
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the stack
+        run: docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+      - name: Test
+        run: docker exec -it seed_web_1 python manage.py test --config.settings.docker_dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build the stack
+        run: docker volume create --name=seed_pgdata
+        run: docker volume create --name=seed_media
         run: docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
       - name: Test
         run: docker exec -it seed_web_1 python manage.py test --config.settings.docker_dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 jobs:
-  tests:
+  django_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,3 +19,16 @@ jobs:
           docker ps
           docker exec seed_web_1 touch /seed/config/settings/local_untracked.py
           docker exec seed_web_1 python manage.py test --settings=config.settings.docker_dev
+  code_formatting:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tox_env: [flake8, docs]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install deps
+        run: |
+          pip install --upgrade pip
+          pip install tox==2.7.0
+      - name: Run tox
+        run: tox -e ${{ matrix.tox_env }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,5 @@ jobs:
       - name: Test
         run: |
           docker ps
+          docker exec seed_web_1 touch /seed/config/settings/local_untracked.py
           docker exec seed_web_1 python manage.py test --settings=config.settings.docker_dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
         tox_env: [flake8, docs]
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
       - name: Install deps
         run: |
           pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tox_env: [flake8, docs]
+        tox_env: [flake8]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,6 @@ jobs:
           docker volume create --name=seed_media
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
       - name: Test
-        run: docker exec -it seed_web_1 python manage.py test --config.settings.docker_dev
+        run: |
+          docker ps
+          docker exec seed_web_1 python manage.py test --config.settings.docker_dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Test
         run: |
           docker ps
-          docker exec seed_web_1 python manage.py test --config.settings.docker_dev
+          docker exec seed_web_1 python manage.py test --settings=config.settings.docker_dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   tests:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Build the stack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build the stack
-        run: docker volume create --name=seed_pgdata
-        run: docker volume create --name=seed_media
-        run: docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+        run: |
+          docker volume create --name=seed_pgdata
+          docker volume create --name=seed_media
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
       - name: Test
         run: docker exec -it seed_web_1 python manage.py test --config.settings.docker_dev


### PR DESCRIPTION
#### Any background context you want to provide?
Travis is mean, and this is a temporary workaround.
EDIT:
Travis is forcing public repos to move from .org to .com, see here: https://docs.travis-ci.com/user/migrate/open-source-repository-migration
We moved seed's repos to the .com site, and then they announced a new pricing model: https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
TLDR; is that you have to request credits now if you're OSS, I reached out to them about this but haven't heard back yet.

Important part:
> Building on a public repositories only
We love our OSS teams who choose to build and test using TravisCI and we fully want to support that community. However, in recent months we have encountered significant abuse of the intention of this offering (increased activity of cryptocurrency miners, TOR nodes operators etc.). Abusers have been tying up our build queues and causing performance reductions for everyone. In order to bring the rules back to fair playing grounds, we are implementing some changes for our public build repositories.

> For those of you who have been building on public repositories (on travis-ci.com, with no paid subscription), we will upgrade you to our trial (free) plan with a 10K credit allotment (which allows around 1000 minutes in a Linux environment).
You will not need to change your build definitions when you are pointed to the new plan
When your credit allotment runs out - we’d love for you to consider which of our plans will meet your needs.
We will be offering an allotment of OSS minutes that will be reviewed and allocated on a case by case basis. Should you want to apply for these credits please open a request with Travis CI support stating that you’d like to be considered for the OSS allotment. Please include:
Your account name and VCS provider (like travis-ci.com/github/[your account name] )
How many credits (build minutes) you’d like to request (should your run out of credits again you can repeat the process to request more or discuss a renewable amount)
Usage will be tracked under your account information so that you can better understand how many credits/minutes are being used
#### What's this PR do?
Runs django tests and flake8 using github actions instead of travis. This might not be our long term solution (using github actions), but it will at least keep us rolling for a bit.

What this does _not_ include is:
- functional tests
- tox api test
- tox docs test
- coveralls integration
- some django tests which hit the PM site, we need to add the SEED_PM_UN and SEED_PM_PW to our repo's secrets, see here: https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository
#### How should this be manually tested?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
