### PR TITLE
Pin jinja to avoid import error

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,6 +21,7 @@ flake8==3.8.1
 pycodestyle==2.6.0
 
 # documentation and spelling
+Jinja2<3.1.0
 Sphinx==2.3.1
 sphinxcontrib-spelling==4.3.0
 sphinx_rtd_theme==0.4.3


### PR DESCRIPTION
#### Any background context you want to provide?
Recent sphinx doc generation has been failing with the following error:
```
ImportError: cannot import name 'environmentfilter' from 'jinja2'
```

#### What are the relevant tickets?
https://github.com/sphinx-doc/sphinx/issues/10291