### PR TITLE
Add the @has_perm_class permission to program metric api endpoints

### DIFF
--- a/seed/static/seed/js/controllers/insights_property_controller.js
+++ b/seed/static/seed/js/controllers/insights_property_controller.js
@@ -342,7 +342,6 @@ angular.module('BE.seed.controller.insights_property', [])
                 },
                 y: {
                   beginAtZero: true,
-                  stacked: true,
                   position: 'left',
                   display: true,
                   title: {

--- a/seed/static/seed/js/controllers/program_setup_controller.js
+++ b/seed/static/seed/js/controllers/program_setup_controller.js
@@ -55,9 +55,6 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
     $scope.property_columns = property_columns;
     $scope.x_axis_columns = x_axis_columns;
 
-    console.log($scope.auth.requires_owner);
-
-
     $scope.get_column_display = function (id) {
       let record = _.find($scope.property_columns, {id: id});
       if (record) {

--- a/seed/static/seed/js/controllers/program_setup_controller.js
+++ b/seed/static/seed/js/controllers/program_setup_controller.js
@@ -10,6 +10,7 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
   'filter_groups',
   'Notification',
   'organization_payload',
+  'auth_payload',
   'property_columns',
   'spinner_utility',
   'x_axis_columns',
@@ -21,6 +22,7 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
     filter_groups,
     Notification,
     organization_payload,
+    auth_payload,
     property_columns,
     spinner_utility,
     x_axis_columns
@@ -28,6 +30,7 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
     spinner_utility.show();
     $scope.id = $stateParams.id;
     $scope.org = organization_payload.organization;
+    $scope.auth = auth_payload.auth;
     $scope.compliance_metrics_error = [];
     $scope.fields = {
       start_year: '',
@@ -51,6 +54,8 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
     }
     $scope.property_columns = property_columns;
     $scope.x_axis_columns = x_axis_columns;
+
+    console.log($scope.auth.requires_owner);
 
 
     $scope.get_column_display = function (id) {

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -1044,6 +1044,19 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           filter_groups: ['filter_groups_service', function (filter_groups_service) {
             var inventory_type = 'Property'; // just properties for now
             return filter_groups_service.get_filter_groups(inventory_type, brief=true);
+          }],
+          auth_payload: ['auth_service', '$stateParams', '$q', function (auth_service, $stateParams, $q) {
+            var organization_id = $stateParams.organization_id;
+            return auth_service.is_authorized(organization_id, ['requires_owner', 'requires_member','requires_viewer'])
+              .then(function (data) {
+                if (data.auth.requires_viewer) {
+                  return data;
+                } else {
+                  return $q.reject('not authorized');
+                }
+              }, function (data) {
+                return $q.reject(data.message);
+              });
           }]
         }
       })
@@ -1088,6 +1101,19 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           filter_groups: ['filter_groups_service', function (filter_groups_service) {
             var inventory_type = 'Property'; // just properties for now
             return filter_groups_service.get_filter_groups(inventory_type, brief=true);
+          }],
+          auth_payload: ['auth_service', '$stateParams', '$q', function (auth_service, $stateParams, $q) {
+            var organization_id = $stateParams.organization_id;
+            return auth_service.is_authorized(organization_id, ['requires_owner', 'requires_member','requires_viewer'])
+              .then(function (data) {
+                if (data.auth.requires_viewer) {
+                  return data;
+                } else {
+                  return $q.reject('not authorized');
+                }
+              }, function (data) {
+                return $q.reject(data.message);
+              });
           }]
         }
       })
@@ -1122,9 +1148,9 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           }],
           auth_payload: ['auth_service', '$stateParams', '$q', function (auth_service, $stateParams, $q) {
             var organization_id = $stateParams.organization_id;
-            return auth_service.is_authorized(organization_id, ['requires_owner'])
+            return auth_service.is_authorized(organization_id, ['requires_viewer'])
               .then(function (data) {
-                if (data.auth.requires_owner) {
+                if (data.auth.requires_viewer) {
                   return data;
                 } else {
                   return $q.reject('not authorized');
@@ -1163,9 +1189,9 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           }],
           auth_payload: ['auth_service', '$stateParams', '$q', function (auth_service, $stateParams, $q) {
             var organization_id = $stateParams.organization_id;
-            return auth_service.is_authorized(organization_id, ['requires_owner'])
+            return auth_service.is_authorized(organization_id, ['requires_viewer'])
               .then(function (data) {
-                if (data.auth.requires_owner) {
+                if (data.auth.requires_viewer) {
                   return data;
                 } else {
                   return $q.reject('not authorized');

--- a/seed/static/seed/partials/accounts.html
+++ b/seed/static/seed/partials/accounts.html
@@ -39,7 +39,7 @@
                                 <a ui-sref="organization_email_templates(::{organization_id: org.id})"><i class="fa fa-envelope"></i>{$:: 'Email Templates' | translate $}</a>
                                 <a ui-sref="organization_labels(::{organization_id: org.id})"><i class="fa fa-tags"></i>{$:: 'Labels' | translate $}</a>
                                 <a ui-sref="organization_members(::{organization_id: org.id})"><i class="fa fa-user"></i>{$:: 'Members' | translate $}</a>
-                                <a ui-sref="program_setup({organization_id: menu.user.organization.id})"><i class="fa fa-tachometer"></i>{$:: 'Program Setup' | translate $}</a>
+                                <a ui-sref="programs(::{organization_id: org.id})"><i class="fa fa-tachometer"></i>{$:: 'Program Setup' | translate $}</a>
                                 <a ui-sref="organization_settings(::{organization_id: org.id})"><i class="fa fa-cogs"></i>Settings</a>
                                 <a ui-sref="organization_sharing(::{organization_id: org.id})" ng-if="::org.is_parent"><i class="fa fa-share-square-o"></i>{$:: 'Sharing' | translate $}</a>
                                 <a ui-sref="organization_sub_orgs(::{organization_id: org.id})" ng-if="::org.is_parent"><i class="fa fa-users"></i>{$:: 'Sub-Organizations' | translate $}</a>

--- a/seed/static/seed/partials/accounts_nav.html
+++ b/seed/static/seed/partials/accounts_nav.html
@@ -6,7 +6,7 @@
      --><a ui-sref="organization_email_templates(::{organization_id: org.id})" ui-sref-active="active" translate>Email Templates</a><!--
      --><a ui-sref="organization_labels(::{organization_id: org.id})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Labels</a><!--
      --><a ui-sref="organization_members(::{organization_id: org.id})" ui-sref-active="active" translate>Members</a><!--
-     --><a ui-sref="programs(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Program Setup</a><!--
+     --><a ui-sref="programs(::{organization_id: org.id})" ui-sref-active="active" translate>Program Setup</a><!--
      --><a ui-sref="organization_settings(::{organization_id: org.id})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Settings</a><!--
      --><a ui-sref="organization_sharing(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sharing</a><!--
      --><a ui-sref="organization_sub_orgs(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sub-Organizations</a>

--- a/seed/static/seed/partials/program_setup.html
+++ b/seed/static/seed/partials/program_setup.html
@@ -22,7 +22,7 @@
             <div class="section_action_container left">
                 <h2><i class="fa fa-tachometer"></i> {$:: 'Program Configuration' | translate $}</h2>
             </div>
-            <div ng-show="selected_compliance_metric" class="section_action_container right_40 section_action_btn pull-right">
+            <div ng-show="selected_compliance_metric && (auth.requires_owner || auth.requires_member)" class="section_action_container right_40 section_action_btn pull-right">
                 <button class="btn btn-info r-margin-right-5" ng-click="click_delete()" translate>Delete</button>
                 <button class="btn btn-primary" ng-disabled="program_settings_not_changed"  ng-click="save_settings()">{$:: 'Save Changes' | translate $} <i class="fa fa-check" ng-show="settings_updated"></i></button>
             </div>
@@ -101,9 +101,9 @@
                                         <li class="r-list-header" translate>X-Axis Field Options</li>
                                         <li ng-repeat="item in selected_compliance_metric.x_axis_columns" class="r-row r-row-centered">
                                             <span class="r-grow">{$:: get_x_axis_display(item) $}</span>
-                                            <i class="fa fa-times r-margin-left-5" ng-click="click_remove_x_axis(item)"></i>
+                                            <i class="fa fa-times r-margin-left-5" ng-click="click_remove_x_axis(item)" ng-show="auth.requires_owner || auth.requires_member"></i>
                                         </li>
-                                        <li class="r-row r-row-centered">
+                                        <li class="r-row r-row-centered" ng-show="auth.requires_owner || auth.requires_member">
                                             <select id="select-x-axis" class="form-control" ng-change="select_x_axis(); program_settings_changed()" ng-model="x_axis_selection">
                                                 <option ng-repeat="x_axis_column in x_axis_columns" ng-value="x_axis_column.id">{$:: x_axis_column.displayName $}</option>
                                             </select>

--- a/seed/static/seed/partials/program_setup.html
+++ b/seed/static/seed/partials/program_setup.html
@@ -57,130 +57,128 @@
                 <b ng-show="has_compliance_metrics" translate>No program selected</b>
                 <p ng-show="has_compliance_metrics"><i class="fa fa-arrow-left r-pad-right-5"></i><span translate>Select a Program to get started!</span></p>
             </div>
-            <div ng-show="selected_compliance_metric || !program_settings_not_changed" class="r-panel r-columns r-no-margin">
-                <div class="section_content">
-                    <div class="r-columns">
-                        <div class="r-column">
-                            <div class="r-panel r-margin-bottom-10">
-                                <div class="r-small-header">
-                                    <p class="r-small-header">General Settings</p>
-                                </div>
-                                <div class="r-panel r-info r-margin-top-10 r-margin-bottom-10">
-                                    Configure your program metric to enable visualizations on the <b><a ui-sref="insights_program(::{organization_id: org.id})" ui-sref-active="active" translate>program overview</a></b> page.
-                                </div>
-                                <ul class="r-list">
-                                    <li class="r-list-header" translate>Program Definition</li>
-                                    <li class="r-row r-row-centered">
-                                        <label for="input-metric-name" class="r-no-wrap r-margin-right-5" translate>Name</label>
-                                        <input id="input-metric-name" type="text" class="form-control" ng-model="selected_compliance_metric.name" ng-change="program_settings_changed()"/>
-                                    </li>
-                                    <li class="r-row r-row-centered">
-                                        <label for="input-compliance-period-start" class="r-no-wrap r-margin-right-5" translate>Compliance Period (years)</label>
-                                        <input id="input-compliance-period-start" type="number" min=1000 max=9000 class="form-control" ng-model="fields.start_year" ng-change="program_settings_changed()"/>
-                                        <span class="r-margin-left-5 r-margin-right-5">to</span>
-                                        <input id="input-compliance-period-end" type="number" min=1000 max=9000 class="form-control" ng-model="fields.end_year" />
-                                    </li>
-                                    <li class="r-row r-row-centered">
-                                        <label for="select-filter-group" class="r-no-wrap r-margin-right-5" translate>Filter Group</label>
-                                        <select id="select-filter-group" class="form-control" ng-model="selected_compliance_metric.filter_group" ng-change="program_settings_changed()">
-                                            <option value=""></option>
-                                            <option ng-repeat="filter_group in filter_groups" ng-value="{$ filter_group.id $}">{$:: filter_group.name $}</option>
-                                        </select>
-                                    </li>
-                                </ul>
-
-                            </div>
-                            <div class="r-panel">
-                                <div class="r-small-header">
-                                    <p class="r-small-header">Visualization Settings</p>
-                                </div>
-                                <div class="r-panel r-info r-margin-top-10 r-margin-bottom-10">
-                                    Select at least one field which will serve as the x-axis for visualizations on the <b><a ui-sref="insights_property(::{organization_id: org.id})" ui-sref-active="active" translate>property insights</a></b> page. Multiple fields can be selected.
-                                </div>
-                                <ul class="r-list">
-                                    <li class="r-list-header" translate>X-Axis Field Options</li>
-                                    <li ng-repeat="item in selected_compliance_metric.x_axis_columns" class="r-row r-row-centered">
-                                        <span class="r-grow">{$:: get_x_axis_display(item) $}</span>
-                                        <i class="fa fa-times r-margin-left-5" ng-click="click_remove_x_axis(item)"></i>
-                                    </li>
-                                    <li class="r-row r-row-centered">
-                                        <select id="select-x-axis" class="form-control" ng-change="select_x_axis(); program_settings_changed()" ng-model="x_axis_selection">
-                                            <option ng-repeat="x_axis_column in x_axis_columns" ng-value="x_axis_column.id">{$:: x_axis_column.displayName $}</option>
-                                        </select>
-                                    </li>
-                                </ul>
-
-                            </div>
-                        </div>
-                        <div class="r-column">
-                            <div class="r-panel r-margin-bottom-10">
-                                <div class="r-small-header">
-                                        <p class="r-small-header">Metric Type Settings</p>
+            <div ng-show="selected_compliance_metric || !program_settings_not_changed" class="r-panel r-columns r-no-margin" disabled>
+                <form class="section_content">
+                    <fieldset ng-disabled="!auth.requires_owner">
+                        <div class="r-columns">
+                            <div class="r-column">
+                                <div class="r-panel r-margin-bottom-10">
+                                    <div class="r-small-header">
+                                        <p class="r-small-header">General Settings</p>
                                     </div>
                                     <div class="r-panel r-info r-margin-top-10 r-margin-bottom-10">
-                                    The overall metric can be made up of an energy metric, an emission metric, or both. At least one type of metric is required and if two are defined, then both metrics must be met for compliance.
+                                        Configure your program metric to enable visualizations on the <b><a ui-sref="insights_program(::{organization_id: org.id})" ui-sref-active="active" translate>program overview</a></b> page.
                                     </div>
-                                <div class="r-columns r-no-margin">
                                     <ul class="r-list">
-                                        <li class="r-list-header" translate>Energy Metric</li>
+                                        <li class="r-list-header" translate>Program Definition</li>
                                         <li class="r-row r-row-centered">
-                                            <label for="select-energy-metric-actual-column" class="r-no-wrap r-margin-right-5" translate>Actual Field</label>
-                                            <select id="select-energy-metric-actual-column" class="form-control" ng-model="selected_compliance_metric.actual_energy_column" ng-change="program_settings_changed()">
-                                                <option value=""></option>
-                                                <option ng-repeat="property_column in property_columns" ng-value="property_column.id">{$:: property_column.displayName $}</option>
-                                            </select>
+                                            <label for="input-metric-name" class="r-no-wrap r-margin-right-5" translate>Name</label>
+                                            <input id="input-metric-name" type="text" class="form-control" ng-model="selected_compliance_metric.name" ng-change="program_settings_changed()"/>
                                         </li>
                                         <li class="r-row r-row-centered">
-                                            <label for="select-energy-metric-target-column" class="r-no-wrap r-margin-right-5" translate>Target Field</label>
-                                            <select id="select-energy-metric-target-column" class="form-control" ng-model="selected_compliance_metric.target_energy_column" ng-change="program_settings_changed()">
-                                                <option value=""></option>
-                                                <option ng-repeat="property_column in property_columns" ng-value="property_column.id">{$:: property_column.displayName $}</option>
-                                            </select>
+                                            <label for="input-compliance-period-start" class="r-no-wrap r-margin-right-5" translate>Compliance Period (years)</label>
+                                            <input id="input-compliance-period-start" type="number" min=1000 max=9000 class="form-control" ng-model="fields.start_year" ng-change="program_settings_changed()"/>
+                                            <span class="r-margin-left-5 r-margin-right-5">to</span>
+                                            <input id="input-compliance-period-end" type="number" min=1000 max=9000 class="form-control" ng-model="fields.end_year" />
                                         </li>
                                         <li class="r-row r-row-centered">
-                                            <label for="select-energy-metric-type" class="r-no-wrap r-margin-right-5" translate>Type</label>
-                                            <select id="select-energy-metric-type" class="form-control" ng-model="selected_compliance_metric.energy_metric_type" ng-change="program_settings_changed()">
+                                            <label for="select-filter-group" class="r-no-wrap r-margin-right-5" translate>Filter Group</label>
+                                            <select id="select-filter-group" class="form-control" ng-model="selected_compliance_metric.filter_group" ng-change="program_settings_changed()">
                                                 <option value=""></option>
-                                                <option value="Target > Actual for Compliance" translatee>Target > Actual for Compliance</option>
-                                                <option value="Target < Actual for Compliance" translatee>Target < Actual for Compliance</option>
+                                                <option ng-repeat="filter_group in filter_groups" ng-value="{$ filter_group.id $}">{$:: filter_group.name $}</option>
                                             </select>
                                         </li>
-                                    </ul>
+                                    </ul>    
+                                </div>
+                                <div class="r-panel">
+                                    <div class="r-small-header">
+                                        <p class="r-small-header">Visualization Settings</p>
+                                    </div>
+                                    <div class="r-panel r-info r-margin-top-10 r-margin-bottom-10">
+                                        Select at least one field which will serve as the x-axis for visualizations on the <b><a ui-sref="insights_property(::{organization_id: org.id})" ui-sref-active="active" translate>property insights</a></b> page. Multiple fields can be selected.
+                                    </div>
                                     <ul class="r-list">
-                                        <li class="r-list-header" translate>Emission Metric</li>
-                                        <li class="r-row r-row-centered">
-                                            <label for="select-emission-metric-actual-column" class="r-no-wrap r-margin-right-5" translate>Actual Field</label>
-                                            <select id="select-emission-metric-actual-column" class="form-control" ng-model="selected_compliance_metric.actual_emission_column" ng-change="program_settings_changed()">
-                                                <option value=""></option>
-                                                <option ng-repeat="property_column in property_columns" ng-value="property_column.id">{$:: property_column.displayName $}</option>
-                                            </select>
+                                        <li class="r-list-header" translate>X-Axis Field Options</li>
+                                        <li ng-repeat="item in selected_compliance_metric.x_axis_columns" class="r-row r-row-centered">
+                                            <span class="r-grow">{$:: get_x_axis_display(item) $}</span>
+                                            <i class="fa fa-times r-margin-left-5" ng-click="click_remove_x_axis(item)"></i>
                                         </li>
                                         <li class="r-row r-row-centered">
-                                            <label for="select-emission-metric-target-column" class="r-no-wrap r-margin-right-5" translate>Target Field</label>
-                                            <select id="select-emission-metric-target-column" class="form-control" ng-model="selected_compliance_metric.target_emission_column" ng-change="program_settings_changed()">
-                                                <option value=""></option>
-                                                <option ng-repeat="property_column in property_columns" ng-value="property_column.id">{$:: property_column.displayName $}</option>
-                                            </select>
-                                        </li>
-                                        <li class="r-row r-row-centered">
-                                            <label for="select-emission-metric-type" class="r-no-wrap r-margin-right-5" translate>Type</label>
-                                            <select id="select-emission-metric-type" class="form-control" ng-model="selected_compliance_metric.emission_metric_type" ng-change="program_settings_changed()">
-                                                <option value=""></option>
-                                                <option value="Target > Actual for Compliance" translate>Target > Actual for Compliance</option>
-                                                <option value="Target < Actual for Compliance" translate>Target < Actual for Compliance</option>
+                                            <select id="select-x-axis" class="form-control" ng-change="select_x_axis(); program_settings_changed()" ng-model="x_axis_selection">
+                                                <option ng-repeat="x_axis_column in x_axis_columns" ng-value="x_axis_column.id">{$:: x_axis_column.displayName $}</option>
                                             </select>
                                         </li>
                                     </ul>
                                 </div>
                             </div>
-                            <div ng-show="compliance_metrics_error.length > 0" class="r-panel r-error r-margin-bottom-10">
-                                <ul class="r-list"><li ng-repeat="error in compliance_metrics_error">{$ error $}</li></ul>
+                            <div class="r-column">
+                                <div class="r-panel r-margin-bottom-10">
+                                    <div class="r-small-header">
+                                            <p class="r-small-header">Metric Type Settings</p>
+                                        </div>
+                                        <div class="r-panel r-info r-margin-top-10 r-margin-bottom-10">
+                                        The overall metric can be made up of an energy metric, an emission metric, or both. At least one type of metric is required and if two are defined, then both metrics must be met for compliance.
+                                        </div>
+                                    <div class="r-columns r-no-margin">
+                                        <ul class="r-list">
+                                            <li class="r-list-header" translate>Energy Metric</li>
+                                            <li class="r-row r-row-centered">
+                                                <label for="select-energy-metric-actual-column" class="r-no-wrap r-margin-right-5" translate>Actual Field</label>
+                                                <select id="select-energy-metric-actual-column" class="form-control" ng-model="selected_compliance_metric.actual_energy_column" ng-change="program_settings_changed()">
+                                                    <option value=""></option>
+                                                    <option ng-repeat="property_column in property_columns" ng-value="property_column.id">{$:: property_column.displayName $}</option>
+                                                </select>
+                                            </li>
+                                            <li class="r-row r-row-centered">
+                                                <label for="select-energy-metric-target-column" class="r-no-wrap r-margin-right-5" translate>Target Field</label>
+                                                <select id="select-energy-metric-target-column" class="form-control" ng-model="selected_compliance_metric.target_energy_column" ng-change="program_settings_changed()">
+                                                    <option value=""></option>
+                                                    <option ng-repeat="property_column in property_columns" ng-value="property_column.id">{$:: property_column.displayName $}</option>
+                                                </select>
+                                            </li>
+                                            <li class="r-row r-row-centered">
+                                                <label for="select-energy-metric-type" class="r-no-wrap r-margin-right-5" translate>Type</label>
+                                                <select id="select-energy-metric-type" class="form-control" ng-model="selected_compliance_metric.energy_metric_type" ng-change="program_settings_changed()">
+                                                    <option value=""></option>
+                                                    <option value="Target > Actual for Compliance" translatee>Target > Actual for Compliance</option>
+                                                    <option value="Target < Actual for Compliance" translatee>Target < Actual for Compliance</option>
+                                                </select>
+                                            </li>
+                                        </ul>
+                                        <ul class="r-list">
+                                            <li class="r-list-header" translate>Emission Metric</li>
+                                            <li class="r-row r-row-centered">
+                                                <label for="select-emission-metric-actual-column" class="r-no-wrap r-margin-right-5" translate>Actual Field</label>
+                                                <select id="select-emission-metric-actual-column" class="form-control" ng-model="selected_compliance_metric.actual_emission_column" ng-change="program_settings_changed()">
+                                                    <option value=""></option>
+                                                    <option ng-repeat="property_column in property_columns" ng-value="property_column.id">{$:: property_column.displayName $}</option>
+                                                </select>
+                                            </li>
+                                            <li class="r-row r-row-centered">
+                                                <label for="select-emission-metric-target-column" class="r-no-wrap r-margin-right-5" translate>Target Field</label>
+                                                <select id="select-emission-metric-target-column" class="form-control" ng-model="selected_compliance_metric.target_emission_column" ng-change="program_settings_changed()">
+                                                    <option value=""></option>
+                                                    <option ng-repeat="property_column in property_columns" ng-value="property_column.id">{$:: property_column.displayName $}</option>
+                                                </select>
+                                            </li>
+                                            <li class="r-row r-row-centered">
+                                                <label for="select-emission-metric-type" class="r-no-wrap r-margin-right-5" translate>Type</label>
+                                                <select id="select-emission-metric-type" class="form-control" ng-model="selected_compliance_metric.emission_metric_type" ng-change="program_settings_changed()">
+                                                    <option value=""></option>
+                                                    <option value="Target > Actual for Compliance" translate>Target > Actual for Compliance</option>
+                                                    <option value="Target < Actual for Compliance" translate>Target < Actual for Compliance</option>
+                                                </select>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div ng-show="compliance_metrics_error.length > 0" class="r-panel r-error r-margin-bottom-10">
+                                    <ul class="r-list"><li ng-repeat="error in compliance_metrics_error">{$ error $}</li></ul>
+                                </div>
                             </div>
-
-
                         </div>
-                    </div>
-                </div>
+                    </fieldset>
+                </form>
             </div>
     </div>
 

--- a/seed/static/seed/partials/program_setup.html
+++ b/seed/static/seed/partials/program_setup.html
@@ -88,7 +88,7 @@
                                                 <option ng-repeat="filter_group in filter_groups" ng-value="{$ filter_group.id $}">{$:: filter_group.name $}</option>
                                             </select>
                                         </li>
-                                    </ul>    
+                                    </ul>
                                 </div>
                                 <div class="r-panel">
                                     <div class="r-small-header">

--- a/seed/static/seed/partials/program_setup.html
+++ b/seed/static/seed/partials/program_setup.html
@@ -59,7 +59,7 @@
             </div>
             <div ng-show="selected_compliance_metric || !program_settings_not_changed" class="r-panel r-columns r-no-margin" disabled>
                 <form class="section_content">
-                    <fieldset ng-disabled="!auth.requires_owner">
+                    <fieldset ng-disabled="!auth.requires_member && !auth.requires_owner">
                         <div class="r-columns">
                             <div class="r-column">
                                 <div class="r-panel r-margin-bottom-10">

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -42,7 +42,7 @@
                 <li><a ui-sref="organization_email_templates({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Email Templates</a></li>
                 <li><a ui-sref="organization_labels({organization_id: menu.user.organization.id})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Labels</a></li>
                 <li><a ui-sref="organization_members({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Members</a></li>
-                <li><a ui-sref="programs({organization_id: menu.user.organization.id})" ng-if="menu.user.organization.is_parent && auth.requires_owner" ui-sref-active="active" translate>Program Setup</a></li>
+                <li><a ui-sref="programs({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Program Setup</a></li>
                 <li><a ui-sref="organization_settings({organization_id: menu.user.organization.id})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Settings</a></li>
                 <li><a ui-sref="organization_sharing({organization_id: menu.user.organization.id})" ng-if="menu.user.organization.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sharing</a></li>
                 <li><a ui-sref="organization_sub_orgs({organization_id: menu.user.organization.id})" ng-if="menu.user.organization.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sub-Organizations</a></li>

--- a/seed/views/v3/compliance_metrics.py
+++ b/seed/views/v3/compliance_metrics.py
@@ -32,7 +32,7 @@ class ComplianceMetricViewSet(viewsets.ViewSet, OrgMixin):
     @require_organization_id_class
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_viewer')
+    @has_perm_class('requires_owner')
     def list(self, request):
         organization_id = self.get_organization(request)
         compliance_metric_queryset = ComplianceMetric.objects.filter(organization=organization_id)
@@ -46,7 +46,7 @@ class ComplianceMetricViewSet(viewsets.ViewSet, OrgMixin):
     @require_organization_id_class
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_viewer')
+    @has_perm_class('requires_owner')
     def retrieve(self, request, pk=0):
         organization = self.get_organization(request)
         if pk == 0:
@@ -225,7 +225,7 @@ class ComplianceMetricViewSet(viewsets.ViewSet, OrgMixin):
     @require_organization_id_class
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_viewer')
+    @has_perm_class('requires_owner')
     @action(detail=True, methods=['GET'])
     def evaluate(self, request, pk):
         organization = self.get_organization(request)

--- a/seed/views/v3/compliance_metrics.py
+++ b/seed/views/v3/compliance_metrics.py
@@ -32,7 +32,7 @@ class ComplianceMetricViewSet(viewsets.ViewSet, OrgMixin):
     @require_organization_id_class
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_owner')
+    @has_perm_class('requires_viewer')
     def list(self, request):
         organization_id = self.get_organization(request)
         compliance_metric_queryset = ComplianceMetric.objects.filter(organization=organization_id)
@@ -46,7 +46,7 @@ class ComplianceMetricViewSet(viewsets.ViewSet, OrgMixin):
     @require_organization_id_class
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_owner')
+    @has_perm_class('requires_viewer')
     def retrieve(self, request, pk=0):
         organization = self.get_organization(request)
         if pk == 0:
@@ -80,7 +80,7 @@ class ComplianceMetricViewSet(viewsets.ViewSet, OrgMixin):
     @require_organization_id_class
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_owner')
+    @has_perm_class('requires_member')
     def destroy(self, request, pk):
         organization_id = self.get_organization(request)
 
@@ -118,7 +118,7 @@ class ComplianceMetricViewSet(viewsets.ViewSet, OrgMixin):
     @require_organization_id_class
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_owner')
+    @has_perm_class('requires_member')
     def create(self, request):
 
         org_id = int(self.get_organization(request))
@@ -177,7 +177,7 @@ class ComplianceMetricViewSet(viewsets.ViewSet, OrgMixin):
     @require_organization_id_class
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_owner')
+    @has_perm_class('requires_member')
     def update(self, request, pk):
         org_id = self.get_organization(request)
 
@@ -225,7 +225,7 @@ class ComplianceMetricViewSet(viewsets.ViewSet, OrgMixin):
     @require_organization_id_class
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_owner')
+    @has_perm_class('requires_viewer')
     @action(detail=True, methods=['GET'])
     def evaluate(self, request, pk):
         organization = self.get_organization(request)


### PR DESCRIPTION
#### Any background context you want to provide?
Users with viewer role could make changes to programs even though this wasn't the intended behavior.

#### What's this PR do?
It changes the api back end and front end to only allow members and owners to create, edit, and delete programs. Viewers can view the Program Setup page but the forms are disabled (i.e. no changes are allowed). Additionally, the Program Overview and Property Insights pages still work for viewers.

#### How should this be manually tested?
Create an user with the viewer role and make sure that you can view but not edit programs on program setup page. Additionally, make sure that program overview and property insights pages still are visible.

#### What are the relevant tickets?
Fixes #3691

#### Screenshots (if appropriate)
