### PR TITLE
feat: added GHG and GHG Intensity

### DIFF
--- a/seed/static/seed/js/controllers/column_mappings_controller.js
+++ b/seed/static/seed/js/controllers/column_mappings_controller.js
@@ -299,13 +299,13 @@ angular.module('BE.seed.controller.column_mappings', [])
       var ghg_columns = _.filter($scope.mappable_property_columns, {data_type: 'ghg'});
       $scope.is_ghg_column = function (mapping) {
         // All of these are on the PropertyState table
-        return mapping.to_table_name == 'PropertyState' && Boolean(_.find(ghg_columns, {column_name: mapping.to_field}))
+        return mapping.to_table_name == 'PropertyState' && Boolean(_.find(ghg_columns, {displayName: mapping.to_field}))
       };
 
       var ghg_intensity_columns = _.filter($scope.mappable_property_columns, {data_type: 'ghg_intensity'});
       $scope.is_ghg_intensity_column = function (mapping) {
         // All of these are on the PropertyState table
-        return mapping.to_table_name == 'PropertyState' && Boolean(_.find(ghg_intensity_columns, {column_name: mapping.to_field}))
+        return mapping.to_table_name == 'PropertyState' && Boolean(_.find(ghg_intensity_columns, {displayName: mapping.to_field}))
       };
 
       var get_default_quantity_units = function (col) {

--- a/seed/static/seed/js/controllers/column_mappings_controller.js
+++ b/seed/static/seed/js/controllers/column_mappings_controller.js
@@ -297,15 +297,15 @@ angular.module('BE.seed.controller.column_mappings', [])
       };
 
       var ghg_columns = _.filter($scope.mappable_property_columns, {data_type: 'ghg'});
-      $scope.is_ghg_column = function (col) {
+      $scope.is_ghg_column = function (mapping) {
         // All of these are on the PropertyState table
-        return col.suggestion_table_name == 'PropertyState' && Boolean(_.find(ghg_columns, {column_name: col.suggestion_column_name}))
+        return mapping.to_table_name == 'PropertyState' && Boolean(_.find(ghg_columns, {column_name: mapping.to_field}))
       };
 
       var ghg_intensity_columns = _.filter($scope.mappable_property_columns, {data_type: 'ghg_intensity'});
-      $scope.is_ghg_intensity_column = function (col) {
+      $scope.is_ghg_intensity_column = function (mapping) {
         // All of these are on the PropertyState table
-        return col.suggestion_table_name == 'PropertyState' && Boolean(_.find(ghg_intensity_columns, {column_name: col.suggestion_column_name}))
+        return mapping.to_table_name == 'PropertyState' && Boolean(_.find(ghg_intensity_columns, {column_name: mapping.to_field}))
       };
 
       var get_default_quantity_units = function (col) {

--- a/seed/static/seed/js/controllers/column_mappings_controller.js
+++ b/seed/static/seed/js/controllers/column_mappings_controller.js
@@ -296,6 +296,18 @@ angular.module('BE.seed.controller.column_mappings', [])
         return mapping.to_table_name === 'PropertyState' && Boolean(_.find(area_columns, {displayName: mapping.to_field}));
       };
 
+      var ghg_columns = _.filter($scope.mappable_property_columns, {data_type: 'ghg'});
+      $scope.is_ghg_column = function (col) {
+        // All of these are on the PropertyState table
+        return col.suggestion_table_name == 'PropertyState' && Boolean(_.find(ghg_columns, {column_name: col.suggestion_column_name}))
+      };
+
+      var ghg_intensity_columns = _.filter($scope.mappable_property_columns, {data_type: 'ghg_intensity'});
+      $scope.is_ghg_intensity_column = function (col) {
+        // All of these are on the PropertyState table
+        return col.suggestion_table_name == 'PropertyState' && Boolean(_.find(ghg_intensity_columns, {column_name: col.suggestion_column_name}))
+      };
+
       var get_default_quantity_units = function (col) {
         // TODO - hook up to org preferences / last mapping in DB
         if ($scope.is_eui_column(col)) {

--- a/seed/static/seed/js/controllers/column_mappings_controller.js
+++ b/seed/static/seed/js/controllers/column_mappings_controller.js
@@ -63,7 +63,7 @@ angular.module('BE.seed.controller.column_mappings', [])
 
       var mapping_display_to_db = function (mapping) {
         // Also, clear from_units if mapping is not for units col
-        if (!$scope.is_eui_column(mapping) && !$scope.is_area_column(mapping)) {
+        if (!$scope.is_area_column(mapping) && !$scope.is_eui_column(mapping) && !$scope.is_ghg_column(mapping) && !$scope.is_ghg_intensity_column(mapping)) {
           mapping.from_units = null;
         }
 
@@ -314,6 +314,10 @@ angular.module('BE.seed.controller.column_mappings', [])
           return 'kBtu/ft**2/year';
         } else if ($scope.is_area_column(col)) {
           return 'ft**2';
+        } else if ($scope.is_ghg_column(col)) {
+          return 'MtCO2e/year';
+        } else if ($scope.is_ghg_intensity_column(col)) {
+          return 'MtCO2e/ft**2/year';
         }
         return null;
       };
@@ -406,7 +410,8 @@ angular.module('BE.seed.controller.column_mappings', [])
 
       $scope.empty_units_present = function () {
         return Boolean(_.find($scope.current_profile.mappings, function (field) {
-          return field.to_table_name === 'PropertyState' && field.from_units === null && ($scope.is_area_column(field) || $scope.is_eui_column(field));
+          let has_units = $scope.is_area_column(field) || $scope.is_eui_column(field) || $scope.is_ghg_column(field) || $scope.is_ghg_intensity_column(field);
+          return field.to_table_name === 'PropertyState' && field.from_units === null && has_units;
         }));
       };
 

--- a/seed/static/seed/js/controllers/column_settings_controller.js
+++ b/seed/static/seed/js/controllers/column_settings_controller.js
@@ -66,7 +66,9 @@ angular.module('BE.seed.controller.column_settings', [])
         {id: 'boolean', label: $translate.instant('Boolean')},
         {id: 'area', label: $translate.instant('Area')},
         {id: 'eui', label: $translate.instant('EUI')},
-        {id: 'geometry', label: $translate.instant('Geometry')}
+        {id: 'geometry', label: $translate.instant('Geometry')},
+        {id: 'ghg', label: $translate.instant('GHG')},
+        {id: 'ghg_intensity', label: $translate.instant('GHG Intensity')}
       ];
 
       $scope.comstock_types = [

--- a/seed/static/seed/partials/column_mappings.html
+++ b/seed/static/seed/partials/column_mappings.html
@@ -152,6 +152,16 @@
                                   <option value="MJ/m**2/year" translate>MJ/m²/year</option>
                                   <option value="kBtu/m**2/year" translate>kBtu/m²/year</option>
                               </select>
+                                <select ng-model="col.from_units" ng-change="flag_change()" ng-if="is_ghg_column(col)">
+                                    <option value="MtCO2e/year" translate>MtCO2e/year</option>
+                                    <option value="kgCO2e/year" translate>kgCO2e/year</option>
+                                </select>
+                                <select ng-model="col.from_units" ng-change="flag_change()" ng-if="is_ghg_intensity_column(col)">
+                                    <option value="MtCO2e/ft**2/year" translate>MtCO2e/ft**2/year</option>
+                                    <option value="kgCO2e/ft**2/year" translate>kgCO2e/ft**2/year</option>
+                                    <option value="MtCO2e/m**2/year" translate>MtCO2e/m**2/year</option>
+                                    <option value="kgCO2e/m**2/year" translate>kgCO2e/m**2/year</option>
+                                </select>
                           </td>
                           <td ng-class="{'danger': is_file_header_duplicate(col)}">
                               <input type="text" class="form-control input-sm tcm_field" ng-model="col.from_field" ng-change="flag_change()" ng-disabled="!profile_action_ok('change_from_field')">

--- a/seed/static/seed/partials/mapping.html
+++ b/seed/static/seed/partials/mapping.html
@@ -176,9 +176,13 @@
                                 </select>
                                 <select ng-model="col.from_units" ng-if="is_ghg_column(col)" ng-change="flag_mappings_change()">
                                     <option value="MtCO2e/year" translate>MtCO2e/year</option>
+                                    <option value="kgCO2e/year" translate>kgCO2e/year</option>
                                 </select>
                                 <select ng-model="col.from_units" ng-if="is_ghg_intensity_column(col)" ng-change="flag_mappings_change()">
+                                    <option value="MtCO2e/ft**2/year" translate>MtCO2e/ft**2/year</option>
                                     <option value="kgCO2e/ft**2/year" translate>kgCO2e/ft**2/year</option>
+                                    <option value="MtCO2e/m**2/year" translate>MtCO2e/m**2/year</option>
+                                    <option value="kgCO2e/m**2/year" translate>kgCO2e/m**2/year</option>
                                 </select>
                             </td>
                             <td ng-class="{'danger': col.is_duplicate || col.suggestion === ''}">


### PR DESCRIPTION
#### Any background context you want to provide?
See ticket.

#### What's this PR do?
Adds GHG and GHG Intensity to column settings data types.

#### How should this be manually tested?
Try to set units on a GHG field and notice them appearing when mapping.

#### What are the relevant tickets?
https://github.com/SEED-platform/seed/issues/2605

#### Screenshots (if appropriate)
Set data type on settings:
<img width="1188" alt="Screen Shot 2022-09-13 at 4 01 55 PM" src="https://user-images.githubusercontent.com/564231/190017954-a2a5ca49-cbce-4c7f-a320-a71cf99566bd.png">
See units on mapping:
<img width="761" alt="Screen Shot 2022-09-13 at 4 00 29 PM" src="https://user-images.githubusercontent.com/564231/190017998-0efce2fd-8952-4b7c-a73e-08af20c72886.png">
GHG Units:
<img width="392" alt="Screen Shot 2022-09-13 at 4 08 58 PM" src="https://user-images.githubusercontent.com/564231/190018182-05b266f8-2725-4f64-89d9-3917e6911db8.png">
GHG Intensity Units:
<img width="456" alt="Screen Shot 2022-09-13 at 4 09 04 PM" src="https://user-images.githubusercontent.com/564231/190018206-93ed79bb-7ead-4de1-b3c0-f864d02ef52f.png">

