### PR TITLE
fix: load taxlot instead of property for analyses

### DIFF
--- a/seed/static/seed/js/controllers/inventory_detail_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_controller.js
@@ -106,13 +106,15 @@ angular.module('BE.seed.controller.inventory_detail', [])
       $scope.profiles = profiles;
       $scope.currentProfile = current_profile;
 
-      $scope.analysis = analyses_payload.analyses.sort(function(a, b) {
-        let key_a = new Date(a.end_time);
-        let key_b = new Date(b.end_time);
-        if (key_a > key_b) return -1;
-        if (key_a < key_b) return 1;
-        return 0;
-      })[0];
+      if (analyses_payload.analyses) {
+        $scope.analysis = analyses_payload.analyses.sort(function(a, b) {
+          let key_a = new Date(a.end_time);
+          let key_b = new Date(b.end_time);
+          if (key_a > key_b) return -1;
+          if (key_a < key_b) return 1;
+          return 0;
+        })[0];
+      }
       $scope.users = users_payload.users;
 
       // Flag columns whose values have changed between imports and edits.

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -1514,7 +1514,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           }],
           analyses_payload: ['inventory_service', 'analyses_service', '$stateParams', 'inventory_payload', function (inventory_service, analyses_service, $stateParams, inventory_payload) {
             if ($stateParams.inventory_type !== 'properties') return [];
-            return analyses_service.get_analyses_for_canonical_property(inventory_payload[type].id);
+            return analyses_service.get_analyses_for_canonical_property(inventory_payload.property.id);
           }],
           columns: ['$stateParams', 'inventory_service', function ($stateParams, inventory_service) {
             if ($stateParams.inventory_type === 'properties') {

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -1513,7 +1513,9 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
             return promise;
           }],
           analyses_payload: ['inventory_service', 'analyses_service', '$stateParams', 'inventory_payload', function (inventory_service, analyses_service, $stateParams, inventory_payload) {
-            return analyses_service.get_analyses_for_canonical_property(inventory_payload.property.id);
+            let type = 'property';
+            if ($stateParams.inventory_type === 'taxlots') type = 'taxlot';
+            return analyses_service.get_analyses_for_canonical_property(inventory_payload[type].id);
           }],
           columns: ['$stateParams', 'inventory_service', function ($stateParams, inventory_service) {
             if ($stateParams.inventory_type === 'properties') {

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -1513,8 +1513,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
             return promise;
           }],
           analyses_payload: ['inventory_service', 'analyses_service', '$stateParams', 'inventory_payload', function (inventory_service, analyses_service, $stateParams, inventory_payload) {
-            let type = 'property';
-            if ($stateParams.inventory_type === 'taxlots') type = 'taxlot';
+            if ($stateParams.inventory_type !== 'properties') return [];
             return analyses_service.get_analyses_for_canonical_property(inventory_payload[type].id);
           }],
           columns: ['$stateParams', 'inventory_service', function ($stateParams, inventory_service) {


### PR DESCRIPTION
#### Any background context you want to provide?
see ticket

#### What's this PR do?
fixes taxlot inventory detail link

#### How should this be manually tested?
click on a taxlot's info icon in the inventory list

#### What are the relevant tickets?
https://github.com/SEED-platform/seed/issues/3001

#### Screenshots (if appropriate)
