### PR TITLE
fix: add helper has child function to the run controller

### DIFF
--- a/seed/static/seed/js/controllers/analysis_run_controller.js
+++ b/seed/static/seed/js/controllers/analysis_run_controller.js
@@ -34,4 +34,10 @@ angular.module('BE.seed.controller.analysis_run', [])
       $scope.views = [view_payload.view];
       $scope.view = view_payload.view;
       $scope.view_id = $stateParams.view_id;
+
+      $scope.has_children = function (value) {
+        if (typeof value == 'object') {
+          return true;
+        }
+      };
     }]);


### PR DESCRIPTION
#### Any background context you want to provide?
UI/UX tweaks for analysis
#### What's this PR do?
adds the has_children helper function to the run controller.  
#### How should this be manually tested?
view single analysis runs. 
#### What are the relevant tickets?
#2818 
#### Screenshots (if appropriate)
![Screen Shot 2021-08-16 at 11 05 16 AM](https://user-images.githubusercontent.com/31779424/129602012-3d5ca465-6f06-4c6f-b515-1033e22173f5.png)

## NOTE: this helper now lives in three controllers - is there a smooth way to just add it once somewhere for DRYness?