### PR TITLE
2499 feat: start analysis frontend

### DIFF
--- a/seed/analysis_pipelines/bsyncr.py
+++ b/seed/analysis_pipelines/bsyncr.py
@@ -21,6 +21,7 @@ from seed.models import (
 from django.core.files.base import ContentFile
 from django.db.models import Count
 from django.conf import settings
+from django.utils import timezone as tz
 
 from celery import chain, shared_task
 
@@ -309,6 +310,7 @@ def _start_analysis(analysis_id, progress_data_key):
     """
     analysis = Analysis.objects.get(id=analysis_id)
     analysis.status = Analysis.RUNNING
+    analysis.start_time = tz.now()
     analysis.save()
 
     progress_data = ProgressData.from_key(progress_data_key)
@@ -399,6 +401,7 @@ def _finish_analysis(analysis_id, progress_data_key):
     """
     analysis = Analysis.objects.get(id=analysis_id)
     analysis.status = Analysis.COMPLETED
+    analysis.end_time = tz.now()
     analysis.save()
 
     progress_data = ProgressData.from_key(progress_data_key)

--- a/seed/analysis_pipelines/pipeline.py
+++ b/seed/analysis_pipelines/pipeline.py
@@ -4,6 +4,8 @@ from seed.lib.progress_data.progress_data import ProgressData
 from seed.models import Analysis, AnalysisPropertyView, AnalysisMessage
 
 from django.db import transaction
+from django.utils import timezone as tz
+
 from celery import shared_task
 
 
@@ -109,6 +111,7 @@ class AnalysisPipeline(abc.ABC):
                 raise AnalysisPipelineException(f'Analysis is already in a terminal state: status {locked_analysis.status}')
 
             locked_analysis.status = Analysis.FAILED
+            locked_analysis.end_time = tz.now()
             locked_analysis.save()
 
             if logger is not None:

--- a/seed/static/seed/js/controllers/inventory_detail_analyses_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_analyses_controller.js
@@ -16,6 +16,9 @@ angular.module('BE.seed.controller.inventory_detail_analyses', [])
     'organization_payload',
     'urls',
     '$log',
+    'analyses_service',
+    'Notification',
+    'uploader_service',
     function (
       $state,
       $scope,
@@ -28,7 +31,10 @@ angular.module('BE.seed.controller.inventory_detail_analyses', [])
       users_payload,
       organization_payload,
       urls,
-      $log
+      $log,
+      analyses_service,
+      Notification,
+      uploader_service,
     ) {
       $scope.item_state = inventory_payload.state;
       $scope.inventory_type = $stateParams.inventory_type;
@@ -40,8 +46,32 @@ angular.module('BE.seed.controller.inventory_detail_analyses', [])
         view_id: $stateParams.view_id
       };
 
+      refresh_analyses = function() {
+        analyses_service.get_analyses_for_canonical_property(inventory_payload.property.id)
+        .then(function(data) {
+          $scope.analyses = data.analyses
+        })
+      }
+
+      $scope.start_analysis = function(analysis_id) {
+        analyses_service.start_analysis(analysis_id)
+        .then(function (result) {
+          if (result.status === 'success') {
+            Notification.primary('Analysis started')
+            refresh_analyses()
+            uploader_service.check_progress_loop(result.progress_key, 0, 1, function() {
+              refresh_analyses()
+            }, function() {
+              refresh_analyses()
+            }, {})
+          } else {
+            Notification.error('Failed to start analysis: ' + result.message)
+          }
+        })
+      }
+
       $scope.open_analysis_modal = function () {
-        var modalInstance = $uibModal.open({
+        $uibModal.open({
           templateUrl: urls.static_url + 'seed/partials/inventory_detail_analyses_modal.html',
           controller: 'inventory_detail_analyses_modal_controller',
           resolve: {
@@ -52,6 +82,15 @@ angular.module('BE.seed.controller.inventory_detail_analyses', [])
           //   var organization_id = user_service.get_organization().id;
           //   return meter_service.get_meters($stateParams.view_id, organization_id);
           // }],
+          }
+        }).result.then(function(data) {
+          if (data) {
+            refresh_analyses()
+            uploader_service.check_progress_loop(data.progress_key, 0, 1, function() {
+              refresh_analyses()
+            }, function() {
+              refresh_analyses()
+            }, {})
           }
         });
       };

--- a/seed/static/seed/js/controllers/inventory_detail_analyses_modal_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_analyses_modal_controller.js
@@ -44,6 +44,7 @@ angular.module('BE.seed.controller.inventory_detail_analyses_modal', [])
           Notification.primary('Created Analysis');
           initialize_new_analysis();
           form.$setPristine();
+          $scope.$close(data);
         }, function (response) {
           $log.error('Error creating new analysis.', response);
           Notification.error('Failed to create Analysis: ' + response.data.message)

--- a/seed/static/seed/js/services/analyses_service.js
+++ b/seed/static/seed/js/services/analyses_service.js
@@ -39,10 +39,24 @@ angular.module('BE.seed.service.analyses', [])
         })
       }
 
+      let start_analysis = function(analysis_id) {
+        let organization_id = user_service.get_organization().id;
+        return $http({
+          url: '/api/v3/analyses/' + analysis_id + '/start/',
+          method: 'POST',
+          params: { organization_id: organization_id },
+        }).then(function (response) {
+          return response.data
+        }).catch(function (response) {
+          return response.data
+        })
+      }
+
       let analyses_factory = {
         get_analyses_for_org: get_analyses_for_org,
         get_analyses_for_canonical_property: get_analyses_for_canonical_property,
         create_analysis: create_analysis,
+        start_analysis: start_analysis,
       };
 
       return analyses_factory;

--- a/seed/static/seed/partials/analyses_table.html
+++ b/seed/static/seed/partials/analyses_table.html
@@ -25,8 +25,10 @@
                     <tr ng-repeat="analysis in analyses  | filter:filter_params:strict">
                         <td>{$:: analysis.name $}</td>
                         <td>
+                            <!-- These glyphicons are temporarily disabled until we implement their functionality
                             <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
-                            <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
+                            <i class="glyphicon glyphicon-trash" aria-hidden="true"></i> -->
+                            <i class="glyphicon glyphicon-play" title="Start Analysis" aria-hidden="true" ng-if="analysis.status === 'Ready'" ng-click="start_analysis(analysis.id)"></i>
                         </td>
                         <td>{$:: analysis.number_of_analysis_property_views $}</td>
                         <td>{$:: analysis.service $}</td>

--- a/seed/views/v3/analyses.py
+++ b/seed/views/v3/analyses.py
@@ -92,9 +92,16 @@ class AnalysisViewSet(viewsets.ViewSet):
         property_id = request.query_params.get('property_id', None)
         analyses = []
         if property_id is not None:
-            analyses_queryset = Analysis.objects.filter(organization=organization_id, analysispropertyview__property=property_id).distinct()
+            analyses_queryset = (
+                Analysis.objects.filter(organization=organization_id, analysispropertyview__property=property_id)
+                .distinct()
+                .order_by('id')
+            )
         else:
-            analyses_queryset = Analysis.objects.filter(organization=organization_id)
+            analyses_queryset = (
+                Analysis.objects.filter(organization=organization_id)
+                .order_by('id')
+            )
         for analysis in analyses_queryset:
             property_view_info = analysis.get_property_view_info(property_id)
             serialized_analysis = AnalysisSerializer(analysis).data


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
Adds FE functionality for starting an analysis from org and property detail pages.

#### How should this be manually tested?
- on property detail page, create a bsyncr analysis
- click the play button next to the analysis name
- create another one on property detail page, then go to the org analysis page and start it from there.

#### What are the relevant tickets?
#2499 

#### Screenshots (if appropriate)
<img width="1385" alt="Screen Shot 2020-12-21 at 4 58 23 PM" src="https://user-images.githubusercontent.com/18518728/102825936-c943d080-43ad-11eb-85b9-36484fdf754a.png">
