### PR TITLE
fix: re-enabled related data on inventory list

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -741,7 +741,7 @@ angular.module('BE.seed.controller.inventory_list', [])
           exclude_ids,
           true,
           $scope.organization.id,
-          false,
+          true,
           $scope.column_filters,
           $scope.column_sorts
         ).then(function (data) {


### PR DESCRIPTION
#### Any background context you want to provide?
See ticket

#### What's this PR do?
re-enables reelated data on the new inventory page

#### How should this be manually tested?
see ticket

#### What are the relevant tickets?
https://github.com/SEED-platform/seed/issues/3390
https://github.com/SEED-platform/seed/issues/3395

#### Screenshots (if appropriate)
