### PR TITLE
On FilterGroup delete, filter groups don't filter≈y

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -177,7 +177,6 @@ angular.module('BE.seed.controller.inventory_list', [])
           $scope.currentFilterGroup = _.last($scope.filterGroups);
 
           Notification.primary('Removed ' + oldFilterGroupName);
-          updateCurrentFilterGroup($scope.currentFilterGroup);
         });
       };
 
@@ -304,6 +303,7 @@ angular.module('BE.seed.controller.inventory_list', [])
           updateColumnFilterSort();
         } else {
           // Clear filter group
+          $scope.currentFilterGroupId = -1
           filter_groups_service.save_last_filter_group(-1, $scope.inventory_type);
           $scope.selected_labels = [];
           $scope.filterUsingLabels();


### PR DESCRIPTION
#### Any background context you want to provide?
lets say a have filter groups Office and Retail.
I select Retail and delete it.
As excepted, it deletes, now no filter group is selected.
I select Office. Nothing happens :open_mouth:

This fixes that
