### PR TITLE
allow generation of credential json for pyseed format

### DIFF
--- a/seed/management/commands/create_test_user_json.py
+++ b/seed/management/commands/create_test_user_json.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
                     'base_url': f"{match.group(1)}//{match.group(2)}",
                     'username': options['username'],
                     'api_key': u.api_key,
-                    'port': int(match.group(3).replace(':','')) if match.group(3) else 80,
+                    'port': int(match.group(3).replace(':', '')) if match.group(3) else 80,
                     'use_ssl': True if 'https' in match.group(1) else False,
                 }
 

--- a/seed/management/commands/create_test_user_json.py
+++ b/seed/management/commands/create_test_user_json.py
@@ -4,6 +4,7 @@
 :author
 """
 import json
+import re
 
 from django.core.management.base import BaseCommand
 
@@ -32,16 +33,34 @@ class Command(BaseCommand):
                             action='store',
                             dest='file')
 
+        parser.add_argument('--pyseed',
+                            help='Write out in the format for pyseed',
+                            action='store_true',
+                            dest='pyseed')
+
     def handle(self, *args, **options):
         if User.objects.filter(username=options['username']).exists():
             u = User.objects.get(username=options['username'])
 
-            data = {
-                'name': 'seed_api_test',
-                'host': options['host'],
-                'username': options['username'],
-                'api_key': u.api_key,
-            }
+            if not options['pyseed']:
+                data = {
+                    'name': 'seed_api_test',
+                    'host': options['host'],
+                    'username': options['username'],
+                    'api_key': u.api_key,
+                }
+            else:
+                # pull out the protocol, port, and url to break up the parts
+                pattern = re.compile(r'^(.*:)//([A-Za-z0-9\-\.]+)(:[0-9]+)?(.*)$')
+                match = pattern.match(options['host'])
+                data = {
+                    'name': 'seed_api_test',
+                    'base_url': f"{match.group(1)}//{match.group(2)}",
+                    'username': options['username'],
+                    'api_key': u.api_key,
+                    'port': int(match.group(3).replace(':','')) if match.group(3) else 80,
+                    'use_ssl': True if 'https' in match.group(1) else False,
+                }
 
             if options['file'] == 'none':
                 print(json.dumps(data))


### PR DESCRIPTION
#### Any background context you want to provide?
Current format of the `create_test_user_json` managed task is 

```
{
  "name": "seed_api_test",
  "host": "http://127.0.0.1:8000",
  "username":  "user@seed-platform.org",
  "api_key": "<mykey>"
}
```

However, this doesn't easily work for py-seed because it requires the host to be broken up into `port` and `use_ssl`

#### What's this PR do?

* Adds a --pyseed arg to the create_test_user_json to save as
```
{
  "name": "seed_api_test",
  "base_url": "http://127.0.0.1",
  "username": "user@seed-platform.org",
  "api_key": "<mykey>",
  "port": 8000,
  "use_ssl": false
}
```

#### How should this be manually tested?
* Run `./manage.py create_test_user_json --username user@seed-platform.org --host http://localhost:8080 --file api_test_user.json --pyseed`

#### What are the relevant tickets?
#3316 

#### Screenshots (if appropriate)
