### PR TITLE
3093 refactor/inventory filter ids only

### DIFF
--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -49,7 +49,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
       return {order_by: sorts};
     }
 
-    inventory_service.get_properties = function (page, per_page, cycle, profile_id, property_view_ids, save_last_cycle = true, organization_id = null, include_related = true, column_filters = null, column_sorts = null) {
+    inventory_service.get_properties = function (page, per_page, cycle, profile_id, property_view_ids, save_last_cycle = true, organization_id = null, include_related = true, column_filters = null, column_sorts = null, ids_only = null) {
       organization_id = organization_id == undefined ? user_service.get_organization().id : organization_id;
 
       var params = {
@@ -57,6 +57,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         page: page,
         per_page: per_page || 999999999,
         include_related: include_related,
+        ids_only: ids_only,
         ...format_column_sorts(column_sorts),
         ...format_column_filters(column_filters),
       };
@@ -289,7 +290,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
     };
 
 
-    inventory_service.get_taxlots = function (page, per_page, cycle, profile_id, inventory_ids, save_last_cycle = true, organization_id = null, include_related = true, column_filters = null, column_sorts = null) {
+    inventory_service.get_taxlots = function (page, per_page, cycle, profile_id, inventory_ids, save_last_cycle = true, organization_id = null, include_related = true, column_filters = null, column_sorts = null, ids_only = null) {
       organization_id = organization_id == undefined ? user_service.get_organization().id : organization_id;
 
       var params = {
@@ -297,6 +298,7 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         page: page,
         per_page: per_page || 999999999,
         include_related: include_related,
+        ids_only: ids_only,
         ...format_column_sorts(column_sorts),
         ...format_column_filters(column_filters),
       };

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -697,7 +697,7 @@ class InventoryViewTests(AssertDictSubsetMixin, DeleteModelsTestCase):
             'ids_only', 'true'
         ), data={}, content_type='application/json')
         self.assertEqual(response.status_code, 400)
-        result = response.json() 
+        result = response.json()
         self.assertEqual(result['success'], False)
         self.assertEqual(result['message'], 'Cannot pass query parameter "ids_only" with "per_page" or "page"')
 
@@ -715,7 +715,6 @@ class InventoryViewTests(AssertDictSubsetMixin, DeleteModelsTestCase):
             'ids_only', 'true'
         ), data={}, content_type='application/json')
         self.assertEqual(response.status_code, 400)
-
 
     def test_get_properties_pint_fields(self):
         state = self.property_state_factory.get_property_state(

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -662,6 +662,15 @@ class InventoryViewTests(AssertDictSubsetMixin, DeleteModelsTestCase):
         self.assertEqual(len(results), 4)
         self.assertEqual(results, [1001, 1002, 1003, 1004])
 
+        response = self.client.post('/api/v3/properties/filter/?{}={}&{}={}'.format(
+            'organization_id', self.org.pk,
+            'ids_only', 'TrUE',
+        ), data={}, content_type='application/json')
+        result = response.json()
+        results = result['results']
+        self.assertEqual(len(results), 4)
+        self.assertEqual(results, [1001, 1002, 1003, 1004])
+
         response = self.client.post('/api/v3/properties/filter/?{}={}&{}={}&{}={}&{}={}'.format(
             'organization_id', self.org.pk,
             'page', 1,

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -626,6 +626,44 @@ class InventoryViewTests(AssertDictSubsetMixin, DeleteModelsTestCase):
         self.assertNotIn(column_name_mappings['number of secret gadgets'], results)
         self.assertNotIn(column_name_mappings['paint color'], results)
 
+    def test_get_properties_select_all(self):
+        state = self.property_state_factory.get_property_state()
+        prprty = self.property_factory.get_property()
+        PropertyView.objects.create(
+            property=prprty, cycle=self.cycle, state=state
+        )
+        state = self.property_state_factory.get_property_state()
+        prprty = self.property_factory.get_property()
+        PropertyView.objects.create(
+            property=prprty, cycle=self.cycle, state=state, id=55
+        )
+        state = self.property_state_factory.get_property_state()
+        prprty = self.property_factory.get_property()
+        PropertyView.objects.create(
+            property=prprty, cycle=self.cycle, state=state
+        )
+        state = self.property_state_factory.get_property_state()
+        prprty = self.property_factory.get_property()
+        PropertyView.objects.create(
+            property=prprty, cycle=self.cycle, state=state, id=10
+        )
+
+        column_name_mappings = {}
+        for c in Column.retrieve_all(self.org.pk, 'property'):
+            if not c['related']:
+                column_name_mappings[c['column_name']] = c['name']
+
+        response = self.client.post('/api/v3/properties/filter/?{}={}&{}={}&{}={}&{}={}'.format(
+            'organization_id', self.org.pk,
+            'page', 1,
+            'per_page', 999999999,
+            'ids_only', 'true',
+        ), data={}, content_type='application/json')
+        result = response.json()
+        results = result['results']
+        self.assertEqual(len(results), 4)
+        self.assertEqual(results, [1, 2, 10, 55])
+
     def test_get_properties_pint_fields(self):
         state = self.property_state_factory.get_property_state(
             self.org,

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -630,7 +630,7 @@ class InventoryViewTests(AssertDictSubsetMixin, DeleteModelsTestCase):
         state = self.property_state_factory.get_property_state()
         prprty = self.property_factory.get_property()
         PropertyView.objects.create(
-            property=prprty, cycle=self.cycle, state=state
+            property=prprty, cycle=self.cycle, state=state, id=1
         )
         state = self.property_state_factory.get_property_state()
         prprty = self.property_factory.get_property()
@@ -640,7 +640,7 @@ class InventoryViewTests(AssertDictSubsetMixin, DeleteModelsTestCase):
         state = self.property_state_factory.get_property_state()
         prprty = self.property_factory.get_property()
         PropertyView.objects.create(
-            property=prprty, cycle=self.cycle, state=state
+            property=prprty, cycle=self.cycle, state=state, id=2
         )
         state = self.property_state_factory.get_property_state()
         prprty = self.property_factory.get_property()

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -6,7 +6,6 @@
 """
 import json
 from datetime import datetime
-from weakref import ProxyType
 
 from django.urls import reverse, reverse_lazy
 from django.test import TestCase

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -630,22 +630,22 @@ class InventoryViewTests(AssertDictSubsetMixin, DeleteModelsTestCase):
         state = self.property_state_factory.get_property_state()
         prprty = self.property_factory.get_property()
         PropertyView.objects.create(
-            property=prprty, cycle=self.cycle, state=state, id=1
+            property=prprty, cycle=self.cycle, state=state, id=1001
         )
         state = self.property_state_factory.get_property_state()
         prprty = self.property_factory.get_property()
         PropertyView.objects.create(
-            property=prprty, cycle=self.cycle, state=state, id=55
+            property=prprty, cycle=self.cycle, state=state, id=1004
         )
         state = self.property_state_factory.get_property_state()
         prprty = self.property_factory.get_property()
         PropertyView.objects.create(
-            property=prprty, cycle=self.cycle, state=state, id=2
+            property=prprty, cycle=self.cycle, state=state, id=1003
         )
         state = self.property_state_factory.get_property_state()
         prprty = self.property_factory.get_property()
         PropertyView.objects.create(
-            property=prprty, cycle=self.cycle, state=state, id=10
+            property=prprty, cycle=self.cycle, state=state, id=1002
         )
 
         column_name_mappings = {}
@@ -662,7 +662,7 @@ class InventoryViewTests(AssertDictSubsetMixin, DeleteModelsTestCase):
         result = response.json()
         results = result['results']
         self.assertEqual(len(results), 4)
-        self.assertEqual(results, [1, 2, 10, 55])
+        self.assertEqual(results, [1001, 1002, 1003, 1004])
 
     def test_get_properties_pint_fields(self):
         state = self.property_state_factory.get_property_state(

--- a/seed/utils/filter_state.py
+++ b/seed/utils/filter_state.py
@@ -38,16 +38,16 @@ def get_filtered_results(request: Request, inventory_type: Literal['property', '
         cycle = Cycle.objects.filter(organization_id=org_id).order_by('name')
         if cycle:
             cycle = cycle.first()
-        else:
-            return JsonResponse({
-                'status': 'error',
-                'message': 'Could not locate cycle',
-                'pagination': {
-                    'total': 0
-                },
-                'cycle_id': None,
-                'results': []
-            })
+    if not cycle:
+        return JsonResponse({
+            'status': 'error',
+            'message': 'Could not locate cycle',
+            'pagination': {
+                'total': 0
+            },
+            'cycle_id': None,
+            'results': []
+        })
 
     if inventory_type == 'property':
         views_list = (

--- a/seed/utils/inventory_filter.py
+++ b/seed/utils/inventory_filter.py
@@ -89,7 +89,7 @@ def get_filtered_results(request: Request, inventory_type: Literal['property', '
         views_list = views_list.filter(id__in=request.data[f'{inventory_type}_view_ids'])
 
     if request.query_params.get('ids_only') == 'true':
-        id_list = [view.id for view in views_list]
+        id_list = views_list.values_list('id', flat=True)
         return JsonResponse({
             'results': id_list
         })

--- a/seed/utils/inventory_filter.py
+++ b/seed/utils/inventory_filter.py
@@ -52,8 +52,8 @@ def get_filtered_results(request: Request, inventory_type: Literal['property', '
 
     if ids_only and (per_page or page):
         return JsonResponse({
-                'success': False,
-                'message': 'Cannot pass query parameter "ids_only" with "per_page" or "page"'
+            'success': False,
+            'message': 'Cannot pass query parameter "ids_only" with "per_page" or "page"'
         }, status=status.HTTP_400_BAD_REQUEST)
 
     page = page or 1

--- a/seed/utils/inventory_filter.py
+++ b/seed/utils/inventory_filter.py
@@ -88,7 +88,7 @@ def get_filtered_results(request: Request, inventory_type: Literal['property', '
     if f'{inventory_type}_view_ids' in request.data and request.data[f'{inventory_type}_view_ids']:
         views_list = views_list.filter(id__in=request.data[f'{inventory_type}_view_ids'])
 
-    if request.query_params.get('ids_only'):
+    if request.query_params.get('ids_only') == 'true':
         id_list = [view.id for view in views_list]
         return JsonResponse({
             'results': id_list

--- a/seed/utils/inventory_filter.py
+++ b/seed/utils/inventory_filter.py
@@ -88,6 +88,12 @@ def get_filtered_results(request: Request, inventory_type: Literal['property', '
     if f'{inventory_type}_view_ids' in request.data and request.data[f'{inventory_type}_view_ids']:
         views_list = views_list.filter(id__in=request.data[f'{inventory_type}_view_ids'])
 
+    if request.query_params.get('ids_only'):
+        id_list = [view.id for view in views_list]
+        return { 
+            'results': id_list 
+            }
+
     paginator = Paginator(views_list, per_page)
 
     try:

--- a/seed/utils/inventory_filter.py
+++ b/seed/utils/inventory_filter.py
@@ -90,9 +90,9 @@ def get_filtered_results(request: Request, inventory_type: Literal['property', '
 
     if request.query_params.get('ids_only'):
         id_list = [view.id for view in views_list]
-        return {
+        return JsonResponse({
             'results': id_list
-        }
+        })
 
     paginator = Paginator(views_list, per_page)
 

--- a/seed/utils/inventory_filter.py
+++ b/seed/utils/inventory_filter.py
@@ -23,7 +23,7 @@ def get_filtered_results(request: Request, inventory_type: Literal['property', '
     per_page = request.query_params.get('per_page')
     org_id = request.query_params.get('organization_id')
     cycle_id = request.query_params.get('cycle')
-    ids_only = request.query_params.get('ids_only') == 'true'
+    ids_only = request.query_params.get('ids_only', 'false').lower() == 'true'
     # check if there is a query paramater for the profile_id. If so, then use that one
     profile_id = request.query_params.get('profile_id', profile_id)
 

--- a/seed/utils/inventory_filter.py
+++ b/seed/utils/inventory_filter.py
@@ -90,9 +90,9 @@ def get_filtered_results(request: Request, inventory_type: Literal['property', '
 
     if request.query_params.get('ids_only'):
         id_list = [view.id for view in views_list]
-        return { 
-            'results': id_list 
-            }
+        return {
+            'results': id_list
+        }
 
     paginator = Paginator(views_list, per_page)
 

--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -47,7 +47,7 @@ from seed.utils.properties import (get_changed_fields,
                                    pair_unpair_property_taxlot,
                                    properties_across_cycles,
                                    update_result_with_master)
-from seed.utils.filter_state import _get_filtered_results
+from seed.utils.filter_state import get_filtered_results
 
 # Global toggle that controls whether or not to display the raw extra
 # data fields in the columns returned for the view.
@@ -290,7 +290,7 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
         """
         List all the properties	with all columns
         """
-        return _get_filtered_results(request, 'property', profile_id=-1)
+        return get_filtered_results(request, 'property', profile_id=-1)
 
     @swagger_auto_schema(
         request_body=AutoSchemaHelper.schema_factory(
@@ -385,7 +385,7 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
                 except TypeError:
                     pass
 
-        return _get_filtered_results(request, 'property', profile_id=profile_id)
+        return get_filtered_results(request, 'property', profile_id=profile_id)
 
     @swagger_auto_schema(
         manual_parameters=[AutoSchemaHelper.query_org_id_field(required=True)],

--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -47,7 +47,7 @@ from seed.utils.properties import (get_changed_fields,
                                    pair_unpair_property_taxlot,
                                    properties_across_cycles,
                                    update_result_with_master)
-from seed.utils.filter_state import get_filtered_results
+from seed.utils.inventory_filter import get_filtered_results
 
 # Global toggle that controls whether or not to display the raw extra
 # data fields in the columns returned for the view.

--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -352,6 +352,11 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
                 required=False,
                 description='If False, related data (i.e. Tax Lot data) is not added to the response (default is True)'
             ),
+            AutoSchemaHelper.query_boolean_field(
+                'ids_only',
+                required=False,
+                description='Function will return a list of property ids instead of property objects'
+            )
         ],
         request_body=AutoSchemaHelper.schema_factory(
             {

--- a/seed/views/v3/taxlots.py
+++ b/seed/views/v3/taxlots.py
@@ -32,7 +32,7 @@ from seed.utils.properties import (get_changed_fields,
                                    pair_unpair_property_taxlot,
                                    update_result_with_master)
 from seed.utils.taxlots import taxlots_across_cycles
-from seed.utils.filter_state import get_filtered_results
+from seed.utils.inventory_filter import get_filtered_results
 
 ErrorState = namedtuple('ErrorState', ['status_code', 'message'])
 

--- a/seed/views/v3/taxlots.py
+++ b/seed/views/v3/taxlots.py
@@ -32,7 +32,7 @@ from seed.utils.properties import (get_changed_fields,
                                    pair_unpair_property_taxlot,
                                    update_result_with_master)
 from seed.utils.taxlots import taxlots_across_cycles
-from seed.utils.filter_state import _get_filtered_results
+from seed.utils.filter_state import get_filtered_results
 
 ErrorState = namedtuple('ErrorState', ['status_code', 'message'])
 
@@ -102,7 +102,7 @@ class TaxlotViewSet(viewsets.ViewSet, OrgMixin, ProfileIdMixin):
         """
         List all the properties
         """
-        return _get_filtered_results(request, 'taxlot', profile_id=-1)
+        return get_filtered_results(request, 'taxlot', profile_id=-1)
 
     @swagger_auto_schema(
         request_body=AutoSchemaHelper.schema_factory(
@@ -193,7 +193,7 @@ class TaxlotViewSet(viewsets.ViewSet, OrgMixin, ProfileIdMixin):
             else:
                 profile_id = request.data['profile_id']
 
-        return _get_filtered_results(request, 'taxlot', profile_id=profile_id)
+        return get_filtered_results(request, 'taxlot', profile_id=profile_id)
 
     @swagger_auto_schema(
         manual_parameters=[

--- a/seed/views/v3/taxlots.py
+++ b/seed/views/v3/taxlots.py
@@ -165,6 +165,11 @@ class TaxlotViewSet(viewsets.ViewSet, OrgMixin, ProfileIdMixin):
                 required=False,
                 description='If False, related data (i.e. Property data) is not added to the response (default is True)'
             ),
+            AutoSchemaHelper.query_boolean_field(
+                'ids_only',
+                required=False,
+                description='Function will return a list of tax lot ids instead of tax lot objects'
+            )
         ],
         request_body=AutoSchemaHelper.schema_factory(
             {


### PR DESCRIPTION
#### Any background context you want to provide?
With paginated inventory lists, it's not critical to return the entire column data when selecting properties or taxlots that are not on page 1.

#### What's this PR do?
Based on a query parameter `?ids_only=true`, the backend will return a json list of property or taxlot ids. If this query param is not passed the function will default to the existing functionality allowing backward compatibility. This should improve performance when applying filters to the entire inventory.

#### How should this be manually tested?
- Run new test /seed/tests/test_views.py:InventoryViewTests.test_get_properties_select_all. 
- Can be tested when the front end "select all" features are implemented.

#### What are the relevant tickets?
#3093
