### PR TITLE
feat: add derived columns list view

### DIFF
--- a/seed/api/v3/urls.py
+++ b/seed/api/v3/urls.py
@@ -17,6 +17,7 @@ from seed.views.v3.cycles import CycleViewSet
 from seed.views.v3.data_quality_checks import DataQualityCheckViewSet
 from seed.views.v3.data_quality_check_rules import DataQualityCheckRuleViewSet
 from seed.views.v3.datasets import DatasetViewSet
+from seed.views.v3.derived_columns import DerivedColumnViewSet
 from seed.views.v3.gbr_properties import GBRPropertyViewSet
 from seed.views.v3.geocode import GeocodeViewSet
 from seed.views.v3.green_assessment_properties import GreenAssessmentPropertyViewSet
@@ -51,6 +52,7 @@ api_v3_router.register(r'column_mapping_profiles', ColumnMappingProfileViewSet, 
 api_v3_router.register(r'columns', ColumnViewSet, basename='columns')
 api_v3_router.register(r'cycles', CycleViewSet, basename='cycles')
 api_v3_router.register(r'datasets', DatasetViewSet, basename='datasets')
+api_v3_router.register(r'derived_columns', DerivedColumnViewSet, basename='derived_columns')
 api_v3_router.register(r'gbr_properties', GBRPropertyViewSet, basename="properties")
 api_v3_router.register(r'geocode', GeocodeViewSet, basename='geocode')
 api_v3_router.register(r'green_assessment_properties', GreenAssessmentPropertyViewSet, basename="green_assessment_properties")

--- a/seed/serializers/derived_columns.py
+++ b/seed/serializers/derived_columns.py
@@ -1,0 +1,27 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+from rest_framework import serializers
+
+from seed.models.derived_columns import DerivedColumn, DerivedColumnParameter
+
+
+class DerivedColumnParameterSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DerivedColumnParameter
+        fields = '__all__'
+
+
+class DerivedColumnSerializer(serializers.ModelSerializer):
+    parameters = serializers.SerializerMethodField()
+
+    class Meta:
+        model = DerivedColumn
+        exclude = ['source_columns']
+
+    def get_parameters(self, obj):
+        derived_column_parameters = DerivedColumnParameter.objects.filter(derived_column=obj.id)
+        return DerivedColumnParameterSerializer(derived_column_parameters, many=True).data

--- a/seed/static/seed/js/controllers/derived_columns_admin_controller.js
+++ b/seed/static/seed/js/controllers/derived_columns_admin_controller.js
@@ -1,0 +1,30 @@
+/*
+ * :copyright (c) 2014 - 2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.
+ * :author
+ */
+
+angular.module('BE.seed.controller.derived_columns_admin', [])
+  .controller('derived_columns_admin_controller', [
+    '$scope',
+    '$log',
+    'auth_payload',
+    'organization_payload',
+    'derived_columns_payload',
+    function ($scope, $log, auth_payload, organization_payload, derived_columns_payload) {
+
+      $scope.auth = auth_payload.auth;
+      $scope.org = organization_payload.organization;
+      $scope.derived_columns = derived_columns_payload.derived_columns;
+
+      $scope.sort_columns = false;
+
+      $scope.toggle_name_order_sort = function () {
+        $scope.sort_columns = !$scope.sort_columns
+        if ($scope.sort_columns) {
+          $scope.derived_columns.sort((a, b) => (a.name > b.name) ? 1 : -1)
+        } else {
+          $scope.derived_columns.sort((a, b) => (a.id > b.id) ? 1 : -1)
+        }
+      };
+    }
+  ]);

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -61,6 +61,7 @@ angular.module('BE.seed.controllers', [
   'BE.seed.controller.delete_file_modal',
   'BE.seed.controller.delete_modal',
   'BE.seed.controller.delete_org_modal',
+  'BE.seed.controller.derived_columns_admin',
   'BE.seed.controller.developer',
   'BE.seed.controller.export_buildingsync_modal',
   'BE.seed.controller.export_report_modal',
@@ -133,6 +134,7 @@ angular.module('BE.seed.services', [
   'BE.seed.service.columns',
   'BE.seed.service.cycle',
   'BE.seed.service.dataset',
+  'BE.seed.service.derived_columns',
   'BE.seed.service.meter',
   'BE.seed.service.flippers',
   'BE.seed.service.geocode',
@@ -1237,6 +1239,34 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           }],
           user_profile_payload: ['user_service', function (user_service) {
             return user_service.get_user_profile();
+          }]
+        }
+      })
+      .state({
+        name: 'organization_derived_columns',
+        url: '/accounts/{organization_id:int}/derived_columns/{inventory_type:properties|taxlots}',
+        templateUrl: static_url + 'seed/partials/derived_columns_admin.html',
+        controller: 'derived_columns_admin_controller',
+        resolve: {
+          organization_payload: ['organization_service', '$stateParams', function (organization_service, $stateParams) {
+            var organization_id = $stateParams.organization_id;
+            return organization_service.get_organization(organization_id);
+          }],
+          derived_columns_payload: ['derived_columns_service', '$stateParams', function (derived_columns_service, $stateParams) {
+            return derived_columns_service.get_derived_columns($stateParams.organization_id, $stateParams.inventory_type);
+          }],
+          auth_payload: ['auth_service', '$stateParams', '$q', function (auth_service, $stateParams, $q) {
+            var organization_id = $stateParams.organization_id;
+            return auth_service.is_authorized(organization_id, ['requires_owner'])
+              .then(function (data) {
+                if (data.auth.requires_owner) {
+                  return data;
+                } else {
+                  return $q.reject('not authorized');
+                }
+              }, function (data) {
+                return $q.reject(data.message);
+              });
           }]
         }
       })

--- a/seed/static/seed/js/services/derived_columns_service.js
+++ b/seed/static/seed/js/services/derived_columns_service.js
@@ -1,0 +1,22 @@
+/**
+ * :copyright (c) 2014 - 2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.
+ * :author
+ */
+angular.module('BE.seed.service.derived_columns', []).factory('derived_columns_service', [
+  '$http',
+  function ($http) {
+
+    const derived_columns_factory = {};
+
+    derived_columns_factory.get_derived_columns = function (organization_id, inventory_type) {
+      return $http({
+        url: '/api/v3/derived_columns/',
+        method: 'GET',
+        params: { organization_id, inventory_type }
+      }).then(function (response) {
+        return response.data;
+      });
+    };
+
+    return derived_columns_factory;
+  }]);

--- a/seed/static/seed/partials/accounts.html
+++ b/seed/static/seed/partials/accounts.html
@@ -40,6 +40,7 @@
                                 <a ui-sref="organization_sub_orgs(::{organization_id: org.id})" ng-if="::org.is_parent"><i class="fa fa-users"></i>{$:: 'Sub-Organizations' | translate $}</a>
                                 <a ui-sref="organization_members(::{organization_id: org.id})"><i class="fa fa-user"></i>{$:: 'Members' | translate $}</a>
                                 <a ui-sref="analyses(::{organization_id: org.id})"><i class="fa fa-bar-chart"></i>{$:: 'Analyses' | translate $}</a>
+                                <a ui-sref="organization_derived_columns(::{organization_id: org.id, inventory_type: 'properties'})"><i class="fa fa-calculator"></i>Derived Columns</a>
                                 <i class="fa fa-cog"></i>
                             </td>
                         </tr>

--- a/seed/static/seed/partials/accounts_nav.html
+++ b/seed/static/seed/partials/accounts_nav.html
@@ -8,3 +8,4 @@
      --><a ui-sref="organization_sub_orgs(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sub-Organizations</a><!--
      --><a ui-sref="organization_members(::{organization_id: org.id})" ui-sref-active="active" translate>Members</a><!--
      --><a ui-sref="analyses(::{organization_id: org.id})" ui-sref-active="active" translate>Analyses</a>
+        <a ui-sref="organization_derived_columns(::{organization_id: org.id, inventory_type: 'properties'})" ui-sref-active="active" translate>Derived Columns</a>

--- a/seed/static/seed/partials/derived_columns_admin.html
+++ b/seed/static/seed/partials/derived_columns_admin.html
@@ -1,0 +1,80 @@
+<div class="page_header_container">
+    <div class="page_header">
+        <div class="left page_action_container">
+            <a ui-sref="organizations" class="page_action"><i class="fa fa-chevron-left"></i> {$:: 'Organizations' | translate $}</a>
+        </div>
+        <div class="page_title">
+            <h1>{$:: org.name $}</h1>
+        </div>
+        <div class="right page_action_container">
+        </div>
+    </div>
+</div>
+
+<div class="section_nav_container">
+    <div class="section_nav" ng-include="::urls.static_url + 'seed/partials/accounts_nav.html'"></div>
+</div>
+
+<div class="section">
+    <div class="section_header_container">
+        <div class="section_header has_no_padding fixed_height_short">
+            <div class="section_action_container left_40">
+                <h2><i class="fa fa-calculator"></i> <span translate>Derived Columns</span></h2>
+            </div>
+        </div>
+    </div>
+    <div class="section_content_container">
+        <div class="section_content with_padding" style="margin-bottom:15px;">
+            <div class="data-quality-tab-container">
+                <ul class="nav nav-tabs" style="margin-bottom:1px;">
+                    <li ui-sref-active="active" heading="{$:: 'View by Property' | translate $}">
+                        <a ui-sref="organization_derived_columns(::{organization_id: org.id, inventory_type: 'properties'})" translate>View by Property</a>
+                    </li>
+                    <li ui-sref-active="active" heading="{$:: 'View by Tax Lot' | translate $}">
+                        <a ui-sref="organization_derived_columns(::{organization_id: org.id, inventory_type: 'taxlots'})" translate>View by Tax Lot</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="table_list_container has_borders">
+                <table id="column-table" class="table has_no_btm_margin">
+                    <thead>
+                        <tr>
+                            <th class="text-left" ng-click="toggle_name_order_sort()">
+                                <span>Derived Column Name<i class="glyphicon glyphicon-sort"></i></span>
+                            </th>
+                            <th class="text-left">
+                                <span>Expression</span>
+                            </th>
+                            <th class="text-center" style="min-width: 120px; width: 120px;">
+                                <span>Actions</span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr ng-if="derived_columns.length > 0" ng-repeat="derived_column in derived_columns">
+                            <td>
+                                {$:: derived_column.name $}
+                            </td>
+                            <td>
+                                {$:: derived_column.expression $}
+                            </td>
+                            <td class="text-center">
+                                <button class="btn btn-info" type="button" ng-click="edit_derived_column(derived_column)">
+                                    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+                                </button>
+                                <button class="btn btn-danger" type="button" ng-click="delete_derived_column(derived_column)">
+                                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                                </button>
+                            </td>
+                        </tr>
+                        <tr ng-if="derived_columns.length == 0" style="background-color: #eee">
+                            <td class="text-center" colspan="3">
+                                <h5>No Derived Columns</h5>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/seed/templates/seed/_scripts.html
+++ b/seed/templates/seed/_scripts.html
@@ -53,6 +53,7 @@
         <script src="{{STATIC_URL}}seed/js/controllers/delete_file_modal_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/delete_modal_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/delete_org_modal_controller.js"></script>
+        <script src="{{STATIC_URL}}seed/js/controllers/derived_columns_admin_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/developer_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/export_buildingsync_modal_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/export_report_modal_controller.js"></script>
@@ -104,6 +105,7 @@
         <script src="{{STATIC_URL}}seed/js/services/cycle_service.js"></script>
         <script src="{{STATIC_URL}}seed/js/services/data_quality_service.js"></script>
         <script src="{{STATIC_URL}}seed/js/services/dataset_service.js"></script>
+        <script src="{{STATIC_URL}}seed/js/services/derived_columns_service.js"></script>
         <script src="{{STATIC_URL}}seed/js/services/meter_service.js"></script>
         <script src="{{STATIC_URL}}seed/js/services/flippers.js"></script>
         <script src="{{STATIC_URL}}seed/js/services/geocode_service.js"></script>

--- a/seed/views/v3/derived_columns.py
+++ b/seed/views/v3/derived_columns.py
@@ -1,0 +1,45 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+from django.http import JsonResponse
+from rest_framework import viewsets
+
+from seed.decorators import ajax_request_class, require_organization_id_class
+from seed.lib.superperms.orgs.decorators import has_perm_class
+from seed.models import DerivedColumn
+from seed.serializers.derived_columns import DerivedColumnSerializer
+from seed.utils.api import api_endpoint_class, OrgMixin
+
+
+class DerivedColumnViewSet(viewsets.ViewSet, OrgMixin):
+    serializer_class = DerivedColumnSerializer
+    model = DerivedColumn
+
+    @require_organization_id_class
+    @api_endpoint_class
+    @ajax_request_class
+    @has_perm_class('requires_viewer')
+    def list(self, request):
+        org = self.get_organization(request)
+
+        filter_params = {
+            'organization': org,
+        }
+
+        inventory_type = {
+            'properties': DerivedColumn.PROPERTY_TYPE,
+            'taxlots': DerivedColumn.TAXLOT_TYPE,
+        }.get(request.query_params.get('inventory_type'))
+
+        if inventory_type is not None:
+            filter_params['inventory_type'] = inventory_type
+
+        queryset = DerivedColumn.objects.filter(**filter_params)
+
+        return JsonResponse({
+            'status': 'success',
+            'derived_columns': DerivedColumnSerializer(queryset, many=True).data
+        })


### PR DESCRIPTION
#### Any background context you want to provide?
Seed is adding ability for users to define columns derived from other columns

#### What's this PR do?
Adds a list API endpoint and an initial iteration of displaying them on the Frontend

#### How should this be manually tested?
Create some derived columns then browse the page. Note the edit/delete buttons do not work yet.
You can create some derived col data by running this command (note you should update the `organization_id` variable if your's isn't `1`)
```bash
python manage.py shell <<-'EOF'
"""
Creates derived columns (but does not create DerivedColumnParameters)
"""

from random import randint

from seed.models import *

BASE_NAME = 'Fancy Column'

# replace org id
organization_id = 1

expressions = [
    '$a + $b + $c',
    '$a / $b * 100',
    '$a * 3.14 + 123 % 100',
    '($a - $b) / ($c + $d)',
]


for i in range(10):
    dc = DerivedColumn.objects.create(
        name=f'{BASE_NAME} {randint(100, 1000)}',
        expression=expressions[randint(0, len(expressions) - 1)],
        organization_id=organization_id,
        inventory_type=DerivedColumn.PROPERTY_TYPE
    )
    print(f'Created derived column with id {dc.id}')
EOF
```

#### What are the relevant tickets?
#1642 

#### Screenshots (if appropriate)
![Screen Shot 2021-05-20 at 7 52 53 PM](https://user-images.githubusercontent.com/18518728/119070318-01732d80-b9a5-11eb-9cbf-a86a1b583273.png)
