### PR TITLE
build(helm): pass SES aws creds to celery deployment

### DIFF
--- a/charts/seed/templates/web-celery-deployment.yaml
+++ b/charts/seed/templates/web-celery-deployment.yaml
@@ -30,6 +30,16 @@ spec:
       - args:
         - /seed/docker/start_celery_docker.sh
         env:
+        - name: AWS_ACCESS_KEY_ID
+          value: <access key id>
+        - name: AWS_SECRET_ACCESS_KEY
+          value: <secret access key>
+        - name: AWS_SES_REGION_NAME
+          value: us-west-2
+        - name: AWS_SES_REGION_ENDPOINT
+          value: email.us-west-2.amazonaws.com
+        - name: SERVER_EMAIL
+          value: info@seed-platform.org
         - name: DJANGO_SETTINGS_MODULE
           value: config.settings.docker
         - name: POSTGRES_DB
@@ -46,7 +56,7 @@ spec:
           value: "5000"
         - name: BSYNCR_SERVER_HOST
           value: bsyncr
-        image: seedplatform/seed:<verison>
+        image: seedplatform/seed:<version>
         imagePullPolicy: Always
         name: web-celery
         resources: {}


### PR DESCRIPTION
#### Any background context you want to provide?
SEED is using post-office for some email services which sends emails in celery. For K8s deployments this means the celery container needs email credentials

#### What's this PR do?
- update web-celery-deployment to include AWS SES email creds

#### How should this be manually tested?
None needed

#### What are the relevant tickets?
#2728 

#### Screenshots (if appropriate)
