### PR TITLE
Fix swagger loading the Meter endpoints

### DIFF
--- a/seed/views/v3/meters.py
+++ b/seed/views/v3/meters.py
@@ -24,7 +24,7 @@ class MeterViewSet(SEEDOrgNoPatchOrOrgCreateModelViewSet):
         org_id = self.get_organization(self.request)
         # get the property id - since the meter is associated with the property (not the property view)
 
-        # eventhough it is named 'property_pk' it is really the property view id
+        # even though it is named 'property_pk' it is really the property view id
         property_view_pk = self.kwargs.get('property_pk', None)
         if not property_view_pk:
             # Return None otherwise swagger will not be able to process the request

--- a/seed/views/v3/meters.py
+++ b/seed/views/v3/meters.py
@@ -23,7 +23,14 @@ class MeterViewSet(SEEDOrgNoPatchOrOrgCreateModelViewSet):
         # get all the meters for the organization
         org_id = self.get_organization(self.request)
         # get the property id - since the meter is associated with the property (not the property view)
-        property_view = PropertyView.objects.get(pk=self.kwargs.get('property_pk', None))
+
+        # eventhough it is named 'property_pk' it is really the property view id
+        property_view_pk = self.kwargs.get('property_pk', None)
+        if not property_view_pk:
+            # Return None otherwise swagger will not be able to process the request
+            return Meter.objects.none()
+
+        property_view = PropertyView.objects.get(pk=property_view_pk)
         self.property_pk = property_view.property.pk
         return Meter.objects.filter(property__organization_id=org_id, property_id=self.property_pk)
 
@@ -34,4 +41,4 @@ class MeterViewSet(SEEDOrgNoPatchOrOrgCreateModelViewSet):
         if self.property_pk:
             serializer.save(property_id=self.property_pk)
         else:
-            raise Exception('No property_pk provided in URL to create the meter')
+            raise Exception('No property_pk (property view id) provided in URL to create the meter')


### PR DESCRIPTION
#### Any background context you want to provide?
Swagger expects a quertyset to be returned 

#### What's this PR do?
* add `Meter.objects.none()` to the Meter `get_quertyset` method.

#### How should this be manually tested?
Does swagger load?

#### What are the relevant tickets?
#3661 

#### Screenshots (if appropriate)
