### PR TITLE
refactor(ci): increase operations per run

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,3 +14,4 @@ jobs:
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity within 60 days. It will be closed if no further activity occurs. Thank you for your contributions.'
           close-issue-message: 'This issue has been closed automatically. If this still affects you please re-open this issue with a comment or contact us so we can look into resolving it.'
           exempt-issue-labels: 'P-1,Impact-1'
+          operations-per-run: 500


### PR DESCRIPTION
#### Any background context you want to provide?
SEED is using a stalebot for closing old issues. The stalebot is configured by default to do 30 "actions" per run (ie per day). This is slow to go through our issues, e.g. from a recent run:
```
Warning: No more operations left! Exiting...
Warning: If you think that not enough issues were processed you could try to increase the quantity related to the operations-per-run (​https://github.com/actions/stale#operations-per-run​) option which is currently set to 30
```

#### What's this PR do?
Increase our actions per day to `500`. If we hit our rate limit then GH will just pause the GH actions ability to make requests for 1 hour, and I can bump it down tomorrow.

> GitHub has a rate limit and if reached will block these API calls for one hour (or API calls from other actions using the same user (a.k.a.: the github-token from the repo-token option)).

#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
