### PR TITLE
Update display of BETTER host configuration

### DIFF
--- a/seed/static/seed/partials/organization_settings.html
+++ b/seed/static/seed/partials/organization_settings.html
@@ -86,7 +86,7 @@
                     <form class="form-horizontal" role="form">
                         <div class="form-group">
                             <div class="col-sm-4">
-                                <p>Please refer to the <a href="https://better.lbl.gov/docs/api/" target="_blank" rel="noopener noreferrer">BETTER documentation</a> to learn how to get an API key. Note, do not prefix the token with "Token ", only include the token itself.</p>
+                                <p>Please refer to the <a href="{$ org.better_host_url $}/docs/api/" target="_blank" rel="noopener noreferrer">BETTER documentation</a> to learn how to get an API key. Note, do not prefix the token with "Token ", only include the token itself. BETTER host is configured to be {$ org.better_host_url $}.</p>
                                 <input type="text" class="form-control" ng-model="org.better_analysis_api_key" ng-disabled="::!auth.requires_owner">
                             </div>
                         </div>

--- a/seed/views/v3/organizations.py
+++ b/seed/views/v3/organizations.py
@@ -121,6 +121,7 @@ def _dict_org(request, organizations):
             'mapquest_api_key': o.mapquest_api_key or '',
             'geocoding_enabled': o.geocoding_enabled,
             'better_analysis_api_key': o.better_analysis_api_key or '',
+            'better_host_url': settings.BETTER_HOST,
             'property_display_field': o.property_display_field,
             'taxlot_display_field': o.taxlot_display_field,
             'display_meter_units': o.display_meter_units,


### PR DESCRIPTION
#### Any background context you want to provide?
On development, or any custom configured `BETTER_HOST` the URL link would always go to production.

#### What's this PR do?
* Adds BETTER_HOST to the org API
* Point to the documentation based on the host URL and display it in the text.

#### How should this be manually tested?
Load settings page for an org and look at the BETTER key section.

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
