### PR TITLE
fix(workflows): include full git context when publishing images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       -
         uses: actions/checkout@v2
         with:
-          ref: develop
+          fetch-depth: 0
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -53,5 +53,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          context: .
+          file: ./Dockerfile
           push: true
           tags: seedplatform/seed:${{ steps.parse_tag.outputs.seed_tag }}


### PR DESCRIPTION
#### Any background context you want to provide?
Previous dockerhub images built by GH actions workflow were missing `.git`. This was discovered by trying to use the `/version/` endpoint of SEED, which would error b/c it was not a git repository.
#### What's this PR do?
Fixes the publishing workflow by using the full git context. see:  https://github.com/marketplace/actions/build-and-push-docker-images#path-context
#### How should this be manually tested?
You can't test the image this would build because we only publish develop and master branches.

Though I built a temporary debug image using this workflow. Pull it and verify you can run git commands used by SEED
```
docker pull seedplatform/seed:debug
docker run -it seedplatform/seed:debug /bin/bash
cd seed
git rev-parse --short=9 HEAD
```
I will delete this image once this is merged.

We should also verify that once this is merged, a new develop image is built, and it also includes the git context.