### PR TITLE
Only return 10 history at max

### DIFF
--- a/seed/models/properties.py
+++ b/seed/models/properties.py
@@ -511,6 +511,12 @@ class PropertyState(models.Model):
                         done_searching = True
                     else:
                         log = tree
+
+                    # ony get 10 histories at max
+                    if len(history) > 10:
+                        history = history[:10]
+                        break
+
             elif log.name == 'Manual Edit':
                 record = record_dict(log.parent1)
                 history.append(record)

--- a/seed/models/properties.py
+++ b/seed/models/properties.py
@@ -472,7 +472,7 @@ class PropertyState(models.Model):
                     if (log.parent1_id is None and log.parent2_id is None) or log.name == 'Manual Edit':
                         break
 
-                    # initalize the tree to None everytime. If not new tree is found, then we will not iterate
+                    # initialize the tree to None everytime. If not new tree is found, then we will not iterate
                     tree = None
 
                     # Check if parent2 has any other parents or is the original import creation. Start with parent2
@@ -512,8 +512,8 @@ class PropertyState(models.Model):
                     else:
                         log = tree
 
-                    # ony get 10 histories at max
-                    if len(history) > 10:
+                    # only get 10 histories at max
+                    if len(history) >= 10:
                         history = history[:10]
                         break
 


### PR DESCRIPTION
#### Any background context you want to provide?
Simply cuts off the number of returned histories to 10.

Maybe we wanted this number to be a arg to the endpoint, or a envvar, or something the user can set in the UI. We can duke it out in the comments, I just wanted to get a fix fix out there.

Ultimately, this is a cheap fix for an expensive problem that we should confront in a real way at a later date. 
#### What's this PR do?

#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
