### PR TITLE
Disable sorting by derived column

### DIFF
--- a/seed/models/columns.py
+++ b/seed/models/columns.py
@@ -1372,6 +1372,7 @@ class Column(models.Model):
         inventory_type: Optional[Literal['property', 'taxlot']] = None,
         only_used: bool = False,
         include_related: bool = True,
+        exclude_derived: bool = False
     ) -> list[dict]:
         """
         Retrieve all the columns for an organization. This method will query for all the columns in the
@@ -1388,8 +1389,11 @@ class Column(models.Model):
         # Grab all the columns out of the database for the organization that are assigned to a
         # table_name. Order extra_data last so that extra data duplicate-checking will happen after
         # processing standard columns
-        columns_db = Column.objects.filter(organization_id=org_id).exclude(table_name='').exclude(
-            table_name=None).order_by('is_extra_data', 'column_name')
+        column_query = Column.objects.filter(organization_id=org_id).exclude(table_name='').exclude(
+            table_name=None)
+        if exclude_derived:
+            column_query = column_query.exclude(derived_column__isnull=False)
+        columns_db = column_query.order_by('is_extra_data', 'column_name')
         columns = []
         for c in columns_db:
             if c.column_name in Column.EXCLUDED_COLUMN_RETURN_FIELDS:

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -994,6 +994,11 @@ angular.module('BE.seed.controller.inventory_list', [])
             title = "Filtering disabled for taxlot columns on the property list.";
           }
         }
+        if (column['derived_column'] != null) {
+          column['enableSorting'] = false;
+          let title = "Sorting and filtering disabled for derived columns.";
+          column['filterHeaderTemplate'] = '<div class="ui-grid-filter-container"><input type="text" title="' + title + '" class="ui-grid-filter-input" disabled=disabled />'
+        }
       }
 
       var findColumn = _.memoize(function (name) {

--- a/seed/utils/inventory_filter.py
+++ b/seed/utils/inventory_filter.py
@@ -90,7 +90,8 @@ def get_filtered_results(request: Request, inventory_type: Literal['property', '
         org_id=org_id,
         inventory_type=inventory_type,
         only_used=False,
-        include_related=include_related
+        include_related=include_related,
+        exclude_derived=True,
     )
     try:
         filters, annotations, order_by = build_view_filters_and_sorts(request.query_params, columns_from_database)
@@ -113,7 +114,8 @@ def get_filtered_results(request: Request, inventory_type: Literal['property', '
             org_id=org_id,
             inventory_type=other_inventory_type,
             only_used=False,
-            include_related=include_related
+            include_related=include_related,
+            exclude_derived=True,
         )
         try:
             filters, annotations, _ = build_view_filters_and_sorts(request.query_params, other_columns_from_database)


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
- UI disables sorting and filtering on derived columns
- API ignores detrived columns in sorting and filtering. You could convince me it should 400 instead. 🤷  This felt right the the API ignore all other invalid column filters.

#### How should this be manually tested?

#### What are the relevant tickets?
https://github.com/SEED-platform/seed/issues/3667

#### Screenshots (if appropriate)
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/30241543/206318661-406b9443-235a-4ab6-9695-c5cd64b59bba.png">
