### PR TITLE
Allow using "http" in links to SEED within outbound emails

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -16,7 +16,7 @@ from seed.serializers.celery import CeleryDatetimeSerializer
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-PROTOCOL = os.environ.get('PROTOCOL','https')
+PROTOCOL = os.environ.get('PROTOCOL', 'https')
 
 SESSION_COOKIE_DOMAIN = None
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -16,6 +16,8 @@ from seed.serializers.celery import CeleryDatetimeSerializer
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+PROTOCOL = os.environ.get('PROTOCOL','https')
+
 SESSION_COOKIE_DOMAIN = None
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 DATA_UPLOAD_MAX_MEMORY_SIZE = None

--- a/seed/tasks.py
+++ b/seed/tasks.py
@@ -61,7 +61,7 @@ def invite_new_user_to_seed(domain, email_address, token, user_pk, first_name):
     context = {
         'email': email_address,
         'domain': domain,
-        'protocol': 'https',
+        'protocol': settings.PROTOCOL,
         'first_name': first_name,
         'signup_url': signup_url
     }
@@ -93,7 +93,8 @@ def invite_to_seed(domain, email_address, token, organization, user_pk, first_na
 
     Returns: nothing
     """
-    sign_up_url = Template("https://{{domain}}{{sign_up_url}}").render(Context({
+    sign_up_url = Template("{{protocol}}://{{domain}}{{sign_up_url}}").render(Context({
+        'protocol': settings.PROTOCOL,
         'domain': domain,
         'sign_up_url': reverse_lazy('landing:signup', kwargs={
             'uidb64': urlsafe_base64_encode(force_bytes(user_pk)),
@@ -136,7 +137,7 @@ def invite_to_organization(domain, new_user, requested_by, new_org):
         'new_user': new_user,
         'first_name': new_user.first_name,
         'domain': domain,
-        'protocol': 'https',
+        'protocol': settings.PROTOCOL,
         'new_org': new_org,
         'requested_by': requested_by,
     }


### PR DESCRIPTION
#### Any background context you want to provide?
- We (OPEN) have been using SEED in Docker on our dev machines, where we don't have an HTTPS proxy set up.
- In these environments, we want generated links back to the SEED application to show with HTTP, not HTTPS.

#### What's this PR do?
- Makes the protocol configurable via an optional environment variable called `PROTOCOL`. When this isn't provided, the default value of `'https'` is used.
- Alters how URLs back to the SEED application are generated for use in emails, particularly the "new user" emails and "added to new organization" emails. These now use the configured protocol (either HTTP or HTTPS).

#### How should this be manually tested?
1. Build a new Docker image using this branch.
2. Copy and paste one of the Docker Compose configuration files from this repository, and set the PROTOCOL environment variable to `'http'`.
3. Make sure to set the `DJANGO_EMAIL_BACKEND` and related email provider variables, so you can send outbound email.
4. Run the SEED Docker image with the configuration file.
5. Log in to SEED and invite a new user.
6. The link in the email to the invited user should include `'http'`, not `'https'`.
7. Back in your running SEED application, create a new organization.
8. Add the new user you just created to the new organization.
9. The link in the email to the invited user should include `'http'`, not `'https'`.
10. Log out.
11. Click the "Forgot Password?" link on the login form.
12. Enter the email address of the new user you just created, then click "Reset my password".
13. The link in the email to the user should include `'http'`, not `'https'`.

#### What are the relevant tickets?
#3386 

#### Screenshots (if appropriate)
Here is an example configuration file that uses the new environment variable: [docker-compose.yml.txt](https://github.com/SEED-platform/seed/files/9123363/docker-compose.yml.txt)
