### PR TITLE
fix(docker): use default PGDATA for postgres

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -18,7 +18,6 @@ services:
       - POSTGRES_DB
       - POSTGRES_USER
       - POSTGRES_PASSWORD
-      - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - seed_pgdata:/var/lib/postgresql/data
       - $HOME/seed-backups:/backups

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - POSTGRES_DB=seed
       - POSTGRES_USER=seed
       - POSTGRES_PASSWORD=super-secret-password
-      - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - seed_pgdata:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
#### Any background context you want to provide?
We added PGDATA to docker compose b/c that's what we're doing in our k8s deployment. But that's not necessary for our local docker-compose, and prevents us from creating new (i.e. empty) volumes and using them with the postgres container.

The changes originally occurred in #3101 

#### What's this PR do?
- removes PGDATA from docker-compose files

#### How should this be manually tested?
- spin it up locally with an existing DB, also try creating a new empty volume and using that for the postgres volume

#### What are the relevant tickets?

#### Screenshots (if appropriate)
