### PR TITLE
#2515 feat: track updates to progress data on frontend

### DIFF
--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -104,6 +104,9 @@ angular.module('BE.seed.controller.data_upload_modal', [])
        *  button.
        * progress: int or float - the progress bar value, i.e. percentage complete
        * complete: bool - true when the upload has finished
+       * status_message: str - status of the task
+       * progress_last_updated: null | int - when not null it indicates the last time the progress bar changed (UNIX Epoch in ms)
+       * progress_last_checked: null | int - when not null it indicates the last time the progress was checked (UNIX Epoch in ms)
        */
       $scope.uploader = {
         invalid_extension_alert: false,
@@ -113,7 +116,9 @@ angular.module('BE.seed.controller.data_upload_modal', [])
         in_progress: false,
         progress: 0,
         complete: false,
-        status_message: ''
+        status_message: '',
+        progress_last_updated: null,
+        progress_last_checked: null,
       };
 
       /**

--- a/seed/static/seed/js/services/uploader_service.js
+++ b/seed/static/seed/js/services/uploader_service.js
@@ -101,7 +101,16 @@ angular.module('BE.seed.service.uploader', []).factory('uploader_service', [
       debug = !_.isUndefined(debug);
       uploader_factory.check_progress(progress_key).then(function (data) {
         $timeout(function () {
-          progress_bar_obj.progress = _.clamp((data.progress * multiplier) + offset, 0, 100);
+          right_now = Date.now();
+          progress_bar_obj.progress_last_checked = right_now;
+
+          new_progress_value = _.clamp((data.progress * multiplier) + offset, 0, 100);
+          updating_progress = new_progress_value != progress_bar_obj.progress || progress_bar_obj.status_message != data.status_message;
+          if (updating_progress) {
+            progress_bar_obj.progress_last_updated = right_now;
+          }
+
+          progress_bar_obj.progress = new_progress_value;
           progress_bar_obj.status_message = data.status_message;
           if (data.progress < 100) {
             uploader_factory.check_progress_loop(progress_key, offset, multiplier, success_fn, failure_fn, progress_bar_obj, debug);

--- a/seed/static/seed/partials/data_upload_modal.html
+++ b/seed/static/seed/partials/data_upload_modal.html
@@ -154,6 +154,12 @@
                         <strong>{$ dataset.filename $}</strong></div>
                     <uib-progressbar class="progress-striped active" value="uploader.progress" type="success"></uib-progressbar>
                     <div class="progress_bar_copy_bottom">{$ uploader.progress | number:0 $}% {$:: 'Complete' | translate $} {$ uploader.status_message ? ': ' + uploader.status_message : '' $}</div>
+                    <!-- Show a hint that SEED is still working when the progress data hasn't been updated in 1 minute -->
+                    <div ng-if="uploader.progress_last_updated != null && uploader.progress_last_checked != null && (uploader.progress_last_checked - uploader.progress_last_updated) / 1000 > 60"
+                         class="progress_bar_copy_bottom">
+                        <i class="fa fa-spinner fa-pulse fa-fw" style="padding-right: 0"></i>
+                        SEED is still working. Please do not refresh or leave this page. (Last updated at {$ uploader.progress_last_checked | date:'hh:mm a' $})
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
#### Any background context you want to provide?
When users are importing/mapping large files some users think SEED is broken b/c we aren't updating the progress bar.

#### What's this PR do?
Adds a note to the geocoding/mapping progress bar which will appear to users if the progress hasn't been updated recently.

#### How should this be manually tested?
Import a large file (or add a long time.sleep in seed.data_importer.match.match_and_link_incoming_properties_and_taxlots). and when mapping (which should take a while) you should eventually (after 1 minute of starting the matching task) see the notice shown in the screenshot below.

#### What are the relevant tickets?
This is a bandaid for #2515 , doesn't fix it as well as we might want but is a nice thing to have for now.

#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2021-01-26 at 4 17 49 PM" src="https://user-images.githubusercontent.com/18518728/105918976-1260f300-5ff2-11eb-88ec-a75c554b4f3f.png">
