### PR TITLE
3052 refactor/top right nav update

### DIFF
--- a/seed/static/seed/js/controllers/menu_controller.js
+++ b/seed/static/seed/js/controllers/menu_controller.js
@@ -11,6 +11,7 @@ angular.module('BE.seed.controller.menu', [])
     '$uibModal',
     '$log',
     'urls',
+    'auth_service',
     'organization_service',
     'user_service',
     'dataset_service',
@@ -26,6 +27,7 @@ angular.module('BE.seed.controller.menu', [])
       $uibModal,
       $log,
       urls,
+      auth_service,
       organization_service,
       user_service,
       dataset_service,
@@ -198,6 +200,21 @@ angular.module('BE.seed.controller.menu', [])
         $state.reload();
         init();
       };
+      // set authorization and organization data to $scope
+      set_auth = function (org_id) {
+        auth_service.is_authorized(org_id, ['requires_owner'])
+          .then(function (data) {
+            $scope.auth = data.auth.requires_owner ? data.auth : 'not authorized'
+          }, function (data) {
+            $scope.auth = data.message;
+          })
+      };
+      set_org = function (org_id) {
+        organization_service.get_organization(org_id)
+          .then(function(data) {
+            $scope.org = data.organization
+          })
+      };
 
       //DMcQ: Set up watch statements to keep nav updated with latest datasets_count, etc.
       //      This isn't the best solution but most expedient. This approach should be refactored later by
@@ -238,6 +255,8 @@ angular.module('BE.seed.controller.menu', [])
             $scope.menu.user.organizations = data.organizations;
             // get the default org for the user
             $scope.menu.user.organization = _.find(data.organizations, {id: _.toInteger(user_service.get_organization().id)});
+            set_auth($scope.menu.user.organization.id)
+            set_org($scope.menu.user.organization.id)
           }).catch(function (error) {
             // user does not have an org
             $rootScope.route_load_error = true;

--- a/seed/static/seed/js/controllers/menu_controller.js
+++ b/seed/static/seed/js/controllers/menu_controller.js
@@ -216,26 +216,17 @@ angular.module('BE.seed.controller.menu', [])
           })
       };
       $scope.mouseover_org = function(org_id) {
-        console.log('>>> Organization ID: ', org_id)
-        console.log('>>> Mouse Over')
         $scope.show_org_id = true
         $scope.hover_org_id = org_id
       };
       $scope.mouseout_org = function() {
-        console.log('<<< Mouse Out')
         $scope.show_org_id = false
-
       }
       $scope.track_mouse = function(e) {
-        $scope.xpos = `${e.clientX-260}px`
-        $scope.ypos = `${e.clientY}px`
-        console.log($scope.xpos)
-        console.log($scope.ypos)
-        $scope.xxpos = '10rem;'
-        $scope.hover_style = {'left': e.clientX, 'top': e.clientY}
+        let xpos = `${e.view.window.innerWidth-e.clientX-105}px`
+        let ypos = `${e.clientY-25}px`
+        $scope.hover_style = `right: ${xpos}; top: ${ypos};`
       }
-
-
 
       //DMcQ: Set up watch statements to keep nav updated with latest datasets_count, etc.
       //      This isn't the best solution but most expedient. This approach should be refactored later by

--- a/seed/static/seed/js/controllers/menu_controller.js
+++ b/seed/static/seed/js/controllers/menu_controller.js
@@ -223,8 +223,8 @@ angular.module('BE.seed.controller.menu', [])
         $scope.show_org_id = false
       }
       $scope.track_mouse = function(e) {
-        let xpos = `${e.view.window.innerWidth-e.clientX-105}px`
-        let ypos = `${e.clientY-25}px`
+        let xpos = `${e.view.window.innerWidth - e.clientX - 105}px`
+        let ypos = `${e.clientY - 25}px`
         $scope.hover_style = `right: ${xpos}; top: ${ypos};`
       }
 

--- a/seed/static/seed/js/controllers/menu_controller.js
+++ b/seed/static/seed/js/controllers/menu_controller.js
@@ -194,6 +194,7 @@ angular.module('BE.seed.controller.menu', [])
        * @param {obj} org
        */
       $scope.set_user_org = function (org) {
+        $scope.mouseout_org()
         user_service.set_organization(org);
         $scope.menu.user.organization = org;
         console.log($scope.menu.user.organization);

--- a/seed/static/seed/js/controllers/menu_controller.js
+++ b/seed/static/seed/js/controllers/menu_controller.js
@@ -215,6 +215,27 @@ angular.module('BE.seed.controller.menu', [])
             $scope.org = data.organization
           })
       };
+      $scope.mouseover_org = function(org_id) {
+        console.log('>>> Organization ID: ', org_id)
+        console.log('>>> Mouse Over')
+        $scope.show_org_id = true
+        $scope.hover_org_id = org_id
+      };
+      $scope.mouseout_org = function() {
+        console.log('<<< Mouse Out')
+        $scope.show_org_id = false
+
+      }
+      $scope.track_mouse = function(e) {
+        $scope.xpos = `${e.clientX-260}px`
+        $scope.ypos = `${e.clientY}px`
+        console.log($scope.xpos)
+        console.log($scope.ypos)
+        $scope.xxpos = '10rem;'
+        $scope.hover_style = {'left': e.clientX, 'top': e.clientY}
+      }
+
+
 
       //DMcQ: Set up watch statements to keep nav updated with latest datasets_count, etc.
       //      This isn't the best solution but most expedient. This approach should be refactored later by

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -367,25 +367,19 @@ a:not([href]) {
       height: 54px;
       border-bottom: 1px solid $gray_lighter;
 
-      // .hover-org-id-header {
-      //   position: absolute;
-      //   background: rgba(255, 255, 255, 0.7);
-      //   color: black;
-      //   // left: 10rem;
-      //   // top: 3rem;
-      //   z-index: 100000;
-      //   padding:3px;
-      //   border: 1px solid black; 
-      //   border-radius: 3px;
-      //   text-align: right;
-      //   justify-content: right;
-      // }
-      .hover-org-id-bottom {
-        text-align: right;
-        padding-right: 1rem;
+      .hover-org-container {
+        position: absolute;
+        background: none;
+        z-index: 10000;
+        width: 100px;
+      }
+      .hover-org-id {
         font-size: 10px;
-        border-top: 1px solid rgb(185, 184, 184);
-        color:gray;
+        background:rgba(255, 255, 255, 0.8);
+        border: 1px solid gray;
+        border-radius: 3px;
+        color: gray;
+        padding:2px;
       }
 
       .logo_container {

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -373,6 +373,7 @@ a:not([href]) {
         z-index: 10000;
         width: 100px;
       }
+
       .hover-org-id {
         font-size: 10px;
         background:rgba(255, 255, 255, 0.8);
@@ -381,10 +382,7 @@ a:not([href]) {
         color: gray;
         padding:2px;
       }
-      .active {
-        background-color: $gray_lightest;
-        text-decoration: none;
-      }
+
       .logo_container {
 
         .logo {
@@ -465,6 +463,11 @@ a:not([href]) {
                 color: #000;
                 font-weight: bold;
                 text-align: center;
+              }
+
+              .active {
+                background-color: $gray_lightest;
+                text-decoration: none;
               }
 
               a {

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -367,6 +367,27 @@ a:not([href]) {
       height: 54px;
       border-bottom: 1px solid $gray_lighter;
 
+      // .hover-org-id-header {
+      //   position: absolute;
+      //   background: rgba(255, 255, 255, 0.7);
+      //   color: black;
+      //   // left: 10rem;
+      //   // top: 3rem;
+      //   z-index: 100000;
+      //   padding:3px;
+      //   border: 1px solid black; 
+      //   border-radius: 3px;
+      //   text-align: right;
+      //   justify-content: right;
+      // }
+      .hover-org-id-bottom {
+        text-align: right;
+        padding-right: 1rem;
+        font-size: 10px;
+        border-top: 1px solid rgb(185, 184, 184);
+        color:gray;
+      }
+
       .logo_container {
 
         .logo {

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -381,7 +381,10 @@ a:not([href]) {
         color: gray;
         padding:2px;
       }
-
+      .active {
+        background-color: $gray_lightest;
+        text-decoration: none;
+      }
       .logo_container {
 
         .logo {

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -427,6 +427,10 @@ a:not([href]) {
             }
           }
 
+          ul.justify-left a {
+            text-align: left;
+          }
+          
           ul.dropdown-menu {
 
             text-align: center;

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -1,16 +1,14 @@
 <div class="header">
+    <div class="hover-org-container" ng-if="show_org_id" style="{$ hover_style $}">
+        <span class='hover-org-id'> 
+            ID: {$ hover_org_id $}
+        </span>
+    </div>
     <div class="add_menu_container">
         <div class="btn-group org-dropdown" uib-dropdown is-open="status.isopen">
             <button id="btnUserOrgs" type="button" class="btn btn-default" uib-dropdown-toggle ng-disabled="disabled" (mouseover)="hover_org()">
                 <span style="color:gray">Current Organization:</span> {$ menu.user.organization.name $} <span class="caret"></span>
             </button>
-            {% comment %} <span 
-                class="hover-org-id-header" 
-                ng-if="show_org_id"
-                style="top: {$ ypos $}; left:50px;"
-            >
-                ID: {$ hover_org_id $}
-            </span> {% endcomment %}
             <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="btnUserOrgs" ng-mousemove="track_mouse($event)">
                 <li ng-if="!menu.user.organizations.length" style="text-align: center;">
                     <span class="glyphicon glyphicon-refresh spinning"></span> <span translate>Loading...</span>
@@ -25,10 +23,7 @@
                         {$ org.name $}
                         <i class="fa fa-check" ng-show="org.id == menu.user.organization.id"></i>
                     </a>
-
-                    {% comment %} <span class="hover-org-id" ng-if="hover_org_id == org.id && show_org_id">Organization ID: {$ hover_org_id $}</span> {% endcomment %}
                 </li>
-                <li ng-if="hover_org_id" class="hover-org-id-bottom" >Organization ID: {$ hover_org_id $}</li>
             </ul>
         </div>
         <div class="btn-group" uib-dropdown ng-hide="menu.user.organization.user_role === 'viewer'">

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -28,26 +28,14 @@
                 </li>
                 <li class="dropdown-header" translate>Organization Settings</li>
                 <li class="divider"></li>
-                <li><a ui-sref="organization_settings({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Settings</a></li>
-                <li><a ui-sref="organization_sharing({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Sharing</a></li>
-                <li><a ui-sref="organization_column_settings({organization_id: menu.user.organization.id, inventory_type: 'properties'})" ui-sref-active="active" translate>Column Settings</a></li>
-                <li><a ui-sref="organization_data_quality({organization_id: menu.user.organization.id, inventory_type: 'properties'})" ui-sref-active="active" translate>Data Quality</a></li>
-                <li><a ui-sref="organization_cycles({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Cycles</a></li>
-                <li><a ui-sref="organization_labels({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Labels</a></li>
-                <li><a ui-sref="organization_members({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Members</a></li>
-                <li><a ui-sref="organization_settings({organization_id: menu.user.organization.id})" translate>More</a></li>
-                <li> ORG ID: {$ menu.user.organization.id $} </li>
-                        {% comment %} <a ui-sref="organization_settings(::{organization_id: org.id})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Settings</a>
-                        <a ui-sref="organization_sharing(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sharing</a>
-                        <a ui-sref="organization_column_settings(::{organization_id: org.id, inventory_type: 'properties'})" ng-if="::auth.requires_owner" ng-class="::{active: state.name === 'organization_column_settings'}" translate>Column Settings</a>
-                        <a ui-sref="organization_column_mappings(::{organization_id: org.id, inventory_type: 'properties'})" ng-if="::auth.requires_owner" ng-class="::{active: state.name === 'organization_column_mappings'}" translate>Column Mappings</a>
-                        <a ui-sref="organization_data_quality(::{organization_id: org.id, inventory_type: 'properties'})" ng-if="::org.is_parent && auth.requires_owner" ng-class="::{active: state.name === 'organization_data_quality'}" translate>Data Quality</a>
-                        <a ui-sref="organization_cycles(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Cycles</a>
-                        <a ui-sref="organization_labels(::{organization_id: org.id})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Labels</a>
-                        <a ui-sref="organization_sub_orgs(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sub-Organizations</a>
-                        <a ui-sref="organization_members(::{organization_id: org.id})" ui-sref-active="active" translate>Members</a>
-                        <a ui-sref="organization_email_templates(::{organization_id: org.id})" ui-sref-active="active" translate>Email Templates</a>
-                        <a ui-sref="organization_derived_columns(::{organization_id: org.id, inventory_type: 'properties'})" ui-sref-active="active" translate>Derived Columns</a> {% endcomment %}
+                <li><a ui-sref="organization_settings({organization_id: org.id})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Settings</a></li>
+                <li><a ui-sref="organization_sharing({organization_id: org.id})" ng-if="org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sharing</a></li>
+                <li><a ui-sref="organization_column_settings({organization_id: org.id, inventory_type: 'properties'})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Column Settings</a></li>
+                <li><a ui-sref="organization_data_quality({organization_id: org.id, inventory_type: 'properties'})" ng-if="org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Data Quality</a></li>
+                <li><a ui-sref="organization_cycles({organization_id: org.id})" ng-if="org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Cycles</a></li>
+                <li><a ui-sref="organization_labels({organization_id: org.id})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Labels</a></li>
+                <li><a ui-sref="organization_members({organization_id: org.id})" ui-sref-active="active" translate>Members</a></li>
+                <li><a ui-sref="organization_settings({organization_id: org.id})" translate>More</a></li>
 
                 <!--<li>
                     <a data-toggle="modal" data-target="#newProjectModalIndex" ng-click="open_create_project_modal()">Project</a>

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -22,6 +22,29 @@
             </button>
             <ul uib-dropdown-menu class="dropdown-menu pull-right" role="menu" aria-labelledby="btnCreateNew">
                 <li class="dropdown-header" translate>Create a new...</li>
+                <li class="dropdown-header" translate> Test </li>
+                {% comment %} <li class="dropdown-header" >{$ ross $} </li> {% endcomment %}
+                <li><a ui-sref="organization_settings(::{organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Settings</a></li>
+                <li><a ui-sref="organization_sharing(::{organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Sharing</a></li>
+                <li><a ui-sref="organization_column_settings(::{organization_id: menu.user.organization.id, inventory_type: 'properties'})" ui-sref-active="active" translate>Column Settings</a></li>
+                <li><a ui-sref="organization_data_quality(::{organization_id: menu.user.organization.id, inventory_type: 'properties'})" ui-sref-active="active" translate>Data Quality</a></li>
+                <li><a ui-sref="organization_cycles(::{organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Cycles</a></li>
+                <li><a ui-sref="organization_labels(::{organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Labels</a></li>
+                <li><a ui-sref="organization_members(::{organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Members</a></li>
+                <li><a ui-sref="organization_settings(::{organization_id: menu.user.organization.id})" translate>More</a></li>
+                <li>abc {$ menu.user.organization $} def</li>
+                        {% comment %} <a ui-sref="organization_settings(::{organization_id: org.id})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Settings</a>
+                        <a ui-sref="organization_sharing(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sharing</a>
+                        <a ui-sref="organization_column_settings(::{organization_id: org.id, inventory_type: 'properties'})" ng-if="::auth.requires_owner" ng-class="::{active: state.name === 'organization_column_settings'}" translate>Column Settings</a>
+                        <a ui-sref="organization_column_mappings(::{organization_id: org.id, inventory_type: 'properties'})" ng-if="::auth.requires_owner" ng-class="::{active: state.name === 'organization_column_mappings'}" translate>Column Mappings</a>
+                        <a ui-sref="organization_data_quality(::{organization_id: org.id, inventory_type: 'properties'})" ng-if="::org.is_parent && auth.requires_owner" ng-class="::{active: state.name === 'organization_data_quality'}" translate>Data Quality</a>
+                        <a ui-sref="organization_cycles(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Cycles</a>
+                        <a ui-sref="organization_labels(::{organization_id: org.id})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Labels</a>
+                        <a ui-sref="organization_sub_orgs(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sub-Organizations</a>
+                        <a ui-sref="organization_members(::{organization_id: org.id})" ui-sref-active="active" translate>Members</a>
+                        <a ui-sref="organization_email_templates(::{organization_id: org.id})" ui-sref-active="active" translate>Email Templates</a>
+                        <a ui-sref="organization_derived_columns(::{organization_id: org.id, inventory_type: 'properties'})" ui-sref-active="active" translate>Derived Columns</a> {% endcomment %}
+
                 <li class="divider"></li>
                 <!--<li>
                     <a data-toggle="modal" data-target="#newProjectModalIndex" ng-click="open_create_project_modal()">Project</a>

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -37,11 +37,15 @@
                 <li><a ui-sref="organization_settings({organization_id: org.id})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Settings</a></li>
                 <li><a ui-sref="organization_sharing({organization_id: org.id})" ng-if="org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sharing</a></li>
                 <li><a ui-sref="organization_column_settings({organization_id: org.id, inventory_type: 'properties'})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Column Settings</a></li>
+                <li><a ui-sref="organization_column_mappings({organization_id: org.id, inventory_type: 'properties'})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Column Mappings</a></li>
                 <li><a ui-sref="organization_data_quality({organization_id: org.id, inventory_type: 'properties'})" ng-if="org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Data Quality</a></li>
                 <li><a ui-sref="organization_cycles({organization_id: org.id})" ng-if="org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Cycles</a></li>
                 <li><a ui-sref="organization_labels({organization_id: org.id})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Labels</a></li>
+                <li><a ui-sref="organization_sub_orgs({organization_id: org.id})" ng-if="org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sub-Organizations</a></li>
                 <li><a ui-sref="organization_members({organization_id: org.id})" ui-sref-active="active" translate>Members</a></li>
-                <li><a ui-sref="organization_members({organization_id: org.id})" translate>More...</a></li>
+                <li><a ui-sref="organization_email_templates({organization_id: org.id})" ui-sref-active="active" translate>Email Templates</a></li>
+                <li><a ui-sref="organization_derived_columns({organization_id: org.id, inventory_type: 'properties'})" ui-sref-active="active" translate>Derived Columns</a></li>
+
 
                 <!--<li>
                     <a data-toggle="modal" data-target="#newProjectModalIndex" ng-click="open_create_project_modal()">Project</a>

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -6,7 +6,7 @@
     </div>
     <div class="add_menu_container">
         <div class="btn-group org-dropdown" uib-dropdown is-open="status.isopen">
-            <button id="btnUserOrgs" type="button" class="btn btn-default" uib-dropdown-toggle ng-disabled="disabled" (mouseover)="hover_org()">
+            <button id="btnUserOrgs" type="button" class="btn btn-default" uib-dropdown-toggle ng-disabled="disabled">
                 <span style="color:gray">Current Organization:</span> {$ menu.user.organization.name $} <span class="caret"></span>
             </button>
             <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="btnUserOrgs" ng-mousemove="track_mouse($event)">

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -21,11 +21,6 @@
                 <span class="sr-only" translate>Toggle Dropdown</span>
             </button>
             <ul uib-dropdown-menu class="dropdown-menu pull-right justify-left" role="menu" aria-labelledby="btnCreateNew">
-                <li class="dropdown-header" translate>Create a new...</li>
-                <li class="divider"></li>
-                <li ng-show="menu.user.organization.user_role !== 'viewer'">
-                    <a data-toggle="modal" data-target="#dataUploadModal" ng-click="open_data_upload_modal()" translate>Data Set</a>
-                </li>
                 <li class="dropdown-header" translate>Organization Settings</li>
                 <li class="divider"></li>
                 <li><a ui-sref="organization_settings({organization_id: org.id})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Settings</a></li>

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -41,7 +41,7 @@
                 <li><a ui-sref="organization_cycles({organization_id: org.id})" ng-if="org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Cycles</a></li>
                 <li><a ui-sref="organization_labels({organization_id: org.id})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Labels</a></li>
                 <li><a ui-sref="organization_members({organization_id: org.id})" ui-sref-active="active" translate>Members</a></li>
-                <li><a ui-sref="organization_settings({organization_id: org.id})" translate>More...</a></li>
+                <li><a ui-sref="organization_members({organization_id: org.id})" translate>More...</a></li>
 
                 <!--<li>
                     <a data-toggle="modal" data-target="#newProjectModalIndex" ng-click="open_create_project_modal()">Project</a>

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -1,18 +1,34 @@
 <div class="header">
     <div class="add_menu_container">
         <div class="btn-group org-dropdown" uib-dropdown is-open="status.isopen">
-            <button id="btnUserOrgs" type="button" class="btn btn-default" uib-dropdown-toggle ng-disabled="disabled">
+            <button id="btnUserOrgs" type="button" class="btn btn-default" uib-dropdown-toggle ng-disabled="disabled" (mouseover)="hover_org()">
                 <span style="color:gray">Current Organization:</span> {$ menu.user.organization.name $} <span class="caret"></span>
             </button>
-            <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="btnUserOrgs">
+            {% comment %} <span 
+                class="hover-org-id-header" 
+                ng-if="show_org_id"
+                style="top: {$ ypos $}; left:50px;"
+            >
+                ID: {$ hover_org_id $}
+            </span> {% endcomment %}
+            <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="btnUserOrgs" ng-mousemove="track_mouse($event)">
                 <li ng-if="!menu.user.organizations.length" style="text-align: center;">
                     <span class="glyphicon glyphicon-refresh spinning"></span> <span translate>Loading...</span>
                 </li>
                 <li ng-repeat="org in menu.user.organizations">
-                    <a href ng-click="set_user_org(org)" ng-class="{'pink-bg': !org.user_role}">{$ org.name $}
+                    <a 
+                        href ng-click="set_user_org(org)" 
+                        ng-class="{'pink-bg': !org.user_role}" 
+                        ng-mouseover="mouseover_org(org.id)"
+                        ng-mouseout="mouseout_org()"
+                    >
+                        {$ org.name $}
                         <i class="fa fa-check" ng-show="org.id == menu.user.organization.id"></i>
                     </a>
+
+                    {% comment %} <span class="hover-org-id" ng-if="hover_org_id == org.id && show_org_id">Organization ID: {$ hover_org_id $}</span> {% endcomment %}
                 </li>
+                <li ng-if="hover_org_id" class="hover-org-id-bottom" >Organization ID: {$ hover_org_id $}</li>
             </ul>
         </div>
         <div class="btn-group" uib-dropdown ng-hide="menu.user.organization.user_role === 'viewer'">

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -35,7 +35,7 @@
                 <li><a ui-sref="organization_cycles({organization_id: org.id})" ng-if="org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Cycles</a></li>
                 <li><a ui-sref="organization_labels({organization_id: org.id})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Labels</a></li>
                 <li><a ui-sref="organization_members({organization_id: org.id})" ui-sref-active="active" translate>Members</a></li>
-                <li><a ui-sref="organization_settings({organization_id: org.id})" translate>More</a></li>
+                <li><a ui-sref="organization_settings({organization_id: org.id})" translate>More...</a></li>
 
                 <!--<li>
                     <a data-toggle="modal" data-target="#newProjectModalIndex" ng-click="open_create_project_modal()">Project</a>

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -2,7 +2,7 @@
     <div class="add_menu_container">
         <div class="btn-group org-dropdown" uib-dropdown is-open="status.isopen">
             <button id="btnUserOrgs" type="button" class="btn btn-default" uib-dropdown-toggle ng-disabled="disabled">
-                {$ menu.user.organization.name $} <span class="caret"></span>
+                <span style="color:gray">Current Organization:</span> {$ menu.user.organization.name $} <span class="caret"></span>
             </button>
             <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="btnUserOrgs">
                 <li ng-if="!menu.user.organizations.length" style="text-align: center;">
@@ -20,19 +20,23 @@
                 <i class="fa fa-plus"></i>
                 <span class="sr-only" translate>Toggle Dropdown</span>
             </button>
-            <ul uib-dropdown-menu class="dropdown-menu pull-right" role="menu" aria-labelledby="btnCreateNew">
+            <ul uib-dropdown-menu class="dropdown-menu pull-right justify-left" role="menu" aria-labelledby="btnCreateNew">
                 <li class="dropdown-header" translate>Create a new...</li>
-                <li class="dropdown-header" translate> Test </li>
-                {% comment %} <li class="dropdown-header" >{$ ross $} </li> {% endcomment %}
-                <li><a ui-sref="organization_settings(::{organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Settings</a></li>
-                <li><a ui-sref="organization_sharing(::{organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Sharing</a></li>
-                <li><a ui-sref="organization_column_settings(::{organization_id: menu.user.organization.id, inventory_type: 'properties'})" ui-sref-active="active" translate>Column Settings</a></li>
-                <li><a ui-sref="organization_data_quality(::{organization_id: menu.user.organization.id, inventory_type: 'properties'})" ui-sref-active="active" translate>Data Quality</a></li>
-                <li><a ui-sref="organization_cycles(::{organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Cycles</a></li>
-                <li><a ui-sref="organization_labels(::{organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Labels</a></li>
-                <li><a ui-sref="organization_members(::{organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Members</a></li>
-                <li><a ui-sref="organization_settings(::{organization_id: menu.user.organization.id})" translate>More</a></li>
-                <li>abc {$ menu.user.organization $} def</li>
+                <li class="divider"></li>
+                <li ng-show="menu.user.organization.user_role !== 'viewer'">
+                    <a data-toggle="modal" data-target="#dataUploadModal" ng-click="open_data_upload_modal()" translate>Data Set</a>
+                </li>
+                <li class="dropdown-header" translate>Organization Settings</li>
+                <li class="divider"></li>
+                <li><a ui-sref="organization_settings({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Settings</a></li>
+                <li><a ui-sref="organization_sharing({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Sharing</a></li>
+                <li><a ui-sref="organization_column_settings({organization_id: menu.user.organization.id, inventory_type: 'properties'})" ui-sref-active="active" translate>Column Settings</a></li>
+                <li><a ui-sref="organization_data_quality({organization_id: menu.user.organization.id, inventory_type: 'properties'})" ui-sref-active="active" translate>Data Quality</a></li>
+                <li><a ui-sref="organization_cycles({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Cycles</a></li>
+                <li><a ui-sref="organization_labels({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Labels</a></li>
+                <li><a ui-sref="organization_members({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Members</a></li>
+                <li><a ui-sref="organization_settings({organization_id: menu.user.organization.id})" translate>More</a></li>
+                <li> ORG ID: {$ menu.user.organization.id $} </li>
                         {% comment %} <a ui-sref="organization_settings(::{organization_id: org.id})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Settings</a>
                         <a ui-sref="organization_sharing(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sharing</a>
                         <a ui-sref="organization_column_settings(::{organization_id: org.id, inventory_type: 'properties'})" ng-if="::auth.requires_owner" ng-class="::{active: state.name === 'organization_column_settings'}" translate>Column Settings</a>
@@ -45,14 +49,10 @@
                         <a ui-sref="organization_email_templates(::{organization_id: org.id})" ui-sref-active="active" translate>Email Templates</a>
                         <a ui-sref="organization_derived_columns(::{organization_id: org.id, inventory_type: 'properties'})" ui-sref-active="active" translate>Derived Columns</a> {% endcomment %}
 
-                <li class="divider"></li>
                 <!--<li>
                     <a data-toggle="modal" data-target="#newProjectModalIndex" ng-click="open_create_project_modal()">Project</a>
                 </li>
                 <li class="divider" ng-show="menu.user.organization.user_role !== 'viewer'"></li>-->
-                <li ng-show="menu.user.organization.user_role !== 'viewer'">
-                    <a data-toggle="modal" data-target="#dataUploadModal" ng-click="open_data_upload_modal()" translate>Data Set</a>
-                </li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
#### Any background context you want to provide?
See issue #3050

#### What's this PR do?
- This PR updates the function and appearance of the `_header` navigation buttons. 
- The `+` button will now direct users to the organization settings of the current organization based on their authorization role 
- The current organization has been reformatted to show the current (selected) organization
- When the user hovers over an organization in the drop-down the organization id will appear above the mouse


#### How should this be manually tested?
- From any page, use the `+` button to navigate to the organization's various settings. Ensure it is the correct organization (check URL for organization id) 
- with an Admin account (role_level = 20) see all child organizations
- with a nonauthorized user check the available settings and organizations. If they do not have permission (role_level = 0) the `+` button will disappear. Partially authorized users (role_level = 10) will be able to click the `+` but will only have access to 'members' and 'more...'
- Hovering over the organization dropdown will show the organization id for all users

#### What are the relevant tickets?
#3052 

### Screenshots (if appropriate)
#### Admin  (`role_level` = 20) hover over organization dropdown 
![Screen Shot 2022-01-05 at 10 23 55 AM](https://user-images.githubusercontent.com/58446472/148264091-ca7302b8-c13c-4992-910a-a84944c92c7e.png)

![Screen Shot 2022-01-05 at 10 23 45 AM](https://user-images.githubusercontent.com/58446472/148264092-6ab774c2-60dd-411b-98a7-3db7c00cd6ce.png)

#### Admin (`role_level` = 20) `+` functionality
![Screen Shot 2022-01-05 at 10 23 24 AM](https://user-images.githubusercontent.com/58446472/148264093-7392bfa8-40d3-4f27-b3f5-bb9d73a43379.png)

#### User (`role_level` = 10) `+` functionality
![Screen Shot 2022-01-05 at 10 24 57 AM](https://user-images.githubusercontent.com/58446472/148264087-c40ae2a4-437d-48f0-88db-0d484fd70ec4.png)

#### User (`role_level` = 10) hover over organization dropdown
![Screen Shot 2022-01-05 at 10 47 45 AM](https://user-images.githubusercontent.com/58446472/148264670-e36223bd-cbc8-41d1-8179-762c3acb1390.png)

#### Non-authorized user (`role_level` = 0) hover over organization dropdown. 
Note: `+` hidden from non-authorized user
![Screen Shot 2022-01-05 at 10 48 15 AM](https://user-images.githubusercontent.com/58446472/148264668-e73bde49-5553-41c9-9665-8fb9c7052171.png)





