### PR TITLE
feat: misc analysis tweaks

### DIFF
--- a/seed/static/seed/partials/analyses.html
+++ b/seed/static/seed/partials/analyses.html
@@ -18,6 +18,7 @@
                             <th translate>Actions</th>
                             <th translate>Number of Properties</th>
                             <th translate>Type</th>
+                            <th translate>Configuration</th>
                             <th translate>Run Status</th>
                             <th translate>Run Date</th>
                             <th translate>Run Duration</th>
@@ -34,6 +35,7 @@
                              </td>
                             <td>{$:: analysis.number_of_analysis_property_views $}</td>
                             <td>{$:: analysis.service $}</td>
+                            <td>{$:: analysis.configuration $}</td>
                             <td class="analysis-status {$:: analysis.status.toLowerCase() $}">{$:: analysis.status $}</td>
                             <td>{$:: analysis.start_time | date : 'MM-dd-yyyy  HH:mm' $}</td>
                             <td>{$:: analysis | get_run_duration $}</td>

--- a/seed/static/seed/partials/analysis_details.html
+++ b/seed/static/seed/partials/analysis_details.html
@@ -4,6 +4,7 @@
             <tr>
                 <th translate>Number of Runs</th>
                 <th translate>Type</th>
+                <th translate>Configuration</th>
                 <th translate>Run Status</th>
                 <th translate>Latest Message</th>
                 <th translate>Run Date</th>
@@ -15,6 +16,7 @@
             <tr>
                 <td>{$:: analysis.number_of_analysis_property_views $}</td>
                 <td>{$:: analysis.service $}</td>
+                <td>{$:: analysis.configuration $}</td>
                 <td class="analysis-status {$:: analysis.status.toLowerCase() $}">{$:: analysis.status $}</td>
                 <td>{$:: (messages | filter : {'analysis_property_view':''})[0]['user_message'] $}</td>
                 <td>{$:: analysis.start_time | date : 'MM-dd-yyyy  HH:mm' $}</td>

--- a/seed/static/seed/partials/inventory_detail_analyses.html
+++ b/seed/static/seed/partials/inventory_detail_analyses.html
@@ -46,6 +46,7 @@
                             <th translate>Analysis Name (User Defined)</th>
                             <th translate>Actions</th>
                             <th translate>Type</th>
+                            <th translate>Configuration</th>
                             <th translate>Run Status</th>
                             <th translate>Run Date</th>
                             <th translate>Run Duration</th>
@@ -62,6 +63,7 @@
                                 <i class="glyphicon glyphicon-trash" title="Delete Analysis" aria-hidden="true" ng-click="delete_analysis(analysis.id)"></i>
                             </td>
                             <td>{$:: analysis.service $}</td>
+                            <td>{$:: analysis.configuration $}</td>
                             <td class="analysis-status {$:: analysis.status.toLowerCase() $}">{$:: analysis.status $}</td>
                             <td>{$:: analysis.start_time | date : 'MM-dd-yyyy  HH:mm' $}</td>
                             <td>{$:: analysis | get_run_duration $}</td>

--- a/seed/views/v3/analyses.py
+++ b/seed/views/v3/analyses.py
@@ -95,12 +95,12 @@ class AnalysisViewSet(viewsets.ViewSet):
             analyses_queryset = (
                 Analysis.objects.filter(organization=organization_id, analysispropertyview__property=property_id)
                 .distinct()
-                .order_by('id')
+                .order_by('-id')
             )
         else:
             analyses_queryset = (
                 Analysis.objects.filter(organization=organization_id)
-                .order_by('id')
+                .order_by('-id')
             )
         for analysis in analyses_queryset:
             property_view_info = analysis.get_property_view_info(property_id)


### PR DESCRIPTION
#### Any background context you want to provide?
We are demoing the analysis functionality soon and would like to make some tweaks on the SEED side.
I would consider this a temporary method of displaying the configuration of an analysis, purely for the demo. We will probably want to find a better way to display the json config down the road.

#### What's this PR do?
- returns analyses from the list endpoint ordered by _reverse_ id (ie newest comes first)
- add the analysis configuration json to the tables that show analysis info

#### How should this be manually tested?
- check all views of analyses to verify configuration is properly being displayed (analysis detail, analyses (org level list), inventory detail analysis list)

#### What are the relevant tickets?

#### Screenshots (if appropriate)
<img width="1386" alt="Screen Shot 2021-01-19 at 12 28 55 PM" src="https://user-images.githubusercontent.com/18518728/105083252-e96cbb00-5a51-11eb-8282-044c614c2370.png">
