### PR TITLE
Return only need columns in compliance evaluate

### DIFF
--- a/seed/models/compliance_metrics.py
+++ b/seed/models/compliance_metrics.py
@@ -72,7 +72,18 @@ class ComplianceMetric(models.Model):
         # get properties (no filter)
         # property_response = properties_across_cycles(self.organization_id, -1, cycle_ids)
         # get properties (applies filter group)
-        property_response = properties_across_cycles_with_filters(self.organization_id, -1, cycle_ids, query_dict)
+        property_response = properties_across_cycles_with_filters(
+            self.organization_id,
+            cycle_ids,
+            query_dict,
+            [
+                self.organization.property_display_field,
+                self.actual_energy_column.id,
+                self.target_energy_column.id,
+                self.actual_emission_column,
+                self.target_emission_column
+            ]
+        )
 
         datasets = {'y': {'data': [], 'label': 'compliant'}, 'n': {'data': [], 'label': 'non-compliant'}, 'u': {'data': [], 'label': 'unknown'}}
         results_by_cycles = {}

--- a/seed/utils/properties.py
+++ b/seed/utils/properties.py
@@ -195,34 +195,16 @@ def properties_across_cycles(org_id, profile_id, cycle_ids=[]):
     return results
 
 
-def properties_across_cycles_with_filters(org_id, profile_id, cycle_ids=[], query_dict={}):
+def properties_across_cycles_with_filters(org_id, cycle_ids=[], query_dict={}, column_ids=[]):
     # Identify column preferences to be used to scope fields/values
     columns_from_database = Column.retrieve_all(org_id, 'property', False)
-
-    if profile_id == -1:
-        show_columns = list(Column.objects.filter(
-            organization_id=org_id
-        ).values_list('id', flat=True))
-    else:
-        try:
-            profile = ColumnListProfile.objects.get(
-                organization_id=org_id,
-                id=profile_id,
-                profile_location=VIEW_LIST,
-                inventory_type=VIEW_LIST_PROPERTY
-            )
-            show_columns = list(ColumnListProfileColumn.objects.filter(
-                column_list_profile_id=profile.id
-            ).values_list('column_id', flat=True))
-        except ColumnListProfile.DoesNotExist:
-            show_columns = None
 
     results = {}
     for cycle_id in cycle_ids:
         # get Filtered Views for this Cycle
         org = Organization.objects.get(pk=org_id)
         property_views = _get_filter_group_views(org_id, cycle_id, query_dict)
-        related_results = TaxLotProperty.serialize(property_views, show_columns, columns_from_database)
+        related_results = TaxLotProperty.serialize(property_views, column_ids, columns_from_database, include_related=False)
         # format
         unit_collapsed_results = [apply_display_unit_preferences(org, x) for x in related_results]
         results[cycle_id] = unit_collapsed_results


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
idk if this will speed up the request, but it definitely shortens the response. 

I got like 200 properties. before and after this commit, the eval request takes ~3 secs, but the response size goes from 750KB to 55KB. the diff like scale with the number of properties. 

It's a start. 

I'll keep working, only push if we can't wait for more optimization.
#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
