### PR TITLE
fix(columns): dedup raw col objs caused by units

### DIFF
--- a/seed/models/columns.py
+++ b/seed/models/columns.py
@@ -985,11 +985,12 @@ class Column(models.Model):
             try:
                 # the from column is the field in the import file, thus the table_name needs to be
                 # blank. Eventually need to handle passing in import_file_id
-                from_org_col, _ = Column.objects.get_or_create(
+                from_org_col, _ = Column.objects.update_or_create(
                     organization=organization,
-                    table_name__in=[None, ''],
+                    table_name='',
                     column_name=field['from_field'],
-                    is_extra_data=False  # Column objects representing raw/header rows are NEVER extra data
+                    is_extra_data=False,  # Column objects representing raw/header rows are NEVER extra data
+                    defaults={'units_pint': field.get('from_units', None)}
                 )
             except Column.MultipleObjectsReturned:
                 # We want to avoid the ambiguity of having multiple Column objects for a specific raw column.
@@ -1000,7 +1001,7 @@ class Column(models.Model):
 
                 all_from_cols = Column.objects.filter(
                     organization=organization,
-                    table_name__in=[None, ''],
+                    table_name='',
                     column_name=field['from_field'],
                     is_extra_data=False
                 )
@@ -1010,7 +1011,8 @@ class Column(models.Model):
 
                 from_org_col = Column.objects.create(
                     organization=organization,
-                    table_name__in=[None, ''],
+                    table_name='',
+                    units_pint=field.get('from_units', None),
                     column_name=field['from_field'],
                     is_extra_data=False  # Column objects representing raw/header rows are NEVER extra data
                 )


### PR DESCRIPTION
#### Any background context you want to provide?
For organizations in the production database, there existed multiple Column records for a single raw header. These "duplicate" Column records were technically different because of their `unit` values. SEED had some logic to help deduplicate these records, but that logic included an invalid Django command that threw an error.

#### What's this PR do?
Fix the invalid Django command and close up known ways that "duplicate" Columns are created again in the future.

#### How should this be manually tested?
For an organization, find or create 2 or more Column records for the same raw field header.  Import a file that uses that header. See that the mapping step of the import process is successful.

#### What are the relevant tickets?
#### Screenshots (if appropriate)


#### Extra Notes
This error came up in production, and it was initially difficult to debug because of the deduplication logic. As a first step to deduplication, all the duplicate Columns were deleted - "erasing the evidence". The nice thing was that users could be able to retry mapping (enough times to dedup all sets of duplicates) and it would eventually be successful.