### PR TITLE
feat: add terms of service

### DIFF
--- a/seed/landing/templates/landing/create_account.html
+++ b/seed/landing/templates/landing/create_account.html
@@ -19,6 +19,7 @@
             <div class="section_forms">
                 <div class="form_title">
                     <h2>{% trans "Create Your Account" %}</h2>
+                    <p>By creating an account, signing in, and using this website, you are agreeing to our <a href="{{ STATIC_URL }}seed/Terms_of_Service.txt" target="_blank" rel="noopener noreferrer">Terms of Service</a>.</p>
                     <form id="AuthNewPassword" class="signup_form" action="" method="post">
                         {% csrf_token %}
                         <table class="signup_table">

--- a/seed/static/seed/Terms_of_Service.txt
+++ b/seed/static/seed/Terms_of_Service.txt
@@ -1,0 +1,34 @@
+Terms of Service ("Terms")
+
+Last updated: (3/26/2021)
+
+Please read these Terms of Service ("Terms", "Terms of Service") carefully before using the
+SEED Platform website operated by the National Renewable Energy Lab ("us", "we", or "our").
+Your access to and use of the Service is conditioned on your acceptance of and compliance with
+these Terms. These Terms apply to all visitors, users and others who access or use the Service.
+By accessing or using the Service you agree to be bound by these Terms. If you disagree
+with any part of the terms then you may not access the Service.
+
+Termination
+We may terminate or suspend access to our Service immediately, without prior notice or liability, for
+any reason whatsoever, including without limitation if you breach the Terms.
+All provisions of the Terms which by their nature should survive termination shall survive
+termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and
+limitations of liability.
+
+Links To Other Web Sites
+Our Service may contain links to third-party web sites or services that are not owned or controlled
+by the National Renewable Energy Lab.
+The National Renewable Energy Lab has no control over, and assumes no responsibility for, the content,
+privacy policies, or practices of any third party web sites or services. You further acknowledge and
+agree that the National Renewable Energy Lab shall not be responsible or liable, directly or indirectly, for any
+damage or loss caused or alleged to be caused by or in connection with use of or reliance on any
+such content, goods or services available on or through any such web sites or services.
+
+Changes
+We reserve the right, at our sole discretion, to modify or replace these Terms at any time. If a
+revision is material we will try to provide at least 30 days' notice prior to any new terms
+taking effect. What constitutes a material change will be determined at our sole discretion.
+
+Contact Us
+If you have any questions about these Terms, please contact us at SEED-Support@lists.lbl.gov

--- a/seed/static/seed/partials/about.html
+++ b/seed/static/seed/partials/about.html
@@ -8,6 +8,7 @@
 
                     <p translate>The Standard Energy Efficiency Data (SEED)™ Platform is a software application that helps organizations easily manage data on the energy performance of large groups of buildings. Users can combine data from multiple sources, clean and validate it, and share the information with others. The software application provides an easy, flexible, and cost-effective method to improve the quality and availability of data to help demonstrate the economic and environmental benefits of energy efficiency, to implement programs, and to target investment activity.</p>
                     <p><a href="http://energy.gov/eere/buildings/standard-energy-efficiency-data-platform" target="_blank" rel="noopener noreferrer" translate>More details</a></p>
+                    <p><a href="{$:: urls.static_url $}/Terms_of_Service.txt" target="_blank" rel="noopener noreferrer">View Terms of Service</a></p>
 
                     <h2>{$:: 'Development Team' | translate $}:</h2>
                     <p>{$:: 'Managed by' | translate $}: <a href="http://www.nrel.gov/" target="_blank" rel="noopener noreferrer" translate>National Renewable Energy Laboratory</a></p>


### PR DESCRIPTION
#### Any background context you want to provide?
SEED is creating a public instance

#### What's this PR do?
Adds terms of service to the "create account" modal, and a link to TOS on the "about" page. Currently this is just a static text file we link to.

I was unable to find the previous terms of service (it was stored in the database), so I found some generic template online.

#### How should this be manually tested?
Check the "create account" modal and "about" page link to TOS.

#### What are the relevant tickets?
#2627 


#### Screenshots (if appropriate)
<img width="1076" alt="Screen Shot 2021-03-26 at 8 16 58 AM" src="https://user-images.githubusercontent.com/18518728/112645278-eef8cf80-8e0b-11eb-869d-1c0ad7686204.png">
<img width="964" alt="Screen Shot 2021-03-26 at 8 17 29 AM" src="https://user-images.githubusercontent.com/18518728/112645272-ed2f0c00-8e0b-11eb-92ee-166a5e2a9cfd.png">
