### PR TITLE
fix: allow pm meter xlsx to have empty first sheet

### DIFF
--- a/seed/views/v3/uploads.py
+++ b/seed/views/v3/uploads.py
@@ -100,10 +100,11 @@ class UploadViewSet(viewsets.ViewSet, OrgMixin):
         if not os.path.exists(os.path.dirname(path)):
             os.makedirs(os.path.dirname(path))
 
-        extension = the_file.name.split(".")[1]
+        extension = the_file.name.split(".")[-1]
         if extension == "xlsx" or extension == "xls":
-            check = pd.read_excel(the_file)
-            if check.empty:
+            df_dict = pd.read_excel(the_file, sheet_name=None)
+            df_empty = [df.empty for _, df in df_dict.items()]
+            if all(df_empty):
                 return JsonResponse({
                     'success': False,
                     'message': "Import %s was empty" % the_file.name


### PR DESCRIPTION
#### Any background context you want to provide?
SEED has a check to determine if an Excel file is empty when uploading

#### What's this PR do?
Fixes issue where it would reject meter spreadsheets that have an empty first sheet (supposedly allowed according to example files).

#### How should this be manually tested?
Upload `seed/seed/data_importer/tests/data/example-pm-monthly-meter-usage.xlsx` and it should work (has an empty first sheet). Upload a spreadsheet where all sheets are empty and it should fail.

#### What are the relevant tickets?
#2634 

#### Screenshots (if appropriate)
