### PR TITLE
2603 fix/column delete memory

### DIFF
--- a/seed/lib/progress_data/progress_data.py
+++ b/seed/lib/progress_data/progress_data.py
@@ -150,6 +150,26 @@ class ProgressData(object):
 
         return self.result()
 
+    def step_with_counter(self):
+        """Step the function by increment_value and save back to the cache with a count"""
+        # load the latest value out of the cache
+        self.load()
+
+        value = self.data['progress']
+        if value + self.increment_value() >= 100.0:
+            value = 100.0
+        else:
+            value += self.increment_value()
+
+        self.data['progress'] = value
+        self.data['status'] = 'running'
+        self.data['completed_records'] = round(value / 100.0 * self.data['total_records'])
+        self.data['status_message'] = f'{self.data["completed_records"]:,} / {self.data["total_records"]:,}'
+
+        self.save()
+
+        return self.result()
+
     def result(self):
         """
         Return the result from the cache

--- a/seed/static/seed/js/controllers/column_settings_controller.js
+++ b/seed/static/seed/js/controllers/column_settings_controller.js
@@ -432,6 +432,7 @@ angular.module('BE.seed.controller.column_settings', [])
       $scope.delete_column = function (column) {
         $uibModal.open({
           backdrop: 'static',
+          keyboard: false,
           templateUrl: urls.static_url + 'seed/partials/delete_column_modal.html',
           controller: 'delete_column_modal_controller',
           resolve: {

--- a/seed/static/seed/js/controllers/delete_column_modal_controller.js
+++ b/seed/static/seed/js/controllers/delete_column_modal_controller.js
@@ -7,13 +7,14 @@ angular.module('BE.seed.controller.delete_column_modal', [])
     '$scope',
     '$window',
     '$log',
+    '$interval',
     '$uibModalInstance',
     'spinner_utility',
     'columns_service',
     'uploader_service',
     'organization_id',
     'column',
-    function ($scope, $window, $log, $uibModalInstance, spinner_utility, columns_service, uploader_service, organization_id, column) {
+    function ($scope, $window, $log, $interval, $uibModalInstance, spinner_utility, columns_service, uploader_service, organization_id, column) {
       $scope.column_name = column.column_name;
 
       $scope.progressBar = {
@@ -21,14 +22,18 @@ angular.module('BE.seed.controller.delete_column_modal', [])
       }
 
       $scope.delete = function () {
-        $scope.state = 'running';
-        columns_service.delete_column_for_org(organization_id, column.id).then(function (data) {
-          // $scope.result = result.data.message;
-          // $scope.state = 'done';
-          uploader_service.check_progress_loop(data.progress_key, 0, 1, function () {
-            console.log('DONE', $scope.progressBar);
-            $scope.result = $scope.progressBar.status_message;
+        $scope.state = 'pending';
+        columns_service.delete_column_for_org(organization_id, column.id).then(function (result) {
+          $scope.state = 'running';
+          $scope.startTime = moment();
+          $scope.interval = $interval(function() {
+            $scope.updateTime();
+          }, 1000);
+          $scope.updateTime();
+          uploader_service.check_progress_loop(result.data.progress_key, 0, 1, function (response) {
+            $scope.result = response.message + ' in ' + $scope.elapsed;
             $scope.state = 'done';
+            $interval.cancel($scope.interval);
           }, function () {
             // Do nothing
           }, $scope.progressBar);
@@ -36,8 +41,48 @@ angular.module('BE.seed.controller.delete_column_modal', [])
           $log.error(err);
           $scope.result = 'Failed to delete column';
           $scope.state = 'done';
+          $interval.cancel($scope.interval);
         });
       };
+
+      $scope.elapsedFn = function () {
+        var diff = moment().diff(this.startTime);
+        return $scope.formatTime(moment.duration(diff));
+      }
+
+      $scope.etaFn = function () {
+        if ($scope.progressBar.completed_records) {
+          if (!$scope.initialCompleted) {
+            $scope.initialCompleted = $scope.progressBar.completed_records;
+          }
+          var diff = moment().diff(this.startTime);
+          var progress = ($scope.progressBar.completed_records - $scope.initialCompleted) / ($scope.progressBar.total_records - $scope.initialCompleted);
+          if (progress) {
+            return $scope.formatTime(moment.duration(diff / progress - diff));
+          }
+        }
+      }
+
+      $scope.updateTime = function () {
+        $scope.elapsed = $scope.elapsedFn();
+        $scope.eta = $scope.etaFn();
+      }
+
+      $scope.formatTime = function (duration) {
+        var h = Math.floor(duration.asHours());
+        var m = duration.minutes();
+        var s = duration.seconds();
+
+        if (h > 0) {
+          var mPadded = m.toString().padStart(2, '0');
+          var sPadded = s.toString().padStart(2, '0');
+          return `${h}:${mPadded}:${sPadded}`;
+        } else if (m > 0) {
+          const sPadded = s.toString().padStart(2, '0');
+          return `${m}:${sPadded}`;
+        }
+        return `${s}s`;
+      }
 
       $scope.refresh = function () {
         spinner_utility.show();

--- a/seed/static/seed/js/controllers/delete_column_modal_controller.js
+++ b/seed/static/seed/js/controllers/delete_column_modal_controller.js
@@ -10,16 +10,28 @@ angular.module('BE.seed.controller.delete_column_modal', [])
     '$uibModalInstance',
     'spinner_utility',
     'columns_service',
+    'uploader_service',
     'organization_id',
     'column',
-    function ($scope, $window, $log, $uibModalInstance, spinner_utility, columns_service, organization_id, column) {
+    function ($scope, $window, $log, $uibModalInstance, spinner_utility, columns_service, uploader_service, organization_id, column) {
       $scope.column_name = column.column_name;
+
+      $scope.progressBar = {
+        progress: 0
+      }
 
       $scope.delete = function () {
         $scope.state = 'running';
-        columns_service.delete_column_for_org(organization_id, column.id).then(function (result) {
-          $scope.result = result.data.message;
-          $scope.state = 'done';
+        columns_service.delete_column_for_org(organization_id, column.id).then(function (data) {
+          // $scope.result = result.data.message;
+          // $scope.state = 'done';
+          uploader_service.check_progress_loop(data.progress_key, 0, 1, function () {
+            console.log('DONE', $scope.progressBar);
+            $scope.result = $scope.progressBar.status_message;
+            $scope.state = 'done';
+          }, function () {
+            // Do nothing
+          }, $scope.progressBar);
         }).catch(function (err) {
           $log.error(err);
           $scope.result = 'Failed to delete column';

--- a/seed/static/seed/js/services/uploader_service.js
+++ b/seed/static/seed/js/services/uploader_service.js
@@ -97,8 +97,7 @@ angular.module('BE.seed.service.uploader', []).factory('uploader_service', [
      * @param {obj} progress_bar_obj: progress bar object, attr 'progress'
      *   is set with the progress
      */
-    uploader_factory.check_progress_loop = function (progress_key, offset, multiplier, success_fn, failure_fn, progress_bar_obj, debug) {
-      debug = !_.isUndefined(debug);
+    uploader_factory.check_progress_loop = function (progress_key, offset, multiplier, success_fn, failure_fn, progress_bar_obj) {
       uploader_factory.check_progress(progress_key).then(function (data) {
         $timeout(function () {
           right_now = Date.now();
@@ -110,10 +109,16 @@ angular.module('BE.seed.service.uploader', []).factory('uploader_service', [
             progress_bar_obj.progress_last_updated = right_now;
           }
 
+          if (data.total_records) {
+            progress_bar_obj.total_records = data.total_records;
+          }
+          if (data.completed_records) {
+            progress_bar_obj.completed_records = data.completed_records;
+          }
           progress_bar_obj.progress = new_progress_value;
           progress_bar_obj.status_message = data.status_message;
           if (data.progress < 100) {
-            uploader_factory.check_progress_loop(progress_key, offset, multiplier, success_fn, failure_fn, progress_bar_obj, debug);
+            uploader_factory.check_progress_loop(progress_key, offset, multiplier, success_fn, failure_fn, progress_bar_obj);
           } else {
             success_fn(data);
           }

--- a/seed/static/seed/partials/delete_column_modal.html
+++ b/seed/static/seed/partials/delete_column_modal.html
@@ -3,19 +3,33 @@
     <h4 class="modal-title" ng-switch-when="running">Deleting Column '{$ column_name $}'</h4>
     <h4 class="modal-title" ng-switch-when="done" translate>Column Deleted</h4>
 </div>
-<div class="modal-body row" ng-switch="state">
+<div class="modal-body row delete-column" ng-switch="state">
     <div class="col-sm-12">
         <div ng-switch-default>
             <p>This will delete the extra_data column '{$ column_name $}' and all associated data.</p>
             <p>This operation may take a long time to complete, are you sure you want to continue?</p>
         </div>
+        <div ng-switch-when="pending">
+            <uib-progressbar class="progress-striped active" value="100" type="info"></uib-progressbar>
+            <p>Please wait, scanning for affected records...</p>
+        </div>
         <div ng-switch-when="running">
-            <uib-progressbar class="progress-striped active" value="progressBar.progress" type="success">{$ progressBar.status_message | translate $}</uib-progressbar>
+            <uib-progressbar class="progress-striped active" value="progressBar.progress" type="success"><span class="status-text">{$ progressBar.status_message $}</span></uib-progressbar>
+            <table class="time-table">
+                <tr>
+                    <td>Elapsed:</td>
+                    <td>{$ elapsed $}</td>
+                </tr>
+                <tr>
+                    <td>ETA:</td>
+                    <td>{$ eta $}</td>
+                </tr>
+            </table>
         </div>
         <div ng-switch-when="done">{$ result $}</div>
     </div>
 </div>
-<div class="modal-footer">
+<div class="modal-footer" ng-if="state !== 'pending' && state !== 'running'">
     <button type="button" class="btn btn-default" ng-click="cancel()" ng-if="state !== 'done'" ng-disabled="state === 'running'">Cancel</button>
     <button type="button" class="btn btn-info" ng-click="delete()" ng-if="state !== 'done'" ng-disabled="state === 'running'" autofocus>Delete</button>
     <button type="button" class="btn btn-info" ng-click="refresh()" ng-if="state === 'done'" autofocus>Refresh</button>

--- a/seed/static/seed/partials/delete_column_modal.html
+++ b/seed/static/seed/partials/delete_column_modal.html
@@ -6,10 +6,11 @@
 <div class="modal-body row" ng-switch="state">
     <div class="col-sm-12">
         <div ng-switch-default>
-            This will delete the extra_data column '{$ column_name $}' and all associated data. Are you sure you want to continue?
+            <p>This will delete the extra_data column '{$ column_name $}' and all associated data.</p>
+            <p>This operation may take a long time to complete, are you sure you want to continue?</p>
         </div>
         <div ng-switch-when="running">
-            <uib-progressbar class="progress-striped active" animate="false" value="100" type="success"></uib-progressbar>
+            <uib-progressbar class="progress-striped active" value="progressBar.progress" type="success">{$ progressBar.status_message | translate $}</uib-progressbar>
         </div>
         <div ng-switch-when="done">{$ result $}</div>
     </div>

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -3688,3 +3688,20 @@ $pairedCellWidth: 60px;
   pointer-events: none;
   opacity: 0.3;
 }
+
+.delete-column {
+  .status-text {
+    color: black;
+    margin: 0 6px;
+    white-space: nowrap;
+  }
+  .time-table {
+    tr:first-child td {
+      padding-bottom: 6px;
+    }
+
+    tr td:first-child {
+      padding-right: 6px;
+    }
+  }
+}

--- a/seed/tests/test_analysis_pipelines.py
+++ b/seed/tests/test_analysis_pipelines.py
@@ -578,7 +578,6 @@ class TestBsyncrPipeline(TestCase):
             # mock the call to _bsyncr_service_request by returning a constructed Response
 
             # ignore model_type
-            _ = model_type
 
             the_response = Response()
             if error_messages is not None:

--- a/seed/tests/test_scenarios.py
+++ b/seed/tests/test_scenarios.py
@@ -55,8 +55,8 @@ class TestMeasures(DeleteModelsTestCase):
         # create new property, state, and view
         new_property_state = self.property_state_factory.get_property_state()
         new_property = Property.objects.create(organization_id=1)
-        _ = PropertyView.objects.create(cycle_id=1, state_id=new_property_state.id,
-                                        property_id=new_property.id)
+        PropertyView.objects.create(cycle_id=1, state_id=new_property_state.id,
+                                    property_id=new_property.id)
         new_scenario = Scenario.objects.create(property_state=new_property_state)
 
         # create a meter and meter readings for the source

--- a/seed/views/v3/columns.py
+++ b/seed/views/v3/columns.py
@@ -177,13 +177,8 @@ class ColumnViewSet(OrgValidateMixin, SEEDOrgNoPatchOrOrgCreateModelViewSet, Org
                 'message': 'Unexpected table_name \'%s\' for column with pk=%s' % (column.table_name, pk)
             }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        return JsonResponse(tasks.delete_organization_column(org_id, column))
-
-        # table_display_name = column.table_name if state_count == 1 else column.table_name + 's'
-        # return JsonResponse({
-        #     'success': True,
-        #     'message': 'Removed \'%s\' from %s %s' % (column.column_name, state_count, table_display_name)
-        # }, status=status.HTTP_200_OK)
+        result = tasks.delete_organization_column(column.id, org_id)
+        return JsonResponse(result)
 
     @swagger_auto_schema(
         request_body=AutoSchemaHelper.schema_factory({

--- a/seed/views/v3/columns.py
+++ b/seed/views/v3/columns.py
@@ -6,7 +6,6 @@
 """
 import json
 
-from django.db import transaction
 from django.http import JsonResponse
 from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
@@ -18,13 +17,9 @@ from seed import tasks
 from seed.decorators import ajax_request_class
 from seed.lib.superperms.orgs.decorators import has_perm_class
 from rest_framework.decorators import action
-from seed.data_importer.tasks import hash_state_object
 from seed.models import (
     Column,
-    DATA_STATE_MATCHING,
     Organization,
-    PropertyState,
-    TaxLotState,
 )
 from seed.serializers.columns import ColumnSerializer
 from seed.serializers.pint import add_pint_unit_suffix

--- a/seed/views/v3/organizations.py
+++ b/seed/views/v3/organizations.py
@@ -260,7 +260,7 @@ class OrganizationViewSet(viewsets.ViewSet):
                 'message': 'Query param `import_file_id` is required'
             }, status=status.HTTP_400_BAD_REQUEST)
         try:
-            _ = ImportFile.objects.get(pk=import_file_id)
+            ImportFile.objects.get(pk=import_file_id)
             organization = Organization.objects.get(pk=pk)
         except ImportFile.DoesNotExist:
             return JsonResponse({


### PR DESCRIPTION
#### Any background context you want to provide?
Deleting an extra_data column worked previously, but only for a relatively small number of records and it was synchronous and not chunked.  If you attempt to delete a column that affects 3M records it can easily exhaust the available memory.

Also see the related ticket

#### What's this PR do?
Moves the column deletion into a chunked celery task with asynchronous progress updates

#### How should this be manually tested?
- Attempt to delete a column associated with a large number of records from an organization's Column Settings page.
- Test with both property and taxlot columns
- Verify that only the affected records have been updated, that the extra_data json blob no longer contains the column, and that their hash values have changed

#### What are the relevant tickets?
#2603 

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/411466/109996194-3c31c780-7ccc-11eb-8833-8d669c238d60.png)
