### PR TITLE
fix: initialize label column width

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -683,7 +683,7 @@ angular.module('BE.seed.controller.inventory_list', [])
         exporterSuppressExport: true,
         pinnedLeft: true,
         visible: true,
-        width: '*',
+        width: $scope.get_label_column_width(),
         maxWidth: $scope.max_label_width
       });
 


### PR DESCRIPTION
#### Any background context you want to provide?
SEED displays selected labels in the inventory list as a collapsable column

#### What's this PR do?
- fixes issue where initially loading the inventory list page with few columns (ie col profile with few columns) resulted in a really wide label column (see linked issue)

#### How should this be manually tested?
- add some labels to properties, make sure the labels are "show in list"
- update your col profile to only include a few columns
- load the inventory list page

#### What are the relevant tickets?
#2748 
