### PR TITLE
Added inventory documents to media view & tests

### DIFF
--- a/seed/tests/test_media.py
+++ b/seed/tests/test_media.py
@@ -19,8 +19,8 @@ from seed.models import (
 from seed.test_helpers.fake import (
     FakeAnalysisFactory,
     FakeAnalysisPropertyViewFactory,
-    FakePropertyStateFactory,
-    FakePropertyFactory
+    FakePropertyFactory,
+    FakePropertyStateFactory
 )
 from seed.views.v3.media import ModelForFileNotFound, check_file_permission
 from seed.views.v3.uploads import get_upload_path

--- a/seed/views/v3/media.py
+++ b/seed/views/v3/media.py
@@ -11,6 +11,7 @@ from seed.models import (
     AnalysisOutputFile,
     BuildingFile,
     ImportFile,
+    InventoryDocument,
     Organization
 )
 from seed.utils.api import OrgMixin
@@ -70,6 +71,13 @@ def check_file_permission(user, filepath):
         except AnalysisOutputFile.DoesNotExist:
             raise ModelForFileNotFound('AnalysisOutputFile not found')
         organization = analysis_property_view.cycle.organization
+
+    elif base_dir == 'inventory_documents':
+        try:
+            inventory_document = InventoryDocument.objects.get(file__in=[absolute_filepath, filepath])
+        except InventoryDocument.DoesNotExist:
+            raise ModelForFileNotFound('InventoryDocument not found')
+        organization = inventory_document.property.organization
     else:
         raise ModelForFileNotFound(f'Base directory for media file is not currently handled: "{base_dir}"')
 


### PR DESCRIPTION
#### What's this PR do?

- Adds directory handling for InventoryDocument media files, so that files that have been uploaded can be downloaded on a server running nginx
- Adds testing for retrieving an InventoryDocument file as an org member to test_media.py

#### How should this be manually tested?

When running SEED with nginx (like on a server), navigate to a property details page, upload a .pdf document, and then try downloading that document.

#3437 