### PR TITLE
Refactor properties_across_cycles_with_filters so it only makes one P…

### DIFF
--- a/seed/static/seed/js/controllers/insights_program_controller.js
+++ b/seed/static/seed/js/controllers/insights_program_controller.js
@@ -66,11 +66,12 @@ angular.module('BE.seed.controller.insights_program', [])
         // console.log("get data for metric id: ", $scope.compliance_metric.id);
         let data = compliance_metric_service.evaluate_compliance_metric($scope.compliance_metric.id).then((data) => {
           $scope.data = data;
-          spinner_utility.hide();
         }).then(() => {
           // console.log( "DATA: ", $scope.data)
           _build_chart();
 
+        }).finally(() => {
+          spinner_utility.hide()
         })
       };
 
@@ -160,6 +161,6 @@ angular.module('BE.seed.controller.insights_program', [])
 
       }
 
-      _load_data();
+      setTimeout(_load_data, 0); // avoid race condition with route transition spinner.
     }
   ]);

--- a/seed/static/seed/js/controllers/insights_property_controller.js
+++ b/seed/static/seed/js/controllers/insights_property_controller.js
@@ -59,7 +59,6 @@ angular.module('BE.seed.controller.insights_property', [])
         spinner_utility.show();
         let data = compliance_metric_service.evaluate_compliance_metric($scope.compliance_metric.id).then((data) => {
           $scope.data = data;
-          spinner_utility.hide();
         }).then(() => {
           // console.log( "DATA RETURNED: ", $scope.data)
           if ($scope.data) {
@@ -94,6 +93,8 @@ angular.module('BE.seed.controller.insights_property', [])
           // once
           _build_chart();
 
+        }).finally(() => {
+          spinner_utility.hide()
         })
       };
 
@@ -418,8 +419,7 @@ angular.module('BE.seed.controller.insights_property', [])
 
       }
 
-      _load_data();
-
+      setTimeout(_load_data, 0); // avoid race condition with route transition spinner.
     }
 
   ]);

--- a/seed/utils/properties.py
+++ b/seed/utils/properties.py
@@ -198,22 +198,22 @@ def properties_across_cycles(org_id, profile_id, cycle_ids=[]):
 def properties_across_cycles_with_filters(org_id, cycle_ids=[], query_dict={}, column_ids=[]):
     # Identify column preferences to be used to scope fields/values
     columns_from_database = Column.retrieve_all(org_id, 'property', False)
+    org = Organization.objects.get(pk=org_id)
 
-    results = {}
-    for cycle_id in cycle_ids:
-        # get Filtered Views for this Cycle
-        org = Organization.objects.get(pk=org_id)
-        property_views = _get_filter_group_views(org_id, cycle_id, query_dict)
-        related_results = TaxLotProperty.serialize(property_views, column_ids, columns_from_database, include_related=False)
-        # format
-        unit_collapsed_results = [apply_display_unit_preferences(org, x) for x in related_results]
-        results[cycle_id] = unit_collapsed_results
+    results = {cycle_id: [] for cycle_id in cycle_ids}
+    property_views = _get_filter_group_views(org_id, cycle_ids, query_dict)
+    views_cycle_ids = [v.cycle_id for v in property_views]
+    related_results = TaxLotProperty.serialize(property_views, column_ids, columns_from_database, include_related=False)
+    unit_collapsed_results = [apply_display_unit_preferences(org, x) for x in related_results]
+
+    for cycle_id, unit_collapsed_result in zip(views_cycle_ids, unit_collapsed_results):
+        results[cycle_id].append(unit_collapsed_result)
 
     return results
 
 
 # helper function for getting filtered properties
-def _get_filter_group_views(org_id, cycle, query_dict):
+def _get_filter_group_views(org_id, cycles, query_dict):
 
     columns = Column.retrieve_all(
         org_id=org_id,
@@ -233,7 +233,7 @@ def _get_filter_group_views(org_id, cycle, query_dict):
 
     views_list = (
         PropertyView.objects.select_related('property', 'state', 'cycle')
-        .filter(property__organization_id=org_id, cycle=cycle)
+        .filter(property__organization_id=org_id, cycle__in=cycles)
     )
 
     views_list = views_list.filter(filters).order_by('id')


### PR DESCRIPTION
…ropertyViews query

#### Any background context you want to provide?
Refactor `properties_across_cycles_with_filters` so it only makes one PropertyViews query. On a db with 3 cycles and 15ish properties in each cycle, this about halves the response time of `/api/v3/compliance_metrics/1/evaluate/` (1200 ms to 600 ms, roughly, still high). I believe the improvement in performance will scale with the number of cycles.  

#### What's this PR do?

#### How should this be manually tested?

#### What are the relevant tickets?
https://github.com/SEED-platform/seed/issues/3657
https://github.com/SEED-platform/seed/issues/3673

#### Screenshots (if appropriate)
