### PR TITLE
chore: always use latest chrome in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
     strategy:
       matrix:
         test_env: [django, functional, api]
-    env:
-      # Available versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-      CHROME_VERSION: 92.0.4515.107
     steps:
       -
         uses: actions/checkout@v2
@@ -58,7 +55,7 @@ jobs:
           npm install
           sudo apt update
           sudo apt install -y xvfb
-          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb
+          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           sudo apt install -y --allow-downgrades /tmp/chrome.deb
           google-chrome --version
       -
@@ -82,6 +79,8 @@ jobs:
         env:
           DISPLAY: ":99"
         run: |
+          CHROME_VERSION=$(google-chrome --version | awk '{ print $NF }')
+          echo "Getting webdriver for chrome version ${CHROME_VERSION}"
           ./node_modules/protractor/bin/webdriver-manager update --versions.chrome=${CHROME_VERSION} --gecko=false
           Xvfb :99 &
           ./node_modules/protractor/bin/protractor seed/static/seed/tests/protractor-tests/protractorConfig.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           sudo apt update
           sudo apt install -y xvfb
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-          sudo apt install -y --allow-downgrades /tmp/chrome.deb
+          sudo apt install -y /tmp/chrome.deb
           google-chrome --version
       -
         name: Test Django

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           sudo apt update
           sudo apt install -y xvfb
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb
-          sudo apt install -y /tmp/chrome.deb
+          sudo apt install -y --allow-downgrades /tmp/chrome.deb
           google-chrome --version
       -
         name: Test Django


### PR DESCRIPTION
#### Any background context you want to provide?
We pinned the chrome version for testing previously. Now apt is complaining b/c when we try to install the package it would downgrade chrome.

#### What's this PR do?
Install latest stable chrome, then parse that version out to install the webdriver

#### How should this be manually tested?
NA

#### What are the relevant tickets?

#### Screenshots (if appropriate)
