### PR TITLE
Add GHG fields to coparent call

### DIFF
--- a/seed/models/columns.py
+++ b/seed/models/columns.py
@@ -74,6 +74,10 @@ class Column(models.Model):
         ('PropertyState', 'source_eui'),
         ('PropertyState', 'source_eui_modeled'),
         ('PropertyState', 'source_eui_weather_normalized'),
+        ('PropertyState', 'total_ghg_emissions'),
+        ('PropertyState', 'total_marginal_ghg_emissions'),
+        ('PropertyState', 'total_ghg_emissions_intensity'),
+        ('PropertyState', 'total_marginal_ghg_emissions_intensity'),
     ]
 
     COLUMN_MERGE_FAVOR_NEW = 0

--- a/seed/models/columns.py
+++ b/seed/models/columns.py
@@ -610,21 +610,25 @@ class Column(models.Model):
             'column_name': 'total_ghg_emissions',
             'table_name': 'PropertyState',
             'display_name': 'Total GHG Emissions',
+            'column_description': 'Total GHG Emissions',
             'data_type': 'number',
         }, {
             'column_name': 'total_marginal_ghg_emissions',
             'table_name': 'PropertyState',
             'display_name': 'Total Marginal GHG Emissions',
+            'column_description': 'Total Marginal GHG Emissions',
             'data_type': 'number',
         }, {
             'column_name': 'total_ghg_emissions_intensity',
             'table_name': 'PropertyState',
             'display_name': 'Total GHG Emissions Intensity',
+            'column_description': 'Total GHG Emissions Intensity',
             'data_type': 'number',
         }, {
             'column_name': 'total_marginal_ghg_emissions_intensity',
             'table_name': 'PropertyState',
             'display_name': 'Total Marginal GHG Emissions Intensity',
+            'column_description': 'Total Marginal GHG Emissions Intensity',
             'data_type': 'number',
         },
     ]

--- a/seed/models/properties.py
+++ b/seed/models/properties.py
@@ -151,7 +151,7 @@ class PropertyState(models.Model):
     ubid = models.CharField(max_length=255, null=True, blank=True)
 
     # If the property is a campus then the pm_parent_property_id is the same
-    # for all the properties. The master campus record (campus=True on Property model) will
+    # for all the properties. The main campus record (campus=True on Property model) will
     # have the pm_property_id set to be the same as the pm_parent_property_id
     pm_parent_property_id = models.CharField(max_length=255, null=True, blank=True)
     pm_property_id = models.CharField(max_length=255, null=True, blank=True)
@@ -181,7 +181,6 @@ class PropertyState(models.Model):
     bounding_box = geomodels.PolygonField(geography=True, null=True, blank=True)
     property_footprint = geomodels.PolygonField(geography=True, null=True, blank=True)
 
-    # footprint = geomodels.PolygonField(geography=True, null=True, blank=True)
     geocoding_confidence = models.CharField(max_length=32, null=True, blank=True)
 
     # EPA's eGRID Subregion Code (https://www.epa.gov/egrid)
@@ -389,7 +388,7 @@ class PropertyState(models.Model):
         Return the history of the property state by parsing through the auditlog. Returns only the ids
         of the parent states and some descriptions.
 
-              master
+              main
               /   \
              /     \
           parent1  parent2
@@ -397,12 +396,12 @@ class PropertyState(models.Model):
         In the records, parent2 is most recent, so make sure to navigate parent two first since we
         are returning the data in reverse over (that is most recent changes first)
 
-        :return: list, history as a list, and the master record
+        :return: list, history as a list, and the main record
         """
 
         """Return history in reverse order."""
         history = []
-        master = {
+        main = {
             'state_id': self.id,
             'state_data': self,
             'date_edited': None,
@@ -436,7 +435,7 @@ class PropertyState(models.Model):
         ).order_by('-id').first()
 
         if log:
-            master = {
+            main = {
                 'state_id': log.state.id,
                 'state_data': log.state,
                 'date_edited': convert_to_js_timestamp(log.created),
@@ -497,7 +496,7 @@ class PropertyState(models.Model):
                 record = record_dict(log)
                 history.append(record)
 
-        return history, master
+        return history, main
 
     @classmethod
     def coparent(cls, state_id):
@@ -552,6 +551,10 @@ class PropertyState(models.Model):
                     ps.energy_score,
                     ps.site_eui,
                     ps.site_eui_modeled,
+                    ps.total_ghg_emissions,
+                    ps.total_marginal_ghg_emissions,
+                    ps.total_ghg_emissions_intensity,
+                    ps.total_marginal_ghg_emissions_intensity,
                     ps.property_notes,
                     ps.property_type,
                     ps.year_ending,
@@ -592,8 +595,10 @@ class PropertyState(models.Model):
                        'address_line_1', 'address_line_2', 'city', 'state', 'postal_code',
                        'longitude', 'latitude',
                        'lot_number', 'gross_floor_area', 'use_description', 'energy_score',
-                       'site_eui', 'site_eui_modeled', 'property_notes', 'property_type',
-                       'year_ending', 'owner', 'owner_email', 'owner_telephone', 'building_count',
+                       'site_eui', 'site_eui_modeled', 'total_ghg_emissions', 'total_marginal_ghg_emissions',
+                       'total_ghg_emissions_intensity', 'total_marginal_ghg_emissions_intensity',
+                       'property_notes', 'property_type', 'year_ending', 'owner',
+                       'owner_email', 'owner_telephone', 'building_count',
                        'year_built', 'recent_sale_date', 'conditioned_floor_area',
                        'occupied_floor_area', 'owner_address', 'owner_postal_code',
                        'home_energy_score_id', 'generation_date', 'release_date',

--- a/seed/models/tax_lots.py
+++ b/seed/models/tax_lots.py
@@ -201,7 +201,7 @@ class TaxLotState(models.Model):
         Return the history of the taxlot state by parsing through the auditlog. Returns only the ids
         of the parent states and some descriptions.
 
-              master
+               main
               /    \
              /      \
           parent1  parent2
@@ -209,12 +209,12 @@ class TaxLotState(models.Model):
         In the records, parent2 is most recent, so make sure to navigate parent two first since we
         are returning the data in reverse over (that is most recent changes first)
 
-        :return: list, history as a list, and the master record
+        :return: list, history as a list, and the main record
         """
 
         """Return history in reverse order."""
         history = []
-        master = {
+        main = {
             'state_id': self.id,
             'state_data': self,
             'date_edited': None,
@@ -243,7 +243,7 @@ class TaxLotState(models.Model):
         ).order_by('-id').first()
 
         if log:
-            master = {
+            main = {
                 'state_id': log.state.id,
                 'state_data': log.state,
                 'date_edited': convert_to_js_timestamp(log.created),
@@ -303,7 +303,7 @@ class TaxLotState(models.Model):
                 record = record_dict(log)
                 history.append(record)
 
-        return history, master
+        return history, main
 
     @classmethod
     def coparent(cls, state_id):


### PR DESCRIPTION
#### Any background context you want to provide?
Looks like the coparent method was missing the new GHG fields.

#### What's this PR do?
* Adds the new GHG canonical fields to the coparent method call which is used in the views. 
* removes the term master record in coparent methods

#### How should this be manually tested?
Unit tests should suffice

#### What are the relevant tickets?
#3174 

#### Screenshots (if appropriate)
