### PR TITLE
add explicit media path for dev users

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -17,6 +17,9 @@ CSRF_COOKIE_SECURE = False
 COMPRESS_ENABLED = compress
 COMPRESS_OFFLINE = compress
 
+# When running in dev mode and without nginx, specify the location of the media files.
+MEDIA_URL = '/media/'
+
 # override this in local_untracked.py
 DATABASES = {
     'default': {


### PR DESCRIPTION
#### Any background context you want to provide?
Media is often served by NGINX, however in dev mode the path was not found.

#### What's this PR do?
Add in the media path to `dev.py`. Path points to the users local `media` folder.

#### How should this be manually tested?
Run a BETTER analysis locally (not in docker) with the dev settings

#### What are the relevant tickets?
 N/A

#### Screenshots (if appropriate)
