### PR TITLE
#2669 fix(authz): let viewers view inventory list page

### DIFF
--- a/seed/views/v3/organizations.py
+++ b/seed/views/v3/organizations.py
@@ -373,7 +373,7 @@ class OrganizationViewSet(viewsets.ViewSet):
 
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_member')
+    @has_perm_class('requires_viewer')
     def retrieve(self, request, pk=None):
         """
         Retrieves a single organization by id.

--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -290,7 +290,7 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
             description='IDs for properties to be checked for which labels are applied.'
         )
     )
-    @has_perm_class('can_modify_data')
+    @has_perm_class('requires_viewer')
     @action(detail=False, methods=['POST'])
     def labels(self, request):
         """
@@ -342,7 +342,7 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
 
     @swagger_auto_schema_org_query_param
     @ajax_request_class
-    @has_perm_class('requires_member')
+    @has_perm_class('requires_viewer')
     @action(detail=True, methods=['GET'])
     def meters(self, request, pk):
         """
@@ -751,7 +751,7 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
     @swagger_auto_schema_org_query_param
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('can_modify_data')
+    @has_perm_class('requires_viewer')
     @action(detail=True, methods=['GET'])
     def links(self, request, pk=None):
         """


### PR DESCRIPTION
#### Any background context you want to provide?
Org users with "viewer" role could not view the inventory list page

#### What's this PR do?
Allows org viewers to view inventory list by tweaking some API permission requirements

#### How should this be manually tested?
Create a viewer role, log in, try to view inventory list page.

#### What are the relevant tickets?
#2669 

#### Screenshots (if appropriate)
