### PR TITLE
Fix/analysis views

### DIFF
--- a/seed/analysis_pipelines/better/pipeline.py
+++ b/seed/analysis_pipelines/better/pipeline.py
@@ -44,7 +44,6 @@ from seed.models import (
     AnalysisPropertyView,
     Column,
     Meter,
-    PropertyView
 )
 
 

--- a/seed/analysis_pipelines/better/pipeline.py
+++ b/seed/analysis_pipelines/better/pipeline.py
@@ -7,7 +7,7 @@
 import logging
 import copy
 
-from django.db.models import Q, Count
+from django.db.models import Count
 from django.core.files.base import ContentFile
 from celery import chain, shared_task
 
@@ -359,21 +359,10 @@ def _process_results(self, analysis_id):
 
     # Update the original PropertyView's PropertyState with analysis results of interest
     analysis_property_views = analysis.analysispropertyview_set.prefetch_related('property', 'cycle').all()
-    property_view_query = Q()
-    for analysis_property_view in analysis_property_views:
-        property_view_query |= (
-            Q(property=analysis_property_view.property)
-            & Q(cycle=analysis_property_view.cycle)
-        )
-    # get original property views keyed by canonical property id and cycle
-    property_views_by_property_cycle_id = {
-        (pv.property.id, pv.cycle.id): pv
-        for pv in PropertyView.objects.filter(property_view_query).prefetch_related('state')
-    }
+    property_view_by_apv_id = AnalysisPropertyView.get_property_views(analysis_property_views)
 
     for analysis_property_view in analysis_property_views:
-        property_cycle_id = (analysis_property_view.property.id, analysis_property_view.cycle.id)
-        property_view = property_views_by_property_cycle_id[property_cycle_id]
+        property_view = property_view_by_apv_id[analysis_property_view.id]
         data = copy.deepcopy(analysis_property_view.parsed_results)
         data.update({'better_seed_analysis_id': analysis_id})
         _update_original_property_state(

--- a/seed/analysis_pipelines/eui.py
+++ b/seed/analysis_pipelines/eui.py
@@ -6,7 +6,7 @@
 """
 import logging
 from celery import chain, shared_task
-from django.db.models import Q, Count
+from django.db.models import Count
 
 from seed.analysis_pipelines.pipeline import (
     AnalysisPipeline,

--- a/seed/static/seed/js/controllers/analysis_controller.js
+++ b/seed/static/seed/js/controllers/analysis_controller.js
@@ -33,6 +33,7 @@ angular.module('BE.seed.controller.analysis', [])
       $scope.users = users_payload.users;
       $scope.views = views_payload.views;
       $scope.view_id = $stateParams.view_id;
+      $scope.original_views = views_payload.original_views;
 
 
       $scope.has_children = function (value) {

--- a/seed/static/seed/partials/analysis_runs.html
+++ b/seed/static/seed/partials/analysis_runs.html
@@ -11,10 +11,13 @@
         <tbody>
             <tr ng-repeat="view in views | filter:filter_params:strict">
                 <td><a ui-sref="analysis_run(::{run_id: view.id, analysis_id: analysis.id, organization_id: org.id})" ui-sref-active="active">{$:: view.id $}</a></td>
-                <td ui-sref="inventory_detail({inventory_type: 'properties', view_id: original_views[view.id]})">
-                    <a href="">
+                <td>
+                    <a ng-if="original_views[view.id]" ui-sref="inventory_detail({inventory_type: 'properties', view_id: original_views[view.id]})">
                         {$:: view.property_state.address_line_1 $} <i class="glyphicon glyphicon-log-out"></i>
                     </a>
+                    <span ng-if="!original_views[view.id]" uib-tooltip="Property no longer exists">
+                        {$:: view.property_state.address_line_1 $}
+                    </span>
                 </td>
                 <td>{$:: (messages | filter : {'analysis_property_view':view.id})[0]['user_message'] $}</td>
                 <td>

--- a/seed/views/v3/analysis_views.py
+++ b/seed/views/v3/analysis_views.py
@@ -5,14 +5,13 @@
 :author
 """
 from drf_yasg.utils import swagger_auto_schema
-from django.db.models import Q
 from django.http import JsonResponse
 from rest_framework import viewsets
 from rest_framework.status import HTTP_409_CONFLICT
 
 from seed.decorators import ajax_request_class, require_organization_id_class
 from seed.lib.superperms.orgs.decorators import has_perm_class
-from seed.models import AnalysisPropertyView, PropertyView
+from seed.models import AnalysisPropertyView
 from seed.serializers.analysis_property_views import AnalysisPropertyViewSerializer
 from seed.utils.api import api_endpoint_class, OrgMixin
 from seed.utils.api_schema import AutoSchemaHelper

--- a/seed/views/v3/analysis_views.py
+++ b/seed/views/v3/analysis_views.py
@@ -36,22 +36,20 @@ class AnalysisPropertyViewViewSet(viewsets.ViewSet, OrgMixin):
                 'status': 'error',
                 'message': "Requested analysis doesn't exist in this organization."
             }, status=HTTP_409_CONFLICT)
+
         serialized_views = []
-        original_views = {}
+        property_views_by_apv_id = AnalysisPropertyView.get_property_views(views_queryset)
         for view in views_queryset:
             serialized_view = AnalysisPropertyViewSerializer(view).data
             serialized_views.append(serialized_view)
-            property_view_query = Q(property=view.property) & Q(cycle=view.cycle)
-            property_views_by_property_cycle_id = {
-                (pv.property.id, pv.cycle.id): pv
-                for pv in PropertyView.objects.filter(property_view_query).prefetch_related('state')
-            }
-            original_views[view.id] = property_views_by_property_cycle_id[(view.property.id, view.cycle.id)].id
 
         return JsonResponse({
             'status': 'success',
             'views': serialized_views,
-            'original_views': original_views
+            'original_views': {
+                apv_id: property_view.id if property_view is not None else None
+                for apv_id, property_view in property_views_by_apv_id.items()
+            }
         })
 
     @swagger_auto_schema(manual_parameters=[AutoSchemaHelper.query_org_id_field(True)])
@@ -68,15 +66,12 @@ class AnalysisPropertyViewViewSet(viewsets.ViewSet, OrgMixin):
                 'status': 'error',
                 'message': "Requested analysis property view doesn't exist in this organization and/or analysis."
             }, status=HTTP_409_CONFLICT)
-        property_view_query = Q(property=view.property) & Q(cycle=view.cycle)
-        property_views_by_property_cycle_id = {
-            (pv.property.id, pv.cycle.id): pv
-            for pv in PropertyView.objects.filter(property_view_query).prefetch_related('state')
-        }
-        original_view = property_views_by_property_cycle_id[(view.property.id, view.cycle.id)].id
+
+        property_view_by_apv_id = AnalysisPropertyView.get_property_views([view])
+        original_view = property_view_by_apv_id[view.id]
 
         return JsonResponse({
             'status': 'success',
             'view': AnalysisPropertyViewSerializer(view).data,
-            'original_view': original_view
+            'original_view': original_view.id if original_view is not None else None
         })


### PR DESCRIPTION
#### Any background context you want to provide?
A few tests broke recently

#### What's this PR do?
- fixes broken test / analyses page by handling case where a property is deleted after running an analysis
- deduplicate fetching PropertyView for analyses by creating a method on AnalysisPropertyView (`get_property_views`).
- fixes issue where links to property views are broken on the /analyses/<id> page by adding the `original_views` data to scope.
- removes link to property detail page if the property view no longer exists (user deleted it after running analysis)

#### How should this be manually tested?
- tests should pass
- should be able to click an address of a property on the /analyses/<id> page and it should go to the property detail page without errors.
- run an analysis, then delete the property from the inventory list. You should not be able to "click" the address to view the detail page.

#### What are the relevant tickets?
#2867 

#### Screenshots
Example property where it was deleted after running analysis
![Screen Shot 2021-09-13 at 4 45 11 PM](https://user-images.githubusercontent.com/18518728/133166093-2f9f8acc-1d40-4b35-a5c8-dec0ae711edd.png)
