### PR TITLE
Update docker's pgdata path

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,8 +10,6 @@ version: '3.4'
 services:
   db-postgres:
     container_name: seed_postgres
-    environment:
-      - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - ref_seed_pgdata:/var/lib/postgresql/data
   web:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,6 +10,8 @@ version: '3.4'
 services:
   db-postgres:
     container_name: seed_postgres
+    environment:
+      - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - ref_seed_pgdata:/var/lib/postgresql/data
   web:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -18,6 +18,7 @@ services:
       - POSTGRES_DB
       - POSTGRES_USER
       - POSTGRES_PASSWORD
+      - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - seed_pgdata:/var/lib/postgresql/data
       - $HOME/seed-backups:/backups

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - POSTGRES_DB=seed
       - POSTGRES_USER=seed
       - POSTGRES_PASSWORD=super-secret-password
+      - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - seed_pgdata:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
#### Any background context you want to provide?
We fixed this in helm, but missed doing it in these files. For unknown reasons, the `pgdata` field needs to be passed to the containers now. The postgres base image may have changed.

#### What's this PR do?
* update the docker-compose files by adding in the `pgdata` env var.

#### How should this be manually tested?
* create required docker volumes (seed_pgdata, seed_media)
* docker-compose up 
* verify that the database authorization works and that you can log into the site

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
