### PR TITLE
Fix get template with no children

### DIFF
--- a/seed/views/v3/portfolio_manager.py
+++ b/seed/views/v3/portfolio_manager.py
@@ -319,7 +319,7 @@ class PortfolioManagerImport(object):
 
                     # the beginning and end of the string needs to be without the doublequote. Remove the escaped double quotes
                     data_to_parse = decoded['data'].replace('"{', '{').replace('}"', '}').replace('"[{', '[{').replace(
-                        '}]"', '}]').replace('\\"', '"')
+                        '}]"', '}]').replace('\\"', '"').replace('"[]"', '[]')
 
                     # print(f'data to parse: {data_to_parse}')
                     child_object = json.loads(data_to_parse)['childrenRows']


### PR DESCRIPTION
#### Any background context you want to provide?
non-empty arrays where parsed with `replace('"[{', '[{').replace('}]"', '}]')`, but not the empty ones. Thus, if `childrenRows` was empty, we'd try to iter through an empty array like it was a string, "[]".

Note, replacing `replace('"[{', '[{').replace('}]"', '}]')` with `replace('"[', '[').replace(']"', ']')` doesn't work, as `[` and `]` are uses in the data and it all gets messed up. 

#### What are the relevant tickets?
 #3593 [#3322](https://github.com/SEED-platform/seed/issues/3322)