### PR TITLE
3127 feat/meter import count

### DIFF
--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -213,8 +213,12 @@ angular.module('BE.seed.controller.data_upload_modal', [])
 
       var present_parsed_meters_confirmation = function (result) {
         $scope.proposed_meters_count = result.proposed_imports.length
-        $scope.proposed_properties_with_meters = new Set(result.proposed_imports.map((meter) => meter.pm_property_id)).size
+        $scope.proposed_meters_count_string = $scope.proposed_meters_count > 1 ? `${$scope.proposed_meters_count} Meters` : `${$scope.proposed_meters_count} Meter`
+        $scope.proposed_properties_count = new Set(result.proposed_imports.map((meter) => meter.pm_property_id)).size
+        $scope.proposed_properties_count_string = $scope.proposed_properties_count > 1 ? `${$scope.proposed_properties_count} Properties` : `${$scope.proposed_properties_count} Property`
+
         $scope.unlinkable_properties = result.unlinkable_pm_ids.length
+        $scope.unlinkable_properties_string = $scope.unlinkable_properties > 1 ? `${$scope.unlinkable_properties} Properties` : `${$scope.unlinkable_properties} Property`
         $scope.proposed_imports_options = {
           data: result.proposed_imports,
           columnDefs: [{
@@ -593,8 +597,10 @@ angular.module('BE.seed.controller.data_upload_modal', [])
             $scope.uploader.status_message = 'saving complete';
             $scope.uploader.progress = 100;
             if (is_meter_data) {
-              $scope.import_meter_count = progress_data.message.length
-              $scope.import_property_count = new Set(progress_data.message.map((meter) => meter.pm_property_id)).size
+              $scope.import_meters_count = progress_data.message.length
+              $scope.import_meters_count_string = $scope.import_meters_count > 1 ? `${$scope.import_meters_count} Meters` : `${$scope.import_meters_count} Meter`
+              $scope.import_properties_count = new Set(progress_data.message.map((meter) => meter.pm_property_id)).size
+              $scope.import_properties_count_string = $scope.import_properties_count > 1 ? `${$scope.import_properties_count} Properties` : `${$scope.import_properties_count} Property`
               $scope.import_results_options = meter_import_results(progress_data.message);
               $scope.step.number = 16;
             } else {

--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -212,6 +212,9 @@ angular.module('BE.seed.controller.data_upload_modal', [])
       };
 
       var present_parsed_meters_confirmation = function (result) {
+        $scope.proposed_meters_count = result.proposed_imports.length
+        $scope.proposed_properties_with_meters = new Set(result.proposed_imports.map((meter) => meter.pm_property_id)).size
+        $scope.unlinkable_properties = result.unlinkable_pm_ids.length
         $scope.proposed_imports_options = {
           data: result.proposed_imports,
           columnDefs: [{
@@ -590,6 +593,8 @@ angular.module('BE.seed.controller.data_upload_modal', [])
             $scope.uploader.status_message = 'saving complete';
             $scope.uploader.progress = 100;
             if (is_meter_data) {
+              $scope.import_meter_count = progress_data.message.length
+              $scope.import_property_count = new Set(progress_data.message.map((meter) => meter.pm_property_id)).size
               $scope.import_results_options = meter_import_results(progress_data.message);
               $scope.step.number = 16;
             } else {

--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -217,8 +217,8 @@ angular.module('BE.seed.controller.data_upload_modal', [])
         $scope.proposed_properties_count = new Set(result.proposed_imports.map((meter) => meter.pm_property_id)).size
         $scope.proposed_properties_count_string = $scope.proposed_properties_count > 1 ? `${$scope.proposed_properties_count} Properties` : `${$scope.proposed_properties_count} Property`
 
-        $scope.unlinkable_properties = result.unlinkable_pm_ids.length
-        $scope.unlinkable_properties_string = $scope.unlinkable_properties > 1 ? `${$scope.unlinkable_properties} Properties` : `${$scope.unlinkable_properties} Property`
+        $scope.unlinkable_properties_count = result.unlinkable_pm_ids.length
+        $scope.unlinkable_properties_count_string = $scope.unlinkable_properties_count > 1 ? `${$scope.unlinkable_properties_count} Properties` : `${$scope.unlinkable_properties} Property`
         $scope.proposed_imports_options = {
           data: result.proposed_imports,
           columnDefs: [{

--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -212,13 +212,12 @@ angular.module('BE.seed.controller.data_upload_modal', [])
       };
 
       var present_parsed_meters_confirmation = function (result) {
-        $scope.proposed_meters_count = result.proposed_imports.length
-        $scope.proposed_meters_count_string = $scope.proposed_meters_count > 1 ? `${$scope.proposed_meters_count} Meters` : `${$scope.proposed_meters_count} Meter`
-        $scope.proposed_properties_count = new Set(result.proposed_imports.map((meter) => meter.pm_property_id)).size
-        $scope.proposed_properties_count_string = $scope.proposed_properties_count > 1 ? `${$scope.proposed_properties_count} Properties` : `${$scope.proposed_properties_count} Property`
-
-        $scope.unlinkable_properties_count = result.unlinkable_pm_ids.length
-        $scope.unlinkable_properties_count_string = $scope.unlinkable_properties_count > 1 ? `${$scope.unlinkable_properties_count} Properties` : `${$scope.unlinkable_properties} Property`
+        $scope.proposed_meters_count = result.proposed_imports.length;
+        $scope.proposed_meters_count_string = $scope.proposed_meters_count > 1 ? `${$scope.proposed_meters_count} Meters` : `${$scope.proposed_meters_count} Meter`;
+        $scope.proposed_properties_count = new Set(result.proposed_imports.map((meter) => meter.pm_property_id)).size;
+        $scope.proposed_properties_count_string = $scope.proposed_properties_count > 1 ? `${$scope.proposed_properties_count} Properties` : `${$scope.proposed_properties_count} Property`;
+        $scope.unlinkable_properties_count = result.unlinkable_pm_ids.length;
+        $scope.unlinkable_properties_count_string = $scope.unlinkable_properties_count > 1 ? `${$scope.unlinkable_properties_count} Properties` : `${$scope.unlinkable_properties} Property`;
         $scope.proposed_imports_options = {
           data: result.proposed_imports,
           columnDefs: [{
@@ -597,10 +596,10 @@ angular.module('BE.seed.controller.data_upload_modal', [])
             $scope.uploader.status_message = 'saving complete';
             $scope.uploader.progress = 100;
             if (is_meter_data) {
-              $scope.import_meters_count = progress_data.message.length
-              $scope.import_meters_count_string = $scope.import_meters_count > 1 ? `${$scope.import_meters_count} Meters` : `${$scope.import_meters_count} Meter`
-              $scope.import_properties_count = new Set(progress_data.message.map((meter) => meter.pm_property_id)).size
-              $scope.import_properties_count_string = $scope.import_properties_count > 1 ? `${$scope.import_properties_count} Properties` : `${$scope.import_properties_count} Property`
+              $scope.import_meters_count = progress_data.message.length;
+              $scope.import_meters_count_string = $scope.import_meters_count > 1 ? `${$scope.import_meters_count} Meters` : `${$scope.import_meters_count} Meter`;
+              $scope.import_properties_count = new Set(progress_data.message.map((meter) => meter.pm_property_id)).size;
+              $scope.import_properties_count_string = $scope.import_properties_count > 1 ? `${$scope.import_properties_count} Properties` : `${$scope.import_properties_count} Property`;
               $scope.import_results_options = meter_import_results(progress_data.message);
               $scope.step.number = 16;
             } else {

--- a/seed/static/seed/js/controllers/green_button_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/green_button_upload_modal_controller.js
@@ -111,6 +111,8 @@ angular.module('BE.seed.controller.green_button_upload_modal', [])
 
       var show_confirmation_info = function () {
         uploader_service.greenbutton_meters_preview($scope.file_id, $scope.organization_id, $scope.view_id).then(function (result) {
+          $scope.proposed_meters_count = result.proposed_imports.length
+          $scope.proposed_meters_count_string = $scope.proposed_meters_count > 1 ? `${$scope.proposed_meters_count} Meters` : `${$scope.proposed_meters_count} Meter` 
           $scope.proposed_imports_options = {
             data: result.proposed_imports,
             columnDefs: base_green_button_col_defs,
@@ -172,6 +174,9 @@ angular.module('BE.seed.controller.green_button_upload_modal', [])
           enableVerticalScrollbar: message.length <= 5 ? uiGridConstants.scrollbars.NEVER : uiGridConstants.scrollbars.WHEN_NEEDED,
           minRowsToShow: grid_rows_to_display(message)
         };
+        $scope.import_meters_count = message.length
+        $scope.import_meters_count_string = $scope.import_meters_count > 1 ? `${$scope.import_meters_count} Meters` : `${$scope.import_meters_count} Meter` 
+
       };
 
       $scope.accept_greenbutton_meters = function () {

--- a/seed/static/seed/partials/data_upload_modal.html
+++ b/seed/static/seed/partials/data_upload_modal.html
@@ -358,8 +358,8 @@
                 <div class="alert alert-warning" ng-if="proposed_imports_options.data.length">
                     <div ng-if="proposed_imports_options.data.length">
                         <div translate><b>METER_READING_COUNTS_TITLE</b></div>
-                        <ul class="meter-count" nf-if="proposed_properties_with_meters">    
-                            <li>{$ proposed_meters_count $} Meters from {$ proposed_properties_with_meters $} Properties</li>
+                        <ul class="meter-count" nf-if="proposed_properties_count">    
+                            <li>{$ proposed_meters_count_string $} from {$ proposed_properties_count_string $}</li>
                         </ul>
                         <div ui-grid="proposed_imports_options" ui-grid-resize-columns></div>
                     </div>
@@ -373,7 +373,7 @@
                 <div class="alert alert-danger" ng-if="unlinkable_pm_ids_options.data.length">
                     <div translate><b>PM_METER_IMPORT_NO_ASSOCIATION</b></div>
                     <ul class="meter-count" ng-if="unlinkable_properties">
-                        <li>{$ unlinkable_properties $} Unlinkable Properties</li>
+                        <li>{$ unlinkable_properties_string $}</li>
                     </ul>
                     <div ui-grid="unlinkable_pm_ids_options" ui-grid-resize-columns></div>
                 </div>
@@ -385,8 +385,8 @@
         <div class="row">
             <div class="alert alert-info">
                 <div translate><b>METER_READING_COUNTS_TITLE</b></div>
-                <ul class="meter-count" ng-if="import_property_count">
-                    <li>{$ import_meter_count $} Meters Imported from {$ import_property_count $} Properties</li>
+                <ul class="meter-count" ng-if="import_properties_count">
+                    <li>{$ import_meters_count_string $} Imported from {$ import_properties_count_string $} </li>
                 </ul>
                 <div ui-grid="import_results_options"></div>
             </div>

--- a/seed/static/seed/partials/data_upload_modal.html
+++ b/seed/static/seed/partials/data_upload_modal.html
@@ -358,7 +358,7 @@
                 <div class="alert alert-warning" ng-if="proposed_imports_options.data.length">
                     <div ng-if="proposed_imports_options.data.length">
                         <div translate><b>METER_READING_COUNTS_TITLE</b></div>
-                        <ul class="meter-count" nf-if="proposed_properties_count">    
+                        <ul class="meter-count" ng-if="proposed_properties_count">    
                             <li>{$ proposed_meters_count_string $} from {$ proposed_properties_count_string $}</li>
                         </ul>
                         <div ui-grid="proposed_imports_options" ui-grid-resize-columns></div>

--- a/seed/static/seed/partials/data_upload_modal.html
+++ b/seed/static/seed/partials/data_upload_modal.html
@@ -372,8 +372,8 @@
                 </div>
                 <div class="alert alert-danger" ng-if="unlinkable_pm_ids_options.data.length">
                     <div translate><b>PM_METER_IMPORT_NO_ASSOCIATION</b></div>
-                    <ul class="meter-count" ng-if="unlinkable_properties">
-                        <li>{$ unlinkable_properties_string $}</li>
+                    <ul class="meter-count" ng-if="unlinkable_properties_count">
+                        <li>{$ unlinkable_properties_count_string $}</li>
                     </ul>
                     <div ui-grid="unlinkable_pm_ids_options" ui-grid-resize-columns></div>
                 </div>

--- a/seed/static/seed/partials/data_upload_modal.html
+++ b/seed/static/seed/partials/data_upload_modal.html
@@ -358,6 +358,9 @@
                 <div class="alert alert-warning" ng-if="proposed_imports_options.data.length">
                     <div ng-if="proposed_imports_options.data.length">
                         <div translate><b>METER_READING_COUNTS_TITLE</b></div>
+                        <ul class="meter-count" nf-if="proposed_properties_with_meters">    
+                            <li>{$ proposed_meters_count $} Meters from {$ proposed_properties_with_meters $} Properties</li>
+                        </ul>
                         <div ui-grid="proposed_imports_options" ui-grid-resize-columns></div>
                     </div>
                     <br>
@@ -369,6 +372,9 @@
                 </div>
                 <div class="alert alert-danger" ng-if="unlinkable_pm_ids_options.data.length">
                     <div translate><b>PM_METER_IMPORT_NO_ASSOCIATION</b></div>
+                    <ul class="meter-count" ng-if="unlinkable_properties">
+                        <li>{$ unlinkable_properties $} Unlinkable Properties</li>
+                    </ul>
                     <div ui-grid="unlinkable_pm_ids_options" ui-grid-resize-columns></div>
                 </div>
             </div>
@@ -379,6 +385,9 @@
         <div class="row">
             <div class="alert alert-info">
                 <div translate><b>METER_READING_COUNTS_TITLE</b></div>
+                <ul class="meter-count" ng-if="import_property_count">
+                    <li>{$ import_meter_count $} Meters Imported from {$ import_property_count $} Properties</li>
+                </ul>
                 <div ui-grid="import_results_options"></div>
             </div>
             <div class="alert alert-danger" ng-if="unlinkable_pm_ids.length">

--- a/seed/static/seed/partials/green_button_upload_modal.html
+++ b/seed/static/seed/partials/green_button_upload_modal.html
@@ -22,7 +22,7 @@
             <div class="alert alert-warning green-button-preview">
                 <div>
                     <div translate><b>METER_READING_COUNTS_TITLE</b></div>
-                    <ul class="meter-count" nf-if="proposed_meters_count">
+                    <ul class="meter-count" ng-if="proposed_meters_count">
                         <li>{$ proposed_meters_count_string $} </li>
                     </ul>
                     <div ui-grid="proposed_imports_options" ui-grid-resize-columns></div>

--- a/seed/static/seed/partials/green_button_upload_modal.html
+++ b/seed/static/seed/partials/green_button_upload_modal.html
@@ -22,6 +22,9 @@
             <div class="alert alert-warning green-button-preview">
                 <div>
                     <div translate><b>METER_READING_COUNTS_TITLE</b></div>
+                    <ul class="meter-count" nf-if="proposed_meters_count">
+                        <li>{$ proposed_meters_count_string $} </li>
+                    </ul>
                     <div ui-grid="proposed_imports_options" ui-grid-resize-columns></div>
                 </div>
                 <br>
@@ -47,6 +50,9 @@
     <div class="data_upload_steps" ng-switch-when="4">
         <div class="alert alert-info green-button-preview">
             <div translate><b>METER_READING_COUNTS_TITLE</b></div>
+            <ul class="meter-count" ng-if="import_meters_count">
+                <li>{$ import_meters_count_string $}</li>
+            </ul>
             <div ui-grid="import_result_options" ui-grid-resize-columns></div>
         </div>
     </div>

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -1810,6 +1810,14 @@ a:not([href]) {
     padding-left: 0;
   }
 
+  .meter-count {
+    margin-bottom: 0px;
+
+    li {
+      padding: 5px;
+    }
+  }
+
 }
 
 .modal-footer {


### PR DESCRIPTION
#### Any background context you want to provide?
After importing meters from a property file there is a display describing which meters and their properties were imported. There is no indicator showing how many meters or properties containing meters were imported. This same flow is repeated for the GreenButton upload.


#### What's this PR do?
Adds property and meter counts to the data upload modal during the meter import and GreenButton upload steps.

#### How should this be manually tested?
Test Property Upload:
- Import a Property file with meter data. Following the property import click "Import Meters from the same file". Note this may take several seconds to appear, and several seconds to prompt the next modal screen.
![Screen Shot 2022-03-08 at 12 34 33 PM](https://user-images.githubusercontent.com/58446472/157311975-8b5264a1-d314-4a90-b84d-e2658ce280e9.png)
- Ensure there are proposed counts for meter counts and unlinkable properties. 
- Click confirm 
- Ensure there is an imported meter count.


Test file: [ESPM_JCC_Custom_Download_BETTERTest.xlsx](https://github.com/SEED-platform/seed/files/8209091/ESPM_JCC_Custom_Download_BETTERTest.xlsx)


Test GreenButton:
Inventory > Property detail (one that has meters) > Meters > Upload GreenButton Data > same process as above.
Test File: /seed/tests/data/example-GreenButton-data.xml


#### What are the relevant tickets?
#3127 

#### Screenshots (if appropriate)
Proposed Meter Imports
![Screen Shot 2022-03-04 at 3 01 56 PM](https://user-images.githubusercontent.com/58446472/156850792-03a4e0e6-35df-48a6-a532-c0fef30cf7f9.png)

Imported Meters
![Screen Shot 2022-03-04 at 3 19 51 PM](https://user-images.githubusercontent.com/58446472/156850815-2dd37b07-66e1-4cbb-8e5a-ad46a5c4fe36.png)

