### PR TITLE
fix: skipping resource_uses with no type

### DIFF
--- a/seed/building_sync/building_sync.py
+++ b/seed/building_sync/building_sync.py
@@ -220,6 +220,8 @@ class BuildingSync(object):
             # process the scenario meters (aka resource uses)
             meters = {}
             for resource_use in scenario['resource_uses']:
+                if resource_use['type'] is None:
+                    continue
                 meter = {
                     'source': Meter.BUILDINGSYNC,
                     'source_id': resource_use['source_id'],


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
Skips the import of buildingsync energy_uses that don't have a type.

#### How should this be manually tested?
See ticket.

#### What are the relevant tickets?
https://github.com/SEED-platform/seed/issues/2696

#### Screenshots (if appropriate)
