### PR TITLE
Reorder the metric type drop down text in Program Configuration

### DIFF
--- a/seed/models/compliance_metrics.py
+++ b/seed/models/compliance_metrics.py
@@ -22,7 +22,7 @@ class ComplianceMetric(models.Model):
     METRIC_TYPES = (
         (TARGET_NONE, ''),
         (TARGET_GT_ACTUAL, 'Target > Actual for Compliance'),
-        (TARGET_LT_ACTUAL, 'Actual > Target for Compliance'),
+        (TARGET_LT_ACTUAL, 'Target < Actual for Compliance'),
     )
 
     organization = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name='compliance_metrics', blank=True, null=True)

--- a/seed/static/seed/partials/program_setup.html
+++ b/seed/static/seed/partials/program_setup.html
@@ -142,7 +142,7 @@
                                             <select id="select-energy-metric-type" class="form-control" ng-model="selected_compliance_metric.energy_metric_type" ng-change="program_settings_changed()">
                                                 <option value=""></option>
                                                 <option value="Target > Actual for Compliance" translatee>Target > Actual for Compliance</option>
-                                                <option value="Actual > Target for Compliance" translatee>Actual > Target for Compliance</option>
+                                                <option value="Target < Actual for Compliance" translatee>Target < Actual for Compliance</option>
                                             </select>
                                         </li>
                                     </ul>
@@ -167,7 +167,7 @@
                                             <select id="select-emission-metric-type" class="form-control" ng-model="selected_compliance_metric.emission_metric_type" ng-change="program_settings_changed()">
                                                 <option value=""></option>
                                                 <option value="Target > Actual for Compliance" translate>Target > Actual for Compliance</option>
-                                                <option value="Actual > Target for Compliance" translate>Actual > Target for Compliance</option>
+                                                <option value="Target < Actual for Compliance" translate>Target < Actual for Compliance</option>
                                             </select>
                                         </li>
                                     </ul>


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
Replace "Actual > Target for Compliance" with "Target < Actual for Compliance"

#### How should this be manually tested?
Create a new program or edit an existing one and ensure that the second option in the dropdown for metric type is equal to "Target < Actual for Compliance".

#### What are the relevant tickets?
Fixes #3692

#### Screenshots (if appropriate)
