### PR TITLE
refactor: navigate to data set list view after saved mapping

### DIFF
--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -662,10 +662,10 @@ angular.module('BE.seed.controller.data_upload_modal', [])
                 // If merges against existing exist, provide slightly different feedback
                 if ($scope.property_merges_against_existing + $scope.tax_lot_merges_against_existing > 0) {
                   $scope.step.number = 8;
-                  $state.go('dataset_list');
                 } else {
                   $scope.step.number = 10;
                 }
+                $state.go('dataset_list');
               });
             }, function (response) {
               handleSystemMatchingError(response.data);

--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -662,6 +662,7 @@ angular.module('BE.seed.controller.data_upload_modal', [])
                 // If merges against existing exist, provide slightly different feedback
                 if ($scope.property_merges_against_existing + $scope.tax_lot_merges_against_existing > 0) {
                   $scope.step.number = 8;
+                  $state.go('dataset_list');
                 } else {
                   $scope.step.number = 10;
                 }


### PR DESCRIPTION
#### Any background context you want to provide?
The process for importing new Data Files from the Data Set List view kicks off a sequence of events to ensure the correct data is imported. The majority of information is presented via a modal overlayed above a relevant page. After the Data File has been imported and matched the background page remains on the Data Mapping screen. This is confusing as a user might be inclined to re-save their mappings. It would be preferable to have the Data Set List as the background page after the Data File has been mapped. 

#### What's this PR do?
Upon completion of the data mapping, the Data Set List view will be set as the background page allowing the user to add more files. A user has the option to view properties by clicking 'View my properties' or import meters from the same file.

#### How should this be manually tested?
Add a new Data File to a Data Set and follow the flow. After the data mapping has been saved, the background screen should transition to the Data Set List view. 


#### What are the relevant tickets?
#2913

#### Screenshots (if appropriate)
https://user-images.githubusercontent.com/58446472/139734835-a51e5c46-c271-4db9-ae77-4a6e02a80996.mov

