### PR TITLE
Celery-queue API endpoint

### DIFF
--- a/seed/api/v3/urls.py
+++ b/seed/api/v3/urls.py
@@ -4,6 +4,8 @@ from django.conf.urls import include, re_path
 from rest_framework import routers
 from rest_framework_nested import routers as nested_routers
 
+from seed.views.main import celery_queue
+
 from seed.views.v3.analyses import AnalysisViewSet
 from seed.views.v3.analysis_messages import AnalysisMessageViewSet
 from seed.views.v3.analysis_views import AnalysisPropertyViewViewSet
@@ -124,5 +126,6 @@ urlpatterns = [
     re_path(r'^', include(analysis_view_messages_router.urls)),
     re_path(r'^', include(properties_router.urls)),
     re_path(r'^', include(taxlots_router.urls)),
+    re_path(r'^celery_queue/$', celery_queue, name='celery_queue'),
     re_path(r'media/(?P<filepath>.*)$', MediaViewSet.as_view()),
 ]

--- a/seed/api/v3/urls.py
+++ b/seed/api/v3/urls.py
@@ -5,7 +5,6 @@ from rest_framework import routers
 from rest_framework_nested import routers as nested_routers
 
 from seed.views.main import celery_queue
-
 from seed.views.v3.analyses import AnalysisViewSet
 from seed.views.v3.analysis_messages import AnalysisMessageViewSet
 from seed.views.v3.analysis_views import AnalysisPropertyViewViewSet

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -14,19 +14,17 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required, permission_required
 from django.http import JsonResponse
 from django.shortcuts import redirect, render
-
 from past.builtins import basestring
 from rest_framework import status
 from rest_framework.decorators import api_view
 
 from seed import tasks
+from seed.celery import app
 from seed.data_importer.models import ImportFile, ImportRecord
 from seed.decorators import ajax_request
 from seed.lib.superperms.orgs.decorators import has_perm, requires_superuser
 from seed.utils.api import api_endpoint
 from seed.views.users import _get_js_role
-
-from seed.celery import app
 
 _log = logging.getLogger(__name__)
 


### PR DESCRIPTION
#### What's this PR do?
Creates an API endpoint for superusers to see the number of active, reserved, and scheduled tasks.  This is helpful for understanding if the celery queue is at max concurrency, or just in use.  I opted for an API endpoint rather than a managed task.

Note: you may see a `AssertionError at /api/v3/celery_queue/` if celery isn't running, and sometimes nondeterministically (no idea why)

##### Sample response
```json
{
  "active": {
    "total": 4,
    "tasks": [
      "seed.data_importer.tasks._save_raw_data_create_tasks",
      "seed.data_importer.tasks._save_raw_data_chunk"
    ]
  },
  "reserved": {
    "total": 0
  },
  "scheduled": {
    "total": 0
  },
  "maxConcurrency": 4
}
```

#### How should this be manually tested?
As a superuser, fetch the `/api/v3/celery-queue` endpoint while celery task are running (or aren't)
#### What are the relevant tickets?
#3315 
