### PR TITLE
3291 add show in list to label creation

### DIFF
--- a/seed/static/seed/js/controllers/data_quality_labels_modal_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_labels_modal_controller.js
@@ -38,7 +38,8 @@ angular.module('BE.seed.controller.data_quality_labels_modal', [])
         $scope.new_label = {
           color: 'gray',
           label: 'default',
-          name: ''
+          name: '',
+          show_in_list: false,
         };
       };
 

--- a/seed/static/seed/js/controllers/update_item_labels_modal_controller.js
+++ b/seed/static/seed/js/controllers/update_item_labels_modal_controller.js
@@ -42,7 +42,8 @@ angular.module('BE.seed.controller.update_item_labels_modal', [])
         $scope.new_label = {
           color: 'gray',
           label: 'default',
-          name: ''
+          name: '',
+          show_in_list: false,
         };
       };
 

--- a/seed/static/seed/partials/data_quality_labels_modal.html
+++ b/seed/static/seed/partials/data_quality_labels_modal.html
@@ -5,8 +5,8 @@
     <div class="modal-body">
         <div class="newLabelInput" style="margin-top:0;">
             <form name="newLabelForm" class="form-inline" role="form" ng-submit="submitNewLabelForm(newLabelForm)" novalidate>
+                <label class="control-label sectionLabel" style="padding-right:20px;" translate>Create new label</label>
                 <div class="form-group" ng-class="{'has-error': newLabelForm.name.$invalid && newLabelForm.name.$dirty }">
-                    <label class="control-label sectionLabel" style="padding-right:20px;" translate>Create new label</label>
                     <div class="input-group" style="padding-right:20px;">
                         <input id="labelName" type="text" name="name" class="form-control" ng-model="new_label.name" placeholder="{$:: 'Label Name' | translate $}" sd-check-label-exists="labels" required>
                         <div uib-dropdown class="input-group-btn">
@@ -20,7 +20,7 @@
                             </ul>
                         </div>
                     </div>
-                    <span translate>Show in List <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" /></span>
+                    <span style="margin-right: 20px;">{$ 'Show in List' | translate $} <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" /></span>
                     <button type="submit" class="btn btn-primary" ng-disabled="newLabelForm.$invalid || disabled" translate>Create label</button>
                     <div class="help-block">
                         <span class="has-error" ng-show="newLabelForm.name.$error.sdCheckLabelExists" translate>This label name is already taken.</span>

--- a/seed/static/seed/partials/data_quality_labels_modal.html
+++ b/seed/static/seed/partials/data_quality_labels_modal.html
@@ -20,6 +20,7 @@
                             </ul>
                         </div>
                     </div>
+                    <span>Show in List <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" ng-click="show_in_list_click()"/></span>
                     <button type="submit" class="btn btn-primary" ng-disabled="newLabelForm.$invalid || disabled" translate>Create label</button>
                     <div class="help-block">
                         <span class="has-error" ng-show="newLabelForm.name.$error.sdCheckLabelExists" translate>This label name is already taken.</span>

--- a/seed/static/seed/partials/data_quality_labels_modal.html
+++ b/seed/static/seed/partials/data_quality_labels_modal.html
@@ -20,7 +20,7 @@
                             </ul>
                         </div>
                     </div>
-                    <span>Show in List <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" ng-click="show_in_list_click()"/></span>
+                    <span translate>Show in List <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" /></span>
                     <button type="submit" class="btn btn-primary" ng-disabled="newLabelForm.$invalid || disabled" translate>Create label</button>
                     <div class="help-block">
                         <span class="has-error" ng-show="newLabelForm.name.$error.sdCheckLabelExists" translate>This label name is already taken.</span>

--- a/seed/static/seed/partials/label_admin.html
+++ b/seed/static/seed/partials/label_admin.html
@@ -36,7 +36,7 @@
                                 </ul>
                             </div>
                         </div>
-                        <span style="white-space: nowrap; margin-right: 10px;">Show in List <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" ng-click="show_in_list_click()" /></span>
+                        <span style="white-space: nowrap; margin-right: 10px;" translate>Show in List <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" /></span>
                         <button id="btnCreateLabel" class="btn btn-primary" ng-disabled="newLabelForm.$invalid" translate>Create label</button>
                         <div class="help-block">
                             <span class="has-error" ng-show="newLabelForm.name.$error.sdCheckLabelExists" translate>This label name is already taken.</span>

--- a/seed/static/seed/partials/label_admin.html
+++ b/seed/static/seed/partials/label_admin.html
@@ -36,7 +36,7 @@
                                 </ul>
                             </div>
                         </div>
-                        <span style="white-space: nowrap; margin-right: 10px;" >{$ 'Show in List' | translate $} <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" /></span>
+                        <span style="white-space: nowrap; margin-right: 20px;" >{$ 'Show in List' | translate $} <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" /></span>
                         <button id="btnCreateLabel" class="btn btn-primary" ng-disabled="newLabelForm.$invalid" translate>Create label</button>
                         <div class="help-block">
                             <span class="has-error" ng-show="newLabelForm.name.$error.sdCheckLabelExists" translate>This label name is already taken.</span>

--- a/seed/static/seed/partials/label_admin.html
+++ b/seed/static/seed/partials/label_admin.html
@@ -36,6 +36,7 @@
                                 </ul>
                             </div>
                         </div>
+                        <span style="white-space: nowrap; margin-right: 10px;">Show in List <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" ng-click="show_in_list_click()" /></span>
                         <button id="btnCreateLabel" class="btn btn-primary" ng-disabled="newLabelForm.$invalid" translate>Create label</button>
                         <div class="help-block">
                             <span class="has-error" ng-show="newLabelForm.name.$error.sdCheckLabelExists" translate>This label name is already taken.</span>
@@ -70,7 +71,6 @@
                             </td>
                             <td style="border-right: 0 none;">
                                 <span editable-checkbox="label.show_in_list" e-title="{$:: 'Show in List' | translate $}" e-name="show_in_list" e-form="rowform">{$:: label.show_in_list ? 'Show in List' : '' | translate $}</span>
-
                             </td>
                             <td style="white-space: nowrap" align="right">
                                 <form editable-form name="rowform" onbeforesave="saveLabel($data, label.id, $index)" ng-show="rowform.$visible" class="form-buttons form-inline" shown="inserted == label">

--- a/seed/static/seed/partials/label_admin.html
+++ b/seed/static/seed/partials/label_admin.html
@@ -36,7 +36,7 @@
                                 </ul>
                             </div>
                         </div>
-                        <span style="white-space: nowrap; margin-right: 10px;" translate>Show in List <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" /></span>
+                        <span style="white-space: nowrap; margin-right: 10px;" >{$ 'Show in List' | translate $} <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" /></span>
                         <button id="btnCreateLabel" class="btn btn-primary" ng-disabled="newLabelForm.$invalid" translate>Create label</button>
                         <div class="help-block">
                             <span class="has-error" ng-show="newLabelForm.name.$error.sdCheckLabelExists" translate>This label name is already taken.</span>

--- a/seed/static/seed/partials/update_item_labels_modal.html
+++ b/seed/static/seed/partials/update_item_labels_modal.html
@@ -20,7 +20,7 @@
                             </ul>
                         </div>
                     </div>
-                    <span style="white-space: nowrap; margin-right: 10px;" translate>Show in List <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" /></span>
+                    <span style="white-space: nowrap; margin-right: 20px;" >{$ 'Show in List' | translate $} <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" /></span>
                     <button type="submit"
                             class="btn btn-primary"
                             ng-disabled="newLabelForm.$invalid || disabled" translate>Create label</button>

--- a/seed/static/seed/partials/update_item_labels_modal.html
+++ b/seed/static/seed/partials/update_item_labels_modal.html
@@ -5,8 +5,8 @@
     <div class="modal-body">
         <div class="newLabelInput" style="margin-top:0;">
             <form name="newLabelForm" class="form-inline" role="form" ng-submit="submitNewLabelForm(newLabelForm)" novalidate>
+                <label class="control-label sectionLabel" style="padding-right:20px;" translate>Create new label</label>
                 <div class="form-group" ng-class="{'has-error': newLabelForm.name.$invalid && newLabelForm.name.$dirty }">
-                    <label class="control-label sectionLabel" style="padding-right:20px;" translate>Create new label</label>
                     <div class="input-group" style="padding-right:20px;">
                         <input id="labelName" type="text" name="name" class="form-control" ng-model="new_label.name" placeholder="{$:: 'Label Name' | translate $}" sd-check-label-exists="labels" required>
                         <div uib-dropdown class="input-group-btn">
@@ -20,6 +20,7 @@
                             </ul>
                         </div>
                     </div>
+                    <span style="white-space: nowrap; margin-right: 10px;" translate>Show in List <input type="checkbox" style="margin-left: 5px;" name="show_in_list" ng-model="new_label.show_in_list" /></span>
                     <button type="submit"
                             class="btn btn-primary"
                             ng-disabled="newLabelForm.$invalid || disabled" translate>Create label</button>


### PR DESCRIPTION
#### Any background context you want to provide?
It would be convenient if a user could select if a label was to be shown in list while creating a new label

#### What's this PR do?
adds a "Show in List" checkbox to all create label forms 
- Label Admin 
- Data Quality Label "+" Modal
- Inventory/Beta/Detail Action Modal

#### How should this be manually tested?
Select a number of properties and add labels through the actions tab with "Show in List". Labels should be shown. 

https://user-images.githubusercontent.com/58446472/178305514-6ac40752-5a0d-4fe1-b6f1-18d46d20f113.mov



#### What are the relevant tickets?
#3291

#### Screenshots (if appropriate)
Label Admin
![Screen Shot 2022-07-11 at 9 33 34 AM](https://user-images.githubusercontent.com/58446472/178305424-f82441d6-485c-4a31-8e0d-33aed531e908.png)


Data Quality Label "+" Modal
![Screen Shot 2022-07-11 at 9 41 04 AM](https://user-images.githubusercontent.com/58446472/178305455-bc9e05b1-7148-4b3d-9c20-17442e3a4355.png)


Inventory/Beta/Detail Action modal
![Screen Shot 2022-07-11 at 9 40 55 AM](https://user-images.githubusercontent.com/58446472/178305481-e1cc082b-238a-4179-ae24-9cbfad8dde36.png)

