### PR TITLE
fix: add nginx/uwsgi protections for oserrors and ioerrors

### DIFF
--- a/docker/nginx-seed.conf
+++ b/docker/nginx-seed.conf
@@ -64,6 +64,10 @@ server {
         uwsgi_pass  seed_upsteam;
         uwsgi_read_timeout 600;
         uwsgi_send_timeout 600;
+
+        # https://stackoverflow.com/a/40375474/2730450
+        uwsgi_ignore_client_abort on;
+
         include     /etc/nginx/uwsgi_params;
     }
 }

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -15,6 +15,11 @@ harakiri = 600
 enable-threads = true
 single-interpreter = true
 
+# https://stackoverflow.com/a/45393743/2730450
+ignore-sigpipe
+ignore-write-errors
+disable-write-exception
+
 [base]
 # chdir to the folder of this config file, plus app/website
 chdir = /seed


### PR DESCRIPTION
#### Any background context you want to provide?
We've seen occasional error messages over time like `OSError: write error`.  uWSGI documentation classifies this primarily as an "annoyance", like if the user disconnects and nginx closes the socket but uWSGI is still working.  The following SO links suggest config improvements to handle these:
https://stackoverflow.com/a/45393743/2730450
https://stackoverflow.com/a/40375474/2730450

#### What's this PR do?
Adds the recommended settings based on SO results