### PR TITLE
refactor: disable the summary tab

### DIFF
--- a/seed/static/seed/partials/inventory_nav.html
+++ b/seed/static/seed/partials/inventory_nav.html
@@ -4,4 +4,5 @@
         <a id="reports" ui-sref="reports(::{inventory_type: inventory_type})" ui-sref-active="active" translate>Reports</a>
         <a id="inventory-cycles" ui-sref="inventory_cycles(::{inventory_type: inventory_type})" ui-sref-active="active" translate>Cross-Cycles</a>
         <a id="inventory-maps" ui-sref="inventory_map(::{inventory_type: inventory_type})" ui-sref-active="active" translate>Map</a>
-        <a id="inventory-summary" ui-sref="inventory_summary(::{inventory_type: inventory_type})" ui-sref-active="active" translate>Summary</a>
+        <!-- disabling this until we can finish polishing this feature -->
+        <!-- <a id="inventory-summary" ui-sref="inventory_summary(::{inventory_type: inventory_type})" ui-sref-active="active" translate>Summary</a> -->


### PR DESCRIPTION
#### Any background context you want to provide?
We decided to hide the "Summary" tab until we get the chance to polish it a bit more.

#### What's this PR do?
- hide the "summary" tab (keep everything else though)

#### How should this be manually tested?
- load the properties page, should see no "Summary" tab

#### What are the relevant tickets?

#### Screenshots (if appropriate)
<img width="535" alt="Screen Shot 2021-11-10 at 11 37 11 AM" src="https://user-images.githubusercontent.com/18518728/141173146-bd5f08ff-1fbb-4ffc-b033-b2c178ecc31b.png">
<img width="490" alt="Screen Shot 2021-11-10 at 11 37 02 AM" src="https://user-images.githubusercontent.com/18518728/141173148-675feb25-26de-42ae-bd27-8b2990b90456.png">

