### PR TITLE
3228 feat/refresh metadata inventory beta

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_beta_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_beta_controller.js
@@ -1069,6 +1069,7 @@ angular.module('BE.seed.controller.inventory_list_beta', [])
           case 'run_data_quality_check': $scope.run_data_quality_check(selectedViewIds); break;
           case 'open_postoffice_modal': $scope.open_postoffice_modal(selectedViewIds); break;
           case 'open_analyses_modal': $scope.open_analyses_modal(selectedViewIds); break;
+          case 'open_refresh_metadata_modal': $scope.open_refresh_metadata_modal(selectedViewIds); break;
           case 'open_geocode_modal': $scope.open_geocode_modal(selectedViewIds); break;
           case 'open_ubid_modal': $scope.open_ubid_modal(selectedViewIds); break;
           case 'open_show_populated_columns_modal': $scope.open_show_populated_columns_modal(); break;
@@ -1078,6 +1079,23 @@ angular.module('BE.seed.controller.inventory_list_beta', [])
         }
         $scope.model_actions = 'none';
       };
+
+      $scope.open_refresh_metadata_modal = function () {
+        $uibModal.open({
+          templateUrl: urls.static_url + 'seed/partials/refresh_metadata_modal.html',
+          controller: 'refresh_metadata_modal_controller',
+          backdrop: 'static',
+          resolve: {
+            ids: function () {
+              return _.map(_.filter($scope.gridApi.selection.getSelectedRows(), function (row) {
+                if ($scope.inventory_type === 'properties') return row.$$treeLevel == 0;
+                return !_.has(row, '$$treeLevel');
+              }), 'id');
+            },
+            inventory_type: _.constant($scope.inventory_type),
+          }
+        });
+      }
 
       $scope.open_analyses_modal = function (selectedViewIds) {
         const modalInstance = $uibModal.open({

--- a/seed/static/seed/partials/inventory_list_beta.html
+++ b/seed/static/seed/partials/inventory_list_beta.html
@@ -37,6 +37,7 @@
                     <option value="run_data_quality_check" ng-disabled="selectedCount === 0" translate>Data Quality Check</option>
                     <option value="open_postoffice_modal" ng-disabled="selectedCount === 0" translate>Email</option>
                     <option value="open_analyses_modal" ng-disabled="selectedCount === 0" translate>Run Analysis</option>
+                    <option value="open_refresh_metadata_modal" ng-disabled="selectedCount === 0" translate>Refresh Metadata</option>
                     <option value="open_geocode_modal" ng-disabled="selectedCount === 0" translate>Geocode</option>
                     <option value="open_ubid_modal" ng-disabled="selectedCount === 0" translate>Decode UBID/ULID</option>
                 </optgroup>


### PR DESCRIPTION
#### Any background context you want to provide?
The "Refresh Metadata" action was only added to the inventory list actions.

#### What's this PR do?
Adds "Refresh Metadata" action to inventory beta list actions.

#### How should this be manually tested?
To test user experience: 
inventory > select a number of properties > actions > refresh metadata > refresh_metadata > watch progress bar go to 100 and modal will close 

To check actual property values 'updated' attribute (more involved):
```
docker exec -it seed_web /bin/bash
python manage.py shell
from seed.models import PropertyState
PropertyState.objects.get(pm_property_id=<PM Property ID of your choice>).propertyview_set.first().property.updated 
>>> old time 
```
inventory > select property with same PM Property ID > actions > refresh metadata ...
... back to shell 
```
PropertyState.objects.get(pm_property_id=<Same PM Property ID>).propertyview_set.first().property.updated
>>> current time
```

#### What are the relevant tickets?
#3228

#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/58446472/168677296-533071f2-2996-4bb8-a540-ace9d13a5513.mov


