### PR TITLE
build: env vars for k8s must be strings

### DIFF
--- a/charts/seed/templates/web-deployment.yaml
+++ b/charts/seed/templates/web-deployment.yaml
@@ -69,7 +69,7 @@ spec:
         - name: GOOGLE_RECAPTCHA_SECRET_KEY
           value: <reCAPTCHA-key>
         - name: INCLUDE_SEED_V2_APIS
-          value: TRUE
+          value: "TRUE"
         image: seedplatform/seed:develop
         imagePullPolicy: Always
         name: web


### PR DESCRIPTION
#### Any background context you want to provide?
Kubernetes deployment env var values must be strings, but yaml treats `TRUE` as a boolean. This was causing errors when trying to run the `kubectl apply -f` command

#### What's this PR do?
Fixes that

#### How should this be manually tested?
N/A

#### What are the relevant tickets?

#### Screenshots (if appropriate)
