### PR TITLE
fix(python-deps): upgrade packages with conflicting versions/specs

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -261,7 +261,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Django Rest Framework
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'oauth2_provider.ext.rest_framework.OAuth2Authentication',
+        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
         'rest_framework.authentication.SessionAuthentication',
         'seed.authentication.SEEDAuthentication',
     ),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -61,14 +61,18 @@ xmlschema==1.1.1
 geojson==2.5.0
 
 # pnnl/buildingid-py
--e git+https://github.com/SEED-platform/buildingid.git@f68219df82191563cc2aca818e0b0fa1b32dd52d#egg=buildingid
+-e git+https://github.com/SEED-platform/buildingid.git@f68219df82191563cc2aca818e0b0fa1b32dd52d#egg=pnnl-buildingid
 
 enum34==1.1.6  # enum34 needs to be specified to support cryptography and oauth2
 oauthlib==2.0.2
 # cffi & cryptography dependencies needs to be installed via bitbucket/github due to a pip segfault with Python 3.6.7
 # -e hg+https://bitbucket.org/cffi/cffi@v1.11.5#egg=cffi
 # -e git+https://github.com/pyca/cryptography@2.5#egg=cryptography
+
+# Used by jwt-oauth2
+django-braces==1.14.0
+
 jwt-oauth2>=0.1.1
-django-oauth-toolkit==0.12.0
+django-oauth-toolkit==1.0.0
 
 future==0.18.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,7 +18,7 @@ vcrpy==2.0.1
 
 # static code analysis
 flake8==3.8.1
-pycodestyle==2.5.0
+pycodestyle==2.6.0
 
 # documentation and spelling
 Sphinx==2.3.1

--- a/seed/utils/viewsets.py
+++ b/seed/utils/viewsets.py
@@ -17,7 +17,7 @@ parser_classes, authentication_classes, and pagination_classes attributes.
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
-from oauth2_provider.ext.rest_framework import OAuth2Authentication
+from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from rest_framework.mixins import (
     CreateModelMixin,
     DestroyModelMixin,


### PR DESCRIPTION
#### Any background context you want to provide?
Test weren't able to run because pip couldn't install several packages. See the list of errors faced and steps taken during debugging: 
```
ERROR: Requested pnnl-buildingid from git+https://github.com/SEED-platform/buildingid.git@f68219df82191563cc2aca818e0b0fa1b32dd52d#egg=buildingid (from -r requirements/base.txt (line 64)) has different name in metadata: 'pnnl-buildingid'
```

Fixed by adding `pnnl-` to `egg` value.

```
ERROR: Cannot install -r requirements/base.txt (line 72) and oauthlib==2.0.2 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested oauthlib==2.0.2
    django-oauth-toolkit 0.12.0 depends on oauthlib==2.0.1
```

Fixed by upgrading to `django-oauth-toolkit` to 1.0.0, since `jwt-oauth2` requires `oauthlib==2.0.2`.

```
ERROR: Cannot install -r requirements/test.txt (line 20), -r requirements/test.txt (line 5) and pycodestyle==2.5.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested pycodestyle==2.5.0
    autopep8 1.4.4 depends on pycodestyle>=2.4.0
    flake8 3.8.1 depends on pycodestyle<2.7.0 and >=2.6.0a1
```

Fixed by upgrading to `pycodestyle==2.6.0`

Running tests locally:
```
ModuleNotFoundError: No module named 'oauth2_provider.ext'
```

Fixed by changing import path of `ext` to `contrib` as mentioned in the changelog: https://github.com/jazzband/django-oauth-toolkit/blob/master/CHANGELOG.md#100-2017-06-07

```
ModuleNotFoundError: No module named 'braces'
```

Fixed by installing `django-braces` since that dependency was dropped in `django-oauth-toolkit` ([changelog](https://github.com/jazzband/django-oauth-toolkit/blob/master/CHANGELOG.md#100-2017-06-07)) but `jwt-oauth2` was using it. 

#### What's this PR do?
Make fixes and upgrade dependencies based on error messages.

#### How should this be manually tested?
Install dependencies locally. Monkey test app.

#### What are the relevant tickets?
#2490 
#### Screenshots (if appropriate)


## Note
This may mean we need to upgrade docker images across different tests and deployments. We can run with the current docker images in each for now since reinstalling Python packages may not need to happen there, but in order to ensure the same environment exist in each, this should happen eventually.
