### PR TITLE
feat: rendering HTML output files in an iframe

### DIFF
--- a/seed/static/seed/partials/analysis_run.html
+++ b/seed/static/seed/partials/analysis_run.html
@@ -4,7 +4,7 @@
     <div class="section_header_container">
         <div class="section_header fixed_height_short">
             <div class="left section_action_container" style="width:100%;">
-                <h2><i class="fa fa-bar-chart"></i> {$:: 'Analyses' | translate $}: {$:: analysis.name $} - Run #{$:: view.id $}</h2>
+                <h2><i class="fa fa-bar-chart"></i> {$:: 'Analyses' | translate $}: <a ui-sref="analysis(::{organization_id: org.id, analysis_id: analysis.id})" ui-sref-active="active">{$:: analysis.name $}</a> - Run #{$:: view.id $}</h2>
             </div>
         </div>
     </div>
@@ -25,7 +25,7 @@
     <div class="section">
         <div class="section_content_container">
                 <div class="section_content with_padding">
-                    <div ng-if="angular.equals(view.parsed_results, {})">
+                    <div ng-if="!angular.equals(view.parsed_results, {}) && view.output_files.length === 0">
                         <pre>{$:: view.parsed_results | json $}</pre>
                     </div>
                     <div ng-repeat="file in view.output_files | filter:filter_params:strict">

--- a/seed/static/seed/partials/analysis_run.html
+++ b/seed/static/seed/partials/analysis_run.html
@@ -19,10 +19,25 @@
 <div class="section_header_container">
     <div class="section_header fixed_height_short has_no_padding">
         <div class="section_action_container left" style="width: 50%;">
-            <span>
-                <h2 translate>Results</h2>
-                <pre>{$:: view.parsed_results | json $}</pre>
-            </span>
+            <h2 translate>Results</h2>
+        </div>
+    </div>
+    <div class="section">
+        <div class="section_content_container">
+                <div class="section_content with_padding">
+                    <div ng-if="angular.equals(view.parsed_results, {})">
+                        <pre>{$:: view.parsed_results | json $}</pre>
+                    </div>
+                    <div ng-repeat="file in view.output_files | filter:filter_params:strict">
+                        <div ng-if="file.content_type == 'html'">
+                            <iframe class="analysis-results" scrolling="no" src="{$:: file.file $}" onload="this.style.height = this.contentWindow.document.documentElement.scrollHeight + 'px'"></iframe>
+                            <div ng-repeat-end ng-if="!$last">
+                                <br />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/seed/static/seed/partials/analysis_runs.html
+++ b/seed/static/seed/partials/analysis_runs.html
@@ -15,7 +15,7 @@
                 <td>{$:: (messages | filter : {'analysis_property_view':view.id})[0]['user_message'] $}</td>
                 <td>
                     <span ng-repeat="file in view.output_files | filter:filter_params:strict">
-                        <a href="{$:: file.file $}">{$:: file.content_type $}</a>
+                        <a href="{$:: file.file $}" target="_blank">{$:: file.content_type $}</a>
                         <span ng-repeat-end ng-if="!$last">,&nbsp;</span>
                     </span>
                 </td>

--- a/seed/static/seed/partials/analysis_runs.html
+++ b/seed/static/seed/partials/analysis_runs.html
@@ -15,7 +15,7 @@
                 <td>{$:: (messages | filter : {'analysis_property_view':view.id})[0]['user_message'] $}</td>
                 <td>
                     <span ng-repeat="file in view.output_files | filter:filter_params:strict">
-                        <a href="{$:: file.file $}" target="_blank">{$:: file.content_type $}</a>
+                        <a href="{$:: file.file $}" download>{$:: file.content_type $} <span class="fa fa-download"></span></a>
                         <span ng-repeat-end ng-if="!$last">,&nbsp;</span>
                     </span>
                 </td>

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -3857,3 +3857,10 @@ FAQ page
 .auto-populate-list > li {
   margin-bottom: 8px;
 }
+
+iframe.analysis-results {
+  border: none;
+  width: 100%;
+  height: 500px;
+  overflow: hidden;
+}


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
Renders any HTML analysis output files in an iframe.

#### How should this be manually tested?
Run a BETTER analysis on a property with sufficient meter data, then view the analysis details.

#### What are the relevant tickets?
https://github.com/SEED-platform/seed/issues/2759

#### Screenshots (if appropriate)
<img width="1228" alt="Screen Shot 2021-07-22 at 5 41 41 PM" src="https://user-images.githubusercontent.com/564231/126722458-bf441957-b548-4e20-a8b4-6da724fa3948.png">
