### PR TITLE
refactor(better): round result to 2 decimal places

### DIFF
--- a/seed/analysis_pipelines/better/helpers.py
+++ b/seed/analysis_pipelines/better/helpers.py
@@ -329,7 +329,10 @@ def _update_original_property_state(property_state, data, data_paths):
         if type(result) is dict and not result:
             # path was probably not valid in the data...
             return None
-        return result
+        elif type(result) is float:
+            return round(result, 2)
+        else:
+            return result
 
     results = {
         data_path.column_name: get_json_path(data_path.json_path, data)


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
- Round floats from BETTER results that are dropped into the inventory list (ie PropertyState) to two decimal places

I think we might actually want to handle this on the frontend in the future, and store results with full precision. But this is a fine fix for now.

#### How should this be manually tested?

#### What are the relevant tickets?
#2834 

#### Screenshots (if appropriate)
![Screen Shot 2021-08-25 at 11 54 23 AM](https://user-images.githubusercontent.com/18518728/130841168-e199b0d9-b479-443e-91ea-175dc6780afb.png)
