### PR TITLE
Add export column mappings

### DIFF
--- a/seed/static/seed/js/controllers/column_mappings_controller.js
+++ b/seed/static/seed/js/controllers/column_mappings_controller.js
@@ -255,6 +255,14 @@ angular.module('BE.seed.controller.column_mappings', [])
         });
       };
 
+      $scope.export_profile = function () {
+        column_mappings_service.export_mapping_profile($scope.org.id,  $scope.current_profile.id).then(function (data) {
+          var blob = new Blob([data], {type: 'text/csv'});
+          saveAs(blob, `${$scope.current_profile.name}_mapping_profile.csv`);
+          Notification.primary(`Data exported for \'${$scope.current_profile.name}\'`);
+        });
+      }
+
       // Track changes to warn users about losing changes when data could be lost
       $scope.changes_possible = false;
 

--- a/seed/static/seed/js/services/column_mappings_service.js
+++ b/seed/static/seed/js/services/column_mappings_service.js
@@ -72,6 +72,17 @@ angular.module('BE.seed.service.column_mappings', []).factory('column_mappings_s
       });
     };
 
+    /**
+     * return column mapping profile in CSV format.
+     * @param  {int} org_id the id of the organization, not needed, but useful to still pass around
+     * @param  {int} profile_id the profile id of the column mapping to be exported
+     */
+     column_mappings_factory.export_mapping_profile = function (org_id, profile_id) {
+      return $http.get('/api/v3/column_mapping_profiles/' + profile_id + '/csv/?organization_id=' + org_id).then(function (response) {
+        return response.data;
+      });
+    };
+
     return column_mappings_factory;
 
   }]);

--- a/seed/static/seed/partials/column_mappings.html
+++ b/seed/static/seed/partials/column_mappings.html
@@ -43,6 +43,9 @@
           <button class="btn btn-info" type="button" ng-click="new_profile()" tooltip-placement="bottom" uib-tooltip="New">
               <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
           </button>
+          <button class="btn btn-secondary" type="button" ng-click="export_profile()" tooltip-placement="bottom" uib-tooltip="Export to CSV">
+            <span class="glyphicon glyphicon-export" aria-hidden="true"></span>
+        </button>
         </div>
     </div>
 </div>

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -57,6 +57,7 @@ $blue: #428bca;
 $beige: #f5f4ec;
 $orange: #fc882a;
 $green: #66b132;
+$lightgreen: #86d875;
 $yellow: #ffc40d;
 $purple: #90f;
 $red: #ff4d4d;
@@ -2315,6 +2316,17 @@ select {
 
   &:hover {
     background-color: darken($orange, 5%);
+  }
+}
+
+.btn-secondary{
+  color: #fff;
+  background-color: $lightgreen;
+  border-color: darken($lightgreen, 5%);
+
+  &:hover {
+    color: #fff;
+    background-color: darken($lightgreen, 10%);
   }
 }
 

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -2319,7 +2319,7 @@ select {
   }
 }
 
-.btn-secondary{
+.btn-secondary {
   color: #fff;
   background-color: $lightgreen;
   border-color: darken($lightgreen, 5%);

--- a/seed/tests/data/bps/README.md
+++ b/seed/tests/data/bps/README.md
@@ -6,4 +6,3 @@
   - Import data from ESPM through the ESPM integration in SEED (or manually export from within ESPM)
   - Import the report directly into SEED with shared ESPM login of the `SEED_City_Test` user.
 - Import "BPS_Sample_AT_XXXXX" files in SEED. I think this has to be done one at a time.
-

--- a/seed/tests/data/bps/README.md
+++ b/seed/tests/data/bps/README.md
@@ -3,6 +3,7 @@
 - Upload the "CBL-building-performance-standards-sample-XXXX" files in SEED
 - Upload the "BPS-sample-Targets-XXXX" files in SEED
 - Upload the following files in ESPM in order listed: Add Properties, Add Meters, and Add Bills To Meters.
-- Import data from ESPM through the ESPM integration in SEED (or manually export from within ESPM)
+  - Import data from ESPM through the ESPM integration in SEED (or manually export from within ESPM)
   - Import the report directly into SEED with shared ESPM login of the `SEED_City_Test` user.
 - Import "BPS_Sample_AT_XXXXX" files in SEED. I think this has to be done one at a time.
+

--- a/seed/views/v3/column_mapping_profiles.py
+++ b/seed/views/v3/column_mapping_profiles.py
@@ -176,12 +176,6 @@ class ColumnMappingProfileViewSet(OrgMixin, ViewSet):
 
         return response
 
-
-
-
-
-
-
     @swagger_auto_schema(
         manual_parameters=[AutoSchemaHelper.query_org_id_field(
             required=False,


### PR DESCRIPTION
#### Any background context you want to provide?

The py-seed has a format that is used to create a column mapping profile via a CSV. See #3610 for the links.

#### What's this PR do?

* Add API method for exporting column mapping profile to CSV
* Add button to column mapping profile page to export the data

#### How should this be manually tested?

* go to the column mapping page
* select one of the profiles
* click on the new lightgreen export button
* change some mappings, save the mappings
* export again
* verify that the files changed

#### What are the relevant tickets?
#3610 

#### Screenshots (if appropriate)
