### PR TITLE
Speed up list analysis

### DIFF
--- a/seed/models/analysis_property_views.py
+++ b/seed/models/analysis_property_views.py
@@ -95,19 +95,19 @@ class AnalysisPropertyView(models.Model):
         property_view_query = models.Q()
         for analysis_property_view in analysis_property_views:
             property_view_query |= (
-                models.Q(property=analysis_property_view.property)
-                & models.Q(cycle=analysis_property_view.cycle)
+                models.Q(property_id=analysis_property_view.property_id)
+                & models.Q(cycle_id=analysis_property_view.cycle_id)
             )
         property_views = PropertyView.objects.filter(property_view_query).prefetch_related('state')
 
         # get original property views keyed by canonical property id and cycle
         property_views_by_property_cycle_id = {
-            (pv.property.id, pv.cycle.id): pv
+            (pv.property_id, pv.cycle_id): pv
             for pv in property_views
         }
 
         return {
             # we use .get() here because the PropertyView might not exist anymore!
-            apv.id: property_views_by_property_cycle_id.get((apv.property.id, apv.cycle.id), None)
+            apv.id: property_views_by_property_cycle_id.get((apv.property_id, apv.cycle_id), None)
             for apv in analysis_property_views
         }

--- a/seed/static/seed/js/services/analyses_service.js
+++ b/seed/static/seed/js/services/analyses_service.js
@@ -32,7 +32,7 @@ angular.module('BE.seed.service.analyses', [])
 
       const get_analyses_for_canonical_property = function (property_id) {
         const org = user_service.get_organization().id;
-        return $http.get('/api/v3/analyses/?organization_id=' + org + '&property_id=' + property_id).then(function (response) {
+        return $http.get('/api/v3/analyses/?&include_views=false&organization_id=' + org + '&property_id=' + property_id).then(function (response) {
           return response.data;
         });
       };

--- a/seed/views/v3/analyses.py
+++ b/seed/views/v3/analyses.py
@@ -137,14 +137,11 @@ class AnalysisViewSet(viewsets.ViewSet, OrgMixin):
             serialized_analysis.update({'highlights': analysis.get_highlights(property_id)})
             analyses.append(serialized_analysis)
 
-        serialized_views = []
         original_views = {}
         if analyses:
             views_queryset = AnalysisPropertyView.objects.filter(analysis__organization_id=organization_id).order_by('-id')
             property_views_by_apv_id = AnalysisPropertyView.get_property_views(views_queryset)
-            for view in views_queryset:
-                serialized_view = AnalysisPropertyViewSerializer(view).data
-                serialized_views.append(serialized_view)
+            serialized_views = AnalysisPropertyViewSerializer(list(views_queryset), many=True).data
             original_views = {
                 apv_id: property_view.id if property_view is not None else None
                 for apv_id, property_view in property_views_by_apv_id.items()


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?

The first commit speeds up the db queries and serialization of the "views" returned by `/api/v3/analyses/` by about 50%
The second makes returning the views optional, as they aren't used. That speed things up _a lot_

#### How should this be manually tested?
1. Create analysis ([as described here](https://github.com/SEED-platform/seed/issues/3343#issue-1296292747)) 
2. Go to property detail page. 
3. Say "wow, so fast."

#### What are the relevant tickets?
https://github.com/SEED-platform/seed/issues/3343

#### Screenshots (if appropriate)
