### PR TITLE
fix: get analysis highlights from analysis results

### DIFF
--- a/seed/analysis_pipelines/utils.py
+++ b/seed/analysis_pipelines/utils.py
@@ -1,0 +1,18 @@
+def get_json_path(json_path, data):
+    """very naive JSON path implementation. WARNING: it only handles key names that are dot separated
+    e.g. 'key1.key2.key3'
+
+    :param json_path: str
+    :param data: dict
+    :return: value, None if path not valid for dict
+    """
+    json_path = json_path.split('.')
+    result = data
+    for key in json_path:
+        result = result.get(key, {})
+
+    if type(result) is dict and not result:
+        # path was probably not valid in the data...
+        return None
+    else:
+        return result

--- a/seed/models/analyses.py
+++ b/seed/models/analyses.py
@@ -88,7 +88,10 @@ class Analysis(models.Model):
 
         results = {}
         if property_id is not None:
-            results = self.analysispropertyview_set.filter(property=property_id).first().parsed_results
+            try:
+                results = self.analysispropertyview_set.get(property=property_id).parsed_results
+            except models.Model.DoesNotExist:
+                return []
         else:
             results = self.parsed_results
 

--- a/seed/models/analyses.py
+++ b/seed/models/analyses.py
@@ -6,10 +6,10 @@
 """
 from django.contrib.postgres.fields import JSONField
 from django.db import models
-from django.db.models import Q
 
 from seed.landing.models import SEEDUser as User
 from seed.lib.superperms.orgs.models import Organization
+from seed.analysis_pipelines.utils import get_json_path
 
 import logging
 logger = logging.getLogger(__name__)
@@ -75,46 +75,63 @@ class Analysis(models.Model):
         }
 
     def get_highlights(self, property_id=None):
-        from seed.models import PropertyView  # avoiding cyclic dependancy
+        """Get analysis highlights for the overall analysis or for a specific property
+
+        :param property_id: int | None, if provided property-specific highlights
+            from the analysis results are returned. Otherwise highlights from the
+            overall analysis are returned.
+        :return: list[dict{}], a list of highlights as dictionaries, each including
+            a `name` and `value`
+        """
         if self.status < self.COMPLETED:
             return []
-        if property_id is not None:
-            analysis_property_view = self.analysispropertyview_set.filter(property=property_id).first()
-        else:
-            analysis_property_view = self.analysispropertyview_set.first()
-        property_view_query = Q(property=analysis_property_view.property) & Q(cycle=analysis_property_view.cycle)
-        property_views_by_property_cycle_id = {
-            (pv.property.id, pv.cycle.id): pv
-            for pv in PropertyView.objects.filter(property_view_query).prefetch_related('state')
-        }
-        property_cycle_id = (analysis_property_view.property.id, analysis_property_view.cycle.id)
-        extra_data = property_views_by_property_cycle_id[property_cycle_id].state.extra_data
 
-        # Bsynchr
+        results = {}
+        if property_id is not None:
+            results = self.analysispropertyview_set.filter(property=property_id).first().parsed_results
+        else:
+            results = self.parsed_results
+
+        # BSyncr
         if self.service == self.BSYNCR:
             return [{'name': 'Unimplemented', 'value': 'Oops!'}]
 
         # BETTER
         elif self.service == self.BETTER:
-            ret = []
-            if extra_data.get('better_cost_savings_combined') is not None:
-                ret.append({
+            highlights = [
+                {
                     'name': 'Potential Cost Savings (USD)',
-                    'value': f'${extra_data["better_cost_savings_combined"]:,.2f}'
-                })
-            if extra_data.get('better_energy_savings_combined') is not None:
+                    'value_template': '${json_value:,.2f}',
+                    'json_path': 'assessment.assessment_energy_use.cost_savings_combined',
+                },
+                {
+                    'name': 'Potential Energy Savings',
+                    'value_template': '{json_value:,.2f} kWh',
+                    'json_path': 'assessment.assessment_energy_use.energy_savings_combined',
+                }
+            ]
+
+            ret = []
+            for highlight in highlights:
+                parsed_result = get_json_path(highlight['json_path'], results)
+                value = 'N/A'
+                if parsed_result is not None:
+                    value = highlight['value_template'].format(json_value=parsed_result)
                 ret.append({
-                    'name': 'Potential Energy Savings (kWh)',
-                    'value': f'{extra_data["better_energy_savings_combined"]:,.2f}'
+                    'name': highlight['name'],
+                    'value': value
                 })
+
             return ret
 
         # EUI
         elif self.service == self.EUI:
-            if extra_data.get('analysis_eui') is not None:
-                return [{'name': 'EUI', 'value': f'{extra_data["analysis_eui"]:,.2f}'}]
-            else:
-                return []
+            eui_result = results.get('EUI')
+            value = 'N/A'
+            if eui_result is not None:
+                value = f'{eui_result:,.2f}'
+
+            return [{'name': 'EUI', 'value': value}]
 
         # Unexpected
         return [{'name': 'Unexpected Analysis Type', 'value': 'Oops!'}]


### PR DESCRIPTION
#### Any background context you want to provide?
SEED has analysis cards with highlights on some pages. The highlights of the cards were always the same and showed the most recent results.

#### What's this PR do?
- fixes issue of different analyses showing the same highlights.
  - this was fixed by pulling analysis results from the AnalysisPropertyView's parsed results instead of the PropertyView's PropertyState. PropertyState will always be updated with the most recent results, so pulling info from there will always get you the most recent data.
- added some formatting to the cards to show `N/A` for some highlights

#### How should this be manually tested?
Run an analysis twice for a property that should get different results (e.g. run one then edit gross floor area then run again). Verify the cards show different values.

#### What are the relevant tickets?
#2873 

#### Screenshots (if appropriate)
![Screen Shot 2021-09-14 at 5 25 11 PM](https://user-images.githubusercontent.com/18518728/133347542-33c06a6f-d609-493f-9a5c-bdd1bcbf65a1.png)
![Screen Shot 2021-09-14 at 5 25 45 PM](https://user-images.githubusercontent.com/18518728/133347547-d7f8150d-7582-4115-8a37-69daebb92e94.png)
