### PR TITLE
fix: taxlots->selectall->delete now works

### DIFF
--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -325,13 +325,18 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
 
       var params = {
         organization_id: organization_id,
-        page: page,
-        per_page: per_page || 999999999,
         include_related: include_related,
         ids_only: ids_only,
         ...format_column_sorts(column_sorts),
         ...format_column_filters(column_filters)
       };
+
+      if (ids_only) {
+        params.ids_only = true;
+      } else {
+        params.page = page;
+        params.per_page = per_page || 999999999;
+      }
 
       return cycle_service.get_cycles().then(function (cycles) {
         var validCycleIds = _.map(cycles.cycles, 'id');


### PR DESCRIPTION
#### Any background context you want to provide?
The new inventory list had a bug where batch deleting did not work for taxlots.

#### What's this PR do?
Allows batch deletes for taxlots.

#### How should this be manually tested?
Load taxlots, select all, delete.

#### What are the relevant tickets?
https://github.com/SEED-platform/seed/issues/3394

#### Screenshots (if appropriate)
