### PR TITLE
fix(views/labels): require non-empty list for inventory_ids

### DIFF
--- a/seed/views/labels.py
+++ b/seed/views/labels.py
@@ -144,6 +144,10 @@ class UpdateInventoryLabelsAPIView(APIView):
         'missing_org': ErrorState(
             status.HTTP_422_UNPROCESSABLE_ENTITY,
             'missing organization_id'
+        ),
+        'missing_inventory_ids': ErrorState(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            'inventory_ids cannot be undefined or empty'
         )
     }
 
@@ -218,9 +222,6 @@ class UpdateInventoryLabelsAPIView(APIView):
             model = self.models[inventory_type]
             inventory_model = self.inventory_models[inventory_type]
             exclude = self.exclude(qs, inventory_type, add_label_ids)
-            inventory_ids = inventory_ids if inventory_ids else [
-                m.pk for m in inventory_model.objects.all()
-            ]
             new_inventory_labels = [
                 self.label_factory(inventory_type, label_id, pk)
                 for label_id in add_label_ids for pk in inventory_ids
@@ -275,7 +276,7 @@ class UpdateInventoryLabelsAPIView(APIView):
         """
         add_label_ids = request.data.get('add_label_ids', [])
         remove_label_ids = request.data.get('remove_label_ids', [])
-        inventory_ids = request.data.get('inventory_ids', None)
+        inventory_ids = request.data.get('inventory_ids', [])
         organization_id = request.query_params['organization_id']
         error = None
         # ensure add_label_ids and remove_label_ids are different
@@ -283,6 +284,8 @@ class UpdateInventoryLabelsAPIView(APIView):
             error = self.errors['disjoint']
         elif not organization_id:
             error = self.errors['missing_org']
+        elif len(inventory_ids) == 0:
+            error = self.errors['missing_inventory_ids']
         if error:
             result = {
                 'status': 'error',


### PR DESCRIPTION
#### Any background context you want to provide?
When providing an empty list to the `inventory_ids` body param, SEED would default to trying to apply labels to all PropertyViews across all Orgs. A validation was in place to prevent this application, but we'd like to remove this default behavior and check against it.

#### What's this PR do?
Fixes this in production.

#### How should this be manually tested?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
