### PR TITLE
3081 refactor/util property taxlot fiter

### DIFF
--- a/seed/utils/filter_state.py
+++ b/seed/utils/filter_state.py
@@ -1,0 +1,169 @@
+"""
+:copyright (c) 2014 - 2022, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
+:author
+"""
+from typing import Optional
+
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.db.utils import DataError
+from django.http import JsonResponse
+from rest_framework import status, viewsets, generics
+from rest_framework.request import Request
+from seed.lib.superperms.orgs.models import Organization
+from seed.models import (VIEW_LIST, VIEW_LIST_PROPERTY,
+                        Column, ColumnListProfile,
+                         ColumnListProfileColumn,  Cycle,
+                         PropertyView)
+from seed.models import TaxLotProperty, TaxLotView
+from seed.search import build_view_filters_and_sorts, FilterException
+from seed.serializers.pint import (apply_display_unit_preferences)
+
+
+def _get_filtered_results(request: Request, profile_id: int, state_type: str='property'):
+        page = request.query_params.get('page', 1)
+        per_page = request.query_params.get('per_page', 1)
+        org_id = request.query_params.get('organization_id')
+        cycle_id = request.query_params.get('cycle')
+        # check if there is a query paramater for the profile_id. If so, then use that one
+        profile_id = request.query_params.get('profile_id', profile_id)
+
+        if not org_id:
+            return JsonResponse(
+                {'status': 'error', 'message': 'Need to pass organization_id as query parameter'},
+                status=status.HTTP_400_BAD_REQUEST)
+        org = Organization.objects.get(id=org_id)
+
+        if cycle_id:
+            cycle = Cycle.objects.get(organization_id=org_id, pk=cycle_id)
+        else:
+            cycle = Cycle.objects.filter(organization_id=org_id).order_by('name')
+            if cycle:
+                cycle = cycle.first()
+            else:
+                return JsonResponse({
+                    'status': 'error',
+                    'message': 'Could not locate cycle',
+                    'pagination': {
+                        'total': 0
+                    },
+                    'cycle_id': None,
+                    'results': []
+                })
+
+        if state_type == 'property':
+            views_list = (
+                PropertyView.objects.select_related('property', 'state', 'cycle')
+                .filter(property__organization_id=org_id, cycle=cycle)
+            )
+
+        include_related = (
+            str(request.query_params.get('include_related', 'true')).lower() == 'true'
+        )
+
+        # Retrieve all the columns that are in the db for this organization
+        columns_from_database = Column.retrieve_all(
+            org_id=org_id,
+            inventory_type=state_type,
+            only_used=False,
+            include_related=include_related
+        )
+        try:
+            filters, annotations, order_by = build_view_filters_and_sorts(request.query_params, columns_from_database)
+        except FilterException as e:
+            return JsonResponse(
+                {
+                    'status': 'error',
+                    'message': f'Error filtering: {str(e)}'
+                },
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        views_list = views_list.annotate(**annotations).filter(filters).order_by(*order_by)
+
+        # Return property views limited to the 'property_view_ids' list. Otherwise, if selected is empty, return all
+        if f'{state_type}_view_ids' in request.data and request.data[f'{state_type}_view_ids']:
+            views_list = views_list.filter(id__in=request.data[f'{state_type}_view_ids'])
+
+        paginator = Paginator(views_list, per_page)
+
+        try:
+            views = paginator.page(page)
+            page = int(page)
+        except PageNotAnInteger:
+            views = paginator.page(1)
+            page = 1
+        except EmptyPage:
+            views = paginator.page(paginator.num_pages)
+            page = paginator.num_pages
+        except DataError as e:
+            return JsonResponse(
+                {
+                    'status': 'error',
+                    'recommended_action': 'update_column_settings',
+                    'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
+                },
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # This uses an old method of returning the show_columns. There is a new method that
+        # is prefered in v2.1 API with the ProfileIdMixin.
+        if state_type == 'property':
+            view_list_state = VIEW_LIST_PROPERTY
+
+        show_columns: Optional[list[int]] = None
+        if profile_id is None:
+            show_columns = None
+        elif profile_id == -1:
+            show_columns = list(Column.objects.filter(
+                organization_id=org_id
+            ).values_list('id', flat=True))
+        else:
+            try:
+                profile = ColumnListProfile.objects.get(
+                    organization_id=org_id,
+                    id=profile_id,
+                    profile_location=VIEW_LIST,
+                    inventory_type=view_list_state
+                )
+                show_columns = list(ColumnListProfileColumn.objects.filter(
+                    column_list_profile_id=profile.id
+                ).values_list('column_id', flat=True))
+            except ColumnListProfile.DoesNotExist:
+                show_columns = None
+
+        try:
+            related_results = TaxLotProperty.serialize(
+                views,
+                show_columns,
+                columns_from_database,
+                include_related
+            )
+        except DataError as e:
+            return JsonResponse(
+                {
+                    'status': 'error',
+                    'recommended_action': 'update_column_settings',
+                    'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
+                },
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # collapse units here so we're only doing the last page; we're already a
+        # realized list by now and not a lazy queryset
+        unit_collapsed_results = [apply_display_unit_preferences(org, x) for x in related_results]
+
+        response = {
+            'pagination': {
+                'page': page,
+                'start': paginator.page(page).start_index(),
+                'end': paginator.page(page).end_index(),
+                'num_pages': paginator.num_pages,
+                'has_next': paginator.page(page).has_next(),
+                'has_previous': paginator.page(page).has_previous(),
+                'total': paginator.count
+            },
+            'cycle_id': cycle.id,
+            'results': unit_collapsed_results
+        }
+
+        return JsonResponse(response)

--- a/seed/utils/filter_state.py
+++ b/seed/utils/filter_state.py
@@ -115,7 +115,7 @@ def _get_filtered_results(request: Request, profile_id: int, state_type: str='pr
         # is prefered in v2.1 API with the ProfileIdMixin.
         if state_type == 'property':
             view_list_state = VIEW_LIST_PROPERTY
-        if state_type == 'taxlot':
+        elif state_type == 'taxlot':
             view_list_state = VIEW_LIST_TAXLOT
 
         show_columns: Optional[list[int]] = None

--- a/seed/utils/filter_state.py
+++ b/seed/utils/filter_state.py
@@ -2,7 +2,6 @@
 :copyright (c) 2014 - 2022, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
 """
-from typing import Optional
 
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.utils import DataError
@@ -16,11 +15,10 @@ from seed.models import (VIEW_LIST, VIEW_LIST_PROPERTY, VIEW_LIST_TAXLOT,
 from seed.models import TaxLotProperty, TaxLotView
 from seed.search import build_view_filters_and_sorts, FilterException
 from seed.serializers.pint import (apply_display_unit_preferences)
-from typing import Sequence, Union, TYPE_CHECKING, Optional, Literal
+from typing import Union, Optional, Literal
 
 
-
-def _get_filtered_results(request: Request, profile_id: int, state_type: Union[Literal['property'], Literal['taxlot'], None] = 'property'):
+def _get_filtered_results(request: Request, state_type: Union[Literal['property'], Literal['taxlot'], None], profile_id: int):
     page = request.query_params.get('page', 1)
     per_page = request.query_params.get('per_page', 1)
     org_id = request.query_params.get('organization_id')

--- a/seed/utils/filter_state.py
+++ b/seed/utils/filter_state.py
@@ -38,16 +38,16 @@ def get_filtered_results(request: Request, inventory_type: Literal['property', '
         cycle = Cycle.objects.filter(organization_id=org_id).order_by('name')
         if cycle:
             cycle = cycle.first()
-        else:
-            return JsonResponse({
-                'status': 'error',
-                'message': 'Could not locate cycle',
-                'pagination': {
-                    'total': 0
-                },
-                'cycle_id': None,
-                'results': []
-            })
+    if not cycle:
+        return JsonResponse({
+            'status': 'error',
+            'message': 'Could not locate cycle',
+            'pagination': {
+                'total': 0
+            },
+            'cycle_id': None,
+            'results': []
+        })
 
     if inventory_type == 'property':
         views_list = (

--- a/seed/utils/filter_state.py
+++ b/seed/utils/filter_state.py
@@ -16,9 +16,11 @@ from seed.models import (VIEW_LIST, VIEW_LIST_PROPERTY, VIEW_LIST_TAXLOT,
 from seed.models import TaxLotProperty, TaxLotView
 from seed.search import build_view_filters_and_sorts, FilterException
 from seed.serializers.pint import (apply_display_unit_preferences)
+from typing import Sequence, Union, TYPE_CHECKING, Optional, Literal
 
 
-def _get_filtered_results(request: Request, profile_id: int, state_type: str = 'property'):
+
+def _get_filtered_results(request: Request, profile_id: int, state_type: Union[Literal['property'], Literal['taxlot'], None] = 'property'):
     page = request.query_params.get('page', 1)
     per_page = request.query_params.get('per_page', 1)
     org_id = request.query_params.get('organization_id')

--- a/seed/utils/filter_state.py
+++ b/seed/utils/filter_state.py
@@ -10,7 +10,7 @@ from django.http import JsonResponse
 from rest_framework import status, viewsets, generics
 from rest_framework.request import Request
 from seed.lib.superperms.orgs.models import Organization
-from seed.models import (VIEW_LIST, VIEW_LIST_PROPERTY,
+from seed.models import (VIEW_LIST, VIEW_LIST_PROPERTY, VIEW_LIST_TAXLOT,
                         Column, ColumnListProfile,
                          ColumnListProfileColumn,  Cycle,
                          PropertyView)
@@ -55,6 +55,12 @@ def _get_filtered_results(request: Request, profile_id: int, state_type: str='pr
                 PropertyView.objects.select_related('property', 'state', 'cycle')
                 .filter(property__organization_id=org_id, cycle=cycle)
             )
+        elif state_type == 'taxlot':
+            views_list = (
+                TaxLotView.objects.select_related('taxlot', 'state', 'cycle')
+                .filter(taxlot__organization_id=org_id, cycle=cycle)
+            )
+
 
         include_related = (
             str(request.query_params.get('include_related', 'true')).lower() == 'true'
@@ -109,6 +115,8 @@ def _get_filtered_results(request: Request, profile_id: int, state_type: str='pr
         # is prefered in v2.1 API with the ProfileIdMixin.
         if state_type == 'property':
             view_list_state = VIEW_LIST_PROPERTY
+        if state_type == 'taxlot':
+            view_list_state = VIEW_LIST_TAXLOT
 
         show_columns: Optional[list[int]] = None
         if profile_id is None:

--- a/seed/utils/filter_state.py
+++ b/seed/utils/filter_state.py
@@ -7,171 +7,169 @@ from typing import Optional
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.utils import DataError
 from django.http import JsonResponse
-from rest_framework import status, viewsets, generics
+from rest_framework import status
 from rest_framework.request import Request
 from seed.lib.superperms.orgs.models import Organization
 from seed.models import (VIEW_LIST, VIEW_LIST_PROPERTY, VIEW_LIST_TAXLOT,
-                        Column, ColumnListProfile,
-                         ColumnListProfileColumn,  Cycle,
-                         PropertyView)
+                         Column, ColumnListProfile, ColumnListProfileColumn,
+                         Cycle, PropertyView)
 from seed.models import TaxLotProperty, TaxLotView
 from seed.search import build_view_filters_and_sorts, FilterException
 from seed.serializers.pint import (apply_display_unit_preferences)
 
 
-def _get_filtered_results(request: Request, profile_id: int, state_type: str='property'):
-        page = request.query_params.get('page', 1)
-        per_page = request.query_params.get('per_page', 1)
-        org_id = request.query_params.get('organization_id')
-        cycle_id = request.query_params.get('cycle')
-        # check if there is a query paramater for the profile_id. If so, then use that one
-        profile_id = request.query_params.get('profile_id', profile_id)
+def _get_filtered_results(request: Request, profile_id: int, state_type: str = 'property'):
+    page = request.query_params.get('page', 1)
+    per_page = request.query_params.get('per_page', 1)
+    org_id = request.query_params.get('organization_id')
+    cycle_id = request.query_params.get('cycle')
+    # check if there is a query paramater for the profile_id. If so, then use that one
+    profile_id = request.query_params.get('profile_id', profile_id)
 
-        if not org_id:
-            return JsonResponse(
-                {'status': 'error', 'message': 'Need to pass organization_id as query parameter'},
-                status=status.HTTP_400_BAD_REQUEST)
-        org = Organization.objects.get(id=org_id)
+    if not org_id:
+        return JsonResponse(
+            {'status': 'error', 'message': 'Need to pass organization_id as query parameter'},
+            status=status.HTTP_400_BAD_REQUEST)
+    org = Organization.objects.get(id=org_id)
 
-        if cycle_id:
-            cycle = Cycle.objects.get(organization_id=org_id, pk=cycle_id)
+    if cycle_id:
+        cycle = Cycle.objects.get(organization_id=org_id, pk=cycle_id)
+    else:
+        cycle = Cycle.objects.filter(organization_id=org_id).order_by('name')
+        if cycle:
+            cycle = cycle.first()
         else:
-            cycle = Cycle.objects.filter(organization_id=org_id).order_by('name')
-            if cycle:
-                cycle = cycle.first()
-            else:
-                return JsonResponse({
-                    'status': 'error',
-                    'message': 'Could not locate cycle',
-                    'pagination': {
-                        'total': 0
-                    },
-                    'cycle_id': None,
-                    'results': []
-                })
+            return JsonResponse({
+                'status': 'error',
+                'message': 'Could not locate cycle',
+                'pagination': {
+                    'total': 0
+                },
+                'cycle_id': None,
+                'results': []
+            })
 
-        if state_type == 'property':
-            views_list = (
-                PropertyView.objects.select_related('property', 'state', 'cycle')
-                .filter(property__organization_id=org_id, cycle=cycle)
-            )
-        elif state_type == 'taxlot':
-            views_list = (
-                TaxLotView.objects.select_related('taxlot', 'state', 'cycle')
-                .filter(taxlot__organization_id=org_id, cycle=cycle)
-            )
-
-
-        include_related = (
-            str(request.query_params.get('include_related', 'true')).lower() == 'true'
+    if state_type == 'property':
+        views_list = (
+            PropertyView.objects.select_related('property', 'state', 'cycle')
+            .filter(property__organization_id=org_id, cycle=cycle)
+        )
+    elif state_type == 'taxlot':
+        views_list = (
+            TaxLotView.objects.select_related('taxlot', 'state', 'cycle')
+            .filter(taxlot__organization_id=org_id, cycle=cycle)
         )
 
-        # Retrieve all the columns that are in the db for this organization
-        columns_from_database = Column.retrieve_all(
-            org_id=org_id,
-            inventory_type=state_type,
-            only_used=False,
-            include_related=include_related
-        )
-        try:
-            filters, annotations, order_by = build_view_filters_and_sorts(request.query_params, columns_from_database)
-        except FilterException as e:
-            return JsonResponse(
-                {
-                    'status': 'error',
-                    'message': f'Error filtering: {str(e)}'
-                },
-                status=status.HTTP_400_BAD_REQUEST
-            )
+    include_related = (
+        str(request.query_params.get('include_related', 'true')).lower() == 'true'
+    )
 
-        views_list = views_list.annotate(**annotations).filter(filters).order_by(*order_by)
-
-        # Return property views limited to the 'property_view_ids' list. Otherwise, if selected is empty, return all
-        if f'{state_type}_view_ids' in request.data and request.data[f'{state_type}_view_ids']:
-            views_list = views_list.filter(id__in=request.data[f'{state_type}_view_ids'])
-
-        paginator = Paginator(views_list, per_page)
-
-        try:
-            views = paginator.page(page)
-            page = int(page)
-        except PageNotAnInteger:
-            views = paginator.page(1)
-            page = 1
-        except EmptyPage:
-            views = paginator.page(paginator.num_pages)
-            page = paginator.num_pages
-        except DataError as e:
-            return JsonResponse(
-                {
-                    'status': 'error',
-                    'recommended_action': 'update_column_settings',
-                    'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
-                },
-                status=status.HTTP_400_BAD_REQUEST
-            )
-
-        # This uses an old method of returning the show_columns. There is a new method that
-        # is prefered in v2.1 API with the ProfileIdMixin.
-        if state_type == 'property':
-            view_list_state = VIEW_LIST_PROPERTY
-        elif state_type == 'taxlot':
-            view_list_state = VIEW_LIST_TAXLOT
-
-        show_columns: Optional[list[int]] = None
-        if profile_id is None:
-            show_columns = None
-        elif profile_id == -1:
-            show_columns = list(Column.objects.filter(
-                organization_id=org_id
-            ).values_list('id', flat=True))
-        else:
-            try:
-                profile = ColumnListProfile.objects.get(
-                    organization_id=org_id,
-                    id=profile_id,
-                    profile_location=VIEW_LIST,
-                    inventory_type=view_list_state
-                )
-                show_columns = list(ColumnListProfileColumn.objects.filter(
-                    column_list_profile_id=profile.id
-                ).values_list('column_id', flat=True))
-            except ColumnListProfile.DoesNotExist:
-                show_columns = None
-
-        try:
-            related_results = TaxLotProperty.serialize(
-                views,
-                show_columns,
-                columns_from_database,
-                include_related
-            )
-        except DataError as e:
-            return JsonResponse(
-                {
-                    'status': 'error',
-                    'recommended_action': 'update_column_settings',
-                    'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
-                },
-                status=status.HTTP_400_BAD_REQUEST
-            )
-
-        # collapse units here so we're only doing the last page; we're already a
-        # realized list by now and not a lazy queryset
-        unit_collapsed_results = [apply_display_unit_preferences(org, x) for x in related_results]
-
-        response = {
-            'pagination': {
-                'page': page,
-                'start': paginator.page(page).start_index(),
-                'end': paginator.page(page).end_index(),
-                'num_pages': paginator.num_pages,
-                'has_next': paginator.page(page).has_next(),
-                'has_previous': paginator.page(page).has_previous(),
-                'total': paginator.count
+    # Retrieve all the columns that are in the db for this organization
+    columns_from_database = Column.retrieve_all(
+        org_id=org_id,
+        inventory_type=state_type,
+        only_used=False,
+        include_related=include_related
+    )
+    try:
+        filters, annotations, order_by = build_view_filters_and_sorts(request.query_params, columns_from_database)
+    except FilterException as e:
+        return JsonResponse(
+            {
+                'status': 'error',
+                'message': f'Error filtering: {str(e)}'
             },
-            'cycle_id': cycle.id,
-            'results': unit_collapsed_results
-        }
+            status=status.HTTP_400_BAD_REQUEST
+        )
 
-        return JsonResponse(response)
+    views_list = views_list.annotate(**annotations).filter(filters).order_by(*order_by)
+
+    # Return property views limited to the 'property_view_ids' list. Otherwise, if selected is empty, return all
+    if f'{state_type}_view_ids' in request.data and request.data[f'{state_type}_view_ids']:
+        views_list = views_list.filter(id__in=request.data[f'{state_type}_view_ids'])
+
+    paginator = Paginator(views_list, per_page)
+
+    try:
+        views = paginator.page(page)
+        page = int(page)
+    except PageNotAnInteger:
+        views = paginator.page(1)
+        page = 1
+    except EmptyPage:
+        views = paginator.page(paginator.num_pages)
+        page = paginator.num_pages
+    except DataError as e:
+        return JsonResponse(
+            {
+                'status': 'error',
+                'recommended_action': 'update_column_settings',
+                'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
+            },
+            status=status.HTTP_400_BAD_REQUEST
+        )
+
+    # This uses an old method of returning the show_columns. There is a new method that
+    # is prefered in v2.1 API with the ProfileIdMixin.
+    if state_type == 'property':
+        view_list_state = VIEW_LIST_PROPERTY
+    elif state_type == 'taxlot':
+        view_list_state = VIEW_LIST_TAXLOT
+
+    show_columns: Optional[list[int]] = None
+    if profile_id is None:
+        show_columns = None
+    elif profile_id == -1:
+        show_columns = list(Column.objects.filter(
+            organization_id=org_id
+        ).values_list('id', flat=True))
+    else:
+        try:
+            profile = ColumnListProfile.objects.get(
+                organization_id=org_id,
+                id=profile_id,
+                profile_location=VIEW_LIST,
+                inventory_type=view_list_state
+            )
+            show_columns = list(ColumnListProfileColumn.objects.filter(
+                column_list_profile_id=profile.id
+            ).values_list('column_id', flat=True))
+        except ColumnListProfile.DoesNotExist:
+            show_columns = None
+
+    try:
+        related_results = TaxLotProperty.serialize(
+            views,
+            show_columns,
+            columns_from_database,
+            include_related
+        )
+    except DataError as e:
+        return JsonResponse(
+            {
+                'status': 'error',
+                'recommended_action': 'update_column_settings',
+                'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
+            },
+            status=status.HTTP_400_BAD_REQUEST
+        )
+
+    # collapse units here so we're only doing the last page; we're already a
+    # realized list by now and not a lazy queryset
+    unit_collapsed_results = [apply_display_unit_preferences(org, x) for x in related_results]
+
+    response = {
+        'pagination': {
+            'page': page,
+            'start': paginator.page(page).start_index(),
+            'end': paginator.page(page).end_index(),
+            'num_pages': paginator.num_pages,
+            'has_next': paginator.page(page).has_next(),
+            'has_previous': paginator.page(page).has_previous(),
+            'total': paginator.count
+        },
+        'cycle_id': cycle.id,
+        'results': unit_collapsed_results
+    }
+
+    return JsonResponse(response)

--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -290,7 +290,7 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
         """
         List all the properties	with all columns
         """
-        return _get_filtered_results(request, profile_id=-1, state_type='property')
+        return _get_filtered_results(request, 'property', profile_id=-1)
 
     @swagger_auto_schema(
         request_body=AutoSchemaHelper.schema_factory(
@@ -385,7 +385,7 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
                 except TypeError:
                     pass
 
-        return _get_filtered_results(request, profile_id=profile_id, state_type='property')
+        return _get_filtered_results(request, 'property', profile_id=profile_id)
 
     @swagger_auto_schema(
         manual_parameters=[AutoSchemaHelper.query_org_id_field(required=True)],

--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -54,6 +54,7 @@ from seed.utils.properties import (get_changed_fields,
                                    pair_unpair_property_taxlot,
                                    properties_across_cycles,
                                    update_result_with_master)
+from seed.utils.filter_state import _get_filtered_results
 
 # Global toggle that controls whether or not to display the raw extra
 # data fields in the columns returned for the view.
@@ -135,150 +136,150 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
             safe=False,
         )
 
-    def _get_filtered_results(self, request: Request, profile_id: int):
-        page = request.query_params.get('page', 1)
-        per_page = request.query_params.get('per_page', 1)
-        org_id = self.get_organization(request)
-        cycle_id = request.query_params.get('cycle')
-        # check if there is a query paramater for the profile_id. If so, then use that one
-        profile_id = request.query_params.get('profile_id', profile_id)
+    # def _get_filtered_results(self, request: Request, profile_id: int):
+    #     page = request.query_params.get('page', 1)
+    #     per_page = request.query_params.get('per_page', 1)
+    #     org_id = self.get_organization(request)
+    #     cycle_id = request.query_params.get('cycle')
+    #     # check if there is a query paramater for the profile_id. If so, then use that one
+    #     profile_id = request.query_params.get('profile_id', profile_id)
 
-        if not org_id:
-            return JsonResponse(
-                {'status': 'error', 'message': 'Need to pass organization_id as query parameter'},
-                status=status.HTTP_400_BAD_REQUEST)
-        org = Organization.objects.get(id=org_id)
+    #     if not org_id:
+    #         return JsonResponse(
+    #             {'status': 'error', 'message': 'Need to pass organization_id as query parameter'},
+    #             status=status.HTTP_400_BAD_REQUEST)
+    #     org = Organization.objects.get(id=org_id)
 
-        if cycle_id:
-            cycle = Cycle.objects.get(organization_id=org_id, pk=cycle_id)
-        else:
-            cycle = Cycle.objects.filter(organization_id=org_id).order_by('name')
-            if cycle:
-                cycle = cycle.first()
-            else:
-                return JsonResponse({
-                    'status': 'error',
-                    'message': 'Could not locate cycle',
-                    'pagination': {
-                        'total': 0
-                    },
-                    'cycle_id': None,
-                    'results': []
-                })
+    #     if cycle_id:
+    #         cycle = Cycle.objects.get(organization_id=org_id, pk=cycle_id)
+    #     else:
+    #         cycle = Cycle.objects.filter(organization_id=org_id).order_by('name')
+    #         if cycle:
+    #             cycle = cycle.first()
+    #         else:
+    #             return JsonResponse({
+    #                 'status': 'error',
+    #                 'message': 'Could not locate cycle',
+    #                 'pagination': {
+    #                     'total': 0
+    #                 },
+    #                 'cycle_id': None,
+    #                 'results': []
+    #             })
 
-        property_views_list = (
-            PropertyView.objects.select_related('property', 'state', 'cycle')
-            .filter(property__organization_id=org_id, cycle=cycle)
-        )
+    #     property_views_list = (
+    #         PropertyView.objects.select_related('property', 'state', 'cycle')
+    #         .filter(property__organization_id=org_id, cycle=cycle)
+    #     )
 
-        include_related = (
-            str(request.query_params.get('include_related', 'true')).lower() == 'true'
-        )
+    #     include_related = (
+    #         str(request.query_params.get('include_related', 'true')).lower() == 'true'
+    #     )
 
-        # Retrieve all the columns that are in the db for this organization
-        columns_from_database = Column.retrieve_all(
-            org_id=org_id,
-            inventory_type='property',
-            only_used=False,
-            include_related=include_related
-        )
-        try:
-            filters, annotations, order_by = build_view_filters_and_sorts(request.query_params, columns_from_database)
-        except FilterException as e:
-            return JsonResponse(
-                {
-                    'status': 'error',
-                    'message': f'Error filtering: {str(e)}'
-                },
-                status=status.HTTP_400_BAD_REQUEST
-            )
+    #     # Retrieve all the columns that are in the db for this organization
+    #     columns_from_database = Column.retrieve_all(
+    #         org_id=org_id,
+    #         inventory_type='property',
+    #         only_used=False,
+    #         include_related=include_related
+    #     )
+    #     try:
+    #         filters, annotations, order_by = build_view_filters_and_sorts(request.query_params, columns_from_database)
+    #     except FilterException as e:
+    #         return JsonResponse(
+    #             {
+    #                 'status': 'error',
+    #                 'message': f'Error filtering: {str(e)}'
+    #             },
+    #             status=status.HTTP_400_BAD_REQUEST
+    #         )
 
-        property_views_list = property_views_list.annotate(**annotations).filter(filters).order_by(*order_by)
+    #     property_views_list = property_views_list.annotate(**annotations).filter(filters).order_by(*order_by)
 
-        # Return property views limited to the 'property_view_ids' list. Otherwise, if selected is empty, return all
-        if 'property_view_ids' in request.data and request.data['property_view_ids']:
-            property_views_list = property_views_list.filter(id__in=request.data['property_view_ids'])
+    #     # Return property views limited to the 'property_view_ids' list. Otherwise, if selected is empty, return all
+    #     if 'property_view_ids' in request.data and request.data['property_view_ids']:
+    #         property_views_list = property_views_list.filter(id__in=request.data['property_view_ids'])
 
-        paginator = Paginator(property_views_list, per_page)
+    #     paginator = Paginator(property_views_list, per_page)
 
-        try:
-            property_views = paginator.page(page)
-            page = int(page)
-        except PageNotAnInteger:
-            property_views = paginator.page(1)
-            page = 1
-        except EmptyPage:
-            property_views = paginator.page(paginator.num_pages)
-            page = paginator.num_pages
-        except DataError as e:
-            return JsonResponse(
-                {
-                    'status': 'error',
-                    'recommended_action': 'update_column_settings',
-                    'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
-                },
-                status=status.HTTP_400_BAD_REQUEST
-            )
+    #     try:
+    #         property_views = paginator.page(page)
+    #         page = int(page)
+    #     except PageNotAnInteger:
+    #         property_views = paginator.page(1)
+    #         page = 1
+    #     except EmptyPage:
+    #         property_views = paginator.page(paginator.num_pages)
+    #         page = paginator.num_pages
+    #     except DataError as e:
+    #         return JsonResponse(
+    #             {
+    #                 'status': 'error',
+    #                 'recommended_action': 'update_column_settings',
+    #                 'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
+    #             },
+    #             status=status.HTTP_400_BAD_REQUEST
+    #         )
 
-        # This uses an old method of returning the show_columns. There is a new method that
-        # is prefered in v2.1 API with the ProfileIdMixin.
-        show_columns: Optional[list[int]] = None
-        if profile_id is None:
-            show_columns = None
-        elif profile_id == -1:
-            show_columns = list(Column.objects.filter(
-                organization_id=org_id
-            ).values_list('id', flat=True))
-        else:
-            try:
-                profile = ColumnListProfile.objects.get(
-                    organization_id=org_id,
-                    id=profile_id,
-                    profile_location=VIEW_LIST,
-                    inventory_type=VIEW_LIST_PROPERTY
-                )
-                show_columns = list(ColumnListProfileColumn.objects.filter(
-                    column_list_profile_id=profile.id
-                ).values_list('column_id', flat=True))
-            except ColumnListProfile.DoesNotExist:
-                show_columns = None
+    #     # This uses an old method of returning the show_columns. There is a new method that
+    #     # is prefered in v2.1 API with the ProfileIdMixin.
+    #     show_columns: Optional[list[int]] = None
+    #     if profile_id is None:
+    #         show_columns = None
+    #     elif profile_id == -1:
+    #         show_columns = list(Column.objects.filter(
+    #             organization_id=org_id
+    #         ).values_list('id', flat=True))
+    #     else:
+    #         try:
+    #             profile = ColumnListProfile.objects.get(
+    #                 organization_id=org_id,
+    #                 id=profile_id,
+    #                 profile_location=VIEW_LIST,
+    #                 inventory_type=VIEW_LIST_PROPERTY
+    #             )
+    #             show_columns = list(ColumnListProfileColumn.objects.filter(
+    #                 column_list_profile_id=profile.id
+    #             ).values_list('column_id', flat=True))
+    #         except ColumnListProfile.DoesNotExist:
+    #             show_columns = None
 
-        try:
-            related_results = TaxLotProperty.serialize(
-                property_views,
-                show_columns,
-                columns_from_database,
-                include_related
-            )
-        except DataError as e:
-            return JsonResponse(
-                {
-                    'status': 'error',
-                    'recommended_action': 'update_column_settings',
-                    'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
-                },
-                status=status.HTTP_400_BAD_REQUEST
-            )
+    #     try:
+    #         related_results = TaxLotProperty.serialize(
+    #             property_views,
+    #             show_columns,
+    #             columns_from_database,
+    #             include_related
+    #         )
+    #     except DataError as e:
+    #         return JsonResponse(
+    #             {
+    #                 'status': 'error',
+    #                 'recommended_action': 'update_column_settings',
+    #                 'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
+    #             },
+    #             status=status.HTTP_400_BAD_REQUEST
+    #         )
 
-        # collapse units here so we're only doing the last page; we're already a
-        # realized list by now and not a lazy queryset
-        unit_collapsed_results = [apply_display_unit_preferences(org, x) for x in related_results]
+    #     # collapse units here so we're only doing the last page; we're already a
+    #     # realized list by now and not a lazy queryset
+    #     unit_collapsed_results = [apply_display_unit_preferences(org, x) for x in related_results]
 
-        response = {
-            'pagination': {
-                'page': page,
-                'start': paginator.page(page).start_index(),
-                'end': paginator.page(page).end_index(),
-                'num_pages': paginator.num_pages,
-                'has_next': paginator.page(page).has_next(),
-                'has_previous': paginator.page(page).has_previous(),
-                'total': paginator.count
-            },
-            'cycle_id': cycle.id,
-            'results': unit_collapsed_results
-        }
+    #     response = {
+    #         'pagination': {
+    #             'page': page,
+    #             'start': paginator.page(page).start_index(),
+    #             'end': paginator.page(page).end_index(),
+    #             'num_pages': paginator.num_pages,
+    #             'has_next': paginator.page(page).has_next(),
+    #             'has_previous': paginator.page(page).has_previous(),
+    #             'total': paginator.count
+    #         },
+    #         'cycle_id': cycle.id,
+    #         'results': unit_collapsed_results
+    #     }
 
-        return JsonResponse(response)
+    #     return JsonResponse(response)
 
     def _move_relationships(self, old_state, new_state):
         """
@@ -441,7 +442,7 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
         """
         List all the properties	with all columns
         """
-        return self._get_filtered_results(request, profile_id=-1)
+        return _get_filtered_results(request, profile_id=-1, state_type='property')
 
     @swagger_auto_schema(
         request_body=AutoSchemaHelper.schema_factory(
@@ -536,7 +537,7 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
                 except TypeError:
                     pass
 
-        return self._get_filtered_results(request, profile_id=profile_id)
+        return _get_filtered_results(request, profile_id=profile_id, state_type='property')
 
     @swagger_auto_schema(
         manual_parameters=[AutoSchemaHelper.query_org_id_field(required=True)],

--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -47,7 +47,7 @@ from seed.utils.properties import (get_changed_fields,
                                    pair_unpair_property_taxlot,
                                    properties_across_cycles,
                                    update_result_with_master)
-from seed.utils.filter_state import _get_filtered_results
+from seed.utils.filter_state import get_filtered_results
 
 # Global toggle that controls whether or not to display the raw extra
 # data fields in the columns returned for the view.
@@ -290,7 +290,7 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
         """
         List all the properties	with all columns
         """
-        return _get_filtered_results(request, 'property', profile_id=-1)
+        return get_filtered_results(request, 'property', profile_id=-1)
 
     @swagger_auto_schema(
         request_body=AutoSchemaHelper.schema_factory(
@@ -385,7 +385,7 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
                 except TypeError:
                     pass
 
-        return _get_filtered_results(request, 'property', profile_id=profile_id)
+        return get_filtered_results(request, 'property', profile_id=profile_id)
 
     @swagger_auto_schema(
         manual_parameters=[AutoSchemaHelper.query_org_id_field(required=True)],

--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -4,11 +4,8 @@
 """
 import os
 from collections import namedtuple
-from typing import Optional
 
-from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Q, Subquery
-from django.db.utils import DataError
 from django.http import HttpResponse, JsonResponse
 from django_filters import CharFilter, DateFilter
 from django_filters import rest_framework as filters
@@ -17,26 +14,22 @@ from rest_framework import status, viewsets, generics
 from rest_framework.decorators import action
 from rest_framework.parsers import JSONParser, MultiPartParser
 from rest_framework.renderers import JSONRenderer
-from rest_framework.request import Request
 from seed.building_sync.building_sync import BuildingSync
 from seed.data_importer.utils import usage_point_id
 from seed.decorators import ajax_request_class
 from seed.hpxml.hpxml import HPXML
 from seed.lib.superperms.orgs.decorators import has_perm_class
-from seed.lib.superperms.orgs.models import Organization
 from seed.models import (AUDIT_USER_EDIT, DATA_STATE_MATCHING,
                          MERGE_STATE_DELETE, MERGE_STATE_MERGED,
-                         MERGE_STATE_NEW, VIEW_LIST, VIEW_LIST_PROPERTY,
-                         BuildingFile, Column, ColumnListProfile,
-                         ColumnListProfileColumn, ColumnMappingProfile, Cycle,
+                         MERGE_STATE_NEW,
+                         BuildingFile, Column,
+                         ColumnMappingProfile, Cycle,
                          Meter, Note, Property, PropertyAuditLog,
                          PropertyMeasure, PropertyState, PropertyView,
                          Simulation)
 from seed.models import StatusLabel as Label
 from seed.models import TaxLotProperty, TaxLotView
-from seed.search import build_view_filters_and_sorts, FilterException
-from seed.serializers.pint import (PintJSONEncoder,
-                                   apply_display_unit_preferences)
+from seed.serializers.pint import (PintJSONEncoder)
 from seed.serializers.properties import (PropertySerializer,
                                          PropertyStateSerializer,
                                          PropertyViewAsStateSerializer,
@@ -135,151 +128,6 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
             PropertyViewAsStateSerializer(list(qs), context={'request': request}, many=True).data,
             safe=False,
         )
-
-    # def _get_filtered_results(self, request: Request, profile_id: int):
-    #     page = request.query_params.get('page', 1)
-    #     per_page = request.query_params.get('per_page', 1)
-    #     org_id = self.get_organization(request)
-    #     cycle_id = request.query_params.get('cycle')
-    #     # check if there is a query paramater for the profile_id. If so, then use that one
-    #     profile_id = request.query_params.get('profile_id', profile_id)
-
-    #     if not org_id:
-    #         return JsonResponse(
-    #             {'status': 'error', 'message': 'Need to pass organization_id as query parameter'},
-    #             status=status.HTTP_400_BAD_REQUEST)
-    #     org = Organization.objects.get(id=org_id)
-
-    #     if cycle_id:
-    #         cycle = Cycle.objects.get(organization_id=org_id, pk=cycle_id)
-    #     else:
-    #         cycle = Cycle.objects.filter(organization_id=org_id).order_by('name')
-    #         if cycle:
-    #             cycle = cycle.first()
-    #         else:
-    #             return JsonResponse({
-    #                 'status': 'error',
-    #                 'message': 'Could not locate cycle',
-    #                 'pagination': {
-    #                     'total': 0
-    #                 },
-    #                 'cycle_id': None,
-    #                 'results': []
-    #             })
-
-    #     property_views_list = (
-    #         PropertyView.objects.select_related('property', 'state', 'cycle')
-    #         .filter(property__organization_id=org_id, cycle=cycle)
-    #     )
-
-    #     include_related = (
-    #         str(request.query_params.get('include_related', 'true')).lower() == 'true'
-    #     )
-
-    #     # Retrieve all the columns that are in the db for this organization
-    #     columns_from_database = Column.retrieve_all(
-    #         org_id=org_id,
-    #         inventory_type='property',
-    #         only_used=False,
-    #         include_related=include_related
-    #     )
-    #     try:
-    #         filters, annotations, order_by = build_view_filters_and_sorts(request.query_params, columns_from_database)
-    #     except FilterException as e:
-    #         return JsonResponse(
-    #             {
-    #                 'status': 'error',
-    #                 'message': f'Error filtering: {str(e)}'
-    #             },
-    #             status=status.HTTP_400_BAD_REQUEST
-    #         )
-
-    #     property_views_list = property_views_list.annotate(**annotations).filter(filters).order_by(*order_by)
-
-    #     # Return property views limited to the 'property_view_ids' list. Otherwise, if selected is empty, return all
-    #     if 'property_view_ids' in request.data and request.data['property_view_ids']:
-    #         property_views_list = property_views_list.filter(id__in=request.data['property_view_ids'])
-
-    #     paginator = Paginator(property_views_list, per_page)
-
-    #     try:
-    #         property_views = paginator.page(page)
-    #         page = int(page)
-    #     except PageNotAnInteger:
-    #         property_views = paginator.page(1)
-    #         page = 1
-    #     except EmptyPage:
-    #         property_views = paginator.page(paginator.num_pages)
-    #         page = paginator.num_pages
-    #     except DataError as e:
-    #         return JsonResponse(
-    #             {
-    #                 'status': 'error',
-    #                 'recommended_action': 'update_column_settings',
-    #                 'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
-    #             },
-    #             status=status.HTTP_400_BAD_REQUEST
-    #         )
-
-    #     # This uses an old method of returning the show_columns. There is a new method that
-    #     # is prefered in v2.1 API with the ProfileIdMixin.
-    #     show_columns: Optional[list[int]] = None
-    #     if profile_id is None:
-    #         show_columns = None
-    #     elif profile_id == -1:
-    #         show_columns = list(Column.objects.filter(
-    #             organization_id=org_id
-    #         ).values_list('id', flat=True))
-    #     else:
-    #         try:
-    #             profile = ColumnListProfile.objects.get(
-    #                 organization_id=org_id,
-    #                 id=profile_id,
-    #                 profile_location=VIEW_LIST,
-    #                 inventory_type=VIEW_LIST_PROPERTY
-    #             )
-    #             show_columns = list(ColumnListProfileColumn.objects.filter(
-    #                 column_list_profile_id=profile.id
-    #             ).values_list('column_id', flat=True))
-    #         except ColumnListProfile.DoesNotExist:
-    #             show_columns = None
-
-    #     try:
-    #         related_results = TaxLotProperty.serialize(
-    #             property_views,
-    #             show_columns,
-    #             columns_from_database,
-    #             include_related
-    #         )
-    #     except DataError as e:
-    #         return JsonResponse(
-    #             {
-    #                 'status': 'error',
-    #                 'recommended_action': 'update_column_settings',
-    #                 'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
-    #             },
-    #             status=status.HTTP_400_BAD_REQUEST
-    #         )
-
-    #     # collapse units here so we're only doing the last page; we're already a
-    #     # realized list by now and not a lazy queryset
-    #     unit_collapsed_results = [apply_display_unit_preferences(org, x) for x in related_results]
-
-    #     response = {
-    #         'pagination': {
-    #             'page': page,
-    #             'start': paginator.page(page).start_index(),
-    #             'end': paginator.page(page).end_index(),
-    #             'num_pages': paginator.num_pages,
-    #             'has_next': paginator.page(page).has_next(),
-    #             'has_previous': paginator.page(page).has_previous(),
-    #             'total': paginator.count
-    #         },
-    #         'cycle_id': cycle.id,
-    #         'results': unit_collapsed_results
-    #     }
-
-    #     return JsonResponse(response)
 
     def _move_relationships(self, old_state, new_state):
         """

--- a/seed/views/v3/taxlots.py
+++ b/seed/views/v3/taxlots.py
@@ -3,30 +3,22 @@
 :author
 """
 from collections import namedtuple
-from typing import Optional
 
-from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Subquery
-from django.db.utils import DataError
 from django.http import JsonResponse
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.parsers import JSONParser
 from rest_framework.renderers import JSONRenderer
-from rest_framework.request import Request
 from seed.decorators import ajax_request_class
 from seed.lib.superperms.orgs.decorators import has_perm_class
-from seed.lib.superperms.orgs.models import Organization
 from seed.models import (AUDIT_USER_EDIT, DATA_STATE_MATCHING,
                          MERGE_STATE_DELETE, MERGE_STATE_MERGED,
-                         MERGE_STATE_NEW, VIEW_LIST, VIEW_LIST_TAXLOT, Column,
-                         ColumnListProfile, ColumnListProfileColumn, Cycle,
+                         MERGE_STATE_NEW,
                          Note, PropertyView, StatusLabel, TaxLot,
                          TaxLotAuditLog, TaxLotProperty, TaxLotState,
                          TaxLotView)
-from seed.search import build_view_filters_and_sorts, FilterException
-from seed.serializers.pint import apply_display_unit_preferences
 from seed.serializers.properties import PropertyViewSerializer
 from seed.serializers.taxlots import (TaxLotSerializer, TaxLotStateSerializer,
                                       TaxLotViewSerializer,
@@ -72,150 +64,6 @@ class TaxlotViewSet(viewsets.ViewSet, OrgMixin, ProfileIdMixin):
         super_organization = self.get_organization(request)
         # TODO: refactor to avoid passing request here
         return get_labels(request, labels, super_organization, 'taxlot_view')
-
-    # def _get_filtered_results(self, request: Request, profile_id: int):
-    #     page = request.query_params.get('page', 1)
-    #     per_page = request.query_params.get('per_page', 1)
-    #     org_id = self.get_organization(request)
-    #     cycle_id = request.query_params.get('cycle')
-    #     # check if there is a query paramater for the profile_id. If so, then use that one
-    #     profile_id = request.query_params.get('profile_id', profile_id)
-    #     if not org_id:
-    #         return JsonResponse(
-    #             {'status': 'error', 'message': 'Need to pass organization_id as query parameter'},
-    #             status=status.HTTP_400_BAD_REQUEST)
-    #     org = Organization.objects.get(id=org_id)
-
-    #     if cycle_id:
-    #         cycle = Cycle.objects.get(organization_id=org_id, pk=cycle_id)
-    #     else:
-    #         cycle = Cycle.objects.filter(organization_id=org_id).order_by('name')
-    #         if cycle:
-    #             cycle = cycle.first()
-    #         else:
-    #             return JsonResponse({
-    #                 'status': 'error',
-    #                 'message': 'Could not locate cycle',
-    #                 'pagination': {
-    #                     'total': 0
-    #                 },
-    #                 'cycle_id': None,
-    #                 'results': []
-    #             })
-
-    #     taxlot_views_list = (
-    #         TaxLotView.objects.select_related('taxlot', 'state', 'cycle')
-    #         .filter(taxlot__organization_id=org_id, cycle=cycle)
-    #     )
-
-    #     include_related = (
-    #         str(request.query_params.get('include_related', 'true')).lower() == 'true'
-    #     )
-
-    #     # Retrieve all the columns that are in the db for this organization
-    #     columns_from_database = Column.retrieve_all(
-    #         org_id=org_id,
-    #         inventory_type='taxlot',
-    #         only_used=False,
-    #         include_related=include_related
-    #     )
-    #     try:
-    #         filters, annotations, order_by = build_view_filters_and_sorts(request.query_params, columns_from_database)
-    #     except FilterException as e:
-    #         return JsonResponse(
-    #             {
-    #                 'status': 'error',
-    #                 'message': f'Error filtering: {str(e)}'
-    #             },
-    #             status=status.HTTP_400_BAD_REQUEST
-    #         )
-
-    #     taxlot_views_list = taxlot_views_list.annotate(**annotations).filter(filters).order_by(*order_by)
-
-    #     # Return taxlot views limited to the 'taxlot_view_ids' list.  Otherwise, if selected is empty, return all
-    #     if 'taxlot_view_ids' in request.data and request.data['taxlot_view_ids']:
-    #         taxlot_views_list = taxlot_views_list.filter(id__in=request.data['taxlot_view_ids'])
-
-    #     paginator = Paginator(taxlot_views_list, per_page)
-
-    #     try:
-    #         taxlot_views = paginator.page(page)
-    #         page = int(page)
-    #     except PageNotAnInteger:
-    #         taxlot_views = paginator.page(1)
-    #         page = 1
-    #     except EmptyPage:
-    #         taxlot_views = paginator.page(paginator.num_pages)
-    #         page = paginator.num_pages
-    #     except DataError as e:
-    #         return JsonResponse(
-    #             {
-    #                 'status': 'error',
-    #                 'recommended_action': 'update_column_settings',
-    #                 'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
-    #             },
-    #             status=status.HTTP_400_BAD_REQUEST
-    #         )
-
-    #     # This uses an old method of returning the show_columns. There is a new method that
-    #     # is preferred in v2.1 API with the ProfileIdMixin.
-    #     show_columns: Optional[list[int]] = None
-    #     if profile_id is None:
-    #         show_columns = None
-    #     elif profile_id == -1:
-    #         show_columns = list(Column.objects.filter(
-    #             organization_id=org_id
-    #         ).values_list('id', flat=True))
-    #     else:
-    #         try:
-    #             profile = ColumnListProfile.objects.get(
-    #                 organization=org,
-    #                 id=profile_id,
-    #                 profile_location=VIEW_LIST,
-    #                 inventory_type=VIEW_LIST_TAXLOT
-    #             )
-    #             show_columns = list(ColumnListProfileColumn.objects.filter(
-    #                 column_list_profile_id=profile.id
-    #             ).values_list('column_id', flat=True))
-    #         except ColumnListProfile.DoesNotExist:
-    #             show_columns = None
-
-    #     try:
-    #         related_results = TaxLotProperty.serialize(
-    #             taxlot_views,
-    #             show_columns,
-    #             columns_from_database,
-    #             include_related,
-    #         )
-    #     except DataError as e:
-    #         return JsonResponse(
-    #             {
-    #                 'status': 'error',
-    #                 'recommended_action': 'update_column_settings',
-    #                 'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
-    #             },
-    #             status=status.HTTP_400_BAD_REQUEST
-    #         )
-
-    #     # collapse units here so we're only doing the last page; we're already a
-    #     # realized list by now and not a lazy queryset
-    #     unit_collapsed_results = [apply_display_unit_preferences(org, x) for x in related_results]
-
-    #     response = {
-    #         'pagination': {
-    #             'page': page,
-    #             'start': paginator.page(page).start_index(),
-    #             'end': paginator.page(page).end_index(),
-    #             'num_pages': paginator.num_pages,
-    #             'has_next': paginator.page(page).has_next(),
-    #             'has_previous': paginator.page(page).has_previous(),
-    #             'total': paginator.count
-    #         },
-    #         'cycle_id': cycle.id,
-    #         'results': unit_collapsed_results
-    #     }
-
-    #     return JsonResponse(response)
 
     @swagger_auto_schema(
         manual_parameters=[

--- a/seed/views/v3/taxlots.py
+++ b/seed/views/v3/taxlots.py
@@ -102,7 +102,7 @@ class TaxlotViewSet(viewsets.ViewSet, OrgMixin, ProfileIdMixin):
         """
         List all the properties
         """
-        return _get_filtered_results(request, profile_id=-1, state_type='taxlot')
+        return _get_filtered_results(request, 'taxlot', profile_id=-1)
 
     @swagger_auto_schema(
         request_body=AutoSchemaHelper.schema_factory(
@@ -193,7 +193,7 @@ class TaxlotViewSet(viewsets.ViewSet, OrgMixin, ProfileIdMixin):
             else:
                 profile_id = request.data['profile_id']
 
-        return _get_filtered_results(request, profile_id=profile_id, state_type='taxlot')
+        return _get_filtered_results(request, 'taxlot', profile_id=profile_id)
 
     @swagger_auto_schema(
         manual_parameters=[

--- a/seed/views/v3/taxlots.py
+++ b/seed/views/v3/taxlots.py
@@ -40,6 +40,7 @@ from seed.utils.properties import (get_changed_fields,
                                    pair_unpair_property_taxlot,
                                    update_result_with_master)
 from seed.utils.taxlots import taxlots_across_cycles
+from seed.utils.filter_state import _get_filtered_results
 
 ErrorState = namedtuple('ErrorState', ['status_code', 'message'])
 
@@ -72,149 +73,149 @@ class TaxlotViewSet(viewsets.ViewSet, OrgMixin, ProfileIdMixin):
         # TODO: refactor to avoid passing request here
         return get_labels(request, labels, super_organization, 'taxlot_view')
 
-    def _get_filtered_results(self, request: Request, profile_id: int):
-        page = request.query_params.get('page', 1)
-        per_page = request.query_params.get('per_page', 1)
-        org_id = self.get_organization(request)
-        cycle_id = request.query_params.get('cycle')
-        # check if there is a query paramater for the profile_id. If so, then use that one
-        profile_id = request.query_params.get('profile_id', profile_id)
-        if not org_id:
-            return JsonResponse(
-                {'status': 'error', 'message': 'Need to pass organization_id as query parameter'},
-                status=status.HTTP_400_BAD_REQUEST)
-        org = Organization.objects.get(id=org_id)
+    # def _get_filtered_results(self, request: Request, profile_id: int):
+    #     page = request.query_params.get('page', 1)
+    #     per_page = request.query_params.get('per_page', 1)
+    #     org_id = self.get_organization(request)
+    #     cycle_id = request.query_params.get('cycle')
+    #     # check if there is a query paramater for the profile_id. If so, then use that one
+    #     profile_id = request.query_params.get('profile_id', profile_id)
+    #     if not org_id:
+    #         return JsonResponse(
+    #             {'status': 'error', 'message': 'Need to pass organization_id as query parameter'},
+    #             status=status.HTTP_400_BAD_REQUEST)
+    #     org = Organization.objects.get(id=org_id)
 
-        if cycle_id:
-            cycle = Cycle.objects.get(organization_id=org_id, pk=cycle_id)
-        else:
-            cycle = Cycle.objects.filter(organization_id=org_id).order_by('name')
-            if cycle:
-                cycle = cycle.first()
-            else:
-                return JsonResponse({
-                    'status': 'error',
-                    'message': 'Could not locate cycle',
-                    'pagination': {
-                        'total': 0
-                    },
-                    'cycle_id': None,
-                    'results': []
-                })
+    #     if cycle_id:
+    #         cycle = Cycle.objects.get(organization_id=org_id, pk=cycle_id)
+    #     else:
+    #         cycle = Cycle.objects.filter(organization_id=org_id).order_by('name')
+    #         if cycle:
+    #             cycle = cycle.first()
+    #         else:
+    #             return JsonResponse({
+    #                 'status': 'error',
+    #                 'message': 'Could not locate cycle',
+    #                 'pagination': {
+    #                     'total': 0
+    #                 },
+    #                 'cycle_id': None,
+    #                 'results': []
+    #             })
 
-        taxlot_views_list = (
-            TaxLotView.objects.select_related('taxlot', 'state', 'cycle')
-            .filter(taxlot__organization_id=org_id, cycle=cycle)
-        )
+    #     taxlot_views_list = (
+    #         TaxLotView.objects.select_related('taxlot', 'state', 'cycle')
+    #         .filter(taxlot__organization_id=org_id, cycle=cycle)
+    #     )
 
-        include_related = (
-            str(request.query_params.get('include_related', 'true')).lower() == 'true'
-        )
+    #     include_related = (
+    #         str(request.query_params.get('include_related', 'true')).lower() == 'true'
+    #     )
 
-        # Retrieve all the columns that are in the db for this organization
-        columns_from_database = Column.retrieve_all(
-            org_id=org_id,
-            inventory_type='taxlot',
-            only_used=False,
-            include_related=include_related
-        )
-        try:
-            filters, annotations, order_by = build_view_filters_and_sorts(request.query_params, columns_from_database)
-        except FilterException as e:
-            return JsonResponse(
-                {
-                    'status': 'error',
-                    'message': f'Error filtering: {str(e)}'
-                },
-                status=status.HTTP_400_BAD_REQUEST
-            )
+    #     # Retrieve all the columns that are in the db for this organization
+    #     columns_from_database = Column.retrieve_all(
+    #         org_id=org_id,
+    #         inventory_type='taxlot',
+    #         only_used=False,
+    #         include_related=include_related
+    #     )
+    #     try:
+    #         filters, annotations, order_by = build_view_filters_and_sorts(request.query_params, columns_from_database)
+    #     except FilterException as e:
+    #         return JsonResponse(
+    #             {
+    #                 'status': 'error',
+    #                 'message': f'Error filtering: {str(e)}'
+    #             },
+    #             status=status.HTTP_400_BAD_REQUEST
+    #         )
 
-        taxlot_views_list = taxlot_views_list.annotate(**annotations).filter(filters).order_by(*order_by)
+    #     taxlot_views_list = taxlot_views_list.annotate(**annotations).filter(filters).order_by(*order_by)
 
-        # Return taxlot views limited to the 'taxlot_view_ids' list.  Otherwise, if selected is empty, return all
-        if 'taxlot_view_ids' in request.data and request.data['taxlot_view_ids']:
-            taxlot_views_list = taxlot_views_list.filter(id__in=request.data['taxlot_view_ids'])
+    #     # Return taxlot views limited to the 'taxlot_view_ids' list.  Otherwise, if selected is empty, return all
+    #     if 'taxlot_view_ids' in request.data and request.data['taxlot_view_ids']:
+    #         taxlot_views_list = taxlot_views_list.filter(id__in=request.data['taxlot_view_ids'])
 
-        paginator = Paginator(taxlot_views_list, per_page)
+    #     paginator = Paginator(taxlot_views_list, per_page)
 
-        try:
-            taxlot_views = paginator.page(page)
-            page = int(page)
-        except PageNotAnInteger:
-            taxlot_views = paginator.page(1)
-            page = 1
-        except EmptyPage:
-            taxlot_views = paginator.page(paginator.num_pages)
-            page = paginator.num_pages
-        except DataError as e:
-            return JsonResponse(
-                {
-                    'status': 'error',
-                    'recommended_action': 'update_column_settings',
-                    'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
-                },
-                status=status.HTTP_400_BAD_REQUEST
-            )
+    #     try:
+    #         taxlot_views = paginator.page(page)
+    #         page = int(page)
+    #     except PageNotAnInteger:
+    #         taxlot_views = paginator.page(1)
+    #         page = 1
+    #     except EmptyPage:
+    #         taxlot_views = paginator.page(paginator.num_pages)
+    #         page = paginator.num_pages
+    #     except DataError as e:
+    #         return JsonResponse(
+    #             {
+    #                 'status': 'error',
+    #                 'recommended_action': 'update_column_settings',
+    #                 'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
+    #             },
+    #             status=status.HTTP_400_BAD_REQUEST
+    #         )
 
-        # This uses an old method of returning the show_columns. There is a new method that
-        # is preferred in v2.1 API with the ProfileIdMixin.
-        show_columns: Optional[list[int]] = None
-        if profile_id is None:
-            show_columns = None
-        elif profile_id == -1:
-            show_columns = list(Column.objects.filter(
-                organization_id=org_id
-            ).values_list('id', flat=True))
-        else:
-            try:
-                profile = ColumnListProfile.objects.get(
-                    organization=org,
-                    id=profile_id,
-                    profile_location=VIEW_LIST,
-                    inventory_type=VIEW_LIST_TAXLOT
-                )
-                show_columns = list(ColumnListProfileColumn.objects.filter(
-                    column_list_profile_id=profile.id
-                ).values_list('column_id', flat=True))
-            except ColumnListProfile.DoesNotExist:
-                show_columns = None
+    #     # This uses an old method of returning the show_columns. There is a new method that
+    #     # is preferred in v2.1 API with the ProfileIdMixin.
+    #     show_columns: Optional[list[int]] = None
+    #     if profile_id is None:
+    #         show_columns = None
+    #     elif profile_id == -1:
+    #         show_columns = list(Column.objects.filter(
+    #             organization_id=org_id
+    #         ).values_list('id', flat=True))
+    #     else:
+    #         try:
+    #             profile = ColumnListProfile.objects.get(
+    #                 organization=org,
+    #                 id=profile_id,
+    #                 profile_location=VIEW_LIST,
+    #                 inventory_type=VIEW_LIST_TAXLOT
+    #             )
+    #             show_columns = list(ColumnListProfileColumn.objects.filter(
+    #                 column_list_profile_id=profile.id
+    #             ).values_list('column_id', flat=True))
+    #         except ColumnListProfile.DoesNotExist:
+    #             show_columns = None
 
-        try:
-            related_results = TaxLotProperty.serialize(
-                taxlot_views,
-                show_columns,
-                columns_from_database,
-                include_related,
-            )
-        except DataError as e:
-            return JsonResponse(
-                {
-                    'status': 'error',
-                    'recommended_action': 'update_column_settings',
-                    'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
-                },
-                status=status.HTTP_400_BAD_REQUEST
-            )
+    #     try:
+    #         related_results = TaxLotProperty.serialize(
+    #             taxlot_views,
+    #             show_columns,
+    #             columns_from_database,
+    #             include_related,
+    #         )
+    #     except DataError as e:
+    #         return JsonResponse(
+    #             {
+    #                 'status': 'error',
+    #                 'recommended_action': 'update_column_settings',
+    #                 'message': f'Error filtering - your data might not match the column settings data type: {str(e)}'
+    #             },
+    #             status=status.HTTP_400_BAD_REQUEST
+    #         )
 
-        # collapse units here so we're only doing the last page; we're already a
-        # realized list by now and not a lazy queryset
-        unit_collapsed_results = [apply_display_unit_preferences(org, x) for x in related_results]
+    #     # collapse units here so we're only doing the last page; we're already a
+    #     # realized list by now and not a lazy queryset
+    #     unit_collapsed_results = [apply_display_unit_preferences(org, x) for x in related_results]
 
-        response = {
-            'pagination': {
-                'page': page,
-                'start': paginator.page(page).start_index(),
-                'end': paginator.page(page).end_index(),
-                'num_pages': paginator.num_pages,
-                'has_next': paginator.page(page).has_next(),
-                'has_previous': paginator.page(page).has_previous(),
-                'total': paginator.count
-            },
-            'cycle_id': cycle.id,
-            'results': unit_collapsed_results
-        }
+    #     response = {
+    #         'pagination': {
+    #             'page': page,
+    #             'start': paginator.page(page).start_index(),
+    #             'end': paginator.page(page).end_index(),
+    #             'num_pages': paginator.num_pages,
+    #             'has_next': paginator.page(page).has_next(),
+    #             'has_previous': paginator.page(page).has_previous(),
+    #             'total': paginator.count
+    #         },
+    #         'cycle_id': cycle.id,
+    #         'results': unit_collapsed_results
+    #     }
 
-        return JsonResponse(response)
+    #     return JsonResponse(response)
 
     @swagger_auto_schema(
         manual_parameters=[
@@ -253,7 +254,7 @@ class TaxlotViewSet(viewsets.ViewSet, OrgMixin, ProfileIdMixin):
         """
         List all the properties
         """
-        return self._get_filtered_results(request, profile_id=-1)
+        return _get_filtered_results(request, profile_id=-1, state_type='taxlot')
 
     @swagger_auto_schema(
         request_body=AutoSchemaHelper.schema_factory(
@@ -344,7 +345,7 @@ class TaxlotViewSet(viewsets.ViewSet, OrgMixin, ProfileIdMixin):
             else:
                 profile_id = request.data['profile_id']
 
-        return self._get_filtered_results(request, profile_id=profile_id)
+        return _get_filtered_results(request, profile_id=profile_id, state_type='taxlot')
 
     @swagger_auto_schema(
         manual_parameters=[

--- a/seed/views/v3/taxlots.py
+++ b/seed/views/v3/taxlots.py
@@ -32,7 +32,7 @@ from seed.utils.properties import (get_changed_fields,
                                    pair_unpair_property_taxlot,
                                    update_result_with_master)
 from seed.utils.taxlots import taxlots_across_cycles
-from seed.utils.filter_state import _get_filtered_results
+from seed.utils.filter_state import get_filtered_results
 
 ErrorState = namedtuple('ErrorState', ['status_code', 'message'])
 
@@ -102,7 +102,7 @@ class TaxlotViewSet(viewsets.ViewSet, OrgMixin, ProfileIdMixin):
         """
         List all the properties
         """
-        return _get_filtered_results(request, 'taxlot', profile_id=-1)
+        return get_filtered_results(request, 'taxlot', profile_id=-1)
 
     @swagger_auto_schema(
         request_body=AutoSchemaHelper.schema_factory(
@@ -193,7 +193,7 @@ class TaxlotViewSet(viewsets.ViewSet, OrgMixin, ProfileIdMixin):
             else:
                 profile_id = request.data['profile_id']
 
-        return _get_filtered_results(request, 'taxlot', profile_id=profile_id)
+        return get_filtered_results(request, 'taxlot', profile_id=profile_id)
 
     @swagger_auto_schema(
         manual_parameters=[


### PR DESCRIPTION
#### Any background context you want to provide?
When viewing the property or taxlot inventory a user may filter by column contents. The backend code to filter properties or taxlots is identical and duplicated across two functions. 

#### What's this PR do?
This PR moves the functionality to a single helper function that can be imported to both property and taxlot files. There are slight differences between the two and a new argument `state_type` has been introduced to differentiate between 'property' and 'taxlot' filtering. 

#### How should this be manually tested?
Filter the inventory for both properties and taxlots and ensure correct functionality.

#### What are the relevant tickets?
#3081 

#### Screenshots (if appropriate)
n/a
