### PR TITLE
fix(workflows): fix release tag parsing for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           if [[ ${GITHUB_EVENT_NAME} == "push" ]]; then
             SEED_TAG=develop
           elif [[ ${GITHUB_EVENT_NAME} == "release" ]]; then
-            SEED_TAG=${GITHUB_REF#v}
+            SEED_TAG=${GITHUB_REF#refs/tags/v}
           else
             echo "Unhandled event type (this shouldn't happen), exiting"
             exit 1


### PR DESCRIPTION
#### Any background context you want to provide?
Publish fails when triggered by release
https://github.com/SEED-platform/seed/runs/1627398200?check_suite_focus=true#step:7:16

#### What's this PR do?
fixes bug where tag had `refs/tags` prefix when triggered by a release.

#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
