### PR TITLE
refactor!: link building file meters to property

### DIFF
--- a/seed/analysis_pipelines/better/buildingsync.py
+++ b/seed/analysis_pipelines/better/buildingsync.py
@@ -82,7 +82,7 @@ def _build_better_input(analysis_property_view, meters):
 
     valid_meters_and_readings = []
     for meter in meters:
-        readings = meter.meter_readings.filter(reading__gte=1.0)
+        readings = meter.meter_readings.filter(reading__gte=1.0).order_by('start_time')
         if readings.count() >= 12:
             valid_meters_and_readings.append({
                 'meter': meter,

--- a/seed/models/building_file.py
+++ b/seed/models/building_file.py
@@ -213,6 +213,7 @@ class BuildingFile(models.Model):
             join.save()
 
         # add in scenarios
+        linked_meters = []
         for s in data.get('scenarios', []):
             # measures = models.ManyToManyField(PropertyMeasure)
 
@@ -319,6 +320,7 @@ class BuildingFile(models.Model):
                 if meter.is_virtual is None:
                     meter.is_virtual = False
                 meter.save()
+                linked_meters.append(meter)
 
                 # meterreadings
                 if meter.type in energy_types:
@@ -381,5 +383,9 @@ class BuildingFile(models.Model):
         else:
             # invalid arguments, must pass both or neither
             return False, None, None, "Invalid arguments passed to BuildingFile.process()"
+
+        for meter in linked_meters:
+            meter.property = property_view.property
+            meter.save()
 
         return True, property_state, property_view, messages


### PR DESCRIPTION
#### Any background context you want to provide?
Building file meters are linked to scenarios but not canonical properties currently

#### What's this PR do?
Links building file meters to canonical properties.

#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
