### PR TITLE
fix: handle additional edge cases for BETTER analysis

### DIFF
--- a/seed/analysis_pipelines/better/buildingsync.py
+++ b/seed/analysis_pipelines/better/buildingsync.py
@@ -79,10 +79,20 @@ def _build_better_input(analysis_property_view, meters):
     if property_state.property_type not in BETTER_TO_BSYNC_PROPERTY_TYPE:
         errors.append(
             f"BETTER analysis requires the property's type must be one of the following: {', '.join(BETTER_TO_BSYNC_PROPERTY_TYPE.keys())}")
+
+    valid_meters_and_readings = []
     for meter in meters:
-        for meter_reading in meter.meter_readings.all():
-            if meter_reading.reading is None:
-                errors.append(f'{meter}: MeterReading starting at {meter_reading.start_time} has no reading value.')
+        readings = meter.meter_readings.filter(reading__gte=1.0)
+        if readings.count() >= 12:
+            valid_meters_and_readings.append({
+                'meter': meter,
+                'readings': readings,
+            })
+    if len(valid_meters_and_readings) == 0:
+        errors.append(
+            f'BETTER analysis requires at least one meter with 12 consecutive readings with values >= 1.0'
+        )
+
     if errors:
         return None, errors
 
@@ -176,12 +186,12 @@ def _build_better_input(analysis_property_view, meters):
                                         *[
                                             E.ResourceUse(
                                                 {'ID': f'ResourceUse-{meter_idx:03}'},
-                                                E.EnergyResource(SEED_TO_BSYNC_RESOURCE_TYPE[meter.type]),
+                                                E.EnergyResource(SEED_TO_BSYNC_RESOURCE_TYPE[meter_and_readings['meter'].type]),
                                                 # SEED stores all meter readings as kBtu
                                                 E.ResourceUnits('kBtu'),
                                                 E.EndUse('All end uses')
                                             )
-                                            for meter_idx, meter in enumerate(meters)
+                                            for meter_idx, meter_and_readings in enumerate(valid_meters_and_readings)
                                         ]
                                     ),
                                     E.TimeSeriesData(
@@ -195,8 +205,8 @@ def _build_better_input(analysis_property_view, meters):
                                                 E.IntervalReading(str(reading.reading)),
                                                 E.ResourceUseID({'IDref': f'ResourceUse-{meter_idx:03}'}),
                                             )
-                                            for meter_idx, meter in enumerate(meters) \
-                                            for reading_idx, reading in enumerate(meter.meter_readings.all())
+                                            for meter_idx, meter_and_readings in enumerate(valid_meters_and_readings) \
+                                            for reading_idx, reading in enumerate(meter_and_readings['readings'])
                                         ]
                                     ),
                                     E.LinkedPremises(

--- a/seed/analysis_pipelines/better/buildingsync.py
+++ b/seed/analysis_pipelines/better/buildingsync.py
@@ -90,7 +90,7 @@ def _build_better_input(analysis_property_view, meters):
             })
     if len(valid_meters_and_readings) == 0:
         errors.append(
-            f'BETTER analysis requires at least one meter with 12 consecutive readings with values >= 1.0'
+            'BETTER analysis requires at least one meter with 12 consecutive readings with values >= 1.0'
         )
 
     if errors:

--- a/seed/analysis_pipelines/better/helpers.py
+++ b/seed/analysis_pipelines/better/helpers.py
@@ -281,7 +281,18 @@ def _create_better_buildings(better_portfolio_id, context):
     better_building_analyses = []
     for input_file in context.analysis.input_files.all():
         analysis_property_view_id = _parse_analysis_property_view_id(input_file.file.path)
-        better_building_id = context.client.create_building(input_file.file.path, better_portfolio_id)
+        better_building_id, errors = context.client.create_building(input_file.file.path, better_portfolio_id)
+        if errors:
+            _check_errors(
+                errors,
+                f'Failed to create building for analysis property view {analysis_property_view_id}',
+                context,
+                analysis_property_view_id,
+                fail_on_error=False
+            )
+            # go to next building
+            continue
+
         better_building_analyses.append(
             BuildingAnalysis(
                 analysis_property_view_id,


### PR DESCRIPTION
#### Any background context you want to provide?
SEED is improving BETTER integration

#### What's this PR do?
- only pass meters and readings with 12 readings of values >= 1.0
- dont fail pipeline if one building fails to be created in BETTER

#### How should this be manually tested?
Import the CSV of PM data and meters (shared by Nick, ask me for access if you need it). Select all buildings and run the analysis. The analysis should skip some buildings b/c of two issues with these properties:
- they have meters with readings of 0.0 (you should see an explicit message about this next to the property)
- they have a location which BETTER fails to geocode (SEED doesn't know when this happens though, we just treat it as an unexpected error and continue)

The analysis should complete, and you should be able to view both the portfolio and building reports

#### What are the relevant tickets?

#### Screenshots (if appropriate)
