### PR TITLE
feat: add sorting for the inventory list notes count

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -485,6 +485,7 @@ angular.module('BE.seed.controller.inventory_list', [])
       $scope.columns.unshift({
         name: 'merged_indicator',
         displayName: '',
+        headerCellTemplate: '<span></span>', // remove header
         cellTemplate: '<div class="ui-grid-row-header-link">' +
           '  <div title="' + $translate.instant("Merged Records") + '" class="ui-grid-cell-contents merged-indicator">' +
           '    <i class="fa fa-code-fork" ng-class="{\'text-muted\': !row.entity.merged_indicator, \'text-info\': row.entity.merged_indicator}"></i>' +
@@ -503,6 +504,7 @@ angular.module('BE.seed.controller.inventory_list', [])
       }, {
         name: 'notes_count',
         displayName: '',
+        headerCellTemplate: '<div role="columnheader" ng-class="{ \'sortable\': sortable }" ui-grid-one-bind-aria-labelledby-grid="col.uid + \'-header-text \' + col.uid + \'-sortdir-text\'" aria-sort="{{col.sort.direction == asc ? \'ascending\' : ( col.sort.direction == desc ? \'descending\' : \'none\')}}"><div role="button" tabindex="0" ng-keydown="handleKeyDown($event)" class="ui-grid-cell-contents ui-grid-header-cell-primary-focus" col-index="renderIndex"><span ui-grid-one-bind-id-grid="col.uid + \'-sortdir-text\'" aria-label="{{getSortDirectionAriaLabel()}}"><i ng-class="{ \'ui-grid-icon-up-dir\': col.sort.direction == asc, \'ui-grid-icon-down-dir\': col.sort.direction == desc, \'ui-grid-icon-up-dir translucent\': !col.sort.direction }" title="{{isSortPriorityVisible() ? i18n.headerCell.priority + \' \' + ( col.sort.priority + 1 ) : null}}" aria-hidden="true"></i><sub ui-grid-visible="isSortPriorityVisible()" class="ui-grid-sort-priority-number">{{col.sort.priority + 1}}</sub></span></div></div>',
         cellTemplate: '<div class="ui-grid-row-header-link">' +
           '  <a title="' + $translate.instant("Go to Notes") + '" class="ui-grid-cell-contents notes-button" ng-if="row.entity.$$treeLevel === 0" ui-sref="inventory_detail_notes(grid.appScope.inventory_type === \'properties\' ? {inventory_type: \'properties\', view_id: row.entity.property_view_id} : {inventory_type: \'taxlots\', view_id: row.entity.taxlot_view_id})">' +
           '    <i class="fa fa-comment" ng-class="{\'text-muted\': !row.entity.notes_count}"></i><div>{$ row.entity.notes_count > 999 ? \'> 999\' : row.entity.notes_count ? row.entity.notes_count : \'\' $}</div>' +
@@ -516,7 +518,7 @@ angular.module('BE.seed.controller.inventory_list', [])
         enableColumnResizing: false,
         enableFiltering: false,
         enableHiding: false,
-        enableSorting: false,
+        enableSorting: true,
         exporterSuppressExport: true,
         pinnedLeft: true,
         visible: true,
@@ -524,6 +526,7 @@ angular.module('BE.seed.controller.inventory_list', [])
       }, {
         name: 'id',
         displayName: '',
+        headerCellTemplate: '<span></span>', // remove header
         cellTemplate: '<div class="ui-grid-row-header-link">' +
           '  <a title="' + $translate.instant("Go to Detail Page") + '" class="ui-grid-cell-contents" ng-if="row.entity.$$treeLevel === 0" ui-sref="inventory_detail(grid.appScope.inventory_type === \'properties\' ? {inventory_type: \'properties\', view_id: row.entity.property_view_id} : {inventory_type: \'taxlots\', view_id: row.entity.taxlot_view_id})">' +
           '    <i class="ui-grid-icon-info-circled"></i>' +

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -3774,3 +3774,8 @@ FAQ page
     max-width: 100%;
   }
 }
+
+// always-visible notes_count icon
+.ui-grid-icon-up-dir.translucent {
+  opacity: 0.1;
+}


### PR DESCRIPTION
#### What's this PR do?
Adds the ability to click the header cell for the notes count (or shift-click to sort by multiple columns)

#### How should this be manually tested?
1. Check that the `notes_count` column now has a visible sort icon by default
2. Check that sorting (and prioritized shift-click sorting works as expected)
3. Check that sort is maintained between page refreshes

#### What are the relevant tickets?
#2509 

#### Screenshots (if appropriate)
Translucent by default:
![image](https://user-images.githubusercontent.com/411466/110980875-8f86c400-8323-11eb-922b-cbba4ecc385a.png)

Sorted:
![image](https://user-images.githubusercontent.com/411466/110980938-a3cac100-8323-11eb-9264-5c4b32332a0e.png)

Prioritized sort:
![image](https://user-images.githubusercontent.com/411466/110980997-bba24500-8323-11eb-8838-1ee83704b05e.png)
