### PR TITLE
Feat/inventory column filtering and sorting

### DIFF
--- a/seed/search.py
+++ b/seed/search.py
@@ -397,7 +397,31 @@ def build_view_filters_and_sorts(filters: QueryDict, columns: list[dict]) -> tup
     """Build a query object usable for `*View.filter(...)` as well as a list of
     column names for usable for `*View.order_by(...)`.
 
-    Specifically:
+    Filters are specified in a similar format as Django queries, as `column_name`
+    or `column_name__lookup`, where `column_name` is a valid Column.column_name,
+    and `__lookup` (which is optional) is any valid Django field lookup:
+      https://docs.djangoproject.com/en/4.0/topics/db/queries/#field-lookups
+
+    One special lookup which is not provided by Django is `__ne` which negates
+    the filter expression.
+
+    Query string examples:
+    - `?city=Denver` - inventory where City is Denver
+    - `?city__ne=Denver` - inventory where City is NOT Denver
+    - `?site_eui__gte=100` - inventory where Site EUI >= 100
+    - `?city=Denver&site_eui__gte=100` - inventory where City is Denver AND Site EUI >= 100
+    - `?my_custom_column__lt=1000` - inventory where the extra data field `my_custom_column` < 1000
+
+    Sorts are specified with the `order_by` parameter, with any valid Column.column_name
+    as the value. By default the column is sorted in ascending order, columns prefixed
+    with `-` will be sorted in descending order.
+
+    Query string examples:
+    - `?order_by=site_eui` - sort by Site EUI in ascending order
+    - `?order_by=-site_eui` - sort by Site EUI in descending order
+    - `?order_by=city&order_by=site_eui` - sort by City, then Site EUI
+
+    This function basically does the following:
     - Ignore any filter/sort that doesn't have a corresponding column
     - Handle cases for extra data
     - Convert filtering values into their proper types (e.g. str -> int)

--- a/seed/search.py
+++ b/seed/search.py
@@ -7,14 +7,16 @@
 Search methods pertaining to buildings.
 
 """
+from datetime import datetime
 import json
 import logging
 import operator
+from typing import Callable, Union
 
 from functools import reduce
 
 from django.db.models import Q
-from django.http.request import RawPostDataException
+from django.http.request import RawPostDataException, QueryDict
 from past.builtins import basestring
 
 from seed.lib.superperms.orgs.models import Organization
@@ -301,3 +303,122 @@ def inventory_search_filter_sort(inventory_type, params, user):
         )
 
     return inventory
+
+
+class FilterException(Exception):
+    pass
+
+
+def _parse_view_filter(filter_expression: str, filter_value: str, columns_by_name: dict[str, dict]) -> Q:
+    """Parse a filter expression into a Q object
+
+    :param filter_expression: should be a valid Column.column_name, with an optional
+                              Django field lookup suffix (e.g. `__gt`, `__icontains`, etc)
+                              https://docs.djangoproject.com/en/4.0/topics/db/queries/#field-lookups
+                              One custom field lookup suffix is allowed, `__ne`,
+                              which negates the expression (i.e. column_name != filter_value)
+    :param filter_value: the value evaluated against the filter_expression
+    :param columns_by_name: mapping of Column.column_name to dict representation of Column
+    :return: query object
+    """
+    data_type_parsers: dict[str, Callable] = {
+        'number': float,
+        'float': float,
+        'integer': int,
+        'string': str,
+        'geometry': str,
+        'datetime': datetime.fromisoformat,
+        'date': datetime.fromisoformat,
+        'boolean': lambda v: v.lower() == 'true',
+        'area': float,
+        'eui': float,
+    }
+
+    column_name, _, _ = filter_expression.partition('__')
+    column = columns_by_name.get(column_name)
+    if column is None:
+        return Q()
+
+    # users indicate negation with a trailing `__ne` (which is not a real Django filter)
+    # so we need to remove it if found
+    is_negated = filter_expression.endswith('__ne')
+    if is_negated:
+        filter_expression, _, _ = filter_expression.rpartition('__ne')
+
+    new_filter_expression = None
+    if column_name == 'campus':
+        # campus is the only column found on the canonical property (TaxLots don't have this column)
+        # all other columns are found in the state
+        new_filter_expression = f'property__{filter_expression}'
+    elif column['is_extra_data']:
+        new_filter_expression = f'state__extra_data__{filter_expression}'
+    else:
+        new_filter_expression = f'state__{filter_expression}'
+
+    parser = data_type_parsers.get(column['data_type'], str)
+    try:
+        new_filter_value = parser(filter_value)
+    except Exception:
+        raise FilterException(f'Invalid data type for "{column_name}". Expected a valid {column["data_type"]} value.')
+
+    new_filter_dict = {new_filter_expression: new_filter_value}
+    if is_negated:
+        return ~Q(**new_filter_dict)
+    else:
+        return Q(**new_filter_dict)
+
+
+def _parse_view_sort(sort_expression: str, columns_by_name: dict[str, dict]) -> Union[None, str]:
+    """Parse a sort expression
+
+    :param sort_expression: should be a valid Column.column_name. Optionally prefixed
+                            with '-' to indicate descending order.
+    :param columns_by_name: mapping of Column.column_name to dict representation of Column
+    :return: the parsed sort expression or None if not valid
+    """
+    column_name = sort_expression.lstrip('-')
+    direction = '-' if sort_expression.startswith('-') else ''
+    if column_name == 'id':
+        return sort_expression
+    elif column_name == 'campus':
+        # campus is the only column which is found exclusively on the Property, not the state
+        return f'property__{sort_expression}'
+    elif column_name in columns_by_name:
+        column = columns_by_name[column_name]
+        if column['is_extra_data']:
+            return f'{direction}state__extra_data__{column_name}'
+        else:
+            return f'{direction}state__{column_name}'
+    else:
+        return None
+
+
+def build_view_filters_and_sorts(filters: QueryDict, columns: list[dict]) -> tuple[Q, list[str]]:
+    """Build a query object usable for `*View.filter(...)` as well as a list of
+    column names for usable for `*View.order_by(...)`.
+
+    Specifically:
+    - Ignore any filter/sort that doesn't have a corresponding column
+    - Handle cases for extra data
+    - Convert filtering values into their proper types (e.g. str -> int)
+
+    :param filters: QueryDict from a request
+    :param columns: list of all valid Columns in dict format
+    :return: filters and sorts
+    """
+    columns_by_name = {
+        c['column_name']: c
+        for c in columns
+    }
+
+    new_filters = Q()
+    for filter_expression, filter_value in filters.items():
+        new_filters &= _parse_view_filter(filter_expression, filter_value, columns_by_name)
+
+    order_by = []
+    for sort_expression in filters.getlist('order_by', ['id']):
+        parsed_sort = _parse_view_sort(sort_expression, columns_by_name)
+        if parsed_sort is not None:
+            order_by.append(parsed_sort)
+
+    return new_filters, order_by

--- a/seed/static/seed/js/controllers/inventory_list_beta_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_beta_controller.js
@@ -829,14 +829,20 @@ angular.module('BE.seed.controller.inventory_list_beta', [])
       $scope.load_inventory = function (page) {
         const page_size = 100;
         spinner_utility.show()
-        return fetch(page, page_size).then(function (data) {
-          $scope.inventory_pagination = data.pagination;
-          processData(data.results);
-          $scope.gridApi.core.notifyDataChange(uiGridConstants.dataChange.EDIT);
-          modalInstance.close();
-          evaluateDerivedColumns();
-          spinner_utility.hide()
-        });
+        return fetch(page, page_size)
+          .then(function (data) {
+            if (data.status === 'error') {
+              Notification.error(data.message);
+              spinner_utility.hide();
+              return;
+            }
+            $scope.inventory_pagination = data.pagination;
+            processData(data.results);
+            $scope.gridApi.core.notifyDataChange(uiGridConstants.dataChange.EDIT);
+            modalInstance.close();
+            evaluateDerivedColumns();
+            spinner_utility.hide()
+          });
       };
 
       $scope.update_cycle = function (cycle) {

--- a/seed/static/seed/js/controllers/inventory_list_beta_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_beta_controller.js
@@ -1136,8 +1136,8 @@ angular.module('BE.seed.controller.inventory_list_beta', [])
         }
       };
 
-      // https://regexr.com/3j1tq
-      const combinedRegex = /^(!?)=\s*(-?\d+(?:\\\.\d+)?)$|^(!?)=?\s*"((?:[^"]|\\")*)"$|^(<=?|>=?)\s*(-?\d+(?:\\\.\d+)?)$/;
+      // https://regexr.com/6cka2
+      const combinedRegex = /^(!?)=\s*(-?\d+(?:\\\.\d+)?)$|^(!?)=?\s*"((?:[^"]|\\")*)"$|^(<=?|>=?)\s*((-?\d+(?:\\\.\d+)?)|(\d{4}-\d{2}-\d{2}))$/;
       const parseFilter = function (expression) {
         // parses an expression string into an object containing operator and value
         const filterData = expression.match(combinedRegex);
@@ -1160,10 +1160,24 @@ angular.module('BE.seed.controller.inventory_list_beta', [])
             } else {
               return {operator: 'exact', value};
             }
-          } else {
+          } else if (!_.isUndefined(filterData[7])) {
             // Numeric Comparison
             operator = filterData[5];
             value = Number(filterData[6].replace('\\.', '.'));
+            switch (operator) {
+              case '<':
+                return {operator: 'lt', value};
+              case '<=':
+                return {operator: 'lte', value};
+              case '>':
+                return {operator: 'gt', value};
+              case '>=':
+                return {operator: 'gte', value};
+            }
+          } else {
+            // Date Comparison
+            operator = filterData[5];
+            value = filterData[8];
             switch (operator) {
               case '<':
                 return {operator: 'lt', value};

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -20,14 +20,45 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       total_taxlots_for_user: 0
     };
 
-    inventory_service.get_properties = function (page, per_page, cycle, profile_id, property_view_ids, save_last_cycle = true, organization_id = null, include_related = true) {
+    const format_column_filters = function (column_filters) {
+      // turn column filter objects into usable query parameters
+      if (!column_filters) {
+        return {};
+      }
+
+      const filters = {};
+      for (const {column_name, operator, value} of column_filters) {
+        filters[`${column_name}__${operator}`] = value;
+      }
+
+      return filters
+    }
+
+    const format_column_sorts = function (column_sorts) {
+      // turn column sort objects into usable query parameter
+      if (!column_sorts) {
+        return [];
+      }
+
+      const sorts = [];
+      for (const {column_name, direction} of column_sorts) {
+        const direction_operator = direction == 'desc' ? '-' : ''
+        sorts.push(`${direction_operator}${column_name}`);
+      }
+
+      return {order_by: sorts};
+    }
+
+    inventory_service.get_properties = function (page, per_page, cycle, profile_id, property_view_ids, save_last_cycle = true, organization_id = null, include_related = true, column_filters = null, column_sorts = null) {
       organization_id = organization_id == undefined ? user_service.get_organization().id : organization_id;
 
       var params = {
         organization_id: organization_id,
         page: page,
         per_page: per_page || 999999999,
-        include_related: include_related
+        include_related: include_related,
+        ...format_column_sorts(column_sorts),
+        ...format_column_filters(column_filters),
       };
 
       return cycle_service.get_cycles().then(function (cycles) {
@@ -253,14 +284,16 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
     };
 
 
-    inventory_service.get_taxlots = function (page, per_page, cycle, profile_id, inventory_ids, save_last_cycle = true, organization_id = null, include_related = true) {
+    inventory_service.get_taxlots = function (page, per_page, cycle, profile_id, inventory_ids, save_last_cycle = true, organization_id = null, include_related = true, column_filters = null, column_sorts = null) {
       organization_id = organization_id == undefined ? user_service.get_organization().id : organization_id;
 
       var params = {
         organization_id: organization_id,
         page: page,
         per_page: per_page || 999999999,
-        include_related: include_related
+        include_related: include_related,
+        ...format_column_sorts(column_sorts),
+        ...format_column_filters(column_filters),
       };
 
       return cycle_service.get_cycles().then(function (cycles) {

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -84,7 +84,12 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         }).then(function (response) {
           return response.data;
         });
-      }).catch(_.constant('Error fetching cycles'));
+      }).catch(function (response) {
+        if (response.data.message) {
+          return response.data
+        }
+        throw response
+      });
     };
 
     inventory_service.properties_cycle = function (profile_id, cycle_ids) {
@@ -319,7 +324,12 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         }).then(function (response) {
           return response.data;
         });
-      }).catch(_.constant('Error fetching cycles'));
+      }).catch(function (response) {
+        if (response.data.message) {
+          return response.data
+        }
+        throw response
+      });
     };
 
     inventory_service.taxlots_cycle = function (profile_id, cycle_ids) {

--- a/seed/tests/test_search.py
+++ b/seed/tests/test_search.py
@@ -1,0 +1,210 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+from django.db.models import Q
+from django.http.request import QueryDict
+from django.test import TestCase
+
+from seed.landing.models import SEEDUser as User
+from seed.models import Column
+from seed.search import FilterException, build_view_filters_and_sorts
+from seed.utils.organizations import create_organization
+
+
+class TestInventoryViewSearchParsers(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.fake_user = User.objects.create(username='test')
+        cls.fake_org, _, _ = create_organization(cls.fake_user)
+
+    def test_parse_filters_works_for_canonical_columns(self):
+        @dataclass
+        class TestCase:
+            name: str
+            input: QueryDict
+            expected: Q
+
+        # -- Setup
+        test_cases = [
+            TestCase('canonical column with number data_type', QueryDict('latitude=12.3'), Q(state__latitude=12.3)),
+            TestCase('canonical column with integer data_type', QueryDict('year_built=123'), Q(state__year_built=123)),
+            TestCase('canonical column with string data_type', QueryDict('custom_id_1=123'), Q(state__custom_id_1='123')),
+            TestCase('canonical column with geometry data_type', QueryDict('property_footprint=abcdefg'), Q(state__property_footprint='abcdefg')),
+            TestCase('canonical column with datetime data_type', QueryDict('updated=2022-01-01 10:11:12'), Q(state__updated=datetime(2022, 1, 1, 10, 11, 12))),
+            TestCase('canonical column with date data_type', QueryDict('year_ending=2022-01-01'), Q(state__year_ending=datetime(2022, 1, 1))),
+            TestCase('canonical column with boolean data_type', QueryDict('campus=True'), Q(property__campus=True)),
+            TestCase('canonical column with area data_type', QueryDict('gross_floor_area=12.3'), Q(state__gross_floor_area=12.3)),
+            TestCase('canonical column with eui data_type', QueryDict('site_eui=12.3'), Q(state__site_eui=12.3)),
+        ]
+
+        for test_case in test_cases:
+            # -- Act
+            columns = Column.retrieve_all(self.fake_org, 'property', only_used=False)
+            filters, _ = build_view_filters_and_sorts(test_case.input, columns)
+
+            # -- Assert
+            self.assertEqual(
+                filters,
+                test_case.expected,
+                f'Failed "{test_case.name}"; actual: {filters}; expected: {test_case.expected}'
+            )
+
+    def test_parse_filters_works_for_extra_data_columns(self):
+        @dataclass
+        class TestCase:
+            name: str
+            input: QueryDict
+            expected: Q
+
+        # -- Setup
+        # create some extra data columns
+        extra_data_columns = [
+            {
+                'column_name': 'test_string',
+                'data_type': 'string',
+                'is_extra_data': True,
+                'table_name': 'PropertyState',
+                'organization': self.fake_org,
+            },
+            {
+                'column_name': 'test_number',
+                'data_type': 'number',
+                'is_extra_data': True,
+                'table_name': 'PropertyState',
+                'organization': self.fake_org,
+            }
+        ]
+        for col in extra_data_columns:
+            Column.objects.create(**col)
+
+        test_cases = [
+            TestCase('extra_data column with string data_type', QueryDict('test_string=hello'), Q(state__extra_data__test_string='hello')),
+            TestCase('extra_data column with number data_type', QueryDict('test_number=12.3'), Q(state__extra_data__test_number=12.3)),
+        ]
+
+        for test_case in test_cases:
+            # -- Act
+            columns = Column.retrieve_all(self.fake_org, 'property', only_used=False)
+            filters, _ = build_view_filters_and_sorts(test_case.input, columns)
+
+            # -- Assert
+            self.assertEqual(
+                filters,
+                test_case.expected,
+                f'Failed "{test_case.name}"; actual: {filters}; expected: {test_case.expected}'
+            )
+
+    def test_parse_filters_returns_empty_q_object_for_invalid_columns(self):
+        # -- Setup
+        query_dict = QueryDict('this_column_does_not_exits=123')
+
+        # -- Act
+        columns = Column.retrieve_all(self.fake_org, 'property', only_used=False)
+        filters, _ = build_view_filters_and_sorts(query_dict, columns)
+
+        # -- Assert
+        self.assertEqual(filters, Q())
+
+    def test_parse_filters_can_handle_multiple_filters(self):
+        # -- Setup
+        query_dict = QueryDict('city=Denver&site_eui=100&gross_floor_area=200')
+
+        # -- Act
+        columns = Column.retrieve_all(self.fake_org, 'property', only_used=False)
+        filters, _ = build_view_filters_and_sorts(query_dict, columns)
+
+        # -- Assert
+        expected = (
+            Q(state__city='Denver')
+            & Q(state__site_eui=100)
+            & Q(state__gross_floor_area=200)
+        )
+        self.assertEqual(filters, expected)
+
+    def test_parse_filters_preserves_field_lookups(self):
+        @dataclass
+        class TestCase:
+            name: str
+            input: QueryDict
+            expected: Q
+
+        # -- Setup
+        test_cases = [
+            TestCase('field lookup <', QueryDict('site_eui__lt=12.3'), Q(state__site_eui__lt=12.3)),
+            TestCase('field lookup <=', QueryDict('site_eui__lte=12.3'), Q(state__site_eui__lte=12.3)),
+            TestCase('field lookup >', QueryDict('site_eui__gt=12.3'), Q(state__site_eui__gt=12.3)),
+            TestCase('field lookup >=', QueryDict('site_eui__gte=12.3'), Q(state__site_eui__gte=12.3)),
+            TestCase('field lookup exact', QueryDict('site_eui__exact=12.3'), Q(state__site_eui__exact=12.3)),
+            TestCase('field lookup icontains', QueryDict('site_eui__icontains=12.3'), Q(state__site_eui__icontains=12.3)),
+        ]
+
+        for test_case in test_cases:
+            # -- Act
+            columns = Column.retrieve_all(self.fake_org, 'property', only_used=False)
+            filters, _ = build_view_filters_and_sorts(test_case.input, columns)
+
+            # -- Assert
+            self.assertEqual(
+                filters,
+                test_case.expected,
+                f'Failed "{test_case.name}"; actual: {filters}; expected: {test_case.expected}'
+            )
+
+    def test_parse_filters_returns_negated_q_object_for_ne_lookup(self):
+        # -- Setup
+        query_dict = QueryDict('city__ne=Denver')
+
+        # -- Act
+        columns = Column.retrieve_all(self.fake_org, 'property', only_used=False)
+        filters, _ = build_view_filters_and_sorts(query_dict, columns)
+
+        # -- Assert
+        self.assertEqual(filters, ~Q(state__city='Denver'))
+
+    def test_parse_filters_raises_exception_when_filter_value_is_invalid(self):
+        # -- Setup
+        # site_eui is a number type, so the string 'hello' will fail to be parsed
+        query_dict = QueryDict('site_eui=hello')
+
+        # -- Act, Assert
+        columns = Column.retrieve_all(self.fake_org, 'property', only_used=False)
+        with self.assertRaises(FilterException):
+            build_view_filters_and_sorts(query_dict, columns)
+
+    def test_parse_sorts_works(self):
+        @dataclass
+        class TestCase:
+            name: str
+            input: QueryDict
+            expected: list[str]
+
+        # -- Setup
+        # create an extra data column
+        Column.objects.create(
+            column_name='test_column',
+            data_type='string',
+            is_extra_data=True,
+            table_name='PropertyState',
+            organization=self.fake_org,
+        )
+
+        test_cases = [
+            TestCase('order_by canonical column', QueryDict('order_by=site_eui'), ['state__site_eui']),
+            TestCase('order_by extra data column', QueryDict('order_by=test_column'), ['state__extra_data__test_column']),
+            TestCase('order_by multiple columns', QueryDict('order_by=city&order_by=site_eui'), ['state__city', 'state__site_eui']),
+            TestCase('order_by defaults to id', QueryDict(''), ['id']),
+            TestCase('order_by can handle descending operator', QueryDict('order_by=-site_eui'), ['-state__site_eui']),
+        ]
+
+        # -- Act
+        for test_case in test_cases:
+            columns = Column.retrieve_all(self.fake_org, 'property', only_used=False)
+            _, order_by = build_view_filters_and_sorts(test_case.input, columns)
+
+            # -- Assert
+            self.assertEqual(
+                order_by,
+                test_case.expected,
+                f'Failed "{test_case.name}"; actual: {order_by}; expected: {test_case.expected}'
+            )


### PR DESCRIPTION
Remaining Todos (won't be addressed in this PR):
- fix bug: if we allow users to filter properties based on taxlot columns (or vice versa) we will have column_name collisions. E.g. `created` for taxlots and `created` for properties (which we are unable to distinguish currently)
- fix bug: some extra_data columns are strings, and trying to use numeric filtering doesn't work
- improvement: find a way to improve how users "use" filtering and sorting. Two main issues:
  - currently we just debounce the filtering whenever a filter or sort is updated. This is confusing to user
  - find a way to summarize/display the sorts and filters applied currently so you can know what's going on even when you're not looking at a column

#### Any background context you want to provide?
- SEED is creating a paginated inventory list, which requires sorting and filtering on the backend

#### What's this PR do?
- adds rudimentary filtering and sorting for the beta inventory list page
  - for the `/api/v3/properties/filter/` endpoint (and the same for taxlots), users can provide query parameters for filtering. The format is `<column_name>=<value>`, which is the Column.column_name. Users can optionally provide django operators like `<column_name>__lt` or `<column_name>__gte`, etc.
  - For the same endpoint, users can provide the `order_by` query parameter in the format `order_by=<column_name>` to sort the results according to that column's values. By default this is in ascending order, users can prefix the column name with a `-` for descending order: `order_by=-<column_name>`. Users can also provide multiple order_by params to sort by multiple columns: `order_by=site_eui&order_by=-created`

NOTE: these changes are all backwards compatible with the existing endpoint API usage

#### How should this be manually tested?
- monkey test the frontend filtering from the beta inventory list page. Try providing good and bad values. Bad values (e.g. a word like "hello" for a datetime column such as `created` should fail gracefully.

#### What are the relevant tickets?
#3047 
#3048 
#3045 

#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/18518728/147616310-29957deb-4276-4143-b50e-2e32e06e9b24.mov


