### PR TITLE
apply org settings to derived col decimals

### DIFF
--- a/seed/static/seed/js/controllers/inventory_detail_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_controller.js
@@ -798,7 +798,7 @@ angular.module('BE.seed.controller.inventory_detail', [])
             .then(res => {
               return {
                 derived_column_id: col.id,
-                value: res.results[0].value
+                value: _.round(res.results[0].value, $scope.organization.display_decimal_places)
               };
             });
         });

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -774,7 +774,8 @@ angular.module('BE.seed.controller.inventory_list', [])
           all_evaluation_results.push(...batched_inventory_ids.map(ids => {
             return derived_columns_service.evaluate($scope.organization.id, col.id, $scope.cycle.selected_cycle.id, ids)
               .then(res => {
-                return { derived_column_id: col.id, results: res.results };
+                formatted_results = res.results.map(x => typeof(x.value) == 'number' ? ({ ...x, 'value': _.round(x.value, $scope.organization.display_decimal_places) }) : x)
+                return { derived_column_id: col.id, results: formatted_results };
               });
           }));
         }

--- a/seed/static/seed/js/controllers/inventory_list_legacy_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_legacy_controller.js
@@ -806,7 +806,8 @@ angular.module('BE.seed.controller.inventory_list_legacy', [])
           all_evaluation_results.push(...batched_inventory_ids.map(ids => {
             return derived_columns_service.evaluate($scope.organization.id, col.id, $scope.cycle.selected_cycle.id, ids)
               .then(res => {
-                return {derived_column_id: col.id, results: res.results};
+                formatted_results = res.results.map(x => typeof (x.value) == 'number' ? ({ ...x, 'value': _.round(x.value, $scope.organization.display_decimal_places) }) : x)
+                return {derived_column_id: col.id, results: formatted_results};
               });
           }));
         }


### PR DESCRIPTION
#### Any background context you want to provide?
Evaluated derived columns could have up to 16 decimal points.

#### What's this PR do?
Applies the `organization.display_decimal_places` setting to derived columns on 
- inventory list 
- inventory list (legacy)
- inventory detail

_NOTE: it is possible to apply a unique decimal count to each derived column as an individual setting, but it will require further development_

#### How should this be manually tested?
- generate derived column that when evaluated will have more than 2 (organization setting) decimal places
- confirm there are only 2 decimals displayed on the inventory list/legacy/detail 

#### What are the relevant tickets?
#3393

#### Screenshots (if appropriate)
dc1 = extra column / 7 
dc2 = PM Property ID / 7
dc3 = dc2 / 7
![Screen Shot 2022-07-18 at 1 26 24 PM](https://user-images.githubusercontent.com/58446472/179602328-00b38f05-3467-4ac2-a7eb-3ebae69f620b.png)
![Screen Shot 2022-07-18 at 1 26 11 PM](https://user-images.githubusercontent.com/58446472/179602330-1a2637c9-6ff9-4432-aab3-db80f8a1b9dc.png)
![Screen Shot 2022-07-18 at 1 25 55 PM](https://user-images.githubusercontent.com/58446472/179602331-ca844ca3-f838-4816-a1de-d83d1271c650.png)

