### PR TITLE
fix: ensured meter type and start/stop times exist

### DIFF
--- a/seed/models/building_file.py
+++ b/seed/models/building_file.py
@@ -289,13 +289,14 @@ class BuildingFile(models.Model):
                 )
                 meter.source = m.get('source')
                 meter.type = m.get('type')
+                if meter.type is None:
+                    meter.type = Meter.OTHER
                 meter.is_virtual = m.get('is_virtual')
                 if meter.is_virtual is None:
                     meter.is_virtual = False
                 meter.save()
 
                 # meterreadings
-
                 if meter.type in energy_types:
                     meter_type = energy_types[meter.type]
                 else:
@@ -310,10 +311,9 @@ class BuildingFile(models.Model):
                         meter_id=meter.id,
                         conversion_factor=meter_conversions.get(mr.get('source_unit'), 1.00)
                     )
-                    for mr
-                    in m.get('readings', [])
+                    for mr in m.get('readings', [])
+                    if mr.get('start_time') is not None and mr.get('end_time') is not None
                 }
-
                 MeterReading.objects.bulk_create(readings)
 
         # merge or create the property state's view

--- a/seed/utils/meters.py
+++ b/seed/utils/meters.py
@@ -228,7 +228,7 @@ class PropertyMeterReadingsExporter():
 
         if meter.type == Meter.COST:
             display_unit = "{} Dollars".format(self._org_country)
-            conversion_factor = 1
+            conversion_factor = 1.00
         else:
             display_unit = self.org_meter_display_settings[type_text]
             conversion_factor = self.factors[type_text][display_unit]


### PR DESCRIPTION
Any background context you want to provide?
see ticket

What's this PR do?
skips importing meter readings that have no start and end time, also sets unknown meter types to "other"

How should this be manually tested?
import the file listed on the ticket

What are the relevant tickets?
#2695

Screenshots (if appropriate)
