### PR TITLE
fix: removed unused function call

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_beta_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_beta_controller.js
@@ -826,7 +826,6 @@ angular.module('BE.seed.controller.inventory_list_beta', [])
             evaluateDerivedColumns();
             $scope.select_none();
             spinner_utility.hide();
-            loadSavedLabels();
           });
       };
 


### PR DESCRIPTION
#### Any background context you want to provide?
The beta inventory filters stopped working.

#### What's this PR do?
Fixes the beta inventory filters:  there was a function call that was no longer needed as loading the labels happens on init instead of on loading the inventory.

#### How should this be manually tested?
Use the beta inventory page and filter the list down.

#### What are the relevant tickets?
---

#### Screenshots (if appropriate)
---
