### PR TITLE
update release notes and remove rtd related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ docs/build/
 docs/scripts/Gemfile.lock
 docs/scripts/.python-version
 docs/scripts/seed_issues.csv
+docs/htmlout
 
 lokalise.cfg
 lokalise.yml

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,7 +1,0 @@
----
-channels:
-  - conda-forge
-dependencies:
-  - gdal
-  - pip:
-      - sphinxcontrib-spelling

--- a/docs/source/developer_resources.rst
+++ b/docs/source/developer_resources.rst
@@ -413,6 +413,19 @@ Best Practices
 8. Use the “DO NOT MERGE” label for Pull Requests that should not be merged
 9. When PR has been reviewed and approved, move the ticket/issue to the 'Ready to Deploy to Dev' box in the GitHub project tracker.
 
+Building Documentation
+----------------------
+
+Older versions of the source code documentation is on read the docs; however, newer versions need to be built and pushed to the seed-website repository manually. To build the documentation follow the script below:
+
+.. code-block:: console
+
+        cd docs
+        rm -rf htmlout
+        sphinx-build -b html source htmlout
+
+For releasing, copy the ``htmlout`` directory into the seed-platform's website repository under ``docs/code_documentation/<new_version>``. Make sure to add the new documenation to the table in the ``docs/developer_resources.md``.
+
 
 Release Instructions
 --------------------
@@ -425,7 +438,7 @@ To make a release do the following:
 
 .. code-block:: console
 
-    python docs/scripts/change_log.py –k GITHUB_API_TOKEN –s 2021-12-27 –e 2022-03-31
+    python docs/scripts/change_log.py –k GITHUB_API_TOKEN –s 2022-03-31 –e 2022-05-29
 
 4. Paste the results (remove unneeded Accepted Pull Requests and the new issues) into the CHANGELOG.md. Cleanup the formatting (if needed).
 5. Make sure that any new UI needing localization has been tagged for translation, and that any new translation keys exist in the lokalise.com project. (see :doc:`translation documentation <translation>`).
@@ -433,4 +446,4 @@ To make a release do the following:
 7. Draft new Release from Github (https://github.com/SEED-platform/seed/releases).
 8. Include list of changes since previous release (i.e. the content in the CHANGELOG.md)
 9. Verify that the Docker versions are built and pushed to Docker hub (https://hub.docker.com/r/seedplatform/seed/tags/).
-10. Go to Read the Docs and enable the latest version to be active (https://readthedocs.org/dashboard/seed-platform/versions/)
+10. Publish the new documentation in the seed-platform website repository (see instructions above under Building Documenation).

--- a/docs/source/developer_resources.rst
+++ b/docs/source/developer_resources.rst
@@ -446,4 +446,4 @@ To make a release do the following:
 7. Draft new Release from Github (https://github.com/SEED-platform/seed/releases).
 8. Include list of changes since previous release (i.e. the content in the CHANGELOG.md)
 9. Verify that the Docker versions are built and pushed to Docker hub (https://hub.docker.com/r/seedplatform/seed/tags/).
-10. Publish the new documentation in the seed-platform website repository (see instructions above under Building Documenation).
+10. Publish the new documentation in the seed-platform website repository (see instructions above under Building Documentation).

--- a/docs/source/developer_resources.rst
+++ b/docs/source/developer_resources.rst
@@ -424,7 +424,7 @@ Older versions of the source code documentation is on read the docs; however, ne
         rm -rf htmlout
         sphinx-build -b html source htmlout
 
-For releasing, copy the ``htmlout`` directory into the seed-platform's website repository under ``docs/code_documentation/<new_version>``. Make sure to add the new documenation to the table in the ``docs/developer_resources.md``.
+For releasing, copy the ``htmlout`` directory into the seed-platform's website repository under ``docs/code_documentation/<new_version>``. Make sure to add the new documentation to the table in the ``docs/developer_resources.md``.
 
 
 Release Instructions

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,0 @@
-conda:
-  file: docs/environment.yml


### PR DESCRIPTION
#### Any background context you want to provide?
read the docs isn't building (and hasn't ever ???) built the documentation correctly. Instead of trying to fix read the docs, maybe we should just put the code documentation on the seed website.

#### What's this PR do?
* remove read the docs related files
* add instructions to release on building documentation

#### How should this be manually tested?
* try building the documentation per the instructions.

#### What are the relevant tickets?
#3275 

#### Screenshots (if appropriate)
