### PR TITLE
2814 refactor: improved handling of BSync skipped meters

### DIFF
--- a/seed/building_sync/building_sync.py
+++ b/seed/building_sync/building_sync.py
@@ -220,8 +220,10 @@ class BuildingSync(object):
             # process the scenario meters (aka resource uses)
             meters = {}
             for resource_use in scenario['resource_uses']:
-                if resource_use['type'] is None:
+                if resource_use['type'] is None or resource_use['units'] is None:
+                    messages['warnings'].append(f'Skipping resource use {resource_use.get("source_id")} due to missing type or units')
                     continue
+
                 meter = {
                     'source': Meter.BUILDINGSYNC,
                     'source_id': resource_use['source_id'],

--- a/seed/building_sync/mappings.py
+++ b/seed/building_sync/mappings.py
@@ -207,10 +207,13 @@ def to_energy_type(energy_type):
     """converts an energy type from BuildingSync into one allowed by SEED
 
     :param energy_type: string, building sync energy type
-    :return: int
+    :return: int | None
     """
     # avoid circular dependency
     from seed.models import Meter
+
+    if energy_type is None:
+        return energy_type
 
     # valid energy type values from the schema (<xs:simpleType name="FuelTypes">) and their maps
     # non-trivial or non-obvious mappings currently map to "Other:" and are flagged with a comment
@@ -280,8 +283,11 @@ def to_energy_units(units):
     """converts energy units from BuildingSync into one allowed by SEED
 
     :param units: string, building sync units
-    :return: string
+    :return: string | None
     """
+
+    if units is None:
+        return None
 
     # valid energy unit values from the schema (<xs:element name="ResourceUnits">) and their maps
     # non-trivial or non-obvious mappings currently map to "Unknown" and are flagged with a comment

--- a/seed/models/building_file.py
+++ b/seed/models/building_file.py
@@ -281,6 +281,30 @@ class BuildingFile(models.Model):
             # meters
             energy_types = dict(Meter.ENERGY_TYPES)
             for m in s.get('meters', []):
+                num_skipped_readings = 0
+                valid_readings = []
+                for mr in m.get('readings', []):
+                    is_usable = (
+                        mr.get('start_time') is not None
+                        and mr.get('end_time') is not None
+                        and mr.get('reading') is not None
+                    )
+                    if is_usable:
+                        valid_readings.append(mr)
+                    else:
+                        num_skipped_readings += 1
+
+                if len(valid_readings) == 0:
+                    # skip this meter
+                    messages['warnings'].append(f'Skipped meter {m.get("source_id")} because it had no valid readings')
+                    continue
+
+                if num_skipped_readings > 0:
+                    messages['warnings'].append(
+                        f'Skipped {num_skipped_readings} readings due to missing start time,'
+                        f' end time, or reading value for meter {meter.source_id}'
+                    )
+
                 # print("BUILDING FILE METER: {}".format(m))
                 # check by scenario_id and source_id
                 meter, _ = Meter.objects.get_or_create(
@@ -302,7 +326,8 @@ class BuildingFile(models.Model):
                 else:
                     meter_type = None
                 meter_conversions = self._kbtu_thermal_conversion_factors().get(meter_type, {})
-                readings = {
+
+                valid_reading_models = {
                     MeterReading(
                         start_time=mr.get('start_time'),
                         end_time=mr.get('end_time'),
@@ -311,10 +336,9 @@ class BuildingFile(models.Model):
                         meter_id=meter.id,
                         conversion_factor=meter_conversions.get(mr.get('source_unit'), 1.00)
                     )
-                    for mr in m.get('readings', [])
-                    if mr.get('start_time') is not None and mr.get('end_time') is not None
+                    for mr in valid_readings
                 }
-                MeterReading.objects.bulk_create(readings)
+                MeterReading.objects.bulk_create(valid_reading_models)
 
         # merge or create the property state's view
         if property_view:

--- a/seed/models/building_file.py
+++ b/seed/models/building_file.py
@@ -302,7 +302,7 @@ class BuildingFile(models.Model):
                 if num_skipped_readings > 0:
                     messages['warnings'].append(
                         f'Skipped {num_skipped_readings} readings due to missing start time,'
-                        f' end time, or reading value for meter {meter.source_id}'
+                        f' end time, or reading value for meter {m.get("source_id")}'
                     )
 
                 # print("BUILDING FILE METER: {}".format(m))


### PR DESCRIPTION
#### Any background context you want to provide?
SEED is improving integration with AT

#### What's this PR do?
- skip meters which are missing readings
- skip meter readings missing start, end, or reading value
- warn users after import about skipping these things

#### How should this be manually tested?
Try to upload the following file, you'll get a warning that it skipped some meters. This is b/c some aucResourceUses don't include TimeSeriesData, or it does but the TimeSeries readings are missing actual reading values e.g.
<img width="570" alt="Screen Shot 2021-08-12 at 12 11 54 PM" src="https://user-images.githubusercontent.com/18518728/129230987-5f14cc62-228f-4d6e-8a3e-cdc4458a7aab.png">

After importing the file, go to meters tab and verify there are no completely empty meters columns.

[buildings_xml_report (12) (1).xml.zip](https://github.com/SEED-platform/seed/files/6976957/buildings_xml_report.12.1.xml.zip)

#### What are the relevant tickets?
#2814 
Also #2743 

#### Screenshots (if appropriate)
<img width="615" alt="Screen Shot 2021-08-12 at 12 15 41 PM" src="https://user-images.githubusercontent.com/18518728/129231529-48f24cdd-b530-4364-9321-01f708ca6569.png">


Full warning text:
```json
Warning(s)/Error(s) occurred while processing the file(s):
{
  "buildings_xml_report (12) (1).xml": {
    "warnings": [
      "Skipping resource use ResourceUseType-70066244180560 due to missing type or units",
      "Skipped meter ResourceUseType-70066237266060 because it had no valid readings",
      "Skipped meter ResourceUseType-70066237389520 because it had no valid readings",
      "Skipped meter ResourceUseType-70066242363280 because it had no valid readings",
      "Skipped meter ResourceUseType-70066242542420 because it had no valid readings",
      "Skipped meter ResourceUseType-70066242602540 because it had no valid readings",
      "Skipped meter ResourceUseType-70066242676280 because it had no valid readings",
      "Skipped meter ResourceUseType-70066242709380 because it had no valid readings",
      "Skipped meter ResourceUseType-70066242791660 because it had no valid readings",
      "Skipped meter ResourceUseType-70066242835640 because it had no valid readings"
    ],
    "errors": []
  }
}
```