### PR TITLE
refactor: dont run CI on arbitrary pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+      - 'develop'
+      - 'main'
 
 jobs:
   # Currently GH Actions provides no simple method for "sharing"


### PR DESCRIPTION
Only run CI workflow when:
- someone pushes to main or develop (ie merge into main or develop)
- any pull request

#### Any background context you want to provide?

#### What's this PR do?

#### How should this be manually tested?

#### What are the relevant tickets?
#2858 

#### Screenshots (if appropriate)
