### PR TITLE
fix: column path does not have a column description

### DIFF
--- a/seed/analysis_pipelines/better/pipeline.py
+++ b/seed/analysis_pipelines/better/pipeline.py
@@ -463,7 +463,7 @@ def _process_results(self, analysis_id):
             is_extra_data=True,
             column_name=column_data_path.column_name,
             display_name=column_data_path.column_display_name,
-            column_description=column_data_path.column_description,
+            column_description=column_data_path.column_display_name,
             organization=analysis.organization,
             table_name='PropertyState',
         )


### PR DESCRIPTION
#### Any background context you want to provide?
See ticket.

#### What's this PR do?
Allows for making BETTER analysis again by removing the column_path attreibute that doesn't exist.

#### How should this be manually tested?
Try making a BETTEER analysis.

#### What are the relevant tickets?
https://github.com/SEED-platform/seed/issues/3302

#### Screenshots (if appropriate)
