### PR TITLE
#2478 feat: stop analysis

### DIFF
--- a/seed/analysis_pipelines/bsyncr.py
+++ b/seed/analysis_pipelines/bsyncr.py
@@ -6,7 +6,12 @@
 """
 import logging
 
-from seed.analysis_pipelines.pipeline import AnalysisPipeline, AnalysisPipelineException, task_create_analysis_property_views
+from seed.analysis_pipelines.pipeline import (
+    AnalysisPipeline,
+    AnalysisPipelineException,
+    task_create_analysis_property_views,
+    check_analysis_status,
+)
 from seed.building_sync.mappings import BUILDINGSYNC_URI, NAMESPACES
 from seed.lib.progress_data.progress_data import ProgressData
 from seed.models import (
@@ -87,6 +92,7 @@ class BsyncrPipeline(AnalysisPipeline):
 
 
 @shared_task
+@check_analysis_status(Analysis.CREATING)
 def _prepare_all_properties(analysis_property_view_ids, analysis_id, progress_data_key):
     """A Celery task which attempts to make BuildingSync files for all AnalysisPropertyViews.
 
@@ -168,6 +174,7 @@ def _prepare_all_properties(analysis_property_view_ids, analysis_id, progress_da
 
 
 @shared_task
+@check_analysis_status(Analysis.CREATING)
 def _finish_preparation(analysis_id, progress_data_key):
     """A Celery task which finishes the preparation for bsyncr analysis
 
@@ -304,6 +311,7 @@ def _parse_analysis_property_view_id(filepath):
 
 
 @shared_task
+@check_analysis_status(Analysis.QUEUED)
 def _start_analysis(analysis_id, progress_data_key):
     """Start bsyncr analysis by making requests to the service
 
@@ -364,6 +372,7 @@ def _start_analysis(analysis_id, progress_data_key):
 
 
 @shared_task
+@check_analysis_status(Analysis.RUNNING)
 def _process_results(analysis_output_file_ids, analysis_id, progress_data_key):
     analysis = Analysis.objects.get(id=analysis_id)
     analysis.status = Analysis.RUNNING
@@ -393,6 +402,7 @@ def _process_results(analysis_output_file_ids, analysis_id, progress_data_key):
 
 
 @shared_task
+@check_analysis_status(Analysis.RUNNING)
 def _finish_analysis(analysis_id, progress_data_key):
     """A Celery task which finishes the analysis run
 

--- a/seed/analysis_pipelines/pipeline.py
+++ b/seed/analysis_pipelines/pipeline.py
@@ -59,9 +59,10 @@ def check_analysis_status(status):
 
         @functools.wraps(func)
         def _check(*args, **kwargs):
+            # try to get the analysis_id from args, then from kwargs
             try:
                 _analysis_id = args[analysis_id_param_idx]
-            except:
+            except IndexError:
                 _analysis_id = kwargs['analysis_id']
             analysis = Analysis.objects.get(id=_analysis_id)
             if analysis.status != status:

--- a/seed/analysis_pipelines/pipeline.py
+++ b/seed/analysis_pipelines/pipeline.py
@@ -1,4 +1,8 @@
 import abc
+import functools
+import inspect
+import json
+import logging
 
 from seed.lib.progress_data.progress_data import ProgressData
 from seed.models import Analysis, AnalysisPropertyView, AnalysisMessage
@@ -7,6 +11,8 @@ from django.db import transaction
 from django.utils import timezone as tz
 
 from celery import shared_task
+
+logger = logging.getLogger(__name__)
 
 
 @shared_task
@@ -31,6 +37,39 @@ def task_create_analysis_property_views(analysis_id, property_view_ids, progress
             user_message=f'Failed to copy property data for PropertyView ID {failure.property_view_id}: {failure.message}',
         )
     return analysis_view_ids
+
+
+def check_analysis_status(status):
+    """Decorator factory for checking the status of the analysis, and raise an
+    exception if the status isn't what was expected
+
+    This can be used as a guard to avoid running a task when an analysis has been
+    stopped or failed elsewhere.
+
+    :param status: int, one of Analysis.STATUS_TYPES
+    :returns: function, a decorator
+    """
+
+    def decorator_check_analysis_status(func):
+        try:
+            params = inspect.getfullargspec(func)
+            analysis_id_param_idx = params.args.index('analysis_id')
+        except ValueError:
+            raise Exception('Decorated function must include an argument named "analysis_id"')
+
+        @functools.wraps(func)
+        def _check(*args, **kwargs):
+            try:
+                _analysis_id = args[analysis_id_param_idx]
+            except:
+                _analysis_id = kwargs['analysis_id']
+            analysis = Analysis.objects.get(id=_analysis_id)
+            if analysis.status != status:
+                raise AnalysisPipelineException(f'Expected analysis status to be {status} but it was {analysis.status}')
+
+            return func(*args, **kwargs)
+        return _check
+    return decorator_check_analysis_status
 
 
 class AnalysisPipelineException(Exception):
@@ -128,6 +167,25 @@ class AnalysisPipeline(abc.ABC):
                     type=AnalysisMessage.ERROR,
                     user_message=message,
                 )
+
+    def stop(self):
+        """Stops the analysis. If analysis is already in a terminal state it does
+        nothing
+        """
+        with transaction.atomic():
+            locked_analysis = Analysis.objects.select_for_update().get(id=self._analysis_id)
+
+            if locked_analysis.in_terminal_state():
+                log_message = {
+                    'analysis_id': self._analysis_id,
+                    'debug_message': 'Attempted to stop analysis when already in a terminal state'
+                }
+                logger.info(json.dumps(log_message))
+                return
+
+            locked_analysis.status = Analysis.STOPPED
+            locked_analysis.end_time = tz.now()
+            locked_analysis.save()
 
     @abc.abstractmethod
     def _prepare_analysis(self, analysis_id, property_view_ids):

--- a/seed/static/seed/js/controllers/analyses_controller.js
+++ b/seed/static/seed/js/controllers/analyses_controller.js
@@ -57,6 +57,21 @@ angular.module('BE.seed.controller.analyses', [])
         })
       }
 
+      $scope.stop_analysis = function(analysis_id) {
+        analysis = $scope.analyses.find(function(a) { return a.id === analysis_id })
+        analysis.status = 'Stopping...'
+
+        analyses_service.stop_analysis(analysis_id)
+        .then(function (result) {
+          if (result.status === 'success') {
+            Notification.primary('Analysis stopped')
+            refresh_analyses()
+          } else {
+            Notification.error('Failed to stop analysis: ' + result.message)
+          }
+        })
+      }
+
     }
   ])
   .filter('get_run_duration', function() {

--- a/seed/static/seed/js/controllers/inventory_detail_analyses_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_analyses_controller.js
@@ -73,6 +73,21 @@ angular.module('BE.seed.controller.inventory_detail_analyses', [])
         })
       }
 
+      $scope.stop_analysis = function(analysis_id) {
+        analysis = $scope.analyses.find(function(a) { return a.id === analysis_id })
+        analysis.status = 'Stopping...'
+
+        analyses_service.stop_analysis(analysis_id)
+        .then(function (result) {
+          if (result.status === 'success') {
+            Notification.primary('Analysis stopped')
+            refresh_analyses()
+          } else {
+            Notification.error('Failed to stop analysis: ' + result.message)
+          }
+        })
+      }
+
       $scope.open_analysis_modal = function () {
         $uibModal.open({
           templateUrl: urls.static_url + 'seed/partials/inventory_detail_analyses_modal.html',

--- a/seed/static/seed/js/services/analyses_service.js
+++ b/seed/static/seed/js/services/analyses_service.js
@@ -76,6 +76,19 @@ angular.module('BE.seed.service.analyses', [])
         })
       }
 
+      let stop_analysis = function(analysis_id) {
+        let organization_id = user_service.get_organization().id;
+        return $http({
+          url: '/api/v3/analyses/' + analysis_id + '/stop/',
+          method: 'POST',
+          params: { organization_id: organization_id },
+        }).then(function (response) {
+          return response.data
+        }).catch(function (response) {
+          return response.data
+        })
+      }
+
       let analyses_factory = {
         get_analyses_for_org: get_analyses_for_org,
         get_analyses_for_canonical_property: get_analyses_for_canonical_property,
@@ -84,7 +97,8 @@ angular.module('BE.seed.service.analyses', [])
         get_analysis_views_for_org: get_analysis_views_for_org,
         get_analysis_view_for_org: get_analysis_view_for_org,
         create_analysis: create_analysis,
-        start_analysis: start_analysis
+        start_analysis: start_analysis,
+        stop_analysis: stop_analysis
       };
 
       return analyses_factory;

--- a/seed/static/seed/partials/analyses.html
+++ b/seed/static/seed/partials/analyses.html
@@ -31,7 +31,8 @@
                                 <!-- These glyphicons are temporarily disabled until we implement their functionality
                                 <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
                                 <i class="glyphicon glyphicon-trash" aria-hidden="true"></i> -->
-                                <i class="glyphicon glyphicon-play" title="Start Analysis" aria-hidden="true" ng-if="['Pending Creation', 'Creating', 'Ready'].indexOf(analysis.status) >= 0" ng-disabled="analysis.status !== 'Ready'" ng-click="start_analysis(analysis.id)"></i>
+                                <i class="glyphicon glyphicon-play" title="Start Analysis" aria-hidden="true" ng-if="analysis.status === 'Ready'" ng-click="start_analysis(analysis.id)"></i>
+                                <i class="glyphicon glyphicon-stop" title="Stop Analysis" aria-hidden="true" ng-if="['Pending Creation', 'Creating', 'Queued', 'Running'].indexOf(analysis.status) >= 0" ng-disabled="['Pending Creation', 'Queued'].indexOf(analysis.status) >= 0" ng-click="stop_analysis(analysis.id)"></i>
                              </td>
                             <td>{$:: analysis.number_of_analysis_property_views $}</td>
                             <td>{$:: analysis.service $}</td>

--- a/seed/static/seed/partials/inventory_detail_analyses.html
+++ b/seed/static/seed/partials/inventory_detail_analyses.html
@@ -60,7 +60,8 @@
                                <!-- These glyphicons are temporarily disabled until we implement their functionality
                                <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
                                <i class="glyphicon glyphicon-trash" aria-hidden="true"></i> -->
-                               <i class="glyphicon glyphicon-play" title="Start Analysis" aria-hidden="true" ng-if="['Pending Creation', 'Creating', 'Ready'].indexOf(analysis.status) >= 0" ng-disabled="analysis.status !== 'Ready'" ng-click="start_analysis(analysis.id)"></i>
+                               <i class="glyphicon glyphicon-play" title="Start Analysis" aria-hidden="true" ng-if="analysis.status === 'Ready'" ng-click="start_analysis(analysis.id)"></i>
+                                <i class="glyphicon glyphicon-stop" title="Stop Analysis" aria-hidden="true" ng-if="['Pending Creation', 'Creating', 'Queued', 'Running'].indexOf(analysis.status) >= 0" ng-disabled="['Pending Creation', 'Queued'].indexOf(analysis.status) >= 0" ng-click="stop_analysis(analysis.id)"></i>
                             </td>
                             <td>{$:: analysis.service $}</td>
                             <td class="analysis-status {$:: analysis.status.toLowerCase() $}">{$:: analysis.status $}</td>

--- a/seed/tests/test_analysis_pipelines.py
+++ b/seed/tests/test_analysis_pipelines.py
@@ -263,6 +263,7 @@ class TestAnalysisPipeline(TestCase):
     def test_check_analysis_status_raises_exception_when_analysis_status_is_not_as_expected(self):
         # Setup
         expected_status = Analysis.RUNNING
+
         @check_analysis_status(expected_status)
         def my_func(analysis_id):
             return 'I did work'

--- a/seed/tests/test_analysis_pipelines.py
+++ b/seed/tests/test_analysis_pipelines.py
@@ -39,7 +39,12 @@ from seed.test_helpers.fake import (
     FakePropertyViewFactory,
 )
 from seed.utils.organizations import create_organization
-from seed.analysis_pipelines.pipeline import AnalysisPipelineException, AnalysisPipeline, task_create_analysis_property_views
+from seed.analysis_pipelines.pipeline import (
+    AnalysisPipelineException,
+    AnalysisPipeline,
+    task_create_analysis_property_views,
+    check_analysis_status
+)
 from seed.analysis_pipelines.bsyncr import _build_bsyncr_input, BsyncrPipeline, _parse_analysis_property_view_id, PREMISES_ID_NAME
 from seed.building_sync.building_sync import BuildingSync
 from seed.building_sync.mappings import NAMESPACES
@@ -167,6 +172,32 @@ class TestAnalysisPipeline(TestCase):
         self.analysis.refresh_from_db()
         self.assertEqual(Analysis.COMPLETED, self.analysis.status)
 
+    def test_stop_sets_status_to_stopped_when_not_in_terminal_state(self):
+        # Setup
+        self.analysis.status = Analysis.RUNNING
+        self.analysis.save()
+        pipeline = MockPipeline(self.analysis.id)
+
+        # Act
+        pipeline.stop()
+
+        # Assert
+        self.analysis.refresh_from_db()
+        self.assertEqual(Analysis.STOPPED, self.analysis.status)
+
+    def test_stop_does_not_change_status_if_already_in_terminal_state(self):
+        # Setup
+        self.analysis.status = Analysis.FAILED
+        self.analysis.save()
+        pipeline = MockPipeline(self.analysis.id)
+
+        # Act
+        pipeline.stop()
+
+        # Assert
+        self.analysis.refresh_from_db()
+        self.assertEqual(Analysis.FAILED, self.analysis.status)
+
     def test_task_create_analysis_property_views_creates_messages_for_failed_property_views(self):
         # Setup
         property_view = (
@@ -183,6 +214,68 @@ class TestAnalysisPipeline(TestCase):
         # a message for the bad property view should have been created
         message = AnalysisMessage.objects.get(analysis=self.analysis)
         self.assertTrue(f'Failed to copy property data for PropertyView ID {bogus_property_view_id}' in message.user_message)
+
+    def test_check_analysis_status_calls_decorated_function_when_status_is_as_expected(self):
+        # Setup
+        @check_analysis_status(Analysis.RUNNING)
+        def my_func(analysis_id):
+            return 'I did work'
+
+        self.analysis.status = Analysis.RUNNING
+        self.analysis.save()
+
+        # Act
+        res = my_func(self.analysis.id)
+
+        # Assert
+        self.assertEqual('I did work', res)
+
+    def test_check_analysis_status_works_when_decorated_func_called_with_kwargs(self):
+        # Setup
+        @check_analysis_status(Analysis.RUNNING)
+        def my_func(analysis_id):
+            return 'I did work'
+
+        self.analysis.status = Analysis.RUNNING
+        self.analysis.save()
+
+        # Act
+        res = my_func(analysis_id=self.analysis.id)
+
+        # Assert
+        self.assertEqual('I did work', res)
+
+    def test_check_analysis_status_works_when_decorated_func_has_multiple_args(self):
+        # Setup
+        @check_analysis_status(Analysis.RUNNING)
+        def my_func(my_param_1, my_param_2, analysis_id, my_param_3):
+            return 'I did work'
+
+        self.analysis.status = Analysis.RUNNING
+        self.analysis.save()
+
+        # Act
+        res = my_func(-1, -1, self.analysis.id, -1)
+
+        # Assert
+        self.assertEqual('I did work', res)
+
+    def test_check_analysis_status_raises_exception_when_analysis_status_is_not_as_expected(self):
+        # Setup
+        expected_status = Analysis.RUNNING
+        @check_analysis_status(expected_status)
+        def my_func(analysis_id):
+            return 'I did work'
+
+        # set status to something unexpected
+        self.analysis.status = Analysis.STOPPED
+        self.analysis.save()
+
+        # Act/Assert
+        with self.assertRaises(AnalysisPipelineException) as context:
+            my_func(self.analysis.id)
+
+        self.assertIn(f'Expected analysis status to be {expected_status}', str(context.exception))
 
 
 # override the BSYNCR_SERVER_HOST b/c otherwise the pipeline will not run (doesn't have to be valid b/c we mock requests)

--- a/seed/views/v3/analyses.py
+++ b/seed/views/v3/analyses.py
@@ -163,3 +163,24 @@ class AnalysisViewSet(viewsets.ViewSet):
                 'status': 'error',
                 'message': str(e)
             }, status=HTTP_409_CONFLICT)
+
+    @swagger_auto_schema(manual_parameters=[AutoSchemaHelper.query_org_id_field()])
+    @require_organization_id_class
+    @api_endpoint_class
+    @ajax_request_class
+    @has_perm_class('requires_member')
+    @action(detail=True, methods=['post'])
+    def stop(self, request, pk):
+        organization_id = int(request.query_params.get('organization_id', 0))
+        try:
+            analysis = Analysis.objects.get(id=pk, organization_id=organization_id)
+            pipeline = AnalysisPipeline.factory(analysis)
+            pipeline.stop()
+            return JsonResponse({
+                'status': 'success',
+            })
+        except Analysis.DoesNotExist:
+            return JsonResponse({
+                'status': 'error',
+                'message': 'Requested analysis doesn\'t exist in this organization.'
+            }, status=HTTP_409_CONFLICT)


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
Adds method for stopping a pipeline, and the analysis endpoint for triggering this stop.

Note that the implementation does **not** stop a running celery task, but prevents future tasks from running (assuming multiple tasks were chained for the pipeline and there are tasks remaining after it was stopped) - see the new `check_analysis_status` decorator used. When `stop` is called, it sets the status to `Stopped`, "ending" the analysis.

The biggest implication of the implementation is that the background task might still update the analysis/analysis property views even after it's been stopped.

#### How should this be manually tested?
This assumes you have bsyncr server setup.
Tweak bsyncr.py to take a long time after starting the analysis. e.g. on line 324 insert
```python
import time
time.sleep(30)
```
create an analysis for a property with valid meters, then start the analysis. You should either see queued or running (depending on how fast it updated the status). If it shows queued you can refresh the page to enable the stop button (should show running). Click the stop button and it should stop the analysis.

#### What are the relevant tickets?
#2478 

#### Screenshots (if appropriate)
<img width="1385" alt="Screen Shot 2020-12-30 at 2 58 18 PM" src="https://user-images.githubusercontent.com/18518728/103378231-a0a78f00-4aaf-11eb-8e9b-e611d9d93946.png">
<img width="1386" alt="Screen Shot 2020-12-30 at 2 58 02 PM" src="https://user-images.githubusercontent.com/18518728/103378232-a1402580-4aaf-11eb-962e-8c4ae8d13837.png">

