### PR TITLE
fix listing of labels for suborgs

### DIFF
--- a/seed/views/v3/labels.py
+++ b/seed/views/v3/labels.py
@@ -102,7 +102,7 @@ class LabelViewSet(DecoratorMixin(drf_api_endpoint), SEEDOrgNoPatchOrOrgCreateMo
 
     def get_queryset(self):
         labels = Label.objects.filter(
-            super_organization=self.get_parent_org(self.request)
+            super_organization=self.get_organization(self.request)
         ).order_by("name").distinct()
         return labels
 


### PR DESCRIPTION
#### Any background context you want to provide?
A suborg's labels are not a function of the parent orgs. If you have a suborg and create a label, then the label is never seen because the creation of the label is at the suborg.

#### What's this PR do?
* query the existing org, not the parent org

#### How should this be manually tested?
* Create a suborg
* Add a new label in the sub org
* Before this PR notice how the labels won't appear
* On this branch, notice how the label is now there
* Try to assign the label to a propety

#### What are the relevant tickets?
#3289 

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/1907354/171907521-38789fb0-6150-4ee7-b445-03432ba5001a.png)

