### PR TITLE
Fix issue with evaluating compliance metric

### DIFF
--- a/seed/models/compliance_metrics.py
+++ b/seed/models/compliance_metrics.py
@@ -75,12 +75,19 @@ class ComplianceMetric(models.Model):
         display_field_id = Column.objects.get(table_name="PropertyState", column_name=self.organization.property_display_field, organization=self.organization).id
         # array of columns to return
         column_ids = [
-            display_field_id,
-            self.actual_energy_column.id,
-            self.target_energy_column.id,
-            self.actual_emission_column.id,
-            self.target_emission_column.id
+            display_field_id
         ]
+
+        if self.actual_energy_column is not None:
+            column_ids.append(self.actual_energy_column.id)
+            if self.target_energy_column is not None:
+                column_ids.append(self.target_energy_column.id)
+
+        if self.actual_emission_column is not None:
+            column_ids.append(self.actual_emission_column.id)
+            if self.target_emission_column is not None:
+                column_ids.append(self.target_emission_column.id)
+
         for col in self.x_axis_columns.all():
             column_ids.append(col.id)
 


### PR DESCRIPTION
#### Any background context you want to provide?
There was an issue with how the column_ids were created for the property_response in the compliance_metrics model.

#### What's this PR do?
It adds checks for whether actual energy, target energy, actual emission, and target emission values are present before adding them to column_ids.

#### How should this be manually tested?
Create a Program with only energy metric, only emission metric, and both metrics. Then make sure each of the three Programs will load on Program Overview and Property Insights pages.

#### What are the relevant tickets?
Fixes #3697

#### Screenshots (if appropriate)
