### PR TITLE
Make PostgreSQL hostname configurable in Docker image

### DIFF
--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -23,7 +23,8 @@ SMTP_ENV_VARS = ['EMAIL_HOST', 'EMAIL_PORT', 'EMAIL_HOST_USER',
 # The optional vars will set the SERVER_EMAIL information as needed
 OPTIONAL_ENV_VARS = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SES_REGION_NAME',
                      'AWS_SES_REGION_ENDPOINT', 'SERVER_EMAIL', 'SENTRY_JS_DSN', 'SENTRY_RAVEN_DSN',
-                     'REDIS_PASSWORD', 'DJANGO_EMAIL_BACKEND'] + SMTP_ENV_VARS
+                     'REDIS_PASSWORD', 'DJANGO_EMAIL_BACKEND',
+                     'POSTGRES_HOST'] + SMTP_ENV_VARS
 
 for loc in ENV_VARS + OPTIONAL_ENV_VARS:
     locals()[loc] = os.environ.get(loc)
@@ -63,7 +64,7 @@ DATABASES = {
         'NAME': POSTGRES_DB, # noqa F405
         'USER': POSTGRES_USER, # noqa F405
         'PASSWORD': POSTGRES_PASSWORD, # noqa F405
-        'HOST': "db-postgres",
+        'HOST': (POSTGRES_HOST if 'POSTGRES_HOST' in os.environ else "db-postgres"),
         'PORT': POSTGRES_PORT, # noqa F405
     }
 }

--- a/docker/start_celery_docker.sh
+++ b/docker/start_celery_docker.sh
@@ -3,7 +3,13 @@
 cd /seed
 
 echo "Waiting for postgres to start"
-/usr/local/wait-for-it.sh --strict -t 0 db-postgres:5432
+if [ -v POSTGRES_HOST ];
+then
+   POSTGRES_ACTUAL_HOST=$POSTGRES_HOST
+else
+   POSTGRES_ACTUAL_HOST=db-postgres
+fi
+/usr/local/wait-for-it.sh --strict -t 0 $POSTGRES_ACTUAL_HOST:$POSTGRES_PORT
 
 echo "Waiting for redis to start"
 /usr/local/wait-for-it.sh --strict -t 0 db-redis:6379

--- a/docker/start_uwsgi_docker.sh
+++ b/docker/start_uwsgi_docker.sh
@@ -3,7 +3,13 @@
 cd /seed
 
 echo "Waiting for postgres to start"
-/usr/local/wait-for-it.sh --strict db-postgres:5432
+if [ -v POSTGRES_HOST ];
+then
+   POSTGRES_ACTUAL_HOST=$POSTGRES_HOST
+else
+   POSTGRES_ACTUAL_HOST=db-postgres
+fi
+/usr/local/wait-for-it.sh --strict $POSTGRES_ACTUAL_HOST:$POSTGRES_PORT
 
 echo "Waiting for redis to start"
 /usr/local/wait-for-it.sh --strict db-redis:6379


### PR DESCRIPTION
#### Any background context you want to provide?
- We (OPEN) have been using SEED via Docker, but with an external PostgreSQL server. This server is hosted at a host name other than "db-postgres" and on a different port from 5432.
- We've had to customize some of the scripts used to configure and start the Docker image to make these configurable to the extent that we need.

#### What's this PR do?
- Allows the SEED Docker image to accept an optional environment variable, which provides the host name for the PostgreSQL database server to use. If this isn't provided, the default host name of "db-postgres" is used.
- Alters the startup scripts for SEED inside a Docker container, so they use the configured host name and port for the PostgreSQL database server, instead of hardcoded values.

#### How should this be manually tested?
1. Build a new SEED Docker image using this branch.
2. Start running a PostgreSQL database server on your development machine or on another computer accessible over the network from where you'll be running SEED.
3. Copy and paste one of the Docker Compose configuration files from the repository, and set the `POSTGRES_HOST` and `POSTGRES_PORT` environment variables through the configuration file.
4. Run the SEED Docker image with the configuration file.
5. Confirm that SEED is able to start, and you are able to log in and use the software as normal.

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
Here is an example configuration file that uses the new environment variable: [docker-compose.yml.txt](https://github.com/SEED-platform/seed/files/9106161/docker-compose.yml.txt)
