### PR TITLE
fix: order exported results by property view id

### DIFF
--- a/seed/views/v3/organizations.py
+++ b/seed/views/v3/organizations.py
@@ -851,7 +851,7 @@ class OrganizationViewSet(viewsets.ViewSet):
         ).filter(
             property__organization_id=organization_id,
             cycle_id__in=cycles
-        )
+        ).order_by('id')
         organization = Organization.objects.get(pk=organization_id)
         results = []
         for cycle in cycles:


### PR DESCRIPTION
#### Any background context you want to provide?
The test `test_report_export_excel_workbook` randomly failed, and we were able to reproduce by changing the ordering of property views in `get_raw_report_data`.
#### What's this PR do?
Adds an order_by condition to deterministically order property views
#### How should this be manually tested?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
