### PR TITLE
#2475 feat: analyses create view

### DIFF
--- a/seed/analysis_pipelines/bsyncr.py
+++ b/seed/analysis_pipelines/bsyncr.py
@@ -42,6 +42,10 @@ class BsyncrPipeline(AnalysisPipeline):
 
     def _prepare_analysis(self, analysis_id, property_view_ids):
         """Internal implementation for preparing bsyncr analysis"""
+        if not settings.BSYNCR_SERVER_HOST:
+            message = 'SEED instance is not configured to run bsyncr analysis. Please contact the server administrator.'
+            self.fail(message, logger=logger)
+            raise AnalysisPipelineException(message)
 
         progress_data = ProgressData('prepare-analysis-bsyncr', analysis_id)
 
@@ -157,7 +161,7 @@ def _prepare_all_properties(analysis_property_view_ids, analysis_id, progress_da
     if len(input_file_paths) == 0:
         pipeline = BsyncrPipeline(analysis.id)
         message = 'No files were able to be prepared for the analysis'
-        pipeline.fail(message)
+        pipeline.fail(message, progress_data_key=progress_data.key, logger=logger)
         # stop the task chain
         raise AnalysisPipelineException(message)
 
@@ -350,7 +354,7 @@ def _start_analysis(analysis_id, progress_data_key):
     if len(output_file_ids) == 0:
         pipeline = BsyncrPipeline(analysis.id)
         message = 'Failed to get results for all properties'
-        pipeline.fail(message)
+        pipeline.fail(message, progress_data_key=progress_data.key, logger=logger)
         # stop the task chain
         raise AnalysisPipelineException(message)
 

--- a/seed/serializers/analyses.py
+++ b/seed/serializers/analyses.py
@@ -9,8 +9,24 @@ from rest_framework import serializers
 from seed.models import Analysis
 
 
+class CustomChoicesField(serializers.ChoiceField):
+    def to_representation(self, obj):
+        if obj == '' and self.allow_blank:
+            return obj
+        return self._choices[obj]
+
+    def to_internal_value(self, data):
+        if data == '' and self.allow_blank:
+            return ''
+
+        for key, val in self._choices.items():
+            if val == data:
+                return key
+        self.fail('invalid_choice', input=data)
+
+
 class AnalysisSerializer(serializers.ModelSerializer):
-    service = serializers.CharField(source='get_service_display')
+    service = CustomChoicesField(Analysis.SERVICE_TYPES)
     status = serializers.CharField(source='get_status_display')
 
     class Meta:

--- a/seed/static/seed/js/controllers/inventory_detail_analyses_modal_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_analyses_modal_controller.js
@@ -14,11 +14,41 @@ angular.module('BE.seed.controller.inventory_detail_analyses_modal', [])
     '$log',
     '$uibModalInstance',
     'Notification',
-    function ($scope, $log, $uibModalInstance) {
+    'analyses_service',
+    'inventory_ids',
+    function (
+      $scope,
+      $log,
+      $uibModalInstance,
+      Notification,
+      analyses_service,
+      inventory_ids,
+    ) {
       // $scope.meters = meters;
+
+      function initialize_new_analysis () {
+        $scope.new_analysis = {name: null, service: null, configuration: null};
+      }
+
       /* Create a new analysis based on user input */
       $scope.submitNewAnalysisForm = function (form) {
-        //create new analysis here
+        if (form.$invalid) {
+          return;
+        }
+        analyses_service.create_analysis(
+          $scope.new_analysis.name,
+          $scope.new_analysis.service,
+          $scope.new_analysis.configuration,
+          inventory_ids,
+        ).then(function (data) {
+          debugger;
+          Notification.primary('Created Analysis');
+          initialize_new_analysis();
+          form.$setPristine();
+        }, function (response) {
+          $log.error('Error creating new analysis.', response);
+          Notification.error('Failed to create Analysis: ' + response.data.message)
+        });
       };
 
       /* User has cancelled dialog */

--- a/seed/static/seed/js/controllers/inventory_detail_analyses_modal_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_analyses_modal_controller.js
@@ -41,7 +41,6 @@ angular.module('BE.seed.controller.inventory_detail_analyses_modal', [])
           $scope.new_analysis.configuration,
           inventory_ids,
         ).then(function (data) {
-          debugger;
           Notification.primary('Created Analysis');
           initialize_new_analysis();
           form.$setPristine();

--- a/seed/static/seed/js/services/analyses_service.js
+++ b/seed/static/seed/js/services/analyses_service.js
@@ -22,9 +22,27 @@ angular.module('BE.seed.service.analyses', [])
         });
       };
 
+      let create_analysis = function(name, service, configuration, property_view_ids) {
+        let organization_id = user_service.get_organization().id;
+        return $http({
+          url: '/api/v3/analyses/',
+          method: 'POST',
+          params: { organization_id: organization_id },
+          data: {
+            name: name,
+            service: service,
+            configuration: configuration,
+            property_view_ids: property_view_ids,
+          }
+        }).then(function (response) {
+          return response.data
+        })
+      }
+
       let analyses_factory = {
         get_analyses_for_org: get_analyses_for_org,
-        get_analyses_for_canonical_property: get_analyses_for_canonical_property
+        get_analyses_for_canonical_property: get_analyses_for_canonical_property,
+        create_analysis: create_analysis,
       };
 
       return analyses_factory;

--- a/seed/static/seed/partials/inventory_detail_analyses_modal.html
+++ b/seed/static/seed/partials/inventory_detail_analyses_modal.html
@@ -4,22 +4,23 @@
     </div>
     <div class="modal-body">
         <div class="newAnalysisInput" style="margin-top:0;">
-            <form role="form" ng-submit="" novalidate>
+            <form name="newAnalysisForm" role="form" ng-submit="submitNewAnalysisForm(newAnalysisForm)" novalidate>
                 <div class="form-group">
                     <label class="control-label sectionLabel" translate>Name</label>
                     <input id="AnalysisName" type="text" name="name" class="form-control"
+                           ng-minlength="1" ng-maxlength="100" ng-model="new_analysis.name"
                            placeholder="{$:: 'Analysis Name' | translate $}" required>
                 </div>
                 <div class="form-group">
                     <label class="control-label sectionLabel">Type</label>
-                    <select class="form-control" ng-model="analysis.service" required>
-                        <option ng-option value="Bsyncr" selected="selected">BSyncr</option>
+                    <select class="form-control" ng-model="new_analysis.service" required>
+                        <option ng-option value="BSyncr" selected="selected">BSyncr</option>
                     </select>
                     <small class="form-text text-muted">Note: BSyncr will use the first meter of type 'electricity' for
                         analysis</small>
                 </div>
+                <button type="submit" class="btn btn-primary" ng-disabled="newAnalysisForm.$invalid" translate>Create Analysis</button>
             </form>
-            <button type="submit" class="btn btn-primary" translate>Create Analysis</button>
         </div>
     </div>
     <div class="modal-footer">

--- a/seed/tests/test_analysis_pipelines.py
+++ b/seed/tests/test_analysis_pipelines.py
@@ -17,7 +17,7 @@ from pytz import timezone
 from requests import Response
 
 from django.db.models import Q
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils.timezone import make_aware
 
 from config.settings.common import TIME_ZONE, BASE_DIR
@@ -185,6 +185,8 @@ class TestAnalysisPipeline(TestCase):
         self.assertTrue(f'Failed to copy property data for PropertyView ID {bogus_property_view_id}' in message.user_message)
 
 
+# override the BSYNCR_SERVER_HOST b/c otherwise the pipeline will not run (doesn't have to be valid b/c we mock requests)
+@override_settings(BSYNCR_SERVER_HOST='bogus.host.com')
 class TestBsyncrPipeline(TestCase):
     def setUp(self):
         user_details = {

--- a/seed/views/v3/analyses.py
+++ b/seed/views/v3/analyses.py
@@ -30,7 +30,7 @@ class CreateAnalysisSerializer(AnalysisSerializer):
         return Analysis.objects.create(
             name=validated_data['name'],
             service=validated_data['service'],
-            configuration=validated_data['configuration'],
+            configuration=validated_data.get('configuration', {}),
             user_id=validated_data['user_id'],
             organization_id=validated_data['organization_id']
         )

--- a/seed/views/v3/analyses.py
+++ b/seed/views/v3/analyses.py
@@ -6,7 +6,7 @@
 """
 from drf_yasg.utils import swagger_auto_schema
 from django.http import JsonResponse
-from rest_framework import viewsets
+from rest_framework import viewsets, serializers
 from rest_framework.decorators import action
 from rest_framework.status import HTTP_409_CONFLICT
 
@@ -19,9 +19,63 @@ from seed.utils.api import api_endpoint_class
 from seed.utils.api_schema import AutoSchemaHelper
 
 
+class CreateAnalysisSerializer(AnalysisSerializer):
+    property_view_ids = serializers.ListField(child=serializers.IntegerField(), allow_empty=False)
+
+    class Meta:
+        model = Analysis
+        fields = ['name', 'service', 'configuration', 'property_view_ids']
+
+    def create(self, validated_data):
+        return Analysis.objects.create(
+            name=validated_data['name'],
+            service=validated_data['service'],
+            configuration=validated_data['configuration'],
+            user_id=validated_data['user_id'],
+            organization_id=validated_data['organization_id']
+        )
+
+
 class AnalysisViewSet(viewsets.ViewSet):
     serializer_class = AnalysisSerializer
     model = Analysis
+
+    @swagger_auto_schema(
+        manual_parameters=[
+            AutoSchemaHelper.query_org_id_field(),
+        ],
+        request_body=CreateAnalysisSerializer,
+    )
+    @require_organization_id_class
+    @api_endpoint_class
+    @ajax_request_class
+    @has_perm_class('requires_member')
+    def create(self, request):
+        serializer = CreateAnalysisSerializer(data=request.data)
+        if not serializer.is_valid():
+            return JsonResponse({
+                'status': 'error',
+                'message': 'Bad request',
+                'errors': serializer.errors
+            })
+
+        analysis = serializer.save(
+            user_id=request.user.id,
+            organization_id=request.query_params['organization_id']
+        )
+        pipeline = AnalysisPipeline.factory(analysis)
+        try:
+            progress_data = pipeline.prepare_analysis(serializer.validated_data['property_view_ids'])
+            return JsonResponse({
+                'status': 'success',
+                'progress_key': progress_data['progress_key'],
+                'progress': progress_data,
+            })
+        except AnalysisPipelineException as e:
+            return JsonResponse({
+                'status': 'error',
+                'message': str(e)
+            }, status=HTTP_409_CONFLICT)
 
     @swagger_auto_schema(
         manual_parameters=[


### PR DESCRIPTION
#### Any background context you want to provide?
SEED is adding ability to run analyses on properties.

#### What's this PR do?
Adds endpoint to create an analysis and start its preparation. Also adds FE logic for the analysis modal so you can create an analysis.

#### How should this be manually tested?
Go to a property's analysis tab, click new analysis and create a bsyncr analysis. For it to actually work you'll need to have bsyncr configured (see #2477 ) and the property will need to have 12+ electricity meter readings.

#### What are the relevant tickets?
#2475 

#### Screenshots (if appropriate)
