### PR TITLE
Fix build and publish scripts by pinning version of Shapely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   # As a result, the DRYest method for now is to use a testing matrix and
   # use conditional steps for actually running the tests.
   unittests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         test_env: [django, functional, api]
@@ -95,7 +95,7 @@ jobs:
         if: ${{ always() }}
         run: docker logs seed_web
   formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         tox_env: [docs, precommit, mypy]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/stale@v4
         with:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,10 @@ django-crispy-forms==1.8.1
 # Persistence stores
 psycopg2-binary==2.8.4
 
+# Shapely 2.X fails to build. Force to use
+# the previous version
+shapely==1.8.5.post1
+
 # background process management
 celery==5.2.2
 django-redis-cache==3.0.0


### PR DESCRIPTION
#### Any background context you want to provide?
`develop` publish builds are failing.

The shapely dependency comes from pnnl-buildingid library which does not have any version constraints on shapely, thus it grabbed the latest shapely which was released on 12/12/2022.
```
pnnl-buildingid==2.0.0
  - click [required: Any, installed: 8.1.3]
  - click-log [required: Any, installed: 0.4.0]
    - click [required: Any, installed: 8.1.3]
  - shapely [required: Any, installed: 1.8.5.post1]
```

#### What's this PR do?
* force the use of 20.04 for most of the builds. This is not likely the issue, but now we will be explicit on what version of Ubuntu we are using.
* Force Shapely 1.8.5.post1 as 2.x version does not build the geos library correctly.

#### How should this be manually tested?
n/a

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
