### PR TITLE
feat: add option to exclude notes when exporting properties

### DIFF
--- a/seed/static/seed/js/controllers/export_inventory_modal_controller.js
+++ b/seed/static/seed/js/controllers/export_inventory_modal_controller.js
@@ -15,18 +15,19 @@ angular.module('BE.seed.controller.export_inventory_modal', []).controller('expo
   'filter_header_string',
   function ($http, $scope, $uibModalInstance, user_service, cycle_id, ids, columns, inventory_type, profile_id, filter_header_string) {
     $scope.export_name = '';
+    $scope.include_notes = true;
     $scope.inventory_type = inventory_type;
 
     $scope.export_selected = function (export_type) {
       var filename = $scope.export_name;
       var ext = '.' + export_type;
       if (!_.endsWith(filename, ext)) filename += ext;
-
       return $http.post('/api/v3/tax_lot_properties/export/', {
         ids: ids,
         filename: filename,
         profile_id: profile_id,
-        export_type: export_type
+        export_type: export_type,
+        include_notes: $scope.include_notes
       }, {
         params: {
           organization_id: user_service.get_organization().id,

--- a/seed/static/seed/partials/export_inventory_modal.html
+++ b/seed/static/seed/partials/export_inventory_modal.html
@@ -2,18 +2,40 @@
     <h4 class="modal-title" id="exportModalLabel" translate>Export your Properties and Tax Lots</h4>
 </div>
 <div class="modal-body form-horizontal" style="padding-bottom: 0;">
-    <div class="form-group">
-        <label class="control-label col-sm-3" for="fileName" translate>Export Name</label>
-        <div class="col-sm-8">
-          <input type="text" class="form-control" id="fileName" ng-model="export_name" placeholder="{$:: 'File Name' | translate $}" required>
+    <div class="section">
+
+        <div class="section_content_container">
+            <div class="section_content with_padding">
+                <label class="control-label col-sm-4" for="fileName" translate>Export Name</label>
+                <form class="form-horizontal" role="form">
+                    <div class="form-group">
+                        <div class="col-sm-6">
+                            <input type="text" class="form-control" id="fileName" ng-model="export_name" placeholder="{$:: 'File Name' | translate $}" required>
+                        </div>
+                    </div>
+                </form>
+            </div>
         </div>
+
+        <div class="section_content_container">
+            <div class="section_content with_padding">
+                <label class="control-label col-sm-4" for="fileName" translate>Include Property Notes</label>
+                <form class="form-horizontal" role="form">
+                    <div class="form-group">
+                        <div class="col-sm-6">
+                            <input type="checkbox" checked class="checkbox" id="include-notes" ng-model="include_notes">
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+
     </div>
 </div>
 <div class="modal-footer">
     <button type="button" class="btn btn-primary" ng-click="export_selected('csv')" ng-disabled="!export_name.length" translate>Export CSV</button>
     <button type="button" class="btn btn-primary" ng-click="export_selected('xlsx')" ng-disabled="!export_name.length" ng-if="inventory_type === 'properties'" translate>Export BuildingSync in Excel format</button>
     <button type="button" class="btn btn-primary" ng-click="export_selected('geojson')" ng-disabled="!export_name.length" translate>Export GeoJSON</button>
-
 </div>
 <div class="modal-footer">
     <button type="button" class="btn btn-default" ng-click="cancel()" translate>Cancel</button>

--- a/seed/static/seed/partials/export_inventory_modal.html
+++ b/seed/static/seed/partials/export_inventory_modal.html
@@ -19,7 +19,7 @@
 
         <div class="section_content_container">
             <div class="section_content with_padding">
-                <label class="control-label col-sm-4" for="fileName" translate>Include Property Notes</label>
+                <label class="control-label col-sm-4" for="fileName" translate>Include Notes</label>
                 <form class="form-horizontal" role="form">
                     <div class="form-group">
                         <div class="col-sm-6">

--- a/seed/views/v3/tax_lot_properties.py
+++ b/seed/views/v3/tax_lot_properties.py
@@ -142,23 +142,25 @@ class TaxLotPropertyViewSet(GenericViewSet):
         data = TaxLotProperty.get_related(model_views, column_ids, columns_from_database)
 
         # add labels and notes
+        include_notes = request.data.get('include_notes')
         for i, record in enumerate(model_views):
             label_string = []
             note_string = []
             for label in list(record.labels.all().order_by('name')):
                 label_string.append(label.name)
-            for note in list(record.notes.all().order_by('created')):
-                note_string.append(
-                    note.created.astimezone().strftime("%Y-%m-%d %I:%M:%S %p") + "\n" +
-                    note.text
-                )
+            if include_notes:
+                for note in list(record.notes.all().order_by('created')):
+                    note_string.append(
+                        note.created.astimezone().strftime("%Y-%m-%d %I:%M:%S %p") + "\n" +
+                        note.text
+                    )
 
             if hasattr(record, 'property'):
                 data[i]['property_labels'] = ','.join(label_string)
-                data[i]['property_notes'] = '\n----------\n'.join(note_string)
+                data[i]['property_notes'] =  '\n----------\n'.join(note_string) if include_notes else '(excluded during export)'
             elif hasattr(record, 'taxlot'):
                 data[i]['taxlot_labels'] = ','.join(label_string)
-                data[i]['taxlot_notes'] = '\n----------\n'.join(note_string)
+                data[i]['taxlot_notes'] = '\n----------\n'.join(note_string) if include_notes else '(excluded during export)'
 
         # force the data into the same order as the IDs
         if ids:

--- a/seed/views/v3/tax_lot_properties.py
+++ b/seed/views/v3/tax_lot_properties.py
@@ -142,7 +142,9 @@ class TaxLotPropertyViewSet(GenericViewSet):
         data = TaxLotProperty.get_related(model_views, column_ids, columns_from_database)
 
         # add labels and notes
-        include_notes = request.data.get('include_notes')
+        include_notes = True
+        if 'include_notes' in request.data.keys():
+            include_notes = request.data.get('include_notes')
         for i, record in enumerate(model_views):
             label_string = []
             note_string = []

--- a/seed/views/v3/tax_lot_properties.py
+++ b/seed/views/v3/tax_lot_properties.py
@@ -157,7 +157,7 @@ class TaxLotPropertyViewSet(GenericViewSet):
 
             if hasattr(record, 'property'):
                 data[i]['property_labels'] = ','.join(label_string)
-                data[i]['property_notes'] =  '\n----------\n'.join(note_string) if include_notes else '(excluded during export)'
+                data[i]['property_notes'] = '\n----------\n'.join(note_string) if include_notes else '(excluded during export)'
             elif hasattr(record, 'taxlot'):
                 data[i]['taxlot_labels'] = ','.join(label_string)
                 data[i]['taxlot_notes'] = '\n----------\n'.join(note_string) if include_notes else '(excluded during export)'

--- a/seed/views/v3/tax_lot_properties.py
+++ b/seed/views/v3/tax_lot_properties.py
@@ -142,9 +142,7 @@ class TaxLotPropertyViewSet(GenericViewSet):
         data = TaxLotProperty.get_related(model_views, column_ids, columns_from_database)
 
         # add labels and notes
-        include_notes = True
-        if 'include_notes' in request.data.keys():
-            include_notes = request.data.get('include_notes')
+        include_notes = request.data.get('include_notes', True)
         for i, record in enumerate(model_views):
             label_string = []
             note_string = []


### PR DESCRIPTION
#### Any background context you want to provide?
The property_notes field was large enough to break Microsoft Excel's cell character limit, causing overflow that would prevent the remaining data from being displayed correctly.

#### What's this PR do?
Adds an option to exclude property notes when exporting.

#### How should this be manually tested?
See the original ticket.

#### What are the relevant tickets?
https://github.com/SEED-platform/seed/issues/2519

#### Screenshots (if appropriate)
<img width="926" alt="Screen Shot 2021-01-29 at 3 25 53 PM" src="https://user-images.githubusercontent.com/564231/106335215-96f97e80-6249-11eb-924a-14b2454f2147.png">
<hr>
<img width="1129" alt="Screen Shot 2021-01-29 at 3 41 36 PM" src="https://user-images.githubusercontent.com/564231/106335228-a082e680-6249-11eb-9e08-cce58c610cbf.png">

