### PR TITLE
Refactor/better aggregate meters

### DIFF
--- a/seed/analysis_pipelines/better/client.py
+++ b/seed/analysis_pipelines/better/client.py
@@ -19,6 +19,24 @@ class BETTERClient:
     def __init__(self, token):
         self._token = f'Token {token}'
 
+    def test_token(self):
+        """Returns true if token is valid
+
+        :return: bool
+        """
+        # TODO: get BETTER to create a "token" endpoint for testing
+        url = f'{self.API_URL}/weathers/'
+        headers = {
+            'accept': 'application/json',
+            'Authorization': self._token,
+        }
+
+        try:
+            response = requests.request("GET", url, headers=headers)
+            return response.status_code != 401
+        except Exception:
+            return False
+
     def get_buildings(self):
         """Get list of all buildings
 

--- a/seed/analysis_pipelines/utils.py
+++ b/seed/analysis_pipelines/utils.py
@@ -145,6 +145,11 @@ def reject_outliers(meter_readings, reject=1):
     raw_values = [reading.reading for reading in meter_readings]
     avg = mean(raw_values)
     stdev = pstdev(raw_values)
+
+    # weird case, but avoids divide by zero
+    if stdev == 0:
+        return meter_readings
+
     filtered_readings = []
     for reading in meter_readings:
         zscore = (reading.reading - avg) / stdev
@@ -164,6 +169,9 @@ def interpolate_monthly_readings(meter_readings):
     :param meter_readings: List[SimpleMeterReading]
     :return: List[SimpleMeterReading]
     """
+    if len(meter_readings) == 0:
+        return []
+
     interpolated_readings = []
     current_reading_index = 0
     current_time = meter_readings[current_reading_index].start_time

--- a/seed/analysis_pipelines/utils.py
+++ b/seed/analysis_pipelines/utils.py
@@ -1,3 +1,10 @@
+from collections import defaultdict, namedtuple
+import datetime
+from statistics import mean, pstdev
+
+from dateutil import relativedelta
+
+
 def get_json_path(json_path, data):
     """very naive JSON path implementation. WARNING: it only handles key names that are dot separated
     e.g. 'key1.key2.key3'
@@ -16,3 +23,167 @@ def get_json_path(json_path, data):
         return None
     else:
         return result
+
+
+# simplified representation of a reading
+SimpleMeterReading = namedtuple('SimpleMeterReading', ['start_time', 'end_time', 'reading'])
+
+
+def _split_reading(meter_reading):
+    """Splits the meter reading into multiple readings, each representing a different
+    calendar month (i.e. starting and ending at beginning of consecutive months).
+    Another way to think of this method is that it "bins" an individual reading into
+    calendar months.
+
+    Because we have to estimate the reading value (ie energy usage) when a reading
+    doesn't cleanly fit in a calendar month (e.g. when it straddles or spans months),
+    the result will not always be perfectly accurate to how much energy was really
+    used in a calendar month.
+
+    Examples - the pipe character, |, represents the start of a month, the brackets, [ ],
+    represent the start and end of the meter readings.
+
+    (1) Reading fits in a single month
+    reading:      [###]      
+    months:  |    |    |    |
+    result:       [###]      
+
+    (2) Reading straddles months
+    reading:   [#####]       
+    months:  |    |    |    |
+    result:  [###][###]      
+
+    (3) Reading straddles and spans months
+    reading:   [##########]  
+    months:  |    |    |    |
+    result:  [###][###][###] 
+
+    :param meter_reading: MeterReading | SimpleMeterReading
+    :return: List[SimpleMeterReading], in sorted order by start_date
+    """
+    reading_unaware_start_time = datetime.datetime(
+        meter_reading.start_time.year,
+        meter_reading.start_time.month,
+        meter_reading.start_time.day,
+        meter_reading.start_time.hour,
+        meter_reading.start_time.minute,
+        meter_reading.start_time.second,
+    )
+    reading_unaware_end_time = datetime.datetime(
+        meter_reading.end_time.year,
+        meter_reading.end_time.month,
+        meter_reading.end_time.day,
+        meter_reading.end_time.hour,
+        meter_reading.end_time.minute,
+        meter_reading.end_time.second,
+    )
+
+    reading_first_month = datetime.datetime(meter_reading.start_time.year, meter_reading.start_time.month, 1)
+    reading_last_month = datetime.datetime(meter_reading.end_time.year, meter_reading.end_time.month, 1)
+    last_month_affected = reading_last_month + relativedelta.relativedelta(months=1)
+
+    # collect all consecutive months this reading "touches"
+    current_time = reading_first_month
+    months_affected = []
+    while current_time <= last_month_affected:
+        months_affected.append(current_time)
+        current_time += relativedelta.relativedelta(months=1)
+
+    # For each month this reading affects create a new "reading" for that month
+    split_readings = []
+    meter_reading_delta = reading_unaware_end_time - reading_unaware_start_time
+    for month_start, month_end in zip(months_affected, months_affected[1:]):
+        # estimate the reading value for this month by calculating
+        # the fraction of the original reading this month covers and multiplying
+        # the "total" (ie original) reading by that fraction
+        overlap_start = max(month_start, reading_unaware_start_time)
+        overlap_end = min(month_end, reading_unaware_end_time)
+        # overlap_delta is essentially the union of time covered by this month and
+        # the time covered by the original reading
+        overlap_delta = overlap_end - overlap_start
+        fraction_of_reading_time = overlap_delta.total_seconds() / meter_reading_delta.total_seconds()
+        month_reading = fraction_of_reading_time * meter_reading.reading
+        split_readings.append(SimpleMeterReading(month_start, month_end, month_reading))
+
+    return split_readings
+
+
+def aggregate_meter_readings(meter_readings):
+    """Aggregate readings into calendar months
+
+    :param: meter_readings, QuerySet[MeterReading]
+    :return: List[SimpleMeterReading]
+    """
+    all_meter_readings = meter_readings.order_by('start_time')
+    aggregated_readings_by_start_time = defaultdict(lambda: 0)
+    for meter_reading in all_meter_readings:
+        for monthly_reading in _split_reading(meter_reading):
+            aggregated_readings_by_start_time[monthly_reading.start_time] += monthly_reading.reading
+
+    aggregated_readings_list = []
+    for start_time, reading in aggregated_readings_by_start_time.items():
+        aggregated_readings_list.append(
+            SimpleMeterReading(
+                start_time,
+                start_time + relativedelta.relativedelta(months=1),
+                reading
+            )
+        )
+
+    return aggregated_readings_list
+
+
+def reject_outliers(meter_readings, reject=1):
+    """Rejects readings whose z-score is greater than the `reject` arg (i.e. standard
+    deviations away from the mean).
+    Useful if you aggregated meter readings and there are some 'artifacts' of
+    partially covered periods.
+
+    :param meter_readings: List[SimpleMeterReading]
+    :param reject: int, z-score threshold
+    """
+    raw_values = [reading.reading for reading in meter_readings]
+    avg = mean(raw_values)
+    stdev = pstdev(raw_values)
+    filtered_readings = []
+    for reading in meter_readings:
+        zscore = (reading.reading - avg) / stdev
+        if abs(zscore) <= reject:
+            filtered_readings.append(reading)
+    return filtered_readings
+
+
+def interpolate_monthly_readings(meter_readings):
+    """Interpolate missing months from first to the last reading
+
+    WARNING: This function makes some assumptions:
+    - Assumes the meter readings are in sorted order (ascending start_time)
+    - Assumes each reading represents a month of data from the first of a month
+    to the first of the following month
+
+    :param meter_readings: List[SimpleMeterReading]
+    :return: List[SimpleMeterReading]
+    """
+    interpolated_readings = []
+    current_reading_index = 0
+    current_time = meter_readings[current_reading_index].start_time
+    while current_reading_index < len(meter_readings):
+        current_reading = meter_readings[current_reading_index]
+        assert current_reading.start_time.day == 1, f'Meter readings should start on the first day of the month; found one starting on {current_reading.start_time.day}'
+
+        if current_time == current_reading.start_time:
+            interpolated_readings.append(current_reading)
+            current_reading_index += 1
+        else:
+            # interpolate reading
+            prev_reading = interpolated_readings[-1]
+            interpolated_readings.append(
+                SimpleMeterReading(
+                    current_time,
+                    current_time + relativedelta.relativedelta(months=1),
+                    prev_reading.reading
+                )
+            )
+        current_time += relativedelta.relativedelta(months=1)
+
+    return interpolated_readings

--- a/seed/analysis_pipelines/utils.py
+++ b/seed/analysis_pipelines/utils.py
@@ -44,19 +44,19 @@ def _split_reading(meter_reading):
     represent the start and end of the meter readings.
 
     (1) Reading fits in a single month
-    reading:      [###]      
+    reading:      [###]
     months:  |    |    |    |
-    result:       [###]      
+    result:       [###]
 
     (2) Reading straddles months
-    reading:   [#####]       
+    reading:   [#####]
     months:  |    |    |    |
-    result:  [###][###]      
+    result:  [###][###]
 
     (3) Reading straddles and spans months
-    reading:   [##########]  
+    reading:   [##########]
     months:  |    |    |    |
-    result:  [###][###][###] 
+    result:  [###][###][###]
 
     :param meter_reading: MeterReading | SimpleMeterReading
     :return: List[SimpleMeterReading], in sorted order by start_date

--- a/seed/static/seed/js/controllers/inventory_detail_analyses_modal_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_analyses_modal_controller.js
@@ -71,6 +71,7 @@ angular.module('BE.seed.controller.inventory_detail_analyses_modal', [])
               benchmark_data: null,
               min_model_r_squared: null,
               portfolio_analysis: false,
+              preprocess_meters: false,
             }
             break;
         }

--- a/seed/static/seed/partials/inventory_detail_analyses_modal.html
+++ b/seed/static/seed/partials/inventory_detail_analyses_modal.html
@@ -64,7 +64,14 @@
                                 </label>
                                 <input ng-model="new_analysis.configuration.min_model_r_squared" type="number" class="form-control" ng-init="new_analysis.configuration.min_model_r_squared=0.6" ng-value="0.6" step=".01" min="0" max="1">
                             </div>
-                            <div class="col-md-6" style="padding-top: 1em; padding-bottom: 1em">
+                            <div class="col-md-3" style="padding-top: 1em; padding-bottom: 1em">
+                                <label class="control-label sectionLabel text-muted">
+                                    Preprocess Meters
+                                    <i class="ui-grid-icon-info-circled" uib-tooltip-html="'If the BETTER analysis continues to fail for your property, it might be worth enabling this option. When selected, SEED will attempt to aggregate and interpolate your meter data into monthly readings for the analysis. Note that this might result in different reported energy usage than when this option is not enabled.'"></i>
+                                </label>
+                                <input ng-model="new_analysis.configuration.preprocess_meters" type="checkbox" style="width: 34px; height: 34px; display: block; margin: 0;">
+                            </div>
+                            <div class="col-md-3" style="padding-top: 1em; padding-bottom: 1em">
                                 <label class="control-label sectionLabel text-muted">
                                     Run Portfolio Analysis
                                     <i class="ui-grid-icon-info-circled" uib-tooltip-html="'Only available if more than one properties were selected for analysis from the inventory list page'"></i>

--- a/seed/tests/test_analysis_pipelines.py
+++ b/seed/tests/test_analysis_pipelines.py
@@ -918,8 +918,20 @@ class TestBETTERPipeline(TestCase):
             )
 
     def test_build_better_input_returns_valid_bsync_document(self):
+        # Setup
+        meters = [
+            {
+                'meter_type': self.meter_nat.type,
+                'readings': self.meter_nat.meter_readings.all()
+            },
+            {
+                'meter_type': self.meter_elec.type,
+                'readings': self.meter_elec.meter_readings.all()
+            },
+        ]
+
         # Act
-        doc, errors = _build_better_input(self.analysis_property_view, [self.meter_nat, self.meter_elec])
+        doc, errors = _build_better_input(self.analysis_property_view, meters)
         tree = etree.parse(BytesIO(doc))
 
         # Assert

--- a/seed/tests/test_analysis_utils.py
+++ b/seed/tests/test_analysis_utils.py
@@ -42,7 +42,6 @@ class TestAnalysisUtils(TestCase):
     def test_split_reading_works_when_reading_straddles_two_months(self):
         # -- Setup
         # this reading starts in January and ends in February
-        # this reading starts in January, covers February, and ends in March
         # More specifically, this reading includes:
         # January:  17 days (~55%)
         # February: 15 days (~45%)

--- a/seed/tests/test_analysis_utils.py
+++ b/seed/tests/test_analysis_utils.py
@@ -1,0 +1,223 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+:copyright (c) 2014 - 2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+from datetime import datetime as dt
+
+from django.test import TestCase
+
+from seed.analysis_pipelines.utils import (
+    SimpleMeterReading,
+    _split_reading,
+    interpolate_monthly_readings,
+)
+
+
+class TestAnalysisUtils(TestCase):
+    def test_split_reading_works_when_reading_is_within_one_month(self):
+        # -- Setup
+        # this reading starts and ends in January
+        reading = SimpleMeterReading(
+            dt(2021, 1, 1),
+            dt(2021, 1, 15),
+            100
+        )
+
+        # -- Act
+        readings = _split_reading(reading)
+
+        # -- Assert
+        expected = [
+            SimpleMeterReading(
+                dt(2021, 1, 1),
+                dt(2021, 2, 1),
+                100
+            )
+        ]
+
+        self.assertListEqual(expected, readings)
+
+    def test_split_reading_works_when_reading_straddles_two_months(self):
+        # -- Setup
+        # this reading starts in January and ends in February
+        # this reading starts in January, covers February, and ends in March
+        # More specifically, this reading includes:
+        # January:  17 days (~55%)
+        # February: 15 days (~45%)
+        # Total:    32 days (100%)
+        reading = SimpleMeterReading(
+            dt(2021, 1, 15),
+            dt(2021, 2, 15),
+            100
+        )
+
+        # -- Act
+        readings = _split_reading(reading)
+
+        # -- Assert
+        expected = [
+            SimpleMeterReading(
+                dt(2021, 1, 1),
+                dt(2021, 2, 1),
+                54.83870967741935
+            ),
+            SimpleMeterReading(
+                dt(2021, 2, 1),
+                dt(2021, 3, 1),
+                45.16129032258064
+            )
+        ]
+
+        self.assertListEqual(expected, readings)
+
+    def test_split_reading_works_when_reading_covers_multiple_months(self):
+        # -- Setup
+        # this reading starts in January, covers February, and ends in March
+        # More specifically, this reading includes:
+        # January:  17 days (~28%)
+        # February: 28 days (~47%)
+        # March:    15 days (~24%)
+        # Total:    60 days (100%)
+        reading = SimpleMeterReading(
+            dt(2021, 1, 15),
+            dt(2021, 3, 15),
+            100
+        )
+
+        # -- Act
+        readings = _split_reading(reading)
+
+        # -- Assert
+        expected = [
+            SimpleMeterReading(
+                dt(2021, 1, 1),
+                dt(2021, 2, 1),
+                28.8135593220339
+            ),
+            SimpleMeterReading(
+                dt(2021, 2, 1),
+                dt(2021, 3, 1),
+                47.45762711864407
+            ),
+            SimpleMeterReading(
+                dt(2021, 3, 1),
+                dt(2021, 4, 1),
+                23.728813559322035
+            )
+        ]
+
+        self.assertListEqual(expected, readings)
+
+    def test_interpolate_works_when_one_month_missing(self):
+        # -- Setup
+        readings = [
+            SimpleMeterReading(
+                dt(2021, 1, 1),
+                dt(2021, 2, 1),
+                1
+            ),
+            # NOTE: missing February!
+            SimpleMeterReading(
+                dt(2021, 3, 1),
+                dt(2021, 4, 1),
+                2
+            )
+        ]
+
+        # -- Act
+        results = interpolate_monthly_readings(readings)
+
+        # -- Assert
+        expected = [
+            SimpleMeterReading(
+                dt(2021, 1, 1),
+                dt(2021, 2, 1),
+                1
+            ),
+            SimpleMeterReading(
+                dt(2021, 2, 1),
+                dt(2021, 3, 1),
+                1
+            ),
+            SimpleMeterReading(
+                dt(2021, 3, 1),
+                dt(2021, 4, 1),
+                2
+            )
+        ]
+
+        self.assertListEqual(expected, results)
+
+    def test_interpolate_works_when_multiple_months_missing(self):
+        # -- Setup
+        readings = [
+            SimpleMeterReading(
+                dt(2021, 1, 1),
+                dt(2021, 2, 1),
+                1
+            ),
+            # NOTE: missing February!
+            SimpleMeterReading(
+                dt(2021, 3, 1),
+                dt(2021, 4, 1),
+                2
+            ),
+            SimpleMeterReading(
+                dt(2021, 4, 1),
+                dt(2021, 5, 1),
+                3
+            ),
+            # NOTE: missing May!
+            # NOTE: missing June!
+            SimpleMeterReading(
+                dt(2021, 7, 1),
+                dt(2021, 8, 1),
+                4
+            )
+        ]
+
+        # -- Act
+        results = interpolate_monthly_readings(readings)
+
+        # -- Assert
+        expected = [
+            SimpleMeterReading(
+                dt(2021, 1, 1),
+                dt(2021, 2, 1),
+                1
+            ),
+            SimpleMeterReading(
+                dt(2021, 2, 1),
+                dt(2021, 3, 1),
+                1
+            ),
+            SimpleMeterReading(
+                dt(2021, 3, 1),
+                dt(2021, 4, 1),
+                2
+            ),
+            SimpleMeterReading(
+                dt(2021, 4, 1),
+                dt(2021, 5, 1),
+                3
+            ),
+            SimpleMeterReading(
+                dt(2021, 5, 1),
+                dt(2021, 6, 1),
+                3
+            ),
+            SimpleMeterReading(
+                dt(2021, 6, 1),
+                dt(2021, 7, 1),
+                3
+            ),
+            SimpleMeterReading(
+                dt(2021, 7, 1),
+                dt(2021, 8, 1),
+                4
+            )
+        ]
+
+        self.assertListEqual(expected, results)


### PR DESCRIPTION
#### Any background context you want to provide?
NREL's ESTCP project includes sample data with spotty meter data which doesn't work well with BETTER by default. There were a few issues with the data that presented new challenges communicating with BETTER:
  1. There were _a lot_ of meter readings and the BSync file created ended up being much too large (see the referenced issue) because SEED is currently dumping meters as they are into the file. We needed to reduce the readings included in the BSync file
  2. The data was pretty incomplete -- there were some missing months and BETTER requires at least 12 _continuous_ months of readings (it assumes usage of 0 for missing months which wrecks the models)

#### What's this PR do?
Adds an option to the BETTER analysis to "preprocess" meters. This should probably be just a temporary implementation because not much thought/knowledge about meters was put into it.
This "preprocessing" basically:
- bins meter readings into monthly readings (i.e. aggregate readings or disperse them)
  - e.g. if you have multiple 15-minute-interval readings it will sum them up for the month
  - e.g. if a reading _spans_ or _straddles_ a month, the algorithm splits the energy usage according to the fraction of the time the reading covers a particular month. This is a big ⚠️ that this is not a great/perfect solution; it assumes even distribution of usage throughout the meter reading interval which is likely not true (especially for readings that span a seasonal change)
- drops outliers (was experiencing some weird months due to binning - especially on the starting/ending boundaries)
- interpolates missing months

#### How should this be manually tested?
Run better analysis with and without preprocessing. It should work.

#### What are the relevant tickets?
#2917 

#### Screenshots (if appropriate)

New option on BETTER analysis
<img width="617" alt="Screen Shot 2021-10-01 at 3 07 25 PM" src="https://user-images.githubusercontent.com/18518728/135881513-c8e5316a-e3dd-41ff-b1a4-23d322ddcd0e.png">

Description of new option
<img width="207" alt="Screen Shot 2021-10-01 at 3 07 34 PM" src="https://user-images.githubusercontent.com/18518728/135881552-5b33e661-dc8c-465a-a403-eb8717be4b6f.png">


