### PR TITLE
filter out derived columns

### DIFF
--- a/seed/static/seed/js/controllers/data_quality_admin_controller.js
+++ b/seed/static/seed/js/controllers/data_quality_admin_controller.js
@@ -125,7 +125,7 @@ angular.module('BE.seed.controller.data_quality_admin', [])
         {id: 'kBtu/m**2/year', label: 'kBtu/m²/year'}
       ];
 
-      $scope.columns = _.map(angular.copy(columns), function (col) {
+      $scope.columns = _.map(angular.copy(columns.filter(col => !col.derived_column)), function (col) {
         if (!_.find(used_columns, ['id', col.id])) {
           col.group = 'Not Mapped';
         } else {


### PR DESCRIPTION
#### Any background context you want to provide?
Data Quality Admin page has a "Field" dropdown for avaliable columns and derived columns. After the recent Derived Column changes duplicate derived column names were visible.

#### What's this PR do?
Removes Derived Column columns from the "Not Mapped" list

#### How should this be manually tested?
With a few derived columns created, go to Data Quality and click "Field". Ensure there are no derived columns in the "Not Mapped" list.

#### What are the relevant tickets?
#3357

#### Screenshots (if appropriate)
Before
![Screen Shot 2022-07-11 at 11 43 16 AM](https://user-images.githubusercontent.com/58446472/178325444-44817fbf-b341-4811-8e77-2a7b114e63e6.png)

After
![Screen Shot 2022-07-11 at 11 42 47 AM](https://user-images.githubusercontent.com/58446472/178325388-0d7ed545-ddfa-4da4-8a4f-60a0a66a97b9.png)

