### PR TITLE
refactor(better): use IP units in standalone HTML report

### DIFF
--- a/seed/analysis_pipelines/better/client.py
+++ b/seed/analysis_pipelines/better/client.py
@@ -185,9 +185,10 @@ class BETTERClient:
             'accept': 'text/html',
             'Authorization': self._token,
         }
+        params = {'unit': 'IP'}
 
         try:
-            response = requests.request("GET", url, headers=headers)
+            response = requests.request("GET", url, headers=headers, params=params)
             if response.status_code != 200:
                 return None, [f'Expected 200 response from BETTER but got {response.status_code}: {response.content}']
 
@@ -266,13 +267,14 @@ class BETTERClient:
         :returns: tuple(tempfile.TemporaryDirectory, list[str]), temporary directory containing result files and list of error messages
         """
         url = f"{self.API_URL}/standalone_html/building_analytics/{analysis_id}/"
-
         headers = {
             'accept': '*/*',
             'Authorization': self._token,
         }
+        params = {'unit': 'IP'}
+
         try:
-            response = requests.request("GET", url, headers=headers)
+            response = requests.request("GET", url, headers=headers, params=params)
             standalone_html = response.text.encode('utf8').decode()
 
         except ConnectionError:


### PR DESCRIPTION
#### Any background context you want to provide?
BETTER HTML reports have unitted values. Previously those defaulted to SI, but an update to BETTER allows the API user to specify what they want

#### What's this PR do?
- request IP units from BETTER for standalone html reports

NOTE: future work would be to look at the seed org settings and request the units according to their settings.

#### How should this be manually tested?
Run a better analysis, the report should use IP units.

#### What are the relevant tickets?
#2835 

#### Screenshots (if appropriate)
