### PR TITLE
fix(building_sync): raise created exceptions

### DIFF
--- a/seed/building_sync/tests/test_validation_client.py
+++ b/seed/building_sync/tests/test_validation_client.py
@@ -12,7 +12,7 @@ from requests.models import Response
 import json
 
 from config.settings.common import BASE_DIR
-from seed.building_sync.validation_client import validate_use_case, DEFAULT_USE_CASE
+from seed.building_sync.validation_client import validate_use_case, DEFAULT_USE_CASE, DEFAULT_SCHEMA_VERSION
 
 
 def responseFactory(status_code, body_dict):
@@ -32,6 +32,7 @@ class TestValidationClient(TestCase):
     def test_validation_single_file_ok(self):
         good_body = {
             'success': True,
+            'schema_version': DEFAULT_SCHEMA_VERSION,
             'validation_results': {
                 'schema': {
                     'valid': True
@@ -54,6 +55,7 @@ class TestValidationClient(TestCase):
     def test_validation_zip_file_ok(self):
         good_body = {
             'success': True,
+            'schema_version': DEFAULT_SCHEMA_VERSION,
             'validation_results': [
                 {
                     'file': 'file1.xml',
@@ -111,6 +113,7 @@ class TestValidationClient(TestCase):
 
         body = {
             'success': True,
+            'schema_version': DEFAULT_SCHEMA_VERSION,
             'validation_results': [
                 {
                     'file': 'file1.xml',
@@ -156,6 +159,7 @@ class TestValidationClient(TestCase):
 
         body = {
             'success': True,
+            'schema_version': DEFAULT_SCHEMA_VERSION,
             'validation_results': [
                 {
                     'file': 'file1.xml',
@@ -185,6 +189,7 @@ class TestValidationClient(TestCase):
     def test_validation_zip_file_ok_when_warnings(self):
         good_body = {
             'success': True,
+            'schema_version': DEFAULT_SCHEMA_VERSION,
             'validation_results': [
                 {
                     'file': 'file1.xml',

--- a/seed/building_sync/validation_client.py
+++ b/seed/building_sync/validation_client.py
@@ -62,13 +62,13 @@ def validate_use_case(file_, filename=None, schema_version=DEFAULT_SCHEMA_VERSIO
         )
 
     if response_body.get('success', False) is not True:
-        ValidationClientException(
+        raise ValidationClientException(
             f"Selection Tool request was not successful: {response.text}",
         )
 
     response_schema_version = response_body.get('schema_version')
     if response_schema_version != schema_version:
-        ValidationClientException(
+        raise ValidationClientException(
             f"Expected schema_version to be '{schema_version}' but it was '{response_schema_version}'",
         )
 


### PR DESCRIPTION
#### Any background context you want to provide?
https://lgtm.com/projects/g/SEED-platform/seed/snapshot/4137da45f19ece8d98493897fbb54839dade5de1/files/seed/building_sync/validation_client.py?sort=name&dir=ASC&mode=heatmap#L65

#### What's this PR do?
Previously the buildingsync validation client was not raising some exceptions it created. This fixes that.

#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
