### PR TITLE
fix: correctly filter columns when updating column profile

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -1087,7 +1087,9 @@ angular.module('BE.seed.controller.inventory_list', [])
       function currentColumns () {
         // Save all columns except first 3
         var gridCols = _.filter($scope.gridApi.grid.columns, function (col) {
-          return !_.includes(['treeBaseRowHeaderCol', 'selectionRowHeaderCol', 'notes_count', 'merged_indicator', 'id'], col.name) && col.visible && col.id;
+          return !_.includes(['treeBaseRowHeaderCol', 'selectionRowHeaderCol', 'notes_count', 'merged_indicator', 'id', 'labels'], col.name)
+            && col.visible
+            && !col.colDef.is_derived_column;
         });
 
         // Ensure pinned ordering first


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
- updating the column list profile was broken on the inventory page when dragging/dropping column headers. This fixes that by properly filtering columns before POSTing

#### How should this be manually tested?
- go to inventory list page
- drag and drop one of the columns (should successfully update the column profile)
- go to column list profile page and verify it was updated
- go back to list profile and it should be correct according to your updated ordering

#### What are the relevant tickets?
#2790 

#### Screenshots (if appropriate)
