### PR TITLE
refactor(workflows): publish image on push to develop or release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - develop
-      - main
+  release:
+    types: [published]
 
 jobs:
   publish:
@@ -35,16 +36,14 @@ jobs:
         name: Parse tag
         id: parse_tag
         run: |
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          PACKAGE_VERSION=$( sed -n 's/.*"version": "\(.*\)",/\1/p' package.json )
-          echo "BRANCH_NAME: ${BRANCH_NAME}"
-          echo "PACKAGE_VERSION: ${PACKAGE_VERSION}"
-          if [[ ${BRANCH_NAME} == "main" ]]; then
-            SEED_TAG=${PACKAGE_VERSION}
-          elif [[ ${BRANCH_NAME} == "develop" ]]; then
+          echo "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}"
+          echo "GITHUB_REF: ${GITHUB_REF}"
+          if [[ ${GITHUB_EVENT_NAME} == "push" ]]; then
             SEED_TAG=develop
+          elif [[ ${GITHUB_EVENT_NAME} == "release" ]]; then
+            SEED_TAG=${GITHUB_REF#v}
           else
-            echo "Branch ${BRANCH_NAME} is not main or develop (this should not happen), exiting"
+            echo "Unhandled event type (this shouldn't happen), exiting"
             exit 1
           fi
           echo ::set-output name=seed_tag::${SEED_TAG}


### PR DESCRIPTION
#### Any background context you want to provide?
Currently we only publish to dockerhub on push to master or develop. Sometimes we create tags that aren't part of this flow.

#### What's this PR do?
Publishes images whenever there's a push to develop (which is tagged as `develop`, or if a release is published (tagged with the tag).

#### How should this be manually tested?
Post-merge, we should see the develop branch get published again. We should publish a temporary test release to verify it's also triggering the workflow and properly tags the image.

