### PR TITLE
3128 feat/dataset feedback number of meters

### DIFF
--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -26,6 +26,7 @@ angular.module('BE.seed.controller.data_upload_modal', [])
   .controller('data_upload_modal_controller', [
     '$http',
     '$scope',
+    '$rootScope',
     '$uibModalInstance',
     '$log',
     '$timeout',
@@ -45,6 +46,7 @@ angular.module('BE.seed.controller.data_upload_modal', [])
     function (
       $http,
       $scope,
+      $rootScope,
       $uibModalInstance,
       $log,
       $timeout,
@@ -187,8 +189,6 @@ angular.module('BE.seed.controller.data_upload_modal', [])
         } else {
           $uibModalInstance.dismiss('cancel');
         }
-        // Following a completed meter import refresh datasets
-        $scope.step.number == 16 ? location.reload() : null
       };
       /**
        * create_dataset: uses the `uploader_service` to create a new data set. If
@@ -390,6 +390,7 @@ angular.module('BE.seed.controller.data_upload_modal', [])
         cycle_id = cycle_id || $scope.selectedCycle.id;
         $scope.uploader.in_progress = true;
         save_raw_assessed_data(file_id, cycle_id, true);
+        $rootScope.$emit('datasets_updated')
       };
 
       /**

--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -187,6 +187,8 @@ angular.module('BE.seed.controller.data_upload_modal', [])
         } else {
           $uibModalInstance.dismiss('cancel');
         }
+        // Following a completed meter import refresh datasets
+        $scope.step.number == 16 ? location.reload() : null
       };
       /**
        * create_dataset: uses the `uploader_service` to create a new data set. If

--- a/seed/static/seed/js/controllers/data_upload_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_upload_modal_controller.js
@@ -390,7 +390,7 @@ angular.module('BE.seed.controller.data_upload_modal', [])
         cycle_id = cycle_id || $scope.selectedCycle.id;
         $scope.uploader.in_progress = true;
         save_raw_assessed_data(file_id, cycle_id, true);
-        $rootScope.$emit('datasets_updated')
+        $rootScope.$emit('datasets_updated');
       };
 
       /**

--- a/seed/static/seed/js/controllers/dataset_list_controller.js
+++ b/seed/static/seed/js/controllers/dataset_list_controller.js
@@ -5,11 +5,12 @@
 angular.module('BE.seed.controller.dataset', [])
   .controller('dataset_list_controller', [
     '$scope',
+    '$rootScope',
     'datasets_payload',
     '$uibModal',
     'urls',
     'dataset_service',
-    function ($scope, datasets_payload, $uibModal, urls, dataset_service) {
+    function ($scope, $rootScope, datasets_payload, $uibModal, urls, dataset_service) {
       $scope.datasets = datasets_payload.datasets;
       $scope.columns = [{
         title: 'Data Set Name'
@@ -130,6 +131,7 @@ angular.module('BE.seed.controller.dataset', [])
        * event broadcast from menu controller when a new dataset is added
        */
       $scope.$on('datasets_updated', refresh_datasets);
+      $rootScope.$on('datasets_updated', refresh_datasets);
 
     }
   ]);

--- a/seed/static/seed/partials/dataset_detail.html
+++ b/seed/static/seed/partials/dataset_detail.html
@@ -41,7 +41,7 @@
                                 <td>{$:: f.created | date: 'MM/dd/yyyy hh:mm:ss a' $}</td>
                                 <td class="is_aligned_right">{$:: f.num_rows || 0 $}</td>
                                 <td>{$:: getCycleName(f.cycle) $}</td>
-                                <td><a id="data-mapping-{$:: $index $}" role="button" class="btn btn-sm btn-primary" ui-sref="mapping(::{importfile_id: f.id})" ng-disabled="::!f.num_rows">{$:: f.number_of_mappings $} {$:: 'Data Mapping' | translate $}</a></td>
+                                <td><a id="data-mapping-{$:: $index $}" role="button" class="btn btn-sm btn-primary" ui-sref="mapping(::{importfile_id: f.id})" ng-disabled="::!f.num_rows || !f.cached_second_to_fifth_row">{$:: f.number_of_mappings $} {$:: 'Data Mapping' | translate $}</a></td>
                                 <td><a id="data-pairing-{$:: $index $}" role="button" class="btn btn-sm btn-primary" ui-sref="pairing(::{importfile_id: f.id, inventory_type: 'properties'})" ng-disabled="::!f.num_rows || !f.mapping_done || !f.matching_done || getCycleName(f.cycle) === undefined">{$:: f.number_of_pairings $} {$:: 'Data Pairing' | translate $}</a></td>
                             </tr>
                         </tbody>

--- a/seed/views/v3/import_files.py
+++ b/seed/views/v3/import_files.py
@@ -1107,7 +1107,7 @@ class ImportFileViewSet(viewsets.ViewSet, OrgMixin):
             meters_parser = MetersParser.factory(import_file.local_file, org_id)
             import_file.num_rows = len(meters_parser.proposed_imports)
             import_file.save()
-            
+
         except ImportFile.DoesNotExist:
             return JsonResponse(
                 {'status': 'error', 'message': 'Could not find import file with pk=' + str(

--- a/seed/views/v3/import_files.py
+++ b/seed/views/v3/import_files.py
@@ -1104,12 +1104,14 @@ class ImportFileViewSet(viewsets.ViewSet, OrgMixin):
                 pk=pk,
                 import_record__super_organization_id=org_id
             )
+            meters_parser = MetersParser.factory(import_file.local_file, org_id)
+            import_file.num_rows = len(meters_parser.proposed_imports)
+            import_file.save()
+            
         except ImportFile.DoesNotExist:
             return JsonResponse(
                 {'status': 'error', 'message': 'Could not find import file with pk=' + str(
                     pk)}, status=status.HTTP_400_BAD_REQUEST)
-
-        meters_parser = MetersParser.factory(import_file.local_file, org_id)
 
         result = {}
         result["validated_type_units"] = meters_parser.validated_type_units()


### PR DESCRIPTION
#### Any background context you want to provide?
If a property file with meter data is imported, SEED generates two different import records. One for the property import, and one for the meter data import. The "# of records" listed in the view indicates the number of properties that were in the imported file. This works fine for the property import, but the meter data import returns 0 for "# of records". 

ImportFiles are SEED models representing a property file that has been imported. SEED reuses this model for meter imports for display purposes but most of the model fields are left blank. The model column `num_rows` is used to populate "# of records". This field was left as None during the meter import.

#### What's this PR do?
Attaches the rows of the proposed meter import file to the `ImportFile.num_rows` property, and updates any conditionals to prevent unexpected functionality.

#### How should this be manually tested?
- Import a Property file with meter data. Following the property import click "Import Meters from the same file". Note this may take several seconds to appear, and several seconds to prompt the next modal screen.
![Screen Shot 2022-03-08 at 12 34 33 PM](https://user-images.githubusercontent.com/58446472/157311975-8b5264a1-d314-4a90-b84d-e2658ce280e9.png)
- Once the proposed meter screen appears go through the meter import steps until complete
- Go to Data, click the relevant data set and there should be 2 data files generated from the recent upload. One for properties, one for meters. 
- The meter import data file should have "Data Mapping" and "Data Pairing" functionality disabled.

Test File: [ESPM_JCC_Custom_Download_BETTERTest.xlsx](https://github.com/SEED-platform/seed/files/8209288/ESPM_JCC_Custom_Download_BETTERTest.xlsx)

#### What are the relevant tickets?
#3158

#### Screenshots (if appropriate)
![Screen Shot 2022-03-08 at 2 55 05 PM](https://user-images.githubusercontent.com/58446472/157332095-ed95b063-1dfe-4009-837c-ff191d177082.png)


![Screen Shot 2022-03-08 at 1 17 59 PM](https://user-images.githubusercontent.com/58446472/157322017-4e49413e-b267-46ca-a237-8a64225fe677.png)

