### PR TITLE
fix: ensure drf always returns json

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -265,13 +265,17 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
         'seed.authentication.SEEDAuthentication',
     ),
-    'DEFAULT_FILTER_BACKENDS':
-        ('django_filters.rest_framework.DjangoFilterBackend',),
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
+    ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     ),
     'DEFAULT_PAGINATION_CLASS':
         'seed.utils.pagination.ResultsListPagination',
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.JSONRenderer',
+    ],
     'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
     'PAGE_SIZE': 25,
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',


### PR DESCRIPTION
#### Any background context you want to provide?
See related issue
https://www.django-rest-framework.org/api-guide/renderers/#setting-the-renderers

#### What's this PR do?
Removes the DRF `BrowsableAPIRenderer`, leaving only `JSONRenderer`

#### How should this be manually tested?
While logged out browse to `/api/version`.  Ensure that json is returned rather than html

#### What are the relevant tickets?
#2558