### PR TITLE
2476 feat: delete analysis view

### DIFF
--- a/seed/analysis_pipelines/bsyncr.py
+++ b/seed/analysis_pipelines/bsyncr.py
@@ -11,6 +11,7 @@ from seed.analysis_pipelines.pipeline import (
     AnalysisPipelineException,
     task_create_analysis_property_views,
     analysis_pipeline_task,
+    StopAnalysisTaskChain
 )
 from seed.building_sync.mappings import BUILDINGSYNC_URI, NAMESPACES
 from seed.lib.progress_data.progress_data import ProgressData
@@ -158,7 +159,7 @@ def _prepare_all_properties(self, analysis_property_view_ids, analysis_id, progr
         message = 'No files were able to be prepared for the analysis'
         pipeline.fail(message, progress_data_key=progress_data.key, logger=logger)
         # stop the task chain
-        raise AnalysisPipelineException(message)
+        raise StopAnalysisTaskChain(message)
 
 
 @shared_task(bind=True)
@@ -343,7 +344,7 @@ def _start_analysis(self, analysis_id, progress_data_key):
         message = 'Failed to get results for all properties'
         pipeline.fail(message, progress_data_key=progress_data.key, logger=logger)
         # stop the task chain
-        raise AnalysisPipelineException(message)
+        raise StopAnalysisTaskChain(message)
 
     return output_file_ids
 

--- a/seed/analysis_pipelines/bsyncr.py
+++ b/seed/analysis_pipelines/bsyncr.py
@@ -51,7 +51,7 @@ class BsyncrPipeline(AnalysisPipeline):
         """Internal implementation for preparing bsyncr analysis"""
         if not settings.BSYNCR_SERVER_HOST:
             message = 'SEED instance is not configured to run bsyncr analysis. Please contact the server administrator.'
-            self.fail(message, logger=logger)
+            self.fail(message, logger)
             raise AnalysisPipelineException(message)
 
         progress_data = ProgressData('prepare-analysis-bsyncr', analysis_id)
@@ -157,7 +157,7 @@ def _prepare_all_properties(self, analysis_property_view_ids, analysis_id, progr
     if len(input_file_paths) == 0:
         pipeline = BsyncrPipeline(analysis.id)
         message = 'No files were able to be prepared for the analysis'
-        pipeline.fail(message, progress_data_key=progress_data.key, logger=logger)
+        pipeline.fail(message, logger, progress_data_key=progress_data.key)
         # stop the task chain
         raise StopAnalysisTaskChain(message)
 
@@ -342,7 +342,7 @@ def _start_analysis(self, analysis_id, progress_data_key):
     if len(output_file_ids) == 0:
         pipeline = BsyncrPipeline(analysis.id)
         message = 'Failed to get results for all properties'
-        pipeline.fail(message, progress_data_key=progress_data.key, logger=logger)
+        pipeline.fail(message, logger, progress_data_key=progress_data.key)
         # stop the task chain
         raise StopAnalysisTaskChain(message)
 

--- a/seed/analysis_pipelines/pipeline.py
+++ b/seed/analysis_pipelines/pipeline.py
@@ -85,6 +85,11 @@ def analysis_pipeline_task(expected_status):
 
         @functools.wraps(func)
         def _run_task(*args, **kwargs):
+            def _stop_task_chain(task_instance):
+                # stops the celery task chain (ie any child tasks)
+                # see: https://github.com/celery/celery/issues/3550
+                task_instance.request.chain = task_instance.request.callbacks = None
+
             # self is first arg, the celery.Task instance, b/c the celery task was decorated with `bind=True`
             _self = args[0]
 
@@ -94,45 +99,76 @@ def analysis_pipeline_task(expected_status):
             except IndexError:
                 _analysis_id = kwargs['analysis_id']
 
-            # Before running the task, make sure the analysis exists and has the expected status
+            # Check the analysis before running the task
+            # If the analysis exists and has the expected status, run the task
+            # If the analysis exists but the status isn't what we expected, and...
+            #   - It WAS stopped or failed, stop the task chain (someone somewhere else stopped/failed the task)
+            #   - It WAS NOT stopped or failed, raise an exception! (something unexpected has happened)
+            # If the analysis no longer exists, stop the task chain (someone somewhere deleted the analysis)
             try:
                 analysis = Analysis.objects.get(id=_analysis_id)
-                if analysis.status != expected_status:
-                    raise AnalysisPipelineException(f'Expected analysis status to be {expected_status} but it was {analysis.status}')
+                if analysis.status == expected_status:
+                    pass
+                elif analysis.status in [Analysis.STOPPED, Analysis.FAILED]:
+                    # assume someone else stopped or failed the analysis and that we shouldn't run the task
+                    log_message = {
+                        'analysis_id': _analysis_id,
+                        'debug_message': 'Analysis has already been stopped or failed before starting the task. '
+                                         'Not running the task and stopping the task chain.'
+                    }
+                    logger.info(json.dumps(log_message))
+                    _stop_task_chain(_self)
+                    return
+                else:
+                    # something Bad has happened
+                    raise AnalysisPipelineException(f'When preparing to run the task {func}, expected analysis status to be {expected_status} but it was {analysis.status}')
             except Analysis.DoesNotExist:
+                # someone deleted the analysis
                 log_message = {
                     'analysis_id': _analysis_id,
                     'debug_message': 'Analysis no longer exists before starting the task. '
                                      'Assuming the analysis was deleted and stopping the celery task chain.'
                 }
                 logger.info(json.dumps(log_message))
-
-                # stop the chain!
-                # see: https://github.com/celery/celery/issues/3550
-                _self.request.chain = _self.request.callbacks = None
+                _stop_task_chain(_self)
                 return
 
             # Catch all exceptions raised by the task
+            # If the exception was to stop the task chain, stop the task chain
             # If the analysis no longer exists, ignore the exception (the analysis was deleted by someone else)
             # If the analysis _does_ still exist, raise the exception (something unexpected happened)
             try:
                 return func(*args, **kwargs)
+            except StopAnalysisTaskChain as e:
+                log_message = {
+                    'analysis_id': _analysis_id,
+                    'debug_message': 'StopAnalysisTaskChain exception raised, stopping the celery task chain.',
+                    'exception': repr(e)
+                }
+                logger.info(json.dumps(log_message))
+                _stop_task_chain(_self)
+                return
             except Exception as e:
                 try:
                     Analysis.objects.get(id=_analysis_id)
+
+                    log_message = {
+                        'analysis_id': _analysis_id,
+                        'debug_message': 'Caught unexpected exception occurred during analysis task (and analysis still exists). Re-raising exception and continuing.',
+                        'exception': repr(e)
+                    }
+                    logger.error(json.dumps(log_message))
                     raise e
                 except Analysis.DoesNotExist:
+                    # someone deleted the analysis, and the error was probably due to that
                     log_message = {
                         'analysis_id': _analysis_id,
                         'debug_message': 'Task raised unhandled exception, but the analysis no longer exists. '
                                          'Assuming the analysis was deleted and stopping the celery task chain.',
-                        'exception': str(e)
+                        'exception': repr(e)
                     }
                     logger.info(json.dumps(log_message))
-
-                    # stop the chain!
-                    # see: https://github.com/celery/celery/issues/3550
-                    _self.request.chain = _self.request.callbacks = None
+                    _stop_task_chain(_self)
                     return
 
         return _run_task
@@ -140,6 +176,14 @@ def analysis_pipeline_task(expected_status):
 
 
 class AnalysisPipelineException(Exception):
+    """An analysis pipeline specific exception"""
+    pass
+
+
+class StopAnalysisTaskChain(Exception):
+    """Analysis pipeline tasks should raise this exception to stop the celery task
+    chain.
+    """
     pass
 
 

--- a/seed/analysis_pipelines/pipeline.py
+++ b/seed/analysis_pipelines/pipeline.py
@@ -109,7 +109,7 @@ def analysis_pipeline_task(expected_status):
 
             #
             # Check the analysis before running the task
-            # 
+            #
             # NOTE: this does not avoid time-of-check to time-of-use (TOCTOU) race conditions
             #   but should be generally sufficient as a guard
             #
@@ -134,7 +134,7 @@ def analysis_pipeline_task(expected_status):
                 log_message = {
                     'analysis_id': _analysis_id,
                     'debug_message': 'Analysis has already been stopped or failed before starting the task. '
-                                        'Not running the task and stopping the task chain.'
+                                     'Not running the task and stopping the task chain.'
                 }
                 logger.info(json.dumps(log_message))
                 _stop_task_chain(_self)

--- a/seed/analysis_pipelines/pipeline.py
+++ b/seed/analysis_pipelines/pipeline.py
@@ -69,6 +69,10 @@ def analysis_pipeline_task(expected_status):
     """
 
     def decorator_analysis_pipeline_task(func):
+        # add a property to indicate this function was wrapped
+        # the only purpose of this is so we can test that all tasks have been properly wrapped
+        func._analysis_pipeline_task = True
+
         params = inspect.getfullargspec(func)
 
         self_error_message = 'Decorated task function must have `self` as first argument, and @shared_task decorator must have `bind=True`'

--- a/seed/analysis_pipelines/pipeline.py
+++ b/seed/analysis_pipelines/pipeline.py
@@ -302,6 +302,15 @@ class AnalysisPipeline(abc.ABC):
             locked_analysis.end_time = tz.now()
             locked_analysis.save()
 
+    def delete(self):
+        """Deletes the analysis.
+
+        Deleting an analysis can cause issues if it has tasks running, but
+        we are currently requiring the tasks to deal with it instead of doing
+        something more complex here.
+        """
+        Analysis.objects.get(id=self._analysis_id).delete()
+
     @abc.abstractmethod
     def _prepare_analysis(self, analysis_id, property_view_ids):
         """Abstract method which should do the work necessary for preparing

--- a/seed/models/analysis_messages.py
+++ b/seed/models/analysis_messages.py
@@ -82,6 +82,14 @@ class AnalysisMessage(models.Model):
         }
         logger.log(logger_level, json.dumps(log_message_dict))
 
+        # truncate the messages to make sure they meet our db constraints
+        MAX_MESSAGE_LENGTH = 255
+        ELIPSIS = '...'
+        if len(user_message) > MAX_MESSAGE_LENGTH:
+            user_message = user_message[:MAX_MESSAGE_LENGTH - len(ELIPSIS)] + ELIPSIS
+        if len(debug_message) > MAX_MESSAGE_LENGTH:
+            debug_message = debug_message[:MAX_MESSAGE_LENGTH - len(ELIPSIS)] + ELIPSIS
+
         return AnalysisMessage.objects.create(
             type=type_,
             analysis_id=analysis_id,

--- a/seed/static/seed/js/controllers/analyses_controller.js
+++ b/seed/static/seed/js/controllers/analyses_controller.js
@@ -72,6 +72,21 @@ angular.module('BE.seed.controller.analyses', [])
         })
       }
 
+      $scope.delete_analysis = function(analysis_id) {
+        analysis = $scope.analyses.find(function(a) { return a.id === analysis_id })
+        analysis.status = 'Deleting...'
+
+        analyses_service.delete_analysis(analysis_id)
+        .then(function (result) {
+          if (result.status === 'success') {
+            Notification.primary('Analysis deleted')
+            refresh_analyses()
+          } else {
+            Notification.error('Failed to delete analysis: ' + result.message)
+          }
+        })
+      }
+
     }
   ])
   .filter('get_run_duration', function() {

--- a/seed/static/seed/js/controllers/inventory_detail_analyses_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_analyses_controller.js
@@ -88,6 +88,21 @@ angular.module('BE.seed.controller.inventory_detail_analyses', [])
         })
       }
 
+      $scope.delete_analysis = function(analysis_id) {
+        analysis = $scope.analyses.find(function(a) { return a.id === analysis_id })
+        analysis.status = 'Deleting...'
+
+        analyses_service.delete_analysis(analysis_id)
+        .then(function (result) {
+          if (result.status === 'success') {
+            Notification.primary('Analysis deleted')
+            refresh_analyses()
+          } else {
+            Notification.error('Failed to delete analysis: ' + result.message)
+          }
+        })
+      }
+
       $scope.open_analysis_modal = function () {
         $uibModal.open({
           templateUrl: urls.static_url + 'seed/partials/inventory_detail_analyses_modal.html',

--- a/seed/static/seed/js/services/analyses_service.js
+++ b/seed/static/seed/js/services/analyses_service.js
@@ -89,6 +89,19 @@ angular.module('BE.seed.service.analyses', [])
         })
       }
 
+      let delete_analysis = function(analysis_id) {
+        let organization_id = user_service.get_organization().id;
+        return $http({
+          url: '/api/v3/analyses/' + analysis_id + '/',
+          method: 'DELETE',
+          params: { organization_id: organization_id },
+        }).then(function (response) {
+          return response.data
+        }).catch(function (response) {
+          return response.data
+        })
+      }
+
       let analyses_factory = {
         get_analyses_for_org: get_analyses_for_org,
         get_analyses_for_canonical_property: get_analyses_for_canonical_property,
@@ -98,7 +111,8 @@ angular.module('BE.seed.service.analyses', [])
         get_analysis_view_for_org: get_analysis_view_for_org,
         create_analysis: create_analysis,
         start_analysis: start_analysis,
-        stop_analysis: stop_analysis
+        stop_analysis: stop_analysis,
+        delete_analysis: delete_analysis
       };
 
       return analyses_factory;

--- a/seed/static/seed/partials/analyses.html
+++ b/seed/static/seed/partials/analyses.html
@@ -28,9 +28,6 @@
                         <tr ng-repeat="analysis in analyses | filter:filter_params:strict">
                             <td><a ui-sref="analysis(::{organization_id: org.id, analysis_id: analysis.id})" ui-sref-active="active">{$:: analysis.name $}</a></td>
                             <td>
-                                <!-- These glyphicons are temporarily disabled until we implement their functionality
-                                <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
-                                <i class="glyphicon glyphicon-trash" aria-hidden="true"></i> -->
                                 <i class="glyphicon glyphicon-play" title="Start Analysis" aria-hidden="true" ng-if="analysis.status === 'Ready'" ng-click="start_analysis(analysis.id)"></i>
                                 <i class="glyphicon glyphicon-stop" title="Stop Analysis" aria-hidden="true" ng-if="['Pending Creation', 'Creating', 'Queued', 'Running'].indexOf(analysis.status) >= 0" ng-disabled="['Pending Creation', 'Queued'].indexOf(analysis.status) >= 0" ng-click="stop_analysis(analysis.id)"></i>
                                 <i class="glyphicon glyphicon-trash" title="Delete Analysis" aria-hidden="true" ng-click="delete_analysis(analysis.id)"></i>

--- a/seed/static/seed/partials/analyses.html
+++ b/seed/static/seed/partials/analyses.html
@@ -33,6 +33,7 @@
                                 <i class="glyphicon glyphicon-trash" aria-hidden="true"></i> -->
                                 <i class="glyphicon glyphicon-play" title="Start Analysis" aria-hidden="true" ng-if="analysis.status === 'Ready'" ng-click="start_analysis(analysis.id)"></i>
                                 <i class="glyphicon glyphicon-stop" title="Stop Analysis" aria-hidden="true" ng-if="['Pending Creation', 'Creating', 'Queued', 'Running'].indexOf(analysis.status) >= 0" ng-disabled="['Pending Creation', 'Queued'].indexOf(analysis.status) >= 0" ng-click="stop_analysis(analysis.id)"></i>
+                                <i class="glyphicon glyphicon-trash" title="Delete Analysis" aria-hidden="true" ng-click="delete_analysis(analysis.id)"></i>
                              </td>
                             <td>{$:: analysis.number_of_analysis_property_views $}</td>
                             <td>{$:: analysis.service $}</td>

--- a/seed/static/seed/partials/inventory_detail_analyses.html
+++ b/seed/static/seed/partials/inventory_detail_analyses.html
@@ -57,11 +57,12 @@
                             <td style="width: 7%; min-width: unset"><a ui-sref="analysis_run(::{inventory_type: inventory_type, view_id: view_id, run_id: analysis.views[0], analysis_id: analysis.id, organization_id: org.id})">{$:: analysis.views[0] $}</a></td>
                             <td><a ui-sref="analysis(::{organization_id: org.id, analysis_id: analysis.id})" ui-sref-active="active">{$:: analysis.name $}</a></td>
                             <td>
-                               <!-- These glyphicons are temporarily disabled until we implement their functionality
-                               <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
-                               <i class="glyphicon glyphicon-trash" aria-hidden="true"></i> -->
-                               <i class="glyphicon glyphicon-play" title="Start Analysis" aria-hidden="true" ng-if="analysis.status === 'Ready'" ng-click="start_analysis(analysis.id)"></i>
+                                <!-- These glyphicons are temporarily disabled until we implement their functionality
+                                <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
+                                <i class="glyphicon glyphicon-trash" aria-hidden="true"></i> -->
+                                <i class="glyphicon glyphicon-play" title="Start Analysis" aria-hidden="true" ng-if="analysis.status === 'Ready'" ng-click="start_analysis(analysis.id)"></i>
                                 <i class="glyphicon glyphicon-stop" title="Stop Analysis" aria-hidden="true" ng-if="['Pending Creation', 'Creating', 'Queued', 'Running'].indexOf(analysis.status) >= 0" ng-disabled="['Pending Creation', 'Queued'].indexOf(analysis.status) >= 0" ng-click="stop_analysis(analysis.id)"></i>
+                                <i class="glyphicon glyphicon-trash" title="Delete Analysis" aria-hidden="true" ng-click="delete_analysis(analysis.id)"></i>
                             </td>
                             <td>{$:: analysis.service $}</td>
                             <td class="analysis-status {$:: analysis.status.toLowerCase() $}">{$:: analysis.status $}</td>

--- a/seed/static/seed/partials/inventory_detail_analyses.html
+++ b/seed/static/seed/partials/inventory_detail_analyses.html
@@ -57,9 +57,6 @@
                             <td style="width: 7%; min-width: unset"><a ui-sref="analysis_run(::{inventory_type: inventory_type, view_id: view_id, run_id: analysis.views[0], analysis_id: analysis.id, organization_id: org.id})">{$:: analysis.views[0] $}</a></td>
                             <td><a ui-sref="analysis(::{organization_id: org.id, analysis_id: analysis.id})" ui-sref-active="active">{$:: analysis.name $}</a></td>
                             <td>
-                                <!-- These glyphicons are temporarily disabled until we implement their functionality
-                                <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
-                                <i class="glyphicon glyphicon-trash" aria-hidden="true"></i> -->
                                 <i class="glyphicon glyphicon-play" title="Start Analysis" aria-hidden="true" ng-if="analysis.status === 'Ready'" ng-click="start_analysis(analysis.id)"></i>
                                 <i class="glyphicon glyphicon-stop" title="Stop Analysis" aria-hidden="true" ng-if="['Pending Creation', 'Creating', 'Queued', 'Running'].indexOf(analysis.status) >= 0" ng-disabled="['Pending Creation', 'Queued'].indexOf(analysis.status) >= 0" ng-click="stop_analysis(analysis.id)"></i>
                                 <i class="glyphicon glyphicon-trash" title="Delete Analysis" aria-hidden="true" ng-click="delete_analysis(analysis.id)"></i>

--- a/seed/tests/test_analysis_pipelines.py
+++ b/seed/tests/test_analysis_pipelines.py
@@ -7,6 +7,7 @@
 from datetime import datetime
 from io import BytesIO
 import json
+import logging
 from os import path
 from unittest.mock import patch
 
@@ -171,8 +172,10 @@ class TestAnalysisPipeline(TestCase):
         pipeline = MockPipeline(self.analysis.id)
         failure_message = 'Bad'
 
+        logger = logging.getLogger('test-logger')
+
         # Act
-        pipeline.fail(failure_message)
+        pipeline.fail(failure_message, logger)
 
         # Assert
         self.analysis.refresh_from_db()
@@ -187,9 +190,11 @@ class TestAnalysisPipeline(TestCase):
         self.analysis.save()
         pipeline = MockPipeline(self.analysis.id)
 
+        logger = logging.getLogger('test-logger')
+
         # Act
         with self.assertRaises(AnalysisPipelineException) as context:
-            pipeline.fail('Double plus ungood')
+            pipeline.fail('Double plus ungood', logger)
 
         # Assert
         self.assertTrue('Analysis is already in a terminal state' in str(context.exception))

--- a/seed/tests/test_analysis_pipelines.py
+++ b/seed/tests/test_analysis_pipelines.py
@@ -89,6 +89,21 @@ class TestAnalysisPipeline(TestCase):
             .get_analysis()
         )
 
+    def test_all_analysis_pipeline_tasks_are_wrapped_with_analysis_pipeline_task_decorator(self):
+        from inspect import getmembers
+        from celery import Task
+        from seed.analysis_pipelines import tasks
+
+        def is_celery_task(v):
+            return isinstance(v, Task)
+
+        celery_tasks = getmembers(tasks, is_celery_task)
+        for _, celery_task in celery_tasks:
+            try:
+                celery_task.__wrapped__._analysis_pipeline_task
+            except AttributeError:
+                self.assertTrue(False, f'Function {celery_task.__wrapped__} must be wrapped by analysis_pipelines.pipeline.analysis_pipeline_task')
+
     def test_prepare_analysis_raises_exception_when_analysis_status_indicates_already_prepared(self):
         # Setup
         # set status as already running, which should prevent the analysis from

--- a/seed/views/v3/analyses.py
+++ b/seed/views/v3/analyses.py
@@ -184,3 +184,23 @@ class AnalysisViewSet(viewsets.ViewSet):
                 'status': 'error',
                 'message': 'Requested analysis doesn\'t exist in this organization.'
             }, status=HTTP_409_CONFLICT)
+
+    @swagger_auto_schema(manual_parameters=[AutoSchemaHelper.query_org_id_field()])
+    @require_organization_id_class
+    @api_endpoint_class
+    @ajax_request_class
+    @has_perm_class('requires_member')
+    def destroy(self, request, pk):
+        organization_id = int(request.query_params.get('organization_id', 0))
+        try:
+            analysis = Analysis.objects.get(id=pk, organization_id=organization_id)
+            pipeline = AnalysisPipeline.factory(analysis)
+            pipeline.delete()
+            return JsonResponse({
+                'status': 'success',
+            })
+        except Analysis.DoesNotExist:
+            return JsonResponse({
+                'status': 'error',
+                'message': 'Requested analysis doesn\'t exist in this organization.'
+            }, status=HTTP_409_CONFLICT)


### PR DESCRIPTION
#### Any background context you want to provide?
SEED is adding ability to run analyses on properties.

#### What's this PR do?
- refactor bsyncr celery tasks (and task wrapper) to more gracefully handle unexpected issues (e.g. someone deleting the analysis). In addition, avoid as much as possible raising unhandled exceptions that are unnecessary
- add a view for deleting an analysis
- add icon for deleting analysis from the frontend
- fix cases where user message or debug message for AnalysisMessage is too long by truncating the message

#### How should this be manually tested?
Monkey test the analysis functionality, deleting analyses in different statuses and see if you can break anything. After deleting an analysis you should no longer see it.

#### What are the relevant tickets?
#2476 

#### Screenshots (if appropriate)
<img width="1378" alt="Screen Shot 2021-01-05 at 5 10 04 PM" src="https://user-images.githubusercontent.com/18518728/103705362-e6190000-4f78-11eb-8a2e-4b5c6518fc31.png">
