### PR TITLE
feat: disable analysis start button if not ready

### DIFF
--- a/seed/static/seed/js/controllers/analyses_controller.js
+++ b/seed/static/seed/js/controllers/analyses_controller.js
@@ -38,6 +38,9 @@ angular.module('BE.seed.controller.analyses', [])
       }
 
       $scope.start_analysis = function(analysis_id) {
+        analysis = $scope.analyses.find(function(a) { return a.id === analysis_id })
+        analysis.status = 'Starting...'
+
         analyses_service.start_analysis(analysis_id)
         .then(function (result) {
           if (result.status === 'success') {

--- a/seed/static/seed/js/controllers/inventory_detail_analyses_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_analyses_controller.js
@@ -54,6 +54,9 @@ angular.module('BE.seed.controller.inventory_detail_analyses', [])
       }
 
       $scope.start_analysis = function(analysis_id) {
+        analysis = $scope.analyses.find(function(a) { return a.id === analysis_id })
+        analysis.status = 'Starting...'
+
         analyses_service.start_analysis(analysis_id)
         .then(function (result) {
           if (result.status === 'success') {

--- a/seed/static/seed/partials/analyses.html
+++ b/seed/static/seed/partials/analyses.html
@@ -15,6 +15,7 @@
                     <thead>
                         <tr>
                             <th translate>Analysis Name (User Defined)</th>
+                            <th translate>Actions</th>
                             <th translate>Number of Properties</th>
                             <th translate>Type</th>
                             <th translate>Run Status</th>
@@ -26,6 +27,12 @@
                     <tbody>
                         <tr ng-repeat="analysis in analyses | filter:filter_params:strict">
                             <td><a ui-sref="analysis(::{organization_id: org.id, analysis_id: analysis.id})" ui-sref-active="active">{$:: analysis.name $}</a></td>
+                            <td>
+                                <!-- These glyphicons are temporarily disabled until we implement their functionality
+                                <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
+                                <i class="glyphicon glyphicon-trash" aria-hidden="true"></i> -->
+                                <i class="glyphicon glyphicon-play" title="Start Analysis" aria-hidden="true" ng-if="['Pending Creation', 'Creating', 'Ready'].indexOf(analysis.status) >= 0" ng-disabled="analysis.status !== 'Ready'" ng-click="start_analysis(analysis.id)"></i>
+                             </td>
                             <td>{$:: analysis.number_of_analysis_property_views $}</td>
                             <td>{$:: analysis.service $}</td>
                             <td class="analysis-status {$:: analysis.status.toLowerCase() $}">{$:: analysis.status $}</td>

--- a/seed/static/seed/partials/inventory_detail_analyses.html
+++ b/seed/static/seed/partials/inventory_detail_analyses.html
@@ -60,7 +60,7 @@
                                <!-- These glyphicons are temporarily disabled until we implement their functionality
                                <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
                                <i class="glyphicon glyphicon-trash" aria-hidden="true"></i> -->
-                               <i class="glyphicon glyphicon-play" title="Start Analysis" aria-hidden="true" ng-if="analysis.status === 'Ready'" ng-click="start_analysis(analysis.id)"></i>
+                               <i class="glyphicon glyphicon-play" title="Start Analysis" aria-hidden="true" ng-if="['Pending Creation', 'Creating', 'Ready'].indexOf(analysis.status) >= 0" ng-disabled="analysis.status !== 'Ready'" ng-click="start_analysis(analysis.id)"></i>
                             </td>
                             <td>{$:: analysis.service $}</td>
                             <td class="analysis-status {$:: analysis.status.toLowerCase() $}">{$:: analysis.status $}</td>

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -3683,3 +3683,8 @@ $pairedCellWidth: 60px;
     pointer-events: none;
   }
 }
+
+.glyphicon[disabled] {
+  pointer-events: none;
+  opacity: 0.3;
+}


### PR DESCRIPTION
#### Any background context you want to provide?
I am bad at css and javascript

#### What's this PR do?
Adds disabled status for play button if analysis is being prepared.

#### How should this be manually tested?
Verify start button is disabled when creating analysis. Verify no play button when state is past creating.

#### What are the relevant tickets?
#2502

#### Screenshots (if appropriate)
<img width="1386" alt="Screen Shot 2020-12-22 at 6 50 40 PM" src="https://user-images.githubusercontent.com/18518728/102944857-041b3680-448a-11eb-8e57-41e8075b094d.png">
