### PR TITLE
fix: add combinedFilter for eui and area columns

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -471,7 +471,8 @@ angular.module('BE.seed.controller.inventory_list', [])
         } else if (col.data_type === 'date') {
           options.filter = inventory_service.dateFilter();
         } else if (col.data_type === 'eui' || col.data_type === 'area') {
-          options.cellFilter = 'number: ' + $scope.organization.display_significant_figures
+          options.filter = inventory_service.combinedFilter();
+          options.cellFilter = 'number: ' + $scope.organization.display_significant_figures;
           options.sortingAlgorithm = naturalSort;
         } else {
           options.filter = inventory_service.combinedFilter();


### PR DESCRIPTION
#### Any background context you want to provide?
See the related ticket

#### What's this PR do?
Adds the combined filter for the affected columns

#### How should this be manually tested?
Check that `eui` and `area` columns can filter for empty (`""`) and non-empty (`!""`) records

#### What are the relevant tickets?
#2574 
