### PR TITLE
Mark /seed as safe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN npm install --unsafe-perm
 WORKDIR /seed
 COPY . /seed/
 COPY ./docker/wait-for-it.sh /usr/local/wait-for-it.sh
+RUN git config --system --add safe.directory /seed
 
 # nginx configuration - replace the root/default nginx config file
 COPY /docker/nginx-seed.conf /etc/nginx/nginx.conf

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -55,6 +55,7 @@ RUN npm install --unsafe-perm
 WORKDIR /seed
 COPY . /seed/
 COPY ./docker/wait-for-it.sh /usr/local/wait-for-it.sh
+RUN git config --system --add safe.directory /seed
 
 EXPOSE 80
 


### PR DESCRIPTION
#### Any background context you want to provide?
Recent versions of git no longer allow users to interact with local git repos when the file owner permissions differ from the current user.

#### What's this PR do?
Updates the system-wide git config for all users (`/etc/gitconfig`) to mark `/seed` as a safe directory, so that the `uwsgi` user can query the current git revision despite the files being owned by `root`.

#### How should this be manually tested?
1. Run `docker-compose up -d`
2. Check that the About page loads the git sha correctly, instead of returning a 500 error.
