### PR TITLE
#2079 refactor(tasks): run geocoding task in celery

### DIFF
--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1180,6 +1180,7 @@ def geocode_buildings_task(file_pk):
     """
     NOTE: This is an older entrypoint into geocoding buildings and should no longer
     be used. Use geocode_and_match_buildings_task instead.
+    TODO: remove this task once api v2 is removed
     """
     progress_data = ProgressData(func_name='geocode_buildings', unique_id=file_pk)
     progress_data.delete()
@@ -1217,6 +1218,7 @@ def map_additional_models(file_pk):
     """
     NOTE: This is an older entrypoint into mapping buildings and should no longer
     be used. Use geocode_and_match_buildings_task instead.
+    TODO: remove this task once api v2 is removed
 
     kicks off mapping models other than PropertyState, returns progress key within the JSON response
     E.g. It creates the PropertyView, Property, Scenario, Meters, etc for BuildingSync files
@@ -1301,6 +1303,7 @@ def match_buildings(file_pk):
     """
     NOTE: This is an older entrypoint into matching buildings and should no longer
     be used. Use geocode_and_match_buildings_task instead.
+    TODO: remove this task once api v2 is removed
 
     kicks off system matching, returns progress key within the JSON response
 

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1168,7 +1168,8 @@ def geocode_and_match_buildings_task(file_pk):
             body=finish_matching.s(file_pk, progress_data.key),
             interval=15)
 
-    progress_data.total = post_geocode_tasks_count
+    geocoding_tasks_count = 1
+    progress_data.total = geocoding_tasks_count + post_geocode_tasks_count
     progress_data.save()
     celery_chain(_geocode_properties_or_tax_lots.s(file_pk, progress_data.key), post_geocode_tasks)()
 
@@ -1185,6 +1186,7 @@ def geocode_buildings_task(file_pk):
 @shared_task
 def _geocode_properties_or_tax_lots(file_pk, progress_key):
     progress_data = ProgressData.from_key(progress_key)
+    progress_data.step('Geocoding')
     property_state_qs = PropertyState.objects.filter(import_file_id=file_pk).exclude(data_state=DATA_STATE_IMPORT)
     if property_state_qs:
         decode_unique_ids(property_state_qs)

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1135,11 +1135,11 @@ def geocode_and_match_buildings_task(file_pk):
         return progress_data.finish_with_error(
             'Import file is not complete. Retry after mapping is complete', )
 
+    if import_file.cycle is None:
+            _log.warn("Import file cycle is None; This should never happen in production")
+
     post_geocode_tasks = None
     if import_file.from_buildingsync:
-        if import_file.cycle is None:
-            _log.warn("This should never happen in production")
-
         source_type_dict = {
             'Portfolio Raw': PORTFOLIO_RAW,
             'Assessed Raw': ASSESSED_RAW,

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1136,7 +1136,7 @@ def geocode_and_match_buildings_task(file_pk):
             'Import file is not complete. Retry after mapping is complete', )
 
     if import_file.cycle is None:
-            _log.warn("Import file cycle is None; This should never happen in production")
+        _log.warn("Import file cycle is None; This should never happen in production")
 
     post_geocode_tasks = None
     if import_file.from_buildingsync:

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1177,6 +1177,10 @@ def geocode_and_match_buildings_task(file_pk):
 
 
 def geocode_buildings_task(file_pk):
+    """
+    NOTE: This is an older entrypoint into geocoding buildings and should no longer
+    be used. Use geocode_and_match_buildings_task instead.
+    """
     async_result = _geocode_properties_or_tax_lots.s(file_pk).apply_async()
     result = [r for r in async_result.collect()]
 
@@ -1208,6 +1212,9 @@ def _geocode_properties_or_tax_lots(file_pk, progress_key):
 
 def map_additional_models(file_pk):
     """
+    NOTE: This is an older entrypoint into mapping buildings and should no longer
+    be used. Use geocode_and_match_buildings_task instead.
+
     kicks off mapping models other than PropertyState, returns progress key within the JSON response
     E.g. It creates the PropertyView, Property, Scenario, Meters, etc for BuildingSync files
 
@@ -1289,6 +1296,9 @@ def finish_mapping_additional_models(result, import_file_id, progress_key):
 # @cprofile()
 def match_buildings(file_pk):
     """
+    NOTE: This is an older entrypoint into matching buildings and should no longer
+    be used. Use geocode_and_match_buildings_task instead.
+
     kicks off system matching, returns progress key within the JSON response
 
     :param file_pk: ImportFile Primary Key

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1181,7 +1181,10 @@ def geocode_buildings_task(file_pk):
     NOTE: This is an older entrypoint into geocoding buildings and should no longer
     be used. Use geocode_and_match_buildings_task instead.
     """
-    async_result = _geocode_properties_or_tax_lots.s(file_pk).apply_async()
+    progress_data = ProgressData(func_name='geocode_buildings', unique_id=file_pk)
+    progress_data.delete()
+    progress_data.save()
+    async_result = _geocode_properties_or_tax_lots.s(file_pk, progress_data.key).apply_async()
     result = [r for r in async_result.collect()]
 
     return result

--- a/seed/data_importer/tests/integration/test_case_a.py
+++ b/seed/data_importer/tests/integration/test_case_a.py
@@ -94,7 +94,7 @@ class TestCaseA(DataMappingBaseTestCase):
         # verify that the lot_number has the tax_lot information. For this case it is one-to-one
         self.assertEqual(ps.lot_number, ts.jurisdiction_tax_lot_id)
 
-        tasks.match_buildings(self.import_file.id)
+        tasks.geocode_and_match_buildings_task(self.import_file.id)
 
         self.assertEqual(TaxLot.objects.count(), 10)
 

--- a/seed/data_importer/tests/integration/test_case_b.py
+++ b/seed/data_importer/tests/integration/test_case_b.py
@@ -76,7 +76,7 @@ class TestCaseB(DataMappingBaseTestCase):
         ).first()
         self.assertEqual(p_test.lot_number, "333/66555;333/66125;333/66148")
 
-        tasks.match_buildings(self.import_file.id)
+        tasks.geocode_and_match_buildings_task(self.import_file.id)
 
         # make sure the the property only has one tax lot and vice versa
         tlv = TaxLotView.objects.filter(state__jurisdiction_tax_lot_id='11160509', cycle=self.cycle)

--- a/seed/data_importer/tests/integration/test_data_import.py
+++ b/seed/data_importer/tests/integration/test_data_import.py
@@ -308,7 +308,7 @@ class TestBuildingSyncImportZip(DataMappingBaseTestCase):
         self.assertEqual(ps.count(), 2)
 
         # -- Act
-        tasks.map_additional_models(self.import_file.pk)
+        tasks.geocode_and_match_buildings_task(self.import_file.pk)
 
         # -- Assert
         ps = PropertyState.objects.filter(address_line_1='123 Main St', import_file=self.import_file)
@@ -377,7 +377,7 @@ class TestBuildingSyncImportXml(DataMappingBaseTestCase):
         self.assertEqual(len(ps), 1)
 
         # -- Act
-        tasks.map_additional_models(self.import_file.pk)
+        tasks.geocode_and_match_buildings_task(self.import_file.pk)
 
         # -- Assert
         ps = PropertyState.objects.filter(address_line_1='123 MAIN BLVD', import_file=self.import_file)
@@ -436,7 +436,7 @@ class TestBuildingSyncImportXmlBadMeasures(DataMappingBaseTestCase):
         self.assertEqual(ps.count(), 1)
 
         # -- Act
-        progress_info = tasks.map_additional_models(self.import_file.pk)
+        progress_info = tasks.geocode_and_match_buildings_task(self.import_file.pk)
 
         # -- Assert
         ps = PropertyState.objects.filter(address_line_1='123 Main St', import_file=self.import_file)

--- a/seed/data_importer/tests/integration/test_demo_v2.py
+++ b/seed/data_importer/tests/integration/test_demo_v2.py
@@ -131,7 +131,7 @@ class TestDemoV2(DataMappingBaseTestCase):
         self.assertEqual(len(ps), 0)
         self.assertEqual(len(ts), 9)
 
-        tasks.match_buildings(self.import_file_tax_lot.id)
+        tasks.geocode_and_match_buildings_task(self.import_file_tax_lot.id)
 
         # Check a single case of the taxlotstate
         self.assertEqual(TaxLotState.objects.filter(address_line_1='2655 Welstone Ave NE').count(), 1)
@@ -160,7 +160,7 @@ class TestDemoV2(DataMappingBaseTestCase):
         self.assertEqual(len(ts), 9)
         self.assertEqual(len(ps), 14)
 
-        tasks.match_buildings(self.import_file_property.id)
+        tasks.geocode_and_match_buildings_task(self.import_file_property.id)
 
         ps = PropertyState.objects.filter(
             data_state=DATA_STATE_MAPPING,

--- a/seed/data_importer/tests/integration/test_matching.py
+++ b/seed/data_importer/tests/integration/test_matching.py
@@ -193,7 +193,7 @@ class TestMatching(DataMappingBaseTestCase):
         new_import_file = ImportFile.objects.create(import_record=self.import_record,
                                                     mapping_done=True)
 
-        tasks.match_buildings(new_import_file.pk)
+        tasks.geocode_and_match_buildings_task(new_import_file.pk)
 
         duplicate_import_file = ImportFile.objects.create(
             import_record=self.import_record,

--- a/seed/data_importer/tests/integration/test_merge_duplicate_rows.py
+++ b/seed/data_importer/tests/integration/test_merge_duplicate_rows.py
@@ -201,7 +201,7 @@ class TestCaseMultipleDuplicateMatching(DataMappingBaseTestCase):
         unique_property_states, _ = match.filter_duplicate_states(ps)
         self.assertEqual(len(unique_property_states), 4)
 
-        tasks.match_buildings(self.import_file.id)
+        tasks.geocode_and_match_buildings_task(self.import_file.id)
 
         self.assertEqual(Property.objects.count(), 3)
         self.assertEqual(PropertyView.objects.count(), 3)

--- a/seed/data_importer/tests/integration/test_properties.py
+++ b/seed/data_importer/tests/integration/test_properties.py
@@ -45,7 +45,7 @@ class TestProperties(DataMappingBaseTestCase):
         tasks.save_raw_data(self.import_file.pk)
         Column.create_mappings(self.fake_mappings, self.org, self.user, self.import_file.id)
         tasks.map_data(self.import_file.pk)
-        tasks.match_buildings(self.import_file.id)
+        tasks.geocode_and_match_buildings_task(self.import_file.id)
 
         # import second file that is currently the same, but should be slightly different
         filename_2 = getattr(self, 'filename', 'example-data-properties-small-changes.xlsx')
@@ -59,7 +59,7 @@ class TestProperties(DataMappingBaseTestCase):
 
         tasks.save_raw_data(self.import_file_2.pk)
         tasks.map_data(self.import_file_2.pk)
-        tasks.match_buildings(self.import_file_2.id)
+        tasks.geocode_and_match_buildings_task(self.import_file_2.id)
 
     def test_coparent(self):
         # find a state id

--- a/seed/data_importer/tests/integration/test_tax_lots.py
+++ b/seed/data_importer/tests/integration/test_tax_lots.py
@@ -43,7 +43,7 @@ class TestProperties(DataMappingBaseTestCase):
         tasks.save_raw_data(self.import_file.pk)
         Column.create_mappings(self.fake_mappings, self.org, self.user, self.import_file.id)
         tasks.map_data(self.import_file.pk)
-        tasks.match_buildings(self.import_file.id)
+        tasks.geocode_and_match_buildings_task(self.import_file.id)
 
         # import second file with tax lot information
         filename_2 = getattr(self, 'filename', 'example-data-taxlots.xlsx')
@@ -59,7 +59,7 @@ class TestProperties(DataMappingBaseTestCase):
         tasks.save_raw_data(self.import_file_2.pk)
         Column.create_mappings(self.fake_mappings, self.org, self.user, self.import_file.id)
         tasks.map_data(self.import_file_2.pk)
-        tasks.match_buildings(self.import_file_2.id)
+        tasks.geocode_and_match_buildings_task(self.import_file_2.id)
 
         # import third file with updated tax lot information
         # filename_3 = getattr(self, 'filename', 'example-data-taxlots-small-changes.xlsx')
@@ -74,7 +74,7 @@ class TestProperties(DataMappingBaseTestCase):
         #
         # tasks.save_raw_data(self.import_file_3.pk')
         # tasks.map_data(self.import_file_3.pk)
-        # tasks.match_buildings(self.import_file_3.id)
+        # tasks.geocode_and_match_buildings_task(self.import_file_3.id)
 
     def test_coparent(self):
         # get the main taxlot state

--- a/seed/data_importer/tests/test_link_incoming.py
+++ b/seed/data_importer/tests/test_link_incoming.py
@@ -8,7 +8,7 @@ from django.contrib.postgres.aggregates.general import ArrayAgg
 
 from django.db.models.aggregates import Count
 
-from seed.data_importer.tasks import match_buildings
+from seed.data_importer.tasks import geocode_and_match_buildings_task
 from seed.models import (
     ASSESSED_RAW,
     DATA_STATE_MAPPING,
@@ -80,7 +80,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2
         base_state_details['import_file_id'] = self.import_file_2.id
@@ -103,7 +103,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # Cycle 3 / ImportFile 3
         base_state_details['import_file_id'] = self.import_file_3.id
@@ -118,7 +118,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_3.mapping_done = True
         self.import_file_3.save()
-        match_buildings(self.import_file_3.id)
+        geocode_and_match_buildings_task(self.import_file_3.id)
 
         # Verify merges and links happened
         self.assertEqual(6, PropertyView.objects.count())
@@ -178,7 +178,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2
         base_state_details['import_file_id'] = self.import_file_2.id
@@ -201,7 +201,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # Cycle 3 / ImportFile 3
         base_state_details['import_file_id'] = self.import_file_3.id
@@ -216,7 +216,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_3.mapping_done = True
         self.import_file_3.save()
-        match_buildings(self.import_file_3.id)
+        geocode_and_match_buildings_task(self.import_file_3.id)
 
         # Verify merges and links happened
         self.assertEqual(6, TaxLotView.objects.count())

--- a/seed/data_importer/tests/test_match_incoming.py
+++ b/seed/data_importer/tests/test_match_incoming.py
@@ -7,7 +7,7 @@
 
 from seed.data_importer.models import ImportFile
 
-from seed.data_importer.tasks import match_buildings
+from seed.data_importer.tasks import geocode_and_match_buildings_task
 from seed.data_importer.match import (
     filter_duplicate_states,
     save_state_match,
@@ -64,7 +64,7 @@ class TestMatchingInImportFile(DataMappingBaseTestCase):
         # set import_file mapping done so that matching can occur.
         self.import_file.mapping_done = True
         self.import_file.save()
-        match_buildings(self.import_file.id)
+        geocode_and_match_buildings_task(self.import_file.id)
 
         # 2 Property, 2 PropertyViews, 3 PropertyState (1 flagged to be ignored)
         self.assertEqual(Property.objects.count(), 2)
@@ -95,7 +95,7 @@ class TestMatchingInImportFile(DataMappingBaseTestCase):
         # set import_file mapping done so that matching can occur.
         self.import_file.mapping_done = True
         self.import_file.save()
-        match_buildings(self.import_file.id)
+        geocode_and_match_buildings_task(self.import_file.id)
 
         # 2 TaxLot, 2 TaxLotViews, 3 TaxLotState (1 flagged to be ignored)
         self.assertEqual(TaxLot.objects.count(), 2)
@@ -132,7 +132,7 @@ class TestMatchingInImportFile(DataMappingBaseTestCase):
         # set import_file mapping done so that matching can occur.
         self.import_file.mapping_done = True
         self.import_file.save()
-        match_buildings(self.import_file.id)
+        geocode_and_match_buildings_task(self.import_file.id)
 
         # 3 Property, 3 PropertyViews, 7 PropertyStates (5 imported, 2 merge results)
         self.assertEqual(Property.objects.count(), 3)
@@ -208,7 +208,7 @@ class TestMatchingInImportFile(DataMappingBaseTestCase):
         # set import_file mapping done so that matching can occur.
         self.import_file.mapping_done = True
         self.import_file.save()
-        match_buildings(self.import_file.id)
+        geocode_and_match_buildings_task(self.import_file.id)
 
         # 3 TaxLot, 3 TaxLotViews, 7 TaxLotStates (5 imported, 2 merge results)
         self.assertEqual(TaxLot.objects.count(), 3)
@@ -274,7 +274,7 @@ class TestMatchingInImportFile(DataMappingBaseTestCase):
         # set import_file mapping done so that matching can occur.
         self.import_file.mapping_done = True
         self.import_file.save()
-        match_buildings(self.import_file.id)
+        geocode_and_match_buildings_task(self.import_file.id)
 
         # 1 Property, 1 PropertyView, 3 PropertyStates (2 imported, 1 merge result)
         self.assertEqual(Property.objects.count(), 1)
@@ -297,7 +297,7 @@ class TestMatchingInImportFile(DataMappingBaseTestCase):
         # set import_file mapping done so that matching can occur.
         self.import_file.mapping_done = True
         self.import_file.save()
-        match_buildings(self.import_file.id)
+        geocode_and_match_buildings_task(self.import_file.id)
 
         # 1 Property, 1 PropertyView, 3 PropertyStates (2 imported, 1 merge result)
         self.assertEqual(Property.objects.count(), 1)
@@ -320,7 +320,7 @@ class TestMatchingInImportFile(DataMappingBaseTestCase):
         # set import_file mapping done so that matching can occur.
         self.import_file.mapping_done = True
         self.import_file.save()
-        match_buildings(self.import_file.id)
+        geocode_and_match_buildings_task(self.import_file.id)
 
         # 1 TaxLot, 1 TaxLotView, 3 TaxLotStates (2 imported, 1 merge result)
         self.assertEqual(TaxLot.objects.count(), 1)
@@ -350,7 +350,7 @@ class TestMatchingInImportFile(DataMappingBaseTestCase):
         # set import_file mapping done so that matching can occur.
         self.import_file.mapping_done = True
         self.import_file.save()
-        match_buildings(self.import_file.id)
+        geocode_and_match_buildings_task(self.import_file.id)
 
         # 2 Property, 2 PropertyView, 2 PropertyStates - No merges
         self.assertEqual(Property.objects.count(), 2)
@@ -384,7 +384,7 @@ class TestMatchingInImportFile(DataMappingBaseTestCase):
         # set import_file mapping done so that matching can occur.
         self.import_file.mapping_done = True
         self.import_file.save()
-        match_buildings(self.import_file.id)
+        geocode_and_match_buildings_task(self.import_file.id)
 
         # 1 Property, 1 PropertyViews, 7 PropertyStates (4 imported, 3 merge results)
         self.assertEqual(Property.objects.count(), 1)
@@ -418,7 +418,7 @@ class TestMatchingOutsideImportFile(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Create duplicate property coming from second ImportFile
         base_details['import_file_id'] = self.import_file_2.id
@@ -426,7 +426,7 @@ class TestMatchingOutsideImportFile(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # 1 Property, 1 PropertyViews, 2 PropertyStates
         self.assertEqual(Property.objects.count(), 1)
@@ -449,7 +449,7 @@ class TestMatchingOutsideImportFile(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Create properties from second ImportFile, one matching existing PropertyState
         base_details['import_file_id'] = self.import_file_2.id
@@ -463,7 +463,7 @@ class TestMatchingOutsideImportFile(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # 2 Property, 2 PropertyViews, 4 PropertyStates (3 imported, 1 merge result)
         self.assertEqual(Property.objects.count(), 2)
@@ -528,7 +528,7 @@ class TestMatchingOutsideImportFile(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Update -States to make the roll up order be 1, 3, 2
         refreshed_ps_3 = PropertyState.objects.get(id=ps_3.id)
@@ -552,7 +552,7 @@ class TestMatchingOutsideImportFile(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # There should only be one PropertyView which is associated to new, merged -State
         self.assertEqual(PropertyView.objects.count(), 1)
@@ -578,7 +578,7 @@ class TestMatchingOutsideImportFile(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Create properties from second ImportFile, one matching existing PropertyState
         base_details['import_file_id'] = self.import_file_2.id
@@ -592,7 +592,7 @@ class TestMatchingOutsideImportFile(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # 2 TaxLot, 2 TaxLotViews, 4 TaxLotStates (3 imported, 1 merge result)
         self.assertEqual(TaxLot.objects.count(), 2)
@@ -657,7 +657,7 @@ class TestMatchingOutsideImportFile(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Make all those states match
         TaxLotState.objects.filter(pk__in=[tls_2.id, tls_3.id]).update(
@@ -677,7 +677,7 @@ class TestMatchingOutsideImportFile(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # There should only be one TaxLotView which is associated to new, merged -State
         self.assertEqual(TaxLotView.objects.count(), 1)
@@ -733,7 +733,7 @@ class TestMatchingImportIntegration(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Verify no duplicates/matched-merges yet
         counts = [
@@ -795,7 +795,7 @@ class TestMatchingImportIntegration(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         self.assertEqual(9, Property.objects.count())
         self.assertEqual(9, PropertyView.objects.count())
@@ -875,7 +875,7 @@ class TestMatchingImportIntegration(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Verify no duplicates/matched-merges yet
         counts = [
@@ -933,7 +933,7 @@ class TestMatchingImportIntegration(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         self.assertEqual(8, TaxLot.objects.count())
         self.assertEqual(8, TaxLotView.objects.count())

--- a/seed/tests/test_import_file_views.py
+++ b/seed/tests/test_import_file_views.py
@@ -609,7 +609,7 @@ class TestViewsMatching(DataMappingBaseTestCase):
         tasks.save_raw_data(self.import_file.pk)
         Column.create_mappings(self.fake_mappings, self.org, self.user, self.import_file.id)
         tasks.map_data(self.import_file.pk)
-        tasks.match_buildings(self.import_file.id)
+        tasks.geocode_and_match_buildings_task(self.import_file.id)
 
         # import second file that is currently the same, but should be slightly different
         filename_2 = getattr(self, 'filename', 'example-data-properties-small-changes.xlsx')
@@ -624,7 +624,7 @@ class TestViewsMatching(DataMappingBaseTestCase):
         tasks.save_raw_data(self.import_file_2.pk)
         Column.create_mappings(self.fake_mappings, self.org, self.user, self.import_file_2.id)
         tasks.map_data(self.import_file_2.pk)
-        tasks.match_buildings(self.import_file_2.id)
+        tasks.geocode_and_match_buildings_task(self.import_file_2.id)
 
         # for api tests
         user_details = {

--- a/seed/tests/test_match_existing.py
+++ b/seed/tests/test_match_existing.py
@@ -19,7 +19,7 @@ from django.utils.timezone import make_aware  # make_aware is used because incon
 
 from pytz import timezone
 
-from seed.data_importer.tasks import match_buildings
+from seed.data_importer.tasks import geocode_and_match_buildings_task
 
 from seed.models import (
     ASSESSED_RAW,
@@ -86,7 +86,7 @@ class TestMatchingPostEdit(DataMappingBaseTestCase):
 
         self.import_file.mapping_done = True
         self.import_file.save()
-        match_buildings(self.import_file.id)
+        geocode_and_match_buildings_task(self.import_file.id)
 
         # Edit the first property to match the second
         new_data = {
@@ -160,7 +160,7 @@ class TestMatchingPostEdit(DataMappingBaseTestCase):
 
         self.import_file.mapping_done = True
         self.import_file.save()
-        match_buildings(self.import_file.id)
+        geocode_and_match_buildings_task(self.import_file.id)
 
         # Edit the first taxlot to match the second
         new_data = {
@@ -258,7 +258,7 @@ class TestMatchingPostMerge(DataMappingBaseTestCase):
 
         self.import_file.mapping_done = True
         self.import_file.save()
-        match_buildings(self.import_file.id)
+        geocode_and_match_buildings_task(self.import_file.id)
 
         # Make sure all 4 are separate
         self.assertEqual(Property.objects.count(), 4)
@@ -324,7 +324,7 @@ class TestMatchingPostMerge(DataMappingBaseTestCase):
 
         self.import_file.mapping_done = True
         self.import_file.save()
-        match_buildings(self.import_file.id)
+        geocode_and_match_buildings_task(self.import_file.id)
 
         # Make sure all 4 are separate
         self.assertEqual(TaxLot.objects.count(), 4)
@@ -414,7 +414,7 @@ class TestMatchingExistingViewMatching(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Create (ED) 'state_order' column and update merge protection column for 'city'
         self.org.column_set.create(
@@ -500,7 +500,7 @@ class TestMatchingExistingViewMatching(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Verify no match merges happen
         ps_1_view = PropertyView.objects.get(state_id=ps_1.id)
@@ -557,7 +557,7 @@ class TestMatchingExistingViewMatching(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Create (ED) 'state_order' column and update merge protection column for 'city'
         self.org.column_set.create(
@@ -639,7 +639,7 @@ class TestMatchingExistingViewMatching(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Verify no match merges happen
         tls_1_view = TaxLotView.objects.get(state_id=tls_1.id)
@@ -710,7 +710,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2
         base_property_details['import_file_id'] = self.import_file_2.id
@@ -733,7 +733,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # Cycle 3 / ImportFile 3
         base_property_details['import_file_id'] = self.import_file_3.id
@@ -748,7 +748,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_3.mapping_done = True
         self.import_file_3.save()
-        match_buildings(self.import_file_3.id)
+        geocode_and_match_buildings_task(self.import_file_3.id)
 
         # Verify no matches or links
         self.assertEqual(9, PropertyView.objects.count())
@@ -870,7 +870,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2
         base_state_details['import_file_id'] = self.import_file_2.id
@@ -893,7 +893,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # Cycle 3 / ImportFile 3
         base_state_details['import_file_id'] = self.import_file_3.id
@@ -908,7 +908,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_3.mapping_done = True
         self.import_file_3.save()
-        match_buildings(self.import_file_3.id)
+        geocode_and_match_buildings_task(self.import_file_3.id)
 
         # Verify no matches or links
         self.assertEqual(9, TaxLotView.objects.count())
@@ -1007,7 +1007,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2
         base_property_details['import_file_id'] = self.import_file_2.id
@@ -1016,7 +1016,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # Cycle 3 / ImportFile 3
         base_property_details['import_file_id'] = self.import_file_3.id
@@ -1025,7 +1025,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_3.mapping_done = True
         self.import_file_3.save()
-        match_buildings(self.import_file_3.id)
+        geocode_and_match_buildings_task(self.import_file_3.id)
 
         self.assertEqual(3, PropertyView.objects.count())
         self.assertEqual(3, PropertyState.objects.count())
@@ -1070,7 +1070,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2
         base_state_details['import_file_id'] = self.import_file_2.id
@@ -1079,7 +1079,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # Cycle 3 / ImportFile 3
         base_state_details['import_file_id'] = self.import_file_3.id
@@ -1088,7 +1088,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_3.mapping_done = True
         self.import_file_3.save()
-        match_buildings(self.import_file_3.id)
+        geocode_and_match_buildings_task(self.import_file_3.id)
 
         self.assertEqual(3, TaxLotView.objects.count())
         self.assertEqual(3, TaxLotState.objects.count())
@@ -1132,7 +1132,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2
         base_property_details['import_file_id'] = self.import_file_2.id
@@ -1140,7 +1140,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # Cycle 3 / ImportFile 3
         base_property_details['import_file_id'] = self.import_file_3.id
@@ -1148,7 +1148,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_3.mapping_done = True
         self.import_file_3.save()
-        match_buildings(self.import_file_3.id)
+        geocode_and_match_buildings_task(self.import_file_3.id)
 
         # Once updates are made to import process, these will correctly fail and be removed
         self.assertEqual(3, PropertyView.objects.count())
@@ -1192,7 +1192,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2
         base_state_details['import_file_id'] = self.import_file_2.id
@@ -1200,7 +1200,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # Cycle 3 / ImportFile 3
         base_state_details['import_file_id'] = self.import_file_3.id
@@ -1208,7 +1208,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_3.mapping_done = True
         self.import_file_3.save()
-        match_buildings(self.import_file_3.id)
+        geocode_and_match_buildings_task(self.import_file_3.id)
 
         # Once updates are made to import process, these will correctly fail and be removed
         self.assertEqual(3, TaxLotView.objects.count())
@@ -1256,7 +1256,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2
         base_property_details['import_file_id'] = self.import_file_2.id
@@ -1265,7 +1265,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # Cycle 3 / ImportFile 3
         base_property_details['import_file_id'] = self.import_file_3.id
@@ -1274,7 +1274,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
 
         self.import_file_3.mapping_done = True
         self.import_file_3.save()
-        match_buildings(self.import_file_3.id)
+        geocode_and_match_buildings_task(self.import_file_3.id)
 
         self.assertEqual(3, PropertyView.objects.count())
         self.assertEqual(3, PropertyState.objects.count())
@@ -1461,7 +1461,7 @@ class TestMatchingExistingViewFullOrgMatchingProperties(DataMappingBaseTestCase)
         # Import file and create -Views and canonical records.
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2
         base_property_details = {
@@ -1501,7 +1501,7 @@ class TestMatchingExistingViewFullOrgMatchingProperties(DataMappingBaseTestCase)
         # Import file and create -Views and canonical records.
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
     def test_properties_whole_org_match_merge_link_preview(self):
         # save all the columns in the state to the database so we can setup column list settings
@@ -1755,7 +1755,7 @@ class TestMatchingExistingViewFullOrgMatchingTaxLots(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Check all property and taxlot sets were created without match merges
         self.assertEqual(6, TaxLot.objects.count())
@@ -1800,7 +1800,7 @@ class TestMatchingExistingViewFullOrgMatchingTaxLots(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
     def test_taxlots_whole_org_match_merge_link_preview(self):
         # save all the columns in the state to the database so we can setup column list settings
@@ -2018,7 +2018,7 @@ class TestMatchingExistingViewFullOrgMatchingUnlinking(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2
         base_property_details = {
@@ -2035,7 +2035,7 @@ class TestMatchingExistingViewFullOrgMatchingUnlinking(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # Propose different `property_name` matching - populated
         summary_1 = whole_org_match_merge_link(self.org.id, 'PropertyState', ['property_name'])
@@ -2067,7 +2067,7 @@ class TestMatchingExistingViewFullOrgMatchingUnlinking(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2
         base_taxlot_details = {
@@ -2084,7 +2084,7 @@ class TestMatchingExistingViewFullOrgMatchingUnlinking(DataMappingBaseTestCase):
         # Import file and create -Views and canonical records.
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # Propose different `district` matching - populated
         summary_1 = whole_org_match_merge_link(self.org.id, 'TaxLotState', ['district'])

--- a/seed/tests/test_meter_usage_import.py
+++ b/seed/tests/test_meter_usage_import.py
@@ -19,7 +19,7 @@ from django.utils.timezone import (
 from pytz import timezone
 
 from seed.data_importer.models import ImportFile, ImportRecord
-from seed.data_importer.tasks import match_buildings
+from seed.data_importer.tasks import geocode_and_match_buildings_task
 from seed.landing.models import SEEDUser as User
 from seed.models import (
     ASSESSED_RAW,
@@ -840,7 +840,7 @@ class MeterUsageImportAdjustedScenarioTest(DataMappingBaseTestCase):
         # set import_file mapping done so that matching can occur.
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         import_record_2, import_file_2 = self.create_import_file(
             self.user, self.org, self.cycle
@@ -853,7 +853,7 @@ class MeterUsageImportAdjustedScenarioTest(DataMappingBaseTestCase):
         # set import_file mapping done so that matching can occur.
         import_file_2.mapping_done = True
         import_file_2.save()
-        match_buildings(import_file_2.id)
+        geocode_and_match_buildings_task(import_file_2.id)
 
         # Import the PM Meters
         filename = "example-pm-monthly-meter-usage.xlsx"

--- a/seed/tests/test_organization_views.py
+++ b/seed/tests/test_organization_views.py
@@ -8,7 +8,7 @@ import json
 
 from django.urls import reverse
 
-from seed.data_importer.tasks import match_buildings
+from seed.data_importer.tasks import geocode_and_match_buildings_task
 from seed.landing.models import SEEDUser as User
 from seed.lib.progress_data.progress_data import ProgressData
 from seed.models import (
@@ -213,7 +213,7 @@ class TestOrganizationPreviewViews(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2 - Create 1 unlinked property
         base_property_details['pm_property_id'] = '2nd Non-Match Set'
@@ -223,7 +223,7 @@ class TestOrganizationPreviewViews(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # Check there doesn't exist links
         self.assertNotEqual(ps_1.propertyview_set.first().property_id, ps_2.propertyview_set.first().property_id)
@@ -283,7 +283,7 @@ class TestOrganizationPreviewViews(DataMappingBaseTestCase):
 
         self.import_file_1.mapping_done = True
         self.import_file_1.save()
-        match_buildings(self.import_file_1.id)
+        geocode_and_match_buildings_task(self.import_file_1.id)
 
         # Cycle 2 / ImportFile 2 - Create 1 unlinked taxlot
         base_taxlot_details['jurisdiction_tax_lot_id'] = '2nd Non-Match Set'
@@ -293,7 +293,7 @@ class TestOrganizationPreviewViews(DataMappingBaseTestCase):
 
         self.import_file_2.mapping_done = True
         self.import_file_2.save()
-        match_buildings(self.import_file_2.id)
+        geocode_and_match_buildings_task(self.import_file_2.id)
 
         # Check there doesn't exist links
         self.assertNotEqual(tls_1.taxlotview_set.first().taxlot_id, tls_2.taxlotview_set.first().taxlot_id)

--- a/seed/tests/test_property_views.py
+++ b/seed/tests/test_property_views.py
@@ -27,7 +27,7 @@ from seed.data_importer.models import (
     ImportFile,
     ImportRecord,
 )
-from seed.data_importer.tasks import match_buildings, save_raw_data
+from seed.data_importer.tasks import geocode_and_match_buildings_task, save_raw_data
 from seed.lib.xml_mapping.mapper import default_buildingsync_profile_mappings
 
 from seed.models import (
@@ -234,7 +234,7 @@ class PropertyViewTests(DataMappingBaseTestCase):
         # set import_file_1 mapping done so that record is "created for users to view".
         import_file_1.mapping_done = True
         import_file_1.save()
-        match_buildings(import_file_1.id)
+        geocode_and_match_buildings_task(import_file_1.id)
 
         _import_record_2, import_file_2 = self.create_import_file(self.user, self.org, self.cycle)
 
@@ -252,7 +252,7 @@ class PropertyViewTests(DataMappingBaseTestCase):
         # set import_file_2 mapping done so that match merging can occur.
         import_file_2.mapping_done = True
         import_file_2.save()
-        match_buildings(import_file_2.id)
+        geocode_and_match_buildings_task(import_file_2.id)
 
         url = reverse('api:v3:properties-filter') + '?cycle_id={}&organization_id={}&page=1&per_page=999999999'.format(self.cycle.pk, self.org.pk)
         response = self.client.post(url, content_type='application/json')

--- a/seed/tests/test_taxlot_views.py
+++ b/seed/tests/test_taxlot_views.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from django.urls import reverse
 from django.utils.timezone import get_current_timezone
 
-from seed.data_importer.tasks import match_buildings
+from seed.data_importer.tasks import geocode_and_match_buildings_task
 from seed.landing.models import SEEDUser as User
 from seed.models import (
     Column,
@@ -197,7 +197,7 @@ class TaxLotViewTests(DataMappingBaseTestCase):
         # set import_file_1 mapping done so that record is "created for users to view".
         import_file_1.mapping_done = True
         import_file_1.save()
-        match_buildings(import_file_1.id)
+        geocode_and_match_buildings_task(import_file_1.id)
 
         _import_record_2, import_file_2 = self.create_import_file(self.user, self.org, self.cycle)
 
@@ -215,7 +215,7 @@ class TaxLotViewTests(DataMappingBaseTestCase):
         # set import_file_2 mapping done so that match merging can occur.
         import_file_2.mapping_done = True
         import_file_2.save()
-        match_buildings(import_file_2.id)
+        geocode_and_match_buildings_task(import_file_2.id)
 
         url = reverse('api:v3:taxlots-filter') + '?cycle_id={}&organization_id={}&page=1&per_page=999999999'.format(self.cycle.pk, self.org.pk)
         response = self.client.post(url, content_type='application/json')

--- a/seed/utils/geocode.py
+++ b/seed/utils/geocode.py
@@ -193,7 +193,7 @@ def _address_geocoding_results(id_addresses, mapquest_api_key):
             results += response.json().get('results')
         except Exception as e:
             if response.status_code == 403:
-                raise MapQuestAPIKeyError
+                raise MapQuestAPIKeyError('Failed geocoding property states due to MapQuest error. Your MapQuest API Key is either invalid or at its limit.')
             else:
                 raise e
 

--- a/seed/views/v3/import_files.py
+++ b/seed/views/v3/import_files.py
@@ -16,7 +16,6 @@ from seed.data_importer.models import ROW_DELIMITER, ImportRecord
 from seed.data_importer.tasks import do_checks
 from seed.data_importer.tasks import geocode_and_match_buildings_task
 from seed.data_importer.tasks import map_data
-from seed.data_importer.tasks import match_buildings as task_match_buildings
 from seed.data_importer.tasks import save_raw_data as task_save_raw
 from seed.data_importer.tasks import \
     validate_use_cases as task_validate_use_cases
@@ -37,7 +36,6 @@ from seed.serializers.pint import apply_display_unit_preferences
 from seed.utils.api import api_endpoint_class
 from seed.utils.api_schema import (AutoSchemaHelper,
                                    swagger_auto_schema_org_query_param)
-from seed.utils.geocode import MapQuestAPIKeyError
 
 _log = logging.getLogger(__name__)
 
@@ -428,7 +426,7 @@ class ImportFileViewSet(viewsets.ViewSet):
         org_id = request.query_params.get('organization_id', None)
 
         try:
-            import_file = ImportFile.objects.get(
+            ImportFile.objects.get(
                 pk=pk,
                 import_record__super_organization_id=org_id
             )


### PR DESCRIPTION
#### Any background context you want to provide?
When importing a large file, you can experience timeouts when starting the final saving process by clicking "Save Mappings". This was happening because in the `start_system_matching_and_geocoding` endpoint, we would start the geocoding task, then block until we got the result, before finally kicking off the matching task and returning the progress data. If the geocoding task took a while to run, or was blocked itself because the worker(s) were already occupied (data quality checks are probably still running for a large file) then it's going to block for a long time. In our case, ELB would timeout after 60s and return an empty HTTP response (which cloudflare doesn't like, and ends up giving a 520 response).

#### What's this PR do?
This address the timeout by not blocking on the geocoding task. Specifically, I chained together the geocoding and matching tasks because the should always happen together.

#### How should this be manually tested?
Because I created a new task for combining the previous tasks, you need to test a few things. It touches geocoding as well as the mapping of additional BuildingSync models (which occurs instead of the buildings matching).
Please test:
- upload a spreadsheet that won't be geocoded (example-pm-properties) and verify it was uploaded properly
- upload a spreadsheet that will be geocoded, and verify it was geocoded successfully (must have valid MapQuest API key in org settings)
- upload a spreadsheet that will be geocoded, but have an INVALID MapQuest API key in org settings; you should get an error reporting a bad or overused key
- upload a BSync file that has measure data (buildingsync_ex01_measures.xml), and verify the Measures were successfully created by checking the property detail page and scrolling to the Measures section

#### What are the relevant tickets?
#2079 
