### PR TITLE
fix(building_sync): get all linked measures for scenario

### DIFF
--- a/seed/building_sync/mappings.py
+++ b/seed/building_sync/mappings.py
@@ -654,11 +654,11 @@ BASE_MAPPING_V2_0 = {
                 'value': 'exist'
             },
             'measure_ids': {
-                'xpath': './auc:ScenarioType/auc:PackageOfMeasures/auc:MeasureIDs',
+                'xpath': './auc:ScenarioType/auc:PackageOfMeasures/auc:MeasureIDs/auc:MeasureID',
                 'type': 'list',
                 'items': {
                     'id': {
-                        'xpath': './auc:MeasureID',
+                        'xpath': '.',
                         'type': 'value',
                         'value': '@IDref'
                     }

--- a/seed/models/building_file.py
+++ b/seed/models/building_file.py
@@ -180,6 +180,7 @@ class BuildingFile(models.Model):
             implementation_status = m['implementation_status'] if m.get('implementation_status') else 'Proposed'
             application_scale = m['application_scale_of_application'] if m.get('application_scale_of_application') else PropertyMeasure.SCALE_ENTIRE_FACILITY
             category_affected = m['system_category_affected'] if m.get('system_category_affected') else PropertyMeasure.CATEGORY_OTHER
+            recommended = str(m.get('recommended', 'false')).lower() == 'true'
             join, _ = PropertyMeasure.objects.get_or_create(
                 property_state_id=self.property_state_id,
                 measure_id=measure.pk,
@@ -187,7 +188,7 @@ class BuildingFile(models.Model):
                 implementation_status=PropertyMeasure.str_to_impl_status(implementation_status),
                 application_scale=PropertyMeasure.str_to_application_scale(application_scale),
                 category_affected=PropertyMeasure.str_to_category_affected(category_affected),
-                recommended=m.get('recommended', 'false') == 'true',
+                recommended=recommended,
             )
             join.description = m.get('description')
             join.cost_mv = m.get('mv_cost')


### PR DESCRIPTION
Also correctly parse "auc:Recommended" for measure

#### Any background context you want to provide?
We weren't properly getting all linked measures for scenarios (bad xpath). Also our check for "recommended" was bad for measures.

#### What's this PR do?
Fixes bsync import

#### How should this be manually tested?
Import [this file](https://gist.github.com/macintoshpie/4ffe5e66d43aba9e4735b048dcb8c567) (an tweaked version of buildingsync_ex01_measures.xml -- added extra measures to one of the scenarios and set recommended = false for one measure). Just use the default bsync column mapping.

Verify that:
- the measure "Retrofit with light emitting diode technologies" has recommended == false and all other measures have recommended == true
- the scenario "LED Only" points to 3 different measures

#### What are the relevant tickets?
#2666 

#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2021-04-08 at 11 33 59 AM" src="https://user-images.githubusercontent.com/18518728/114071504-6c85fc00-985e-11eb-8bd1-51d4d75ccb4d.png">
<img width="1440" alt="Screen Shot 2021-04-08 at 11 33 46 AM" src="https://user-images.githubusercontent.com/18518728/114071509-6d1e9280-985e-11eb-81f1-b3a838020f79.png">
