### PR TITLE
Make "From" address in password-reset emails configurable when using Docker

### DIFF
--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -48,7 +48,7 @@ ALLOWED_HOSTS = ['*']
 # another backend (e.g., SMTP), then please update this model to support both and
 # create a pull request.
 EMAIL_BACKEND = os.environ.get('DJANGO_EMAIL_BACKEND', 'django_ses.SESBackend')
-PASSWORD_RESET_EMAIL = SERVER_EMAIL
+PASSWORD_RESET_EMAIL = SERVER_EMAIL # noqa F405
 DEFAULT_FROM_EMAIL = SERVER_EMAIL  # noqa F405
 POST_OFFICE = {
     'BACKENDS': {

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -48,6 +48,7 @@ ALLOWED_HOSTS = ['*']
 # another backend (e.g., SMTP), then please update this model to support both and
 # create a pull request.
 EMAIL_BACKEND = os.environ.get('DJANGO_EMAIL_BACKEND', 'django_ses.SESBackend')
+PASSWORD_RESET_EMAIL = SERVER_EMAIL
 DEFAULT_FROM_EMAIL = SERVER_EMAIL  # noqa F405
 POST_OFFICE = {
     'BACKENDS': {


### PR DESCRIPTION
#### Any background context you want to provide?
- We (OPEN) would like to use our own email address for emails from SEED.
- The "From" address for "forgot password" emails wasn't configurable in the Docker image for SEED. (It was always set to "info@seed-platform.org".)

#### What's this PR do?
- In order to set this From address, we've made the `PASSWORD_RESET_EMAIL` take its value from the main `SERVER_EMAIL` environment variable, when running SEED in a Docker image.

#### How should this be manually tested?
1. Build a new Docker image using this branch.
2. Copy and paste one of the Docker Compose configuration files from this repository, and set the `SERVER_EMAIL` environment variable.
3. Make sure to set the `DJANGO_EMAIL_BACKEND` variable and other email-related environment variables so that you can send outbound email.
4. Run the Docker image with the configuration file.
5. Log in to SEED and create a new user, with an email address you control.
6. Log out.
7. Follow the link in the "new user" email you receive after creating the new account. Set your account's password.
8. Go to the "Forgot Password?" page. Enter the email address for the account you just created.
9. You should receive an email at the same address that received the "new user" email.
10. The "From" address of this email should be what you set for the `SERVER_EMAIL` variable.

#### What are the relevant tickets?
Associated with Issue #3402 

#### Screenshots (if appropriate)
Here is an example configuration file that uses the SERVER_EMAIL environment variable: 
[docker-compose.yml.txt](https://github.com/SEED-platform/seed/files/9133304/docker-compose.yml.txt)
