### PR TITLE
fix(intermittent failed test): implied ordering is explicit

### DIFF
--- a/seed/tests/test_match_existing.py
+++ b/seed/tests/test_match_existing.py
@@ -1292,7 +1292,7 @@ class TestMatchMergeLink(DataMappingBaseTestCase):
         """
         # Apply the same meter and an overlapping meter reading to each Property
         tz_obj = timezone(TIME_ZONE)
-        for i, property in enumerate(Property.objects.all()):
+        for i, property in enumerate(Property.objects.order_by('id').all()):
             meter = Meter.objects.create(
                 property=property,
                 source=Meter.PORTFOLIO_MANAGER,


### PR DESCRIPTION
#### Any background context you want to provide?
Intermittent failed test re: merging properties with meters.

#### What's this PR do?
The testing logic implicitly relied on querying Properties in ID order. That is made explicit with this PR.

#### How should this be manually tested?
Nothing to do but wait and see if this intermittent failure happens again.
```
Traceback (most recent call last):
  File "/seed/seed/tests/test_match_existing.py", line 1342, in test_match_merge_link_for_properties_meters_persist_in_different_situations
    self.assertTrue(agg_meter.meter_readings.filter(reading=100).exists())
```

#### What are the relevant tickets?
#### Screenshots (if appropriate)
