### PR TITLE
add total ghg emission intensity to report view

### DIFF
--- a/seed/analysis_pipelines/co2.py
+++ b/seed/analysis_pipelines/co2.py
@@ -419,7 +419,7 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
             'Average Annual CO2 (kgCO2e)': co2['average_annual_kgco2e'],
             'Annual Coverage %': co2['annual_coverage_percent'],
             'Total Annual Meter Reading (MWh)': co2['total_annual_electricity_mwh'],
-            'Total GHG Emissions Intensity (kgCO2e/ft2/year and kgCO2e/m2/year)': co2['average_annual_kgco2e'] / property_view.state.gross_floor_area.magnitude
+            'Total GHG Emissions Intensity (kgCO2e/ft\u00b2/year)': co2['average_annual_kgco2e'] / property_view.state.gross_floor_area.magnitude
         }
         analysis_property_view.save()
         if save_co2_results:

--- a/seed/analysis_pipelines/co2.py
+++ b/seed/analysis_pipelines/co2.py
@@ -415,7 +415,6 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
             continue
 
         # save the results
-        logging.error('>>> co2 %s', co2)
         analysis_property_view.parsed_results = {
             'Average Annual CO2 (kgCO2e)': co2['average_annual_kgco2e'],
             'Annual Coverage %': co2['annual_coverage_percent'],

--- a/seed/analysis_pipelines/co2.py
+++ b/seed/analysis_pipelines/co2.py
@@ -415,10 +415,12 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
             continue
 
         # save the results
+        logging.error('>>> co2 %s', co2)
         analysis_property_view.parsed_results = {
             'Average Annual CO2 (kgCO2e)': co2['average_annual_kgco2e'],
             'Annual Coverage %': co2['annual_coverage_percent'],
-            'Total Annual Meter Reading (MWh)': co2['total_annual_electricity_mwh']
+            'Total Annual Meter Reading (MWh)': co2['total_annual_electricity_mwh'],
+            'Total GHG Emissions Intensity (kgCO2e/ft2/year and kgCO2e/m2/year)': co2['average_annual_kgco2e'] / property_view.state.gross_floor_area.magnitude
         }
         analysis_property_view.save()
         if save_co2_results:


### PR DESCRIPTION
#### Any background context you want to provide?
CO2 Analysis report was missing "Total GHG Emissions Intensity"

#### What's this PR do?
Adds "Total GHG Emissions Intensity" to CO2 Analysis report

#### How should this be manually tested?
Upload a building file and its meters (ex: ESPM_JCC_Custom_Download_BETTERTest.xlsx). Then go to any property detail and change eGRID Subregion Code to "AZNM" and run a CO2 analysis
- "Total GHG Emissions Intensity" should be displayed in the analysis report

#### What are the relevant tickets?
#3300 

#### Screenshots (if appropriate)
<img width="1436" alt="Screen Shot 2022-07-13 at 2 46 34 PM" src="https://user-images.githubusercontent.com/58446472/178831301-5d8db6ad-7963-4a3a-9561-a5502b954b92.png">

