### PR TITLE
feat: add ui for deleting cycles

### DIFF
--- a/seed/static/seed/js/controllers/cycle_admin_controller.js
+++ b/seed/static/seed/js/controllers/cycle_admin_controller.js
@@ -8,7 +8,6 @@ angular.module('BE.seed.controller.cycle_admin', [])
     '$scope',
     '$log',
     'urls',
-    'simple_modal_service',
     'Notification',
     'cycle_service',
     'cycles_payload',
@@ -16,7 +15,8 @@ angular.module('BE.seed.controller.cycle_admin', [])
     'auth_payload',
     '$translate',
     '$sce',
-    function ($scope, $log, urls, simple_modal_service, Notification, cycle_service, cycles_payload, organization_payload, auth_payload, $translate, $sce) {
+    '$uibModal',
+    function ($scope, $log, urls, Notification, cycle_service, cycles_payload, organization_payload, auth_payload, $translate, $sce, $uibModal) {
 
       $scope.org = organization_payload.organization;
       $scope.auth = auth_payload.auth;
@@ -93,17 +93,6 @@ angular.module('BE.seed.controller.cycle_admin', [])
         });
       };
 
-      //commented out 6.15.17 ability to delete cycle is commented out dbressan code cov work
-      // $scope.deleteCycle = function (cycle) {
-      //   cycle_service.delete_cycle_for_org(cycle, $scope.org.id).then(function () {
-      //     var msg = 'Cycle deleted.';
-      //     Notification.primary(msg);
-      //     cycle_service.get_cycles_for_org($scope.org.id).then(processCycles);
-      //   }, function (message) {
-      //     $log.error('Error deleting cycle.', message);
-      //   });
-      // };
-
       $scope.opened = {};
       $scope.open = function ($event, elementOpened) {
         $event.preventDefault();
@@ -153,5 +142,20 @@ angular.module('BE.seed.controller.cycle_admin', [])
 
       initialize_new_cycle();
 
+      $scope.showDeleteCycleModal = function(cycle_id, cycle_name) {
+        const delete_cycle_modal = $uibModal.open({
+          templateUrl: urls.static_url + 'seed/partials/delete_cycle_modal.html',
+          controller: 'delete_cycle_modal_controller',
+          resolve: {
+            cycle_id: () => cycle_id,
+            cycle_name: () => cycle_name,
+          }
+        })
+        delete_cycle_modal.result.then(function(es) {
+          cycle_service.get_cycles_for_org($scope.org.id).then(processCycles)
+        }).catch(function() {
+          cycle_service.get_cycles_for_org($scope.org.id).then(processCycles)
+        });
+      }
     }
   ]);

--- a/seed/static/seed/js/controllers/delete_cycle_modal_controller.js
+++ b/seed/static/seed/js/controllers/delete_cycle_modal_controller.js
@@ -1,0 +1,59 @@
+/**
+ * :copyright (c) 2014 - 2020, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.
+ * :author
+ */
+angular.module('BE.seed.controller.delete_cycle_modal', [])
+  .controller('delete_cycle_modal_controller', [
+    '$scope',
+    '$window',
+    '$state',
+    '$q',
+    '$uibModalInstance',
+    'inventory_service',
+    'cycle_service',
+    'cycle_id',
+    'cycle_name',
+    function ($scope, $window, $state, $q, $uibModalInstance, inventory_service, cycle_service, cycle_id, cycle_name) {
+      $scope.cycle_id = cycle_id;
+      $scope.cycle_name = cycle_name;
+
+      $scope.cycle_has_properties = null;
+      $scope.cycle_has_taxlots = null;
+      $scope.cycle_has_inventory = null;
+      $scope.delete_cycle_success = null;
+
+      // determine if there are any properties or tax lots in the cycle
+      // when fetching inventory, to reduce overhead ask for only 1 inventory per page and first page
+      $q.all([
+        inventory_service.get_properties(1, 1, {id: $scope.cycle_id}, null, null, false),
+        inventory_service.get_taxlots(1, 1, {id: $scope.cycle_id}, null, null, false)
+      ]).then(function(responses) {
+        $scope.cycle_has_properties = responses[0].results.length > 0;
+        $scope.cycle_has_taxlots = responses[1].results.length > 0;
+        $scope.cycle_has_inventory = $scope.cycle_has_properties || $scope.cycle_has_taxlots;
+      });
+
+      // open an inventory list page in a new tab
+      $scope.goToInventoryList = function(inventory_type) {
+        inventory_service.save_last_cycle($scope.cycle_id);
+        const inventory_url = $state.href('inventory_list', {inventory_type: inventory_type});
+        $window.open(inventory_url,'_blank');
+      };
+
+      $scope.cancel = function () {
+        $uibModalInstance.dismiss();
+      };
+
+      // user confirmed deletion of cycle
+      $scope.confirmDelete = function () {
+        cycle_service.delete_cycle($scope.cycle_id)
+          .then(function(res) {
+            $scope.delete_cycle_success = true;
+          })
+          .catch(function(res) {
+            console.error('Failed to delete cycle: ')
+            console.error(res)
+            $scope.delete_cycle_success = false;
+          })
+      };
+    }]);

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -54,6 +54,7 @@ angular.module('BE.seed.controllers', [
   'BE.seed.controller.dataset',
   'BE.seed.controller.dataset_detail',
   'BE.seed.controller.delete_column_modal',
+  'BE.seed.controller.delete_cycle_modal',
   'BE.seed.controller.delete_dataset_modal',
   'BE.seed.controller.delete_file_modal',
   'BE.seed.controller.delete_modal',

--- a/seed/static/seed/js/services/cycle_service.js
+++ b/seed/static/seed/js/services/cycle_service.js
@@ -89,13 +89,8 @@ angular.module('BE.seed.service.cycle', []).factory('cycle_service', [
       });
     };
 
-    cycle_factory.delete_cycle = function (cycle) {
-      return cycle_factory.delete_cycle_for_org(cycle, user_service.get_organization().id);
-    };
-
-    cycle_factory.delete_cycle_for_org = function (cycle, org_id) {
-      return $http.delete('/api/v3/cycles/' + cycle.id + '/', {
-        data: cycle,
+    cycle_factory.delete_cycle = function (cycle_id, org_id) {
+      return $http.delete('/api/v3/cycles/' + cycle_id + '/', {
         params: {
           organization_id: org_id
         }

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -20,7 +20,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       total_taxlots_for_user: 0
     };
 
-    inventory_service.get_properties = function (page, per_page, cycle, profile_id, property_view_ids) {
+    inventory_service.get_properties = function (page, per_page, cycle, profile_id, property_view_ids, save_last_cycle=true) {
 
       var params = {
         organization_id: user_service.get_organization().id,
@@ -34,7 +34,9 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         var lastCycleId = inventory_service.get_last_cycle();
         if (_.has(cycle, 'id')) {
           params.cycle = cycle.id;
-          inventory_service.save_last_cycle(cycle.id);
+          if (save_last_cycle === true) {
+            inventory_service.save_last_cycle(cycle.id);
+          }
         } else if (_.includes(validCycleIds, lastCycleId)) {
           params.cycle = lastCycleId;
         }
@@ -249,7 +251,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
     };
 
 
-    inventory_service.get_taxlots = function (page, per_page, cycle, profile_id, inventory_ids) {
+    inventory_service.get_taxlots = function (page, per_page, cycle, profile_id, inventory_ids, save_last_cycle=true) {
       var params = {
         organization_id: user_service.get_organization().id,
         page: page,
@@ -262,7 +264,9 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         var lastCycleId = inventory_service.get_last_cycle();
         if (cycle) {
           params.cycle = cycle.id;
-          inventory_service.save_last_cycle(cycle.id);
+          if (save_last_cycle === true) {
+            inventory_service.save_last_cycle(cycle.id);
+          }
         } else if (_.includes(validCycleIds, lastCycleId)) {
           params.cycle = lastCycleId;
         }

--- a/seed/static/seed/partials/cycle_admin.html
+++ b/seed/static/seed/partials/cycle_admin.html
@@ -83,7 +83,8 @@
                                 <button type="button" ng-disabled="rowform.$waiting" ng-click="rowform.$cancel()" class="btn btn-default btn-rowform" translate>cancel</button>
                             </form>
                             <div class="buttons" ng-show="!rowform.$visible">
-                                <button class="btn btn-default btn-rowform" ng-click="rowform.$show()" translate>edit</button>
+                                <button class="btn btn-default btn-rowform" ng-click="rowform.$show()" translate>Edit</button>
+                                <button class="btn btn-danger" ng-click="showDeleteCycleModal(cycle.id, cycle.name)" translate>Delete</button>
                             </div>
                         </td>
                     </tr>

--- a/seed/static/seed/partials/delete_cycle_modal.html
+++ b/seed/static/seed/partials/delete_cycle_modal.html
@@ -1,0 +1,54 @@
+<div class="modal-header">
+    <h4 class="modal-title" translate>Delete User?</h4>
+</div>
+<div class="modal-body">
+    <div ng-if="cycle_has_inventory == null" class="container-fluid">
+        <div class="row">
+            <div class="col-sm-12">
+                <i class="fa fa-spinner fa-pulse fa-fw" style="padding-right: 0"></i>Searching for Properties and Tax Lots in this Cycle...
+            </div>
+        </div>
+    </div>
+    <div ng-if="cycle_has_inventory == true" class="container-fluid">
+        <div class="row">
+            <div class="col-sm-12">
+                Unable to delete cycle <em>{$ cycle_name $}</em>. You must delete all existing Properties and Tax Lots in <em>{$ cycle_name $}</em> before you can delete this cycle.
+            </div>
+        </div>
+        <div ng-if="cycle_has_properties == true" class="row">
+            <div class="col-sm-8 col-sm-offset-2" style="padding-top: 5px; padding-bottom: 5px;">
+                <button type="button" class="btn btn-info" ng-click="goToInventoryList('properties')">View Properties in this cycle</a>
+            </div>
+        </div>
+        <div ng-if="cycle_has_taxlots == true" class="row">
+            <div class="col-sm-8 col-sm-offset-2" style="padding-top: 5px;">
+                <button type="button" class="btn btn-info" ng-click="goToInventoryList('taxlots')">View Tax Lots in this cycle</a>
+            </div>
+        </div>
+    </div>
+    <div ng-if="cycle_has_inventory == false && delete_cycle_success == null" class="container-fluid">
+        <div class="row">
+            <div class="col-sm-12">
+                Are you sure you want to delete cycle <em>{$ cycle_name $}</em>? It has no Property or Tax Lot data.
+            </div>
+        </div>
+    </div>
+    <div ng-if="delete_cycle_success == true" class="container-fluid">
+        <div class="row">
+            <div class="col-sm-12">
+                Successfully deleted <em>{$ cycle_name $}</em>.
+            </div>
+        </div>
+    </div>
+    <div ng-if="delete_cycle_success == false" class="container-fluid">
+        <div class="row">
+            <div class="col-sm-12">
+                Sorry, something unexpected happened. Please refresh the page and try again. If the problem persists please contact the SEED Platform management team.
+            </div>
+        </div>
+    </div>
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-default" ng-click="cancel()">{$delete_cycle_success == null ? 'Cancel' : 'Close'$}</button>
+    <button ng-if="cycle_has_inventory == false && delete_cycle_success == null" type="button" class="btn btn-danger" ng-click="confirmDelete()" autofocus translate>Yes, Delete Cycle</button>
+</div>

--- a/seed/static/seed/partials/delete_cycle_modal.html
+++ b/seed/static/seed/partials/delete_cycle_modal.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-    <h4 class="modal-title" translate>Delete User?</h4>
+    <h4 class="modal-title" translate>Delete Cycle?</h4>
 </div>
 <div class="modal-body">
     <div ng-if="cycle_has_inventory == null" class="container-fluid">

--- a/seed/templates/seed/_scripts.html
+++ b/seed/templates/seed/_scripts.html
@@ -45,6 +45,7 @@
         <script src="{{STATIC_URL}}seed/js/controllers/dataset_detail_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/dataset_list_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/delete_column_modal_controller.js"></script>
+        <script src="{{STATIC_URL}}seed/js/controllers/delete_cycle_modal_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/delete_dataset_modal_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/delete_file_modal_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/delete_modal_controller.js"></script>


### PR DESCRIPTION
#### Any background context you want to provide?
Users cannot delete cycles from the frontend

#### What's this PR do?
Adds ability to delete cycles from the frontend.

#### How should this be manually tested?
Create cycles with and without properties/taxlots. Navigate to the org cycles page, try to delete each cycle. You should be shown buttons to view the properties or taxlots depending on what's in the cycle. If you delete all properties and taxlots you should be allowed to delete the cycle.

#### What are the relevant tickets?
#1113 

#### Screenshots (if appropriate)
Note that it now says "Delete Cycle?" instead of "Delete User?" but I haven't updated the screenshots.

<img width="1440" alt="Screen Shot 2021-02-03 at 5 29 24 PM" src="https://user-images.githubusercontent.com/18518728/106828118-c55ecb80-6646-11eb-9e04-72e6b964116b.png">
<img width="1437" alt="Screen Shot 2021-02-03 at 5 30 13 PM" src="https://user-images.githubusercontent.com/18518728/106828124-c7c12580-6646-11eb-8417-e8fdb771dfba.png">
<img width="1440" alt="Screen Shot 2021-02-03 at 5 30 56 PM" src="https://user-images.githubusercontent.com/18518728/106828129-c98ae900-6646-11eb-95c7-2cf6541cb8c1.png">
