### PR TITLE
refactor(bsync): parse meter data from AllResourceTotals

### DIFF
--- a/seed/building_sync/mappings.py
+++ b/seed/building_sync/mappings.py
@@ -820,6 +820,11 @@ BASE_MAPPING_V2 = {
                 'xpath': './auc:TimeSeriesData/auc:TimeSeries',
                 'type': 'list',
                 'items': {
+                    'id': {
+                        'xpath': '.',
+                        'type': 'value',
+                        'value': '@ID',
+                    },
                     'start_time': {
                         'xpath': './auc:StartTimestamp',
                         'type': 'value',
@@ -841,6 +846,24 @@ BASE_MAPPING_V2 = {
                         'xpath': './auc:ResourceUseID',
                         'type': 'value',
                         'value': '@IDref'
+                    }
+                }
+            },
+            # Audit Template stores some meter readings in AllResourceTotals...
+            'audit_template_all_resource_totals': {
+                'xpath': './auc:AllResourceTotals/auc:AllResourceTotal[auc:UserDefinedFields/auc:UserDefinedField/auc:FieldName="Linked Time Series ID"]',
+                'type': 'list',
+                'items': {
+                    'linked_time_series_id': {
+                        'xpath': './auc:UserDefinedFields/auc:UserDefinedField[auc:FieldName="Linked Time Series ID"]/auc:FieldValue',
+                        'type': 'value',
+                        'value': 'text',
+                    },
+                    'site_energy_use': {
+                        'xpath': './auc:SiteEnergyUse',
+                        'type': 'value',
+                        'value': 'text',
+                        'formatter': to_float,
                     }
                 }
             }


### PR DESCRIPTION
#### Any background context you want to provide?
Audit Template tool puts some meter data inside of AllResourceTotal instead of TimeSeries (as we would expect)
![Screen Shot 2021-08-23 at 10 44 29 AM](https://user-images.githubusercontent.com/18518728/130497412-bc378591-1b37-47f2-81f9-54c96ac0a9ca.png)


#### What's this PR do?
Parses meter readings from AllResourceTotals in addition to the TimeSeries readings.

NOTE: because SEED only allows one reading for a meter for a specific time span, we must create a _new_ meter to store these readings. This is fine for now, but we should consider removing that constraint and adding a "type" for a reading like BuildingSync's `auc:ReadingType` (e.g. point, median, mean, peak, etc). I add a "Site Energy Use" prefix to the original "meter" (ie ResourceUse) for the meter ID.

#### How should this be manually tested?
Upload a recent Audit template file which contains meter readings (peak, as well as regular readings). Verify meters were imported.

[example_SF_audit_report_BS_v2.3_081321.xml.zip](https://github.com/SEED-platform/seed/files/7034068/example_SF_audit_report_BS_v2.3_081321.xml.zip)

#### What are the relevant tickets?
#2828 

#### Screenshots (if appropriate)
![Screen Shot 2021-08-23 at 12 25 11 PM](https://user-images.githubusercontent.com/18518728/130497998-5435fac0-15e4-4ae9-bdfb-f31255ba9177.png)
