### PR TITLE
Replace deprecated function django.urls.url

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -5,7 +5,7 @@
 :author
 """
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include, re_path
 from django.urls import path
 from django.conf.urls.static import static
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
@@ -33,8 +33,8 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
-    url(r'^accounts/password/reset/done/$', password_reset_done, name='password_reset_done'),
-    url(
+    re_path(r'^accounts/password/reset/done/$', password_reset_done, name='password_reset_done'),
+    re_path(
         r'^accounts/password/reset/complete/$',
         password_reset_complete,
         name='password_reset_complete',
@@ -46,19 +46,19 @@ urlpatterns = [
     ),
 
     # Application
-    url(r'^', include(('seed.landing.urls', "seed.landing"), namespace="landing")),
-    url(r'^app/', include(('seed.urls', "seed"), namespace="seed")),
-    url(r'^documentation/', include(('seed.docs.urls', 'seed.docs'), namespace='docs')),
+    re_path(r'^', include(('seed.landing.urls', "seed.landing"), namespace="landing")),
+    re_path(r'^app/', include(('seed.urls', "seed"), namespace="seed")),
+    re_path(r'^documentation/', include(('seed.docs.urls', 'seed.docs'), namespace='docs')),
 
     # root configuration items
-    url(r'^i18n/', include('django.conf.urls.i18n')),
-    url(r'^robots\.txt', robots_txt, name='robots_txt'),
+    re_path(r'^i18n/', include('django.conf.urls.i18n')),
+    re_path(r'^robots\.txt', robots_txt, name='robots_txt'),
 
     # API
-    url(r'^api/swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    url(r'^api/version/$', version, name='version'),
-    url(r'^api/', include((api, "seed"), namespace='api')),
-    url(r'^oauth/', include(('oauth2_jwt_provider.urls', 'oauth2_jwt_provider'), namespace='oauth2_provider'))
+    re_path(r'^api/swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    re_path(r'^api/version/$', version, name='version'),
+    re_path(r'^api/', include((api, "seed"), namespace='api')),
+    re_path(r'^oauth/', include(('oauth2_jwt_provider.urls', 'oauth2_jwt_provider'), namespace='oauth2_provider'))
 ]
 
 handler404 = 'seed.views.main.error404'
@@ -73,8 +73,8 @@ if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     urlpatterns += [
         # test URLs
-        url(r'^angular_js_tests/$', angular_js_tests, name='angular_js_tests'),
+        re_path(r'^angular_js_tests/$', angular_js_tests, name='angular_js_tests'),
 
         # admin
-        url(r'^admin/', admin.site.urls),
+        re_path(r'^admin/', admin.site.urls),
     ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -66,7 +66,7 @@ django-braces==1.14.0
 # Use forked jwt-oauth2 b/c the published version broke when updating to Django 3.x
 # See: https://docs.djangoproject.com/en/dev/releases/3.0/#removed-private-python-2-compatibility-apis
 # jwt-oauth2>=0.1.1
--e git+https://github.com/SEED-platform/jwt-oauth2.git@f2db7e16803969f6121129a7b2fa04d09ec5f5e9#egg=jwt-oauth2
+-e git+https://github.com/SEED-platform/jwt-oauth2.git@0490b817b9b74b7363c4b39fc0a175f58a14c967#egg=jwt-oauth2
 django-oauth-toolkit==1.2.0
 
 future==0.18.2

--- a/seed/api/base/urls.py
+++ b/seed/api/base/urls.py
@@ -4,7 +4,7 @@
 :copyright (c) 2014 - 2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
 """
-from django.conf.urls import url, include
+from django.conf.urls import re_path, include
 from django.conf import settings
 
 from seed.api.v1.urls import urlpatterns as apiv1
@@ -17,11 +17,11 @@ urlpatterns = []
 if settings.INCLUDE_SEED_V2_APIS:
     urlpatterns = [
         # add flat urls namespace for non-conforming endpoints, ugh
-        url(r'^v1/', include((apiv1, 'seed'), namespace='v1')),
-        url(r'^v2/', include((apiv2, 'seed'), namespace='v2')),
-        url(r'^v2.1/', include((apiv2_1, 'seed'), namespace='v2.1')),
+        re_path(r'^v1/', include((apiv1, 'seed'), namespace='v1')),
+        re_path(r'^v2/', include((apiv2, 'seed'), namespace='v2')),
+        re_path(r'^v2.1/', include((apiv2_1, 'seed'), namespace='v2.1')),
     ]
 
 urlpatterns += [
-    url(r'^v3/', include((apiv3, 'seed'), namespace='v3')),
+    re_path(r'^v3/', include((apiv3, 'seed'), namespace='v3')),
 ]

--- a/seed/api/v1/urls.py
+++ b/seed/api/v1/urls.py
@@ -5,7 +5,7 @@
 :author
 """
 
-from django.conf.urls import url, include
+from django.conf.urls import re_path, include
 from rest_framework import routers
 
 from seed.views.main import (
@@ -20,20 +20,20 @@ router = routers.DefaultRouter()
 
 urlpatterns = [
     # template routes
-    url(r'^', include(router.urls)),
-    url(r'^set_default_columns/$', set_default_columns, name='set_default_columns'),
-    url(
+    re_path(r'^', include(router.urls)),
+    re_path(r'^set_default_columns/$', set_default_columns, name='set_default_columns'),
+    re_path(
         r'^get_default_building_detail_columns/$',
         get_default_building_detail_columns,
         name='get_default_building_detail_columns'
     ),
-    url(
+    re_path(
         r'^set_default_building_detail_columns/$',
         set_default_building_detail_columns,
         name='set_default_building_detail_columns'
     ),
-    url(r'^public_search/$', public_search, name='public_search'),
-    url(
+    re_path(r'^public_search/$', public_search, name='public_search'),
+    re_path(
         r'^delete_organization_inventory/$',
         delete_organization_inventory,
         name='delete_organization_inventory'

--- a/seed/api/v2/urls.py
+++ b/seed/api/v2/urls.py
@@ -4,7 +4,7 @@
 :copyright (c) 2014 - 2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
 """
-from django.conf.urls import url, include
+from django.conf.urls import re_path, include
 from rest_framework import routers
 
 from seed.api.base.views import test_view_with_arg, TestReverseViewSet
@@ -75,76 +75,76 @@ api_v2_router.register(r'users', UserViewSet, basename="users")
 
 urlpatterns = [
     # v2 api
-    url(r'^', include(api_v2_router.urls)),
+    re_path(r'^', include(api_v2_router.urls)),
     # ajax routes
-    url(r'^version/$', version, name='version'),
+    re_path(r'^version/$', version, name='version'),
     # data uploader related things
-    url(r'get_upload_details/$', get_upload_details, name='get_upload_details'),
-    url(r'^schema/$', get_api_schema, name='schema'),
-    url(
+    re_path(r'get_upload_details/$', get_upload_details, name='get_upload_details'),
+    re_path(r'^schema/$', get_api_schema, name='schema'),
+    re_path(
         r'projects/(?P<pk>\w+)/add/$',
         ProjectViewSet.as_view({'put': 'add'}),
         name='projects-add-inventory'
     ),
-    url(
+    re_path(
         r'projects/(?P<pk>\w+)/remove/$',
         ProjectViewSet.as_view({'put': 'remove'}),
         name='projects-remove-inventory'
     ),
-    url(
+    re_path(
         r'projects/(?P<pk>\w+)/update/$',
         ProjectViewSet.as_view({'put': 'update_details'}),
         name='projects-update'
     ),
-    url(
+    re_path(
         r'projects/(?P<pk>\w+)/move/$',
         ProjectViewSet.as_view({'put': 'move'}),
         name='projects-move'
     ),
-    url(
+    re_path(
         r'projects/(?P<pk>\w+)/copy/$',
         ProjectViewSet.as_view({'put': 'copy'}),
         name='projects-copy'
     ),
-    url(
+    re_path(
         r'labels-property/$',
         UpdateInventoryLabelsAPIView.as_view(),
         {'inventory_type': 'property'},
         name="property-labels",
     ),
-    url(
+    re_path(
         r'labels-taxlot/$',
         UpdateInventoryLabelsAPIView.as_view(),
         {'inventory_type': 'taxlot'},
         name="taxlot-labels",
     ),
-    url(
+    re_path(
         r'^test_view_with_arg/([0-9]{1})/$',
         test_view_with_arg,
         name='testviewarg'
     ),
-    url(
+    re_path(
         r'^export_reports_data/$',
         Report.as_view({'get': 'export_reports_data'}),
         name='export_reports_data'
     ),
-    url(
+    re_path(
         r'^get_property_report_data/$',
         Report.as_view({'get': 'get_property_report_data'}),
         name='property_report_data'
     ),
-    url(
+    re_path(
         r'^get_aggregated_property_report_data/$',
         Report.as_view({'get': 'get_aggregated_property_report_data'}),
         name='aggregated_property_report_data'
     ),
-    # url(
+    # re_path(
     #     r'^property/',
     #     UpdateInventoryLabelsAPIView.as_view(),
     #     {'inventory_type': 'property'},
     #     name="property_labels",
     # ),
-    # url(
+    # re_path(
     #     r'^taxlot/$',
     #     UpdateInventoryLabelsAPIView.as_view(),
     #     {'inventory_type': 'taxlot'},

--- a/seed/api/v2_1/urls.py
+++ b/seed/api/v2_1/urls.py
@@ -4,7 +4,7 @@
 :copyright (c) 2014 - 2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
 """
-from django.conf.urls import url, include
+from django.conf.urls import re_path, include
 from rest_framework_nested import routers
 
 from seed.api.v2_1.views import PropertyViewSetV21
@@ -28,7 +28,7 @@ taxlots_router = routers.NestedSimpleRouter(router, r'taxlots', lookup='taxlots'
 taxlots_router.register(r'notes', NoteViewSet, basename='taxlot-notes')
 
 urlpatterns = [
-    url(r'^', include(router.urls)),
-    url(r'^', include(properties_router.urls)),
-    url(r'^', include(taxlots_router.urls)),
+    re_path(r'^', include(router.urls)),
+    re_path(r'^', include(properties_router.urls)),
+    re_path(r'^', include(taxlots_router.urls)),
 ]

--- a/seed/api/v3/urls.py
+++ b/seed/api/v3/urls.py
@@ -1,6 +1,6 @@
 # !/usr/bin/env python
 # encoding: utf-8
-from django.conf.urls import url, include
+from django.conf.urls import re_path, include
 
 from rest_framework import routers
 
@@ -102,23 +102,23 @@ taxlots_router.register(r'notes', NoteViewSet, basename='taxlot-notes')
 
 
 urlpatterns = [
-    url(r'^', include(api_v3_router.urls)),
-    url(r'^', include(data_quality_checks_router.urls)),
-    url(
+    re_path(r'^', include(api_v3_router.urls)),
+    re_path(r'^', include(data_quality_checks_router.urls)),
+    re_path(
         r'^labels_property/$',
         LabelInventoryViewSet.as_view(),
         {'inventory_type': 'property'},
     ),
-    url(
+    re_path(
         r'^labels_taxlot/$',
         LabelInventoryViewSet.as_view(),
         {'inventory_type': 'taxlot'},
     ),
-    url(r'^', include(organizations_router.urls)),
-    url(r'^', include(analysis_views_router.urls)),
-    url(r'^', include(analysis_messages_router.urls)),
-    url(r'^', include(analysis_view_messages_router.urls)),
-    url(r'^', include(properties_router.urls)),
-    url(r'^', include(taxlots_router.urls)),
-    url(r'media/(?P<filepath>.*)$', MediaViewSet.as_view()),
+    re_path(r'^', include(organizations_router.urls)),
+    re_path(r'^', include(analysis_views_router.urls)),
+    re_path(r'^', include(analysis_messages_router.urls)),
+    re_path(r'^', include(analysis_view_messages_router.urls)),
+    re_path(r'^', include(properties_router.urls)),
+    re_path(r'^', include(taxlots_router.urls)),
+    re_path(r'media/(?P<filepath>.*)$', MediaViewSet.as_view()),
 ]

--- a/seed/docs/urls.py
+++ b/seed/docs/urls.py
@@ -5,12 +5,12 @@
 :author
 """
 
-from django.conf.urls import url
+from django.conf.urls import re_path
 
 from seed.docs.views import (
     faq_page
 )
 
 urlpatterns = [
-    url(r'^$', faq_page, name='documentation'),
+    re_path(r'^$', faq_page, name='documentation'),
 ]

--- a/seed/landing/urls.py
+++ b/seed/landing/urls.py
@@ -6,7 +6,7 @@
 """
 
 from django.conf import settings
-from django.conf.urls import url
+from django.conf.urls import re_path
 from django.contrib.auth.views import (
     logout_then_login, PasswordChangeView, PasswordChangeDoneView
 )
@@ -17,21 +17,21 @@ from seed.landing.views import (
 )
 
 urlpatterns = [
-    url(r'^$', landing_page, name='landing_page'),
-    url(r'^accounts/login/$', login_view, name='login'),
-    url(
+    re_path(r'^$', landing_page, name='landing_page'),
+    re_path(r'^accounts/login/$', login_view, name='login'),
+    re_path(
         r'^accounts/logout/$',
         logout_then_login,
         name='logout'
     ),
-    url(r'^accounts/password/reset/$', password_reset, name='password_reset'),
-    url(r'^accounts/password/reset/done/$', password_reset_done, name='password_reset_done'),
-    url(
+    re_path(r'^accounts/password/reset/$', password_reset, name='password_reset'),
+    re_path(r'^accounts/password/reset/done/$', password_reset_done, name='password_reset_done'),
+    re_path(
         r'^accounts/password/reset/complete/$',
         password_reset_complete,
         name='password_reset_complete',
     ),
-    url(
+    re_path(
         (
             r'^accounts/setup/(?P<uidb64>[0-9A-Za-z_\-]+)/'
             '(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/$'
@@ -39,13 +39,13 @@ urlpatterns = [
         signup,
         name='signup'
     ),
-    url(
+    re_path(
         r'^password_change/$',
         PasswordChangeView.as_view(),
         {'template_name': 'landing/password_change_form.html'},
         name="password_change"
     ),
-    url(
+    re_path(
         r'^password_change/done/$',
         PasswordChangeDoneView.as_view(),
         {'template_name': 'landing/password_change_done.html'}
@@ -54,8 +54,8 @@ urlpatterns = [
 
 if settings.INCLUDE_ACCT_REG:
     urlpatterns += [
-        url(r'^accounts/create/$', create_account, name='create_account'),
-        url(r'^account_activation_sent/$', account_activation_sent, name='account_activation_sent'),
-        url(r'^activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+        re_path(r'^accounts/create/$', create_account, name='create_account'),
+        re_path(r'^account_activation_sent/$', account_activation_sent, name='account_activation_sent'),
+        re_path(r'^activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
             activate, name='activate')
     ]

--- a/seed/landing/urls.py
+++ b/seed/landing/urls.py
@@ -56,6 +56,5 @@ if settings.INCLUDE_ACCT_REG:
     urlpatterns += [
         re_path(r'^accounts/create/$', create_account, name='create_account'),
         re_path(r'^account_activation_sent/$', account_activation_sent, name='account_activation_sent'),
-        re_path(r'^activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
-            activate, name='activate')
+        re_path(r'^activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$', activate, name='activate')
     ]

--- a/seed/urls.py
+++ b/seed/urls.py
@@ -5,12 +5,12 @@
 :author
 """
 
-from django.conf.urls import url
+from django.conf.urls import re_path
 
 from seed.views.main import (
     home,
 )
 
 urlpatterns = [
-    url(r'^$', home, name='home'),
+    re_path(r'^$', home, name='home'),
 ]


### PR DESCRIPTION
#### Any background context you want to provide?

done in tandem with [jwt-oauth2 #1](https://github.com/macintoshpie/jwt-oauth2/pull/1), which replaces deprecated functions in a dependencies

#### What's this PR do?

Replace deprecated function django.urls.url

#### How should this be manually tested?

```
python -Wd manage.py test
```
has no  warning for this function, in contrast to the same command on master.

#### What are the relevant tickets?

#2891 

#### Screenshots (if appropriate)
