### PR TITLE
fix: use the correct id for related note count lookups

### DIFF
--- a/seed/models/tax_lot_properties.py
+++ b/seed/models/tax_lot_properties.py
@@ -319,7 +319,7 @@ class TaxLotProperty(models.Model):
                     lookups['related_view_id']: getattr(join, lookups['related_view_id'])
                 })
 
-            join_dict['notes_count'] = join_note_counts.get(join.id, 0)
+            join_dict['notes_count'] = join_note_counts.get(getattr(join, lookups['related_view_id']), 0)
             join_dict['merged_indicator'] = getattr(join, lookups['related_view']).state_id in join_merged_state_ids
 
             # remove the measures from this view for now


### PR DESCRIPTION
#### Any background context you want to provide?
See the related ticket

#### What's this PR do?
Uses the PropertyView/TaxlotView ID instead of the TaxLotProperty join ID

#### How should this be manually tested?
1. Add a note to child rows in both the property and taxlot tabs
2. Refresh the inventory list view and check that the note counts on child rows are correct

#### What are the relevant tickets?
#2577 
