### PR TITLE
feat(analyses): auto-poll analysis progress on frontend

### DIFF
--- a/seed/analysis_pipelines/better/pipeline.py
+++ b/seed/analysis_pipelines/better/pipeline.py
@@ -8,7 +8,6 @@ import logging
 import copy
 
 from django.db.models import Q, Count
-from django.utils import timezone as tz
 from django.core.files.base import ContentFile
 from celery import chain, shared_task
 
@@ -38,7 +37,6 @@ from seed.analysis_pipelines.better.helpers import (
     _update_original_property_state,
 )
 
-from seed.lib.progress_data.progress_data import ProgressData
 from seed.models import (
     Analysis,
     AnalysisInputFile,

--- a/seed/analysis_pipelines/better/pipeline.py
+++ b/seed/analysis_pipelines/better/pipeline.py
@@ -108,7 +108,7 @@ class BETTERPipeline(AnalysisPipeline):
             raise AnalysisPipelineException(
                 f'Analysis configuration is invalid: {"; ".join(validation_errors)}')
 
-        progress_data = ProgressData('prepare-analysis-better', self._analysis_id)
+        progress_data = self.get_progress_data(analysis)
 
         # Steps:
         # 1) ...starting
@@ -118,17 +118,15 @@ class BETTERPipeline(AnalysisPipeline):
         progress_data.save()
 
         chain(
-            task_create_analysis_property_views.si(self._analysis_id, property_view_ids, progress_data.key),
-            _prepare_all_properties.s(self._analysis_id, progress_data.key),
-            _finish_preparation.si(self._analysis_id, progress_data.key, start_analysis)
+            task_create_analysis_property_views.si(self._analysis_id, property_view_ids),
+            _prepare_all_properties.s(self._analysis_id),
+            _finish_preparation.si(self._analysis_id, start_analysis)
         ).apply_async()
-
-        return progress_data.result()
 
     def _start_analysis(self):
         """Internal implementation for starting the BETTER analysis"""
 
-        progress_data = ProgressData('start-analysis-better', self._analysis_id)
+        progress_data = self.get_progress_data()
 
         # Steps:
         # 1) ...starting
@@ -138,28 +136,27 @@ class BETTERPipeline(AnalysisPipeline):
         progress_data.save()
 
         chain(
-            _start_analysis.si(self._analysis_id, progress_data.key),
-            _process_results.si(self._analysis_id, progress_data.key),
-            _finish_analysis.si(self._analysis_id, progress_data.key),
+            _start_analysis.si(self._analysis_id),
+            _process_results.si(self._analysis_id),
+            _finish_analysis.si(self._analysis_id),
         ).apply_async()
-
-        return progress_data.result()
 
 
 @shared_task(bind=True)
 @analysis_pipeline_task(Analysis.CREATING)
-def _prepare_all_properties(self, analysis_view_ids_by_property_view_id, analysis_id, progress_data_key):
+def _prepare_all_properties(self, analysis_view_ids_by_property_view_id, analysis_id):
     """A Celery task which attempts to make BuildingSync files for all AnalysisPropertyViews.
 
     :param analysis_view_ids_by_property_view_id: dictionary[int:int]
     :param analysis_id: int
-    :param progress_data_key: str
     :returns: void
     """
-    progress_data = ProgressData.from_key(progress_data_key)
+    analysis = Analysis.objects.get(id=analysis_id)
+    pipeline = BETTERPipeline(analysis.id)
+
+    progress_data = pipeline.get_progress_data(analysis)
     progress_data.step('Creating files for analysis')
 
-    analysis = Analysis.objects.get(id=analysis_id)
     analysis_property_views = AnalysisPropertyView.objects.filter(id__in=analysis_view_ids_by_property_view_id.values())
     input_file_paths = []
     for analysis_property_view in analysis_property_views:
@@ -207,28 +204,22 @@ def _prepare_all_properties(self, analysis_view_ids_by_property_view_id, analysi
         input_file_paths.append(analysis_input_file.file.path)
 
     if len(input_file_paths) == 0:
-        pipeline = BETTERPipeline(analysis.id)
         message = 'No files were able to be prepared for the analysis'
-        pipeline.fail(message, logger, progress_data_key=progress_data.key)
+        pipeline.fail(message, logger)
         # stop the task chain
         raise StopAnalysisTaskChain(message)
 
 
 @shared_task(bind=True)
 @analysis_pipeline_task(Analysis.CREATING)
-def _finish_preparation(self, analysis_id, progress_data_key, start_analysis):
+def _finish_preparation(self, analysis_id, start_analysis):
     """A Celery task which finishes the preparation for BETTER analysis
 
     :param analysis_id: int
-    :param progress_data_key: str
     :param start_analysis: bool
     """
-    analysis = Analysis.objects.get(id=analysis_id)
-    analysis.status = Analysis.READY
-    analysis.save()
-
-    progress_data = ProgressData.from_key(progress_data_key)
-    progress_data.finish_with_success()
+    pipeline = BETTERPipeline(analysis_id)
+    pipeline.set_analysis_status_to_ready('Analysis is ready to be started')
 
     if start_analysis:
         pipeline = BETTERPipeline(analysis_id)
@@ -237,16 +228,13 @@ def _finish_preparation(self, analysis_id, progress_data_key, start_analysis):
 
 @shared_task(bind=True)
 @analysis_pipeline_task(Analysis.QUEUED)
-def _start_analysis(self, analysis_id, progress_data_key):
+def _start_analysis(self, analysis_id):
     """Start better analysis by making requests to the service"""
-    analysis = Analysis.objects.get(id=analysis_id)
-    analysis.status = Analysis.RUNNING
-    analysis.start_time = tz.now()
-    analysis.save()
-
-    progress_data = ProgressData.from_key(progress_data_key)
+    pipeline = BETTERPipeline(analysis_id)
+    progress_data = pipeline.set_analysis_status_to_running()
     progress_data.step('Sending requests to BETTER service')
 
+    analysis = Analysis.objects.get(id=analysis_id)
     client = BETTERClient(analysis.organization.better_analysis_api_key)
     context = BETTERPipelineContext(analysis, progress_data, client)
 
@@ -297,13 +285,12 @@ def _start_analysis(self, analysis_id, progress_data_key):
 
 @shared_task(bind=True)
 @analysis_pipeline_task(Analysis.RUNNING)
-def _process_results(self, analysis_id, progress_data_key):
+def _process_results(self, analysis_id):
     """Store results from the analysis in the original PropertyState"""
+    pipeline = BETTERPipeline(analysis_id)
     analysis = Analysis.objects.get(id=analysis_id)
-    analysis.status = Analysis.RUNNING
-    analysis.save()
 
-    progress_data = ProgressData.from_key(progress_data_key)
+    progress_data = pipeline.get_progress_data(analysis)
     progress_data.step('Processing results')
 
     # store all measure recommendations
@@ -400,16 +387,10 @@ def _process_results(self, analysis_id, progress_data_key):
 
 @shared_task(bind=True)
 @analysis_pipeline_task(Analysis.RUNNING)
-def _finish_analysis(self, analysis_id, progress_data_key):
+def _finish_analysis(self, analysis_id):
     """A Celery task which finishes the analysis run
 
     :param analysis_id: int
-    :param progress_data_key: str
     """
-    analysis = Analysis.objects.get(id=analysis_id)
-    analysis.status = Analysis.COMPLETED
-    analysis.end_time = tz.now()
-    analysis.save()
-
-    progress_data = ProgressData.from_key(progress_data_key)
-    progress_data.finish_with_success()
+    pipeline = BETTERPipeline(analysis_id)
+    pipeline.set_analysis_status_to_completed()

--- a/seed/analysis_pipelines/bsyncr.py
+++ b/seed/analysis_pipelines/bsyncr.py
@@ -17,7 +17,6 @@ from seed.analysis_pipelines.pipeline import (
     StopAnalysisTaskChain
 )
 from seed.building_sync.mappings import BUILDINGSYNC_URI, NAMESPACES
-from seed.lib.progress_data.progress_data import ProgressData
 from seed.models import (
     Analysis,
     AnalysisInputFile,
@@ -31,7 +30,6 @@ from django.core.files.base import ContentFile, File as BaseFile
 from django.core.files.images import ImageFile
 from django.db.models import Count
 from django.conf import settings
-from django.utils import timezone as tz
 
 from celery import chain, shared_task
 
@@ -135,7 +133,7 @@ def _prepare_all_properties(self, analysis_view_ids_by_property_view_id, analysi
     :param analysis_view_ids_by_property_view_id: dictionary[int:int]
     :param analysis_id: int
     :returns: void
-    """    
+    """
     analysis = Analysis.objects.get(id=analysis_id)
     pipeline = BsyncrPipeline(analysis.id)
     progress_data = pipeline.get_progress_data(analysis)
@@ -342,7 +340,7 @@ def _start_analysis(self, analysis_id):
     progress_data = pipeline.set_analysis_status_to_running()
     progress_data.step('Sending requests to bsyncr service')
 
-    analysis = Analysis.objects.get(id=analysis_id)    
+    analysis = Analysis.objects.get(id=analysis_id)
 
     ANALYSIS_STATUS_CHECK_FREQUENCY = 5
     bsyncr_model_type = BSYNCR_MODEL_TYPE_MAP[analysis.configuration['model_type']]

--- a/seed/analysis_pipelines/pipeline.py
+++ b/seed/analysis_pipelines/pipeline.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import logging
 
+from seed.decorators import get_prog_key
 from seed.lib.progress_data.progress_data import ProgressData
 from seed.models import Analysis, AnalysisPropertyView, AnalysisMessage
 
@@ -282,33 +283,43 @@ class AnalysisPipeline(abc.ABC):
 
         :param property_view_ids: list[int]
         :param start_analysis: bool, if true, the pipeline should immediately start the analysis after preparation
-        :returns: str, ProgressData.result
+        :returns: ProgressData.result
         """
         with transaction.atomic():
             locked_analysis = Analysis.objects.select_for_update().get(id=self._analysis_id)
             if locked_analysis.status is Analysis.PENDING_CREATION:
                 locked_analysis.status = Analysis.CREATING
                 locked_analysis.save()
+                progress_data = ProgressData(
+                    self._get_progress_data_key_prefix(locked_analysis),
+                    self._analysis_id,
+                )
             else:
                 raise AnalysisPipelineException('Analysis has already been prepared or is currently being prepared')
 
-        return self._prepare_analysis(property_view_ids, start_analysis)
+        self._prepare_analysis(property_view_ids, start_analysis)
+        return progress_data.result()
 
     def start_analysis(self):
         """Entrypoint for starting an analysis.
 
-        :returns: str, ProgressData.result
+        :returns: ProgressData.result
         """
         with transaction.atomic():
             locked_analysis = Analysis.objects.select_for_update().get(id=self._analysis_id)
             if locked_analysis.status is Analysis.READY:
                 locked_analysis.status = Analysis.QUEUED
                 locked_analysis.save()
+                progress_data = ProgressData(
+                    self._get_progress_data_key_prefix(locked_analysis),
+                    self._analysis_id,
+                )
             else:
                 statuses = dict(Analysis.STATUS_TYPES)
                 raise AnalysisPipelineException(f'Analysis cannot be started. Its status should be "{statuses[Analysis.READY]}" but it is "{statuses[locked_analysis.status]}"')
 
-        return self._start_analysis()
+        self._start_analysis()
+        return progress_data.result()
 
     def fail(self, message, logger, progress_data_key=None):
         """Fails the analysis. Creates an AnalysisMessage and logs it
@@ -323,6 +334,10 @@ class AnalysisPipeline(abc.ABC):
             if progress_data_key is not None:
                 progress_data = ProgressData.from_key(progress_data_key)
                 progress_data.finish_with_error(message)
+            else:
+                progress_data = self.get_progress_data(locked_analysis)
+                if progress_data is not None:
+                    progress_data.finish_with_error(message)
 
             if locked_analysis.in_terminal_state():
                 raise AnalysisPipelineException(f'Analysis is already in a terminal state: status {locked_analysis.status}')
@@ -367,6 +382,126 @@ class AnalysisPipeline(abc.ABC):
         """
         Analysis.objects.get(id=self._analysis_id).delete()
 
+    def set_analysis_status_to_ready(self, status_message):
+        """Sets the analysis status to READY and saves the analysis start time.
+        This method should be called once for an analysis. In addition, it should
+        only be called by the pipeline once the analysis task has officially finished
+        creation/preparation.
+
+        Therefore, this should only be called in the context of a pipeline task.
+
+        :param status_message: str, message to use for the finished ProgressData
+            for the creating/preparation process
+        :returns: None
+        """
+        with transaction.atomic():
+            locked_analysis = Analysis.objects.select_for_update().get(id=self._analysis_id)
+
+            if locked_analysis.status == Analysis.CREATING:
+                progress_data = self.get_progress_data(locked_analysis)
+                progress_data.finish_with_success(status_message)
+
+                locked_analysis.status = Analysis.READY
+                locked_analysis.start_time = tz.now()
+                locked_analysis.save()
+            else:
+                statuses = dict(Analysis.STATUS_TYPES)
+                raise AnalysisPipelineException(
+                    f'Analysis status can\'t be set to READY. '
+                    f'Its status should be "{statuses[Analysis.CREATING]}" but it is "{statuses[locked_analysis.status]}"'
+                )
+
+    def set_analysis_status_to_running(self):
+        """Sets the analysis status to RUNNING and saves the analysis start time.
+        This method should be called once for an analysis. In addition, it should
+        only be called by the pipeline once the analysis task has officially started
+        (ie a worker has picked up the actual work of the task).
+
+        Therefore, this should only be called in the context of a pipeline task.
+
+        :returns: ProgressData
+        """
+        with transaction.atomic():
+            locked_analysis = Analysis.objects.select_for_update().get(id=self._analysis_id)
+
+            if locked_analysis.status == Analysis.QUEUED:
+                progress_data = self.get_progress_data(locked_analysis)
+                progress_data.finish_with_success('Analysis is now being run')
+
+                locked_analysis.status = Analysis.RUNNING
+                locked_analysis.start_time = tz.now()
+                locked_analysis.save()
+
+                return ProgressData(
+                    self._get_progress_data_key_prefix(locked_analysis),
+                    locked_analysis.id
+                )
+            else:
+                statuses = dict(Analysis.STATUS_TYPES)
+                raise AnalysisPipelineException(
+                    f'Analysis status can\'t be set to RUNNING. '
+                    f'Its status should be "{statuses[Analysis.QUEUED]}" but it is "{statuses[locked_analysis.status]}"'
+                )
+
+    def set_analysis_status_to_completed(self):
+        """Sets the analysis status to COMPLETED and saves the analysis end time.
+        This method should be called once for an analysis. In addition, it should
+        only be called by the pipeline once the analysis task has officially ended
+        (ie all work for the analysis is finished).
+
+        Therefore, this should only be called in the context of a pipeline task.
+
+        :returns: None
+        """
+        with transaction.atomic():
+            locked_analysis = Analysis.objects.select_for_update().get(id=self._analysis_id)
+
+            if locked_analysis.status == Analysis.RUNNING:
+                progress_data = self.get_progress_data(locked_analysis)
+                progress_data.finish_with_success('Analysis is complete')
+
+                locked_analysis.status = Analysis.COMPLETED
+                locked_analysis.end_time = tz.now()
+                locked_analysis.save()
+            else:
+                statuses = dict(Analysis.STATUS_TYPES)
+                raise AnalysisPipelineException(
+                    f'Analysis status can\'t be set to COMPLETED. '
+                    f'Its status should be "{statuses[Analysis.RUNNING]}" but it is "{statuses[locked_analysis.status]}"'
+                )
+
+    def _get_progress_data_key_prefix(self, analysis):
+        statuses = dict(Analysis.STATUS_TYPES)
+        return f'analysis-{statuses[analysis.status]}'
+
+    def get_progress_data(self, analysis=None):
+        """Get the ProgressData for the current task. If the analysis doesn't currently
+        have progress data, this method returns None
+
+        :returns: ProgressData | None
+        """
+        if analysis is None:
+            analysis = Analysis.objects.get(id=self._analysis_id)
+
+        if (
+            # PENDING_CREATION doesn't have progress data due to... uninteresting reasons...
+            analysis.status is Analysis.PENDING_CREATION
+            # READY doesn't have progress data b/c it's waiting for the user to kick it off
+            or analysis.status is Analysis.READY
+            # Terminal states (e.g. Failed, Stopped, Complete) don't have progress data
+            or analysis.in_terminal_state()
+        ):
+            return None
+
+        progress_key = get_prog_key(
+            self._get_progress_data_key_prefix(analysis),
+            self._analysis_id
+        )
+        try:
+            return ProgressData.from_key(progress_key)
+        except Exception:
+            raise Exception(f'Expected analysis to have progress data, but {progress_key} was not found')
+
     @abc.abstractmethod
     def _prepare_analysis(self, property_view_ids, start_analysis):
         """Abstract method which should do the work necessary for preparing
@@ -376,7 +511,7 @@ class AnalysisPipeline(abc.ABC):
         :param start_analysis: bool, if true, the pipeline should be started immediately
             after preparation is finished. It is the responsibility of the pipline
             implementation to make sure this happens by calling `pipeline.start_analysis()`
-        :returns: str, ProgressData.result
+        :returns: None
         """
         pass
 
@@ -385,6 +520,6 @@ class AnalysisPipeline(abc.ABC):
         """Abstract method which should start the analysis, e.g. make HTTP requests
         to the analysis service.
 
-        :returns: str, ProgressData.result
+        :returns: None
         """
         pass

--- a/seed/static/seed/js/controllers/analyses_controller.js
+++ b/seed/static/seed/js/controllers/analyses_controller.js
@@ -13,7 +13,6 @@ angular.module('BE.seed.controller.analyses', [])
     'urls',
     'analyses_service',
     'Notification',
-    'uploader_service',
     function (
       $scope,
       analyses_payload,
@@ -23,12 +22,19 @@ angular.module('BE.seed.controller.analyses', [])
       urls,
       analyses_service,
       Notification,
-      uploader_service
     ) {
       $scope.org = organization_payload.organization;
       $scope.auth = auth_payload.auth;
       $scope.analyses = analyses_payload.analyses;
       $scope.users = users_payload.users;
+
+      // Stores functions for stopping the polling of analysis progress. Keyed by analysis id
+      const analysis_polling_stoppers = {}
+
+      $scope.$on('$destroy', () => {
+        // cancel all polling
+        Object.values(analysis_polling_stoppers).forEach(stop_func => stop_func())
+      })
 
       const refresh_analyses = function () {
         analyses_service.get_analyses_for_org($scope.org.id)
@@ -37,39 +43,41 @@ angular.module('BE.seed.controller.analyses', [])
           });
       };
 
-      // Check the progress of the analysis. Every time a task completes, refresh
-      // the analysis for the $scope and see if there's another trackable task to check
-      const check_analysis_progress_loop = (analysis_id) => {
-        analyses_service.get_progress_key(analysis_id)
+      const refresh_analysis = (analysis_id) => {
+        // update analysis in scope
+        return analyses_service.get_analysis_for_org(analysis_id, $scope.org.id)
           .then(data => {
-            if (!data.progress_key) {
-              // analysis isn't in a trackable state/status, stop checking
-              return
-            }
-
             const analysis_index = $scope.analyses.findIndex(analysis => {
               return analysis.id === analysis_id
             })
-            $scope.analyses[analysis_index]._tracking_progress = true
-
-            uploader_service.check_progress_loop(data.progress_key, 0, 1, () => {
-              analyses_service.get_analysis_for_org(analysis_id, $scope.org.id)
-                .then(data => {
-                  const analysis_index = $scope.analyses.findIndex(analysis => {
-                    return analysis.id === analysis_id
-                  })
-                  $scope.analyses[analysis_index] = data.analysis
-
-                  // start tracking the progress again
-                  check_analysis_progress_loop(analysis_id)
-                })
-            }, () => {},
-            {})
+            $scope.analyses[analysis_index] = data.analysis
+            return data.analysis
           })
       }
 
+      // add flag to the analysis indicating it has no currently running tasks
+      // Used to determine if we should indicate on UI if an analysis's status is being polled
+      const mark_analysis_not_active = (analysis_id) => {
+        const analysis_index = $scope.analyses.findIndex(analysis => {
+          return analysis.id === analysis_id
+        })
+        $scope.analyses[analysis_index]._finished_with_tasks = true
+      }
+
+      // Entry point for keeping track of analysis progress
+      // Refreshes analysis in $scope when necessary
+      const poll_analysis_progress = (analysis) => {
+        if (analysis_polling_stoppers[analysis.id]) {
+          analysis_polling_stoppers[analysis.id]()
+        }
+
+        const stop_func = analyses_service.check_progress_loop(analysis, refresh_analysis, mark_analysis_not_active)        
+        analysis_polling_stoppers[analysis.id] = stop_func
+      }
+
+      // start polling all of the analyses
       $scope.analyses.forEach(analysis => {
-        check_analysis_progress_loop(analysis.id)
+        poll_analysis_progress(analysis)
       })
 
       $scope.start_analysis = function (analysis_id) {
@@ -82,12 +90,10 @@ angular.module('BE.seed.controller.analyses', [])
           .then(function (result) {
             if (result.status === 'success') {
               Notification.primary('Analysis started');
-              refresh_analyses();
-              uploader_service.check_progress_loop(result.progress_key, 0, 1, function () {
-                refresh_analyses();
-              }, function () {
-                refresh_analyses();
-              }, {});
+              refresh_analysis(analysis_id)
+                .then((updated_analysis) => {
+                  poll_analysis_progress(updated_analysis)
+                })
             } else {
               Notification.error('Failed to start analysis: ' + result.message);
             }
@@ -104,7 +110,10 @@ angular.module('BE.seed.controller.analyses', [])
           .then(function (result) {
             if (result.status === 'success') {
               Notification.primary('Analysis stopped');
-              refresh_analyses();
+              refresh_analysis(analysis_id)
+                .then((updated_analysis) => {
+                  poll_analysis_progress(updated_analysis)
+                })
             } else {
               Notification.error('Failed to stop analysis: ' + result.message);
             }
@@ -121,7 +130,12 @@ angular.module('BE.seed.controller.analyses', [])
           .then(function (result) {
             if (result.status === 'success') {
               Notification.primary('Analysis deleted');
-              refresh_analyses();
+              // stop polling and remove the analysis from the scope
+              analysis_polling_stoppers[analysis_id]()
+              const analysis_index = $scope.analyses.findIndex(analysis => {
+                return analysis.id === analysis_id
+              })
+              $scope.analyses.splice(analysis_index, 1)
             } else {
               Notification.error('Failed to delete analysis: ' + result.message);
             }

--- a/seed/static/seed/js/controllers/analysis_details_controller.js
+++ b/seed/static/seed/js/controllers/analysis_details_controller.js
@@ -1,0 +1,45 @@
+/*
+ * :copyright (c) 2014 - 2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.
+ * :author
+ */
+
+angular.module('BE.seed.controller.analysis_details', [])
+  .controller('analysis_details_controller', [
+    '$scope',
+    '$state',
+    'analyses_service',
+    function (
+      $scope,
+      $state,
+      analyses_service
+    ) {
+      let stop_func = () => {}
+      const starting_analysis_status = $scope.analysis.status
+
+      $scope.$on('$destroy', () => {
+        stop_func()
+      })
+
+      const refresh_analysis = (analysis_id) => {
+        // update analysis in scope
+        return analyses_service.get_analysis_for_org(analysis_id, $scope.org.id)
+          .then(data => {
+            $scope.analysis = data.analysis
+            return data.analysis
+          })
+      }
+
+      // add flag to the analysis indicating it has no currently running tasks
+      // Used to determine if we should indicate on UI if an analysis's status is being polled
+      const mark_analysis_not_active = (analysis_id) => {
+        $scope.analysis._finished_with_tasks = true
+
+        // if the status of the analysis has changed since we first loaded the page, refresh everything
+        // so that analysis results and messages are updated. (this is lazy, but is good enough for now)
+        if (starting_analysis_status != $scope.analysis.status) {
+          $state.reload()
+        }
+      }
+
+      stop_func = analyses_service.check_progress_loop($scope.analysis, refresh_analysis, mark_analysis_not_active)
+    }]);

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -41,6 +41,7 @@ angular.module('BE.seed.controllers', [
   'BE.seed.controller.admin',
   'BE.seed.controller.analyses',
   'BE.seed.controller.analysis',
+  'BE.seed.controller.analysis_details',
   'BE.seed.controller.analysis_run',
   'BE.seed.controller.api',
   'BE.seed.controller.column_mapping_profile_modal',

--- a/seed/static/seed/js/services/analyses_service.js
+++ b/seed/static/seed/js/services/analyses_service.js
@@ -2,11 +2,15 @@ angular.module('BE.seed.service.analyses', [])
   .factory('analyses_service', [
     '$http',
     '$log',
+    '$timeout',
     'user_service',
+    'uploader_service',
     function (
       $http,
       $log,
-      user_service
+      $timeout,
+      user_service,
+      uploader_service
     ) {
 
       const get_analyses_for_org = function (org_id) {
@@ -23,7 +27,7 @@ angular.module('BE.seed.service.analyses', [])
       };
 
       const get_analysis_for_org = function (analysis_id, org_id) {
-        return $http.get('/api/v3/analyses/' + analysis_id + '?organization_id=' + org_id).then(function (response) {
+        return $http.get('/api/v3/analyses/' + analysis_id + '/?organization_id=' + org_id).then(function (response) {
           return response.data;
         });
       };
@@ -128,6 +132,84 @@ angular.module('BE.seed.service.analyses', [])
         });
       }
 
+      /**
+       * check_progress_loop: polls progress data of an analysis
+       *
+       * @param {obj} {id, status}: object containing id and status of the analysis to poll
+       * @param {async fn} status_update_callback: called every time a progress data is completed. Provided one parameter, analysis id
+       * @param {fn} no_current_task_callback: called when there are no more progress data for the analysis. Provided one parameter, analysis id
+       * @returns {fn}: a function which when called stops the polling
+       */
+      const check_progress_loop = function ({ id, status }, status_update_callback, no_current_task_callback) {
+        // These statuses are assumed to have no progress data
+        const NOT_ACTIVE_STATUSES = [
+          'Pending Creation',
+          'Ready',
+          'Completed',
+          'Stopped',
+          'Failed',
+        ]
+        if (NOT_ACTIVE_STATUSES.indexOf(status) >= 0) {
+          no_current_task_callback(id)
+          return () => {}
+        }
+
+        // stop_func allows the caller of check_progress_loop to cancel the polling
+        let stop = false
+        const stop_func = () => {
+          stop = true
+        }
+
+        const POLLING_DELAY_MS = 1500
+        // recursive func for checking the progress of the analysis.
+        // Gets the key for the current progress data, polls it until it finishes
+        // then starts over by getting the new key for the next progress data.
+        // Termination condition is when there's no progress data (ie no progress key
+        // returned by the get_progress_key service)
+        const get_key_and_check_progress = () => {
+          get_progress_key(id)
+            .then(data => {
+              const progress_key = data.progress_key
+              if (!progress_key) {
+                // analysis isn't in a trackable state/status, stop checking
+                no_current_task_callback(id)
+                return
+              }
+
+              const check_progress_loop = () => {
+                $timeout(() => {
+                  if (stop) {
+                    return
+                  }
+
+                  uploader_service.check_progress(progress_key)
+                    .then(data => {
+                      if (data.progress < 100) {
+                        // keep polling, not done yet
+                        check_progress_loop()
+                      } else {
+                        // progress data has finished
+                        // let caller know the task has finished
+                        status_update_callback(id)
+                          .then(() => {
+                            // start tracking the next task
+                            get_key_and_check_progress(id, status_update_callback)
+                          })
+                      }
+                    })
+                }, POLLING_DELAY_MS)
+              }
+
+              // kick off polling the progress data
+              check_progress_loop()
+            })
+        }
+
+        // finally kick off the polling process
+        get_key_and_check_progress()
+        return stop_func
+      }
+
       const analyses_factory = {
         get_analyses_for_org: get_analyses_for_org,
         get_analyses_for_canonical_property: get_analyses_for_canonical_property,
@@ -141,6 +223,7 @@ angular.module('BE.seed.service.analyses', [])
         delete_analysis: delete_analysis,
         get_summary: get_summary,
         get_progress_key: get_progress_key,
+        check_progress_loop: check_progress_loop,
       };
 
       return analyses_factory;

--- a/seed/static/seed/js/services/analyses_service.js
+++ b/seed/static/seed/js/services/analyses_service.js
@@ -115,6 +115,19 @@ angular.module('BE.seed.service.analyses', [])
         });
       }
 
+      const get_progress_key = function (analysis_id) {
+        const organization_id = user_service.get_organization().id;
+        return $http({
+          url: '/api/v3/analyses/' + analysis_id + '/progress_key/',
+          method: 'GET',
+          params: { organization_id: organization_id }
+        }).then(function (response) {
+          return response.data;
+        }).catch(function (response) {
+          return response.data;
+        });
+      }
+
       const analyses_factory = {
         get_analyses_for_org: get_analyses_for_org,
         get_analyses_for_canonical_property: get_analyses_for_canonical_property,
@@ -127,6 +140,7 @@ angular.module('BE.seed.service.analyses', [])
         stop_analysis: stop_analysis,
         delete_analysis: delete_analysis,
         get_summary: get_summary,
+        get_progress_key: get_progress_key,
       };
 
       return analyses_factory;

--- a/seed/static/seed/partials/analyses.html
+++ b/seed/static/seed/partials/analyses.html
@@ -47,7 +47,12 @@
                                 <li ng-repeat="(key, value) in setting">{$:: key $} = {$:: value $}</li>
                             </ul>
                         </td>
-                        <td class="analysis-status {$:: analysis.status.toLowerCase() $}">{$:: analysis.status $}</td>
+                        <td class="analysis-status {$:: analysis.status.toLowerCase() $}">
+                            <i
+                                class="fa fa-refresh fa-pulse fa-fw" style="padding-right: 0"
+                                ng-if="analysis._tracking_progress"></i>
+                            {$:: analysis.status $}
+                        </td>
                         <td>{$:: analysis.start_time | date : 'MM-dd-yyyy HH:mm' $}</td>
                         <td>{$:: analysis | get_run_duration $}</td>
                         <td>{$:: users | filter : {'user_id':analysis.user} | getAnalysisRunAuthor $}</td>

--- a/seed/static/seed/partials/analyses.html
+++ b/seed/static/seed/partials/analyses.html
@@ -47,11 +47,11 @@
                                 <li ng-repeat="(key, value) in setting">{$:: key $} = {$:: value $}</li>
                             </ul>
                         </td>
-                        <td class="analysis-status {$:: analysis.status.toLowerCase() $}">
+                        <td class="analysis-status {$ analysis.status.toLowerCase() $}">
                             <i
                                 class="fa fa-refresh fa-pulse fa-fw" style="padding-right: 0"
-                                ng-if="analysis._tracking_progress"></i>
-                            {$:: analysis.status $}
+                                ng-if="!analysis._finished_with_tasks"></i>
+                            {$ analysis.status $}
                         </td>
                         <td>{$:: analysis.start_time | date : 'MM-dd-yyyy HH:mm' $}</td>
                         <td>{$:: analysis | get_run_duration $}</td>

--- a/seed/static/seed/partials/analysis.html
+++ b/seed/static/seed/partials/analysis.html
@@ -10,7 +10,9 @@
     </div>
     <div class="section_content_container">
         <div class="section_content">
-            <div ng-include="::urls.static_url + 'seed/partials/analysis_details.html'"></div>
+            <div ng-controller="analysis_details_controller">
+                <div ng-include="::urls.static_url + 'seed/partials/analysis_details.html'"></div>
+            </div>
             <div ng-include="::urls.static_url + 'seed/partials/analysis_runs.html'"></div>
         </div>
     </div>

--- a/seed/static/seed/partials/analysis_card.html
+++ b/seed/static/seed/partials/analysis_card.html
@@ -1,7 +1,12 @@
-<div class="row analysis-status {$:: analysis.status.toLowerCase() $}">
+<div class="row analysis-status {$ analysis.status.toLowerCase() $}">
     <h1 class="grow">{$:: analysis.name $} <small>Run #{$:: analysis.views[0] $}</small></h1>
         <!-- <span class="link" ui-sref="analysis(::{organization_id: org.id, analysis_id: analysis.id})">Analysis {$:: analysis.name $}</span> -->
-    <span>{$:: analysis.status $}</span>
+    <span>
+        <i
+            class="fa fa-refresh fa-pulse fa-fw" style="padding-right: 0"
+            ng-if="!analysis._finished_with_tasks"></i>
+        {$ analysis.status $}
+    </span>
     <span>
         <i class="glyphicon glyphicon-play link" title="Start Analysis" aria-hidden="true"
            ng-if="analysis.status === 'Ready'" ng-click="start_analysis(analysis.id)"></i>

--- a/seed/static/seed/partials/analysis_details.html
+++ b/seed/static/seed/partials/analysis_details.html
@@ -22,7 +22,12 @@
                     <li ng-repeat="(key, value) in setting">{$:: key $} = {$:: value $}</li>
                 </ul>
             </td>
-        <td class="analysis-status {$:: analysis.status.toLowerCase() $}">{$:: analysis.status $}</td>
+        <td class="analysis-status {$ analysis.status.toLowerCase() $}">
+            <i
+                class="fa fa-refresh fa-pulse fa-fw" style="padding-right: 0"
+                ng-if="!analysis._finished_with_tasks"></i>
+            {$ analysis.status $}
+        </td>
         <td>{$:: (messages | filter : {'analysis_property_view':null})[0]['user_message'] $}</td>
         <td>{$:: analysis.start_time | date : 'MM-dd-yyyy HH:mm' $}</td>
         <td>{$:: analysis | get_run_duration $}</td>

--- a/seed/static/seed/partials/analysis_run.html
+++ b/seed/static/seed/partials/analysis_run.html
@@ -25,12 +25,18 @@
     <div class="section">
         <div class="section_content_container">
                 <div class="section_content with_padding">
-                    <div ng-if="!angular.equals(view.parsed_results, {}) && view.output_files.length === 0">
+                    <div ng-if="analysis.service === 'BSyncr' && !angular.equals(view.parsed_results, {}) && view.output_files.length === 0">
                         <pre>{$:: view.parsed_results | json $}</pre>
                     </div>
                     <div ng-repeat="file in view.output_files | filter:filter_params:strict">
                         <div ng-if="file.content_type == 'html'">
                             <iframe class="analysis-results" scrolling="no" src="{$:: file.file $}" onload="this.style.height = this.contentWindow.document.documentElement.scrollHeight + 'px'"></iframe>
+                            <div ng-repeat-end ng-if="!$last">
+                                <br />
+                            </div>
+                        </div>
+                        <div ng-if="file.content_type == 'PNG'" style='width: 50%; min-width: 200px;'>
+                            <img src="{$:: file.file $}" style="width: 100%"></img>
                             <div ng-repeat-end ng-if="!$last">
                                 <br />
                             </div>

--- a/seed/static/seed/partials/analysis_run.html
+++ b/seed/static/seed/partials/analysis_run.html
@@ -10,7 +10,9 @@
     </div>
     <div class="section_content_container">
         <div class="section_content">
-            <div ng-include="::urls.static_url + 'seed/partials/analysis_details.html'"></div>
+            <div ng-controller="analysis_details_controller">
+                <div ng-include="::urls.static_url + 'seed/partials/analysis_details.html'"></div>
+            </div>
             <div ng-include="::urls.static_url + 'seed/partials/analysis_runs.html'"></div>
         </div>
     </div>

--- a/seed/static/seed/partials/analysis_run.html
+++ b/seed/static/seed/partials/analysis_run.html
@@ -25,7 +25,7 @@
     <div class="section">
         <div class="section_content_container">
                 <div class="section_content with_padding">
-                    <div ng-if="analysis.service === 'BSyncr' && !angular.equals(view.parsed_results, {}) && view.output_files.length === 0">
+                    <div ng-if="analysis.service !== 'BETTER' && !angular.equals(view.parsed_results, {}) && view.output_files.length === 0">
                         <pre>{$:: view.parsed_results | json $}</pre>
                     </div>
                     <div ng-repeat="file in view.output_files | filter:filter_params:strict">

--- a/seed/static/seed/partials/analysis_runs.html
+++ b/seed/static/seed/partials/analysis_runs.html
@@ -16,7 +16,7 @@
                 <td>
                     <span ng-repeat="file in view.output_files | filter:filter_params:strict">
                         <a ng-if="file['analysis_property_views'].length > 1" href="{$:: file.file $}" download>Portfolio Report <span class="fa fa-download"></span></a>
-                        <a ng-if="file['analysis_property_views'].length == 1" href="{$:: file.file $}" download>Building Report <span class="fa fa-download"></span></a>
+                        <a ng-if="file['analysis_property_views'].length == 1" href="{$:: file.file $}" download>{$:: file.content_type == 'html' ? 'Building Report' : file.content_type $}<span class="fa fa-download"></span></a>
                         <span ng-repeat-end ng-if="!$last">, </span>
                     </span>
                 </td>

--- a/seed/static/seed/partials/inventory_detail.html
+++ b/seed/static/seed/partials/inventory_detail.html
@@ -111,7 +111,9 @@
                     </span>
                 </div>
             </div>
-            <div ng-if="analysis" ng-include="::urls.static_url + 'seed/partials/analysis_card.html'" class="tab-content-card"></div>
+            <!-- NOTE: This is bad, using a controller created for someone else but it will work
+                     we should refactor this into a AnalysisCard component. -->
+            <div ng-if="analysis" ng-controller="analysis_details_controller" ng-include="::urls.static_url + 'seed/partials/analysis_card.html'" class="tab-content-card"></div>
         </div>
 
 

--- a/seed/static/seed/partials/inventory_detail_analyses.html
+++ b/seed/static/seed/partials/inventory_detail_analyses.html
@@ -40,7 +40,9 @@
                 <b>{$:: type $}</b> <small>({$:: analyses.length $})</small>
             </uib-tab-heading>
             <div class="tab-content-cards">
-                <div ng-repeat="analysis in analyses" ng-include="::urls.static_url + 'seed/partials/analysis_card.html'" class="tab-content-card">
+                <!-- NOTE: This is bad, using a controller created for someone else but it will work
+                     we should refactor this into a AnalysisCard component. -->
+                <div ng-repeat="analysis in analyses" ng-controller="analysis_details_controller" ng-include="::urls.static_url + 'seed/partials/analysis_card.html'" class="tab-content-card">
                 </div>
             </div>
         </uib-tab>

--- a/seed/templates/seed/_scripts.html
+++ b/seed/templates/seed/_scripts.html
@@ -33,6 +33,7 @@
         <script src="{{STATIC_URL}}seed/js/controllers/admin_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/analyses_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/analysis_controller.js"></script>
+        <script src="{{STATIC_URL}}seed/js/controllers/analysis_details_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/analysis_run_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/api_controller.js"></script>
         <script src="{{STATIC_URL}}seed/js/controllers/column_mapping_profile_modal_controller.js"></script>


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
TLDR: for any page showing an analysis in a list or detailed view, SEED will now begin polling its status for updates so that it knows when to refresh it. This involved updating how progress data are created/tracked in the analysis pipelines.

SPECIFICALLY:
- add a method the the analyses_service which will continuously poll the status of an analysis until it determines theres no more progress data to track (`analyses_service.check_progress_loop(...)`)
- use method above in all views that render analyses so that they're refreshed when the status of the analysis changes
- part of accomplishing the above was adding a new endpoint `/analyses/<analysis id>/progress_key/` which returns the current `ProgressData` key (or null if there's no current `ProgressData` for the analysis).
  - This involved standardizing the progress data for all analysis pipelines. Progress data is now dependent on `Analysis.status`, and pipeline authors just need to use `pipeline.get_progress_data()` to get the current progress data.
  - As a result, pipeline authors must call the `AnalysisPipeline` base class methods for updating the status of the analysis instead of doing it directly (e.g. don't do `analysis.status = Analysis.COMPLETED; analysis.save()`). These methods are:
    - `set_analysis_status_to_ready`
    - `set_analysis_status_to_running`
    - `set_analysis_status_to_completed`
    - the existing `prepare_analysis`, `start_analysis`, `stop_analysis`, and `fail_analysis` methods already handle this for the remaining statuses.
   - the goal of these changes is to standardize the analysis pipeline web interface and hopefully simplify how pipelines are written - now pipeline authors just need to call these methods and not worry about finishing progress data, keeping track of progress data keys, updating the start/end time of the analysis, etc.

#### How should this be manually tested?
I'd recommend importing the anonymized JCC spreadsheet and meter data to start with. Then run try running different analyses and verify that the statuses are being updated correctly. It should NOT continue polling when the page is changed. It should NOT continue polling when the analysis finishes (fails, stopped, or completed).

Here are the pages affected (ie they should show live reloading as the analysis is being created/running/finishing):
- Analyses list page: `/app/#/accounts/<org id>/analyses`
- Analysis page: `/app/#/accounts/<org id>/analyses/<analysis id>`
- Analysis property view page: `/app/#/accounts/<org id>/analyses/<analysis id>/runs/<analysis property view id>` -- this one should actually refresh the whole page to show the results when the analysis is complete
- List of analyses for individual property: `/app/#/properties/<property_id>/analyses` -- this one should also refresh the whole page to view the results of the completed analysis
- Property details page with an analysis card: `/app/#/properties/<property_id>` (NOTE: might not see it here b/c the card is the most recently _completed_ analysis)

#### What are the relevant tickets?
#2816 

#### Screenshots (if appropriate)
![Screen Shot 2021-09-03 at 1 56 02 PM](https://user-images.githubusercontent.com/18518728/132059620-5da79510-ab14-4b07-a5e2-8437e65e0694.png)
![Screen Shot 2021-09-03 at 1 56 16 PM](https://user-images.githubusercontent.com/18518728/132059627-50499038-fe89-4308-8f82-62c1bf545a9a.png)
![Screen Shot 2021-09-03 at 1 56 54 PM](https://user-images.githubusercontent.com/18518728/132059631-c7e956b5-bc4c-41c7-ad16-27124b8c4d96.png)
![Screen Shot 2021-09-03 at 1 56 34 PM](https://user-images.githubusercontent.com/18518728/132059642-4c927495-f405-4d49-b5cf-091601ab1cfe.png)
