### PR TITLE
Fix note's API result to not include related model's view ID

### DIFF
--- a/seed/serializers/notes.py
+++ b/seed/serializers/notes.py
@@ -4,6 +4,7 @@
 :copyright (c) 2014 - 2022, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.
 :author
 """
+
 from rest_framework import serializers
 
 from seed.models import Note
@@ -20,3 +21,13 @@ class NoteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Note
         exclude = ('property_view', 'taxlot_view', 'user', 'organization')
+
+    def to_representation(self, instance):
+        """Override the to_representation method to remove the property or taxlot view id if it is null"""
+        ret = super().to_representation(instance)
+        # only show the non-null (taxlot|property)_view_id
+        if ret['property_view_id'] is None:
+            del ret['property_view_id']
+        elif ret['taxlot_view_id'] is None:
+            del ret['taxlot_view_id']
+        return ret

--- a/seed/tests/test_note_views.py
+++ b/seed/tests/test_note_views.py
@@ -90,7 +90,7 @@ class NoteViewTests(TestCase):
         self.assertEqual(result['note_type'], 'Note')
         self.assertEqual(result['text'], payload['text'])
         self.assertEqual(result['property_view_id'], self.pv.pk)
-        self.assertIsNone(result['taxlot_view_id'])
+        self.assertTrue('taxlot_view_id' not in result)
         self.assertEqual(result['organization_id'], self.org.pk)
         self.assertEqual(result['user_id'], self.user.pk)
 
@@ -109,7 +109,7 @@ class NoteViewTests(TestCase):
         # check that the note was attached to the property
         self.assertEqual(result['note_type'], 'Note')
         self.assertEqual(result['text'], payload['text'])
-        self.assertIsNone(result['property_view_id'])
+        self.assertTrue('property_view_id' not in result)
         self.assertEqual(result['taxlot_view_id'], self.tl.pk)
 
     def test_update_note(self):

--- a/seed/views/notes.py
+++ b/seed/views/notes.py
@@ -17,7 +17,9 @@ _log = logging.getLogger(__name__)
 
 
 class NoteViewSet(SEEDOrgCreateUpdateModelViewSet):
-    """API endpoint for creating, retrieving, updating, and deleting notes.
+    """API endpoint for creating, retrieving, updating, and deleting notes. If it is an
+    automated message which is typically trigger by a manual edit, then log_data will
+    be populated with the data that was changed.
 
             Returns::
                 [
@@ -25,7 +27,13 @@ class NoteViewSet(SEEDOrgCreateUpdateModelViewSet):
                         'id': Note's primary key,
                         'note_type': Is it a note or automated log message,
                         'name': Superfluous name,
-                        'text': Note's text
+                        'text': Note's text,
+                        'log_data': [{
+                            "field": Modified field name,
+                            "state_id": State's primary key,
+                            "new_value": New value,
+                            "previous_value": Previous value if any
+                        }]
                     }
                 ]
 

--- a/seed/views/notes.py
+++ b/seed/views/notes.py
@@ -17,12 +17,13 @@ _log = logging.getLogger(__name__)
 
 
 class NoteViewSet(SEEDOrgCreateUpdateModelViewSet):
-    """API endpoint for viewing and creating notes.
+    """API endpoint for creating, retrieving, updating, and deleting notes.
 
             Returns::
                 [
                     {
-                        'id': Note's primary key
+                        'id': Note's primary key,
+                        'note_type': Is it a note or automated log message,
                         'name': Superfluous name,
                         'text': Note's text
                     }


### PR DESCRIPTION
#### Any background context you want to provide?
The Note's API returns both the `property_view_id` and `taxlot_view_id` even though only one of the two will be populated. 

#### What's this PR do?
Removed the `null` view id from the return by overloading the `to_representation` method

#### How should this be manually tested?
* create notes on a property and a taxlot
* monkey test the CRUD operations in the UI
* Also updated the API documentation

#### What are the relevant tickets?
#3634 

#### Screenshots (if appropriate
Before:
<img width="451" alt="image" src="https://user-images.githubusercontent.com/1907354/204859800-77607d9b-ccbe-465e-850b-13dca007fcef.png">

After:
<img width="455" alt="image" src="https://user-images.githubusercontent.com/1907354/204859651-2897cdc6-eab6-4b42-9bad-6c6836f2fd50.png">
