### PR TITLE
cleanup scratch dir before starting restore

### DIFF
--- a/docker/backup_k8s/tar_backup_database.sh
+++ b/docker/backup_k8s/tar_backup_database.sh
@@ -92,4 +92,6 @@ tar -cJf $ARCHIVE /var/lib/postgresql/data
 # push archived db to s3
 aws s3 cp $ARCHIVE $S3_BUCKET/$LATEST_DIR
 
+send_slack_notification "[$ENVIRONMENT]-tar-db-backup-uploaded-to-$S3_BUCKET/$LATEST_DIR/$ARCHIVE"
+
 exit 0

--- a/docker/backup_k8s/tar_backup_database.sh
+++ b/docker/backup_k8s/tar_backup_database.sh
@@ -67,6 +67,10 @@ fi
 
 # work in the scratch volume for storage
 cd /scratch
+# make sure that the scratch volume does not have
+# any preexisting dumps as it will crash the pg_restore
+# command below.
+rm -f seed*.dump
 
 # Download latest S3 backup
 aws s3 cp $S3_BUCKET/$LATEST_DIR . --recursive --exclude "*" --include "seed*.dump"


### PR DESCRIPTION
Fix the tar backup of database. Needed to make sure that the scratch volume had no prior dumps.