### PR TITLE
Add bulk meter reading API for faster creation

### DIFF
--- a/seed/data_importer/utils.py
+++ b/seed/data_importer/utils.py
@@ -104,6 +104,11 @@ def kbtu_thermal_conversion_factors(country):
         factors['Coke']['MLbs. (million pounds)'] = 12399999.00
         factors['Coke']['Tonnes (metric)'] = 27338.67
         factors['Coke']['Tons'] = 24800.00
+        factors['Default']['GJ'] = 947.82
+        factors['Default']['Btu'] = 0.001
+        factors['Default']['kBtu (thousand Btu)'] = 1.00
+        factors['Default']['MBtu/MMBtu (million Btu)'] = 1000.00
+        factors['Default']['ton hours'] = 12.00
         factors['Diesel']['Gallons (UK)'] = 165.73
         factors['Diesel']['Gallons (US)'] = 138.00
         factors['Diesel']['GJ'] = 947.82
@@ -277,6 +282,11 @@ def kbtu_thermal_conversion_factors(country):
         factors['Coke']['MLbs. (million pounds)'] = 12394875.00
         factors['Coke']['Tonnes (metric)'] = 27325.56
         factors['Coke']['Tons'] = 24789.75
+        factors['Default']['GJ'] = 947.82
+        factors['Default']['Btu'] = 0.001
+        factors['Default']['kBtu (thousand Btu)'] = 1.00
+        factors['Default']['MBtu/MMBtu (million Btu)'] = 1000.00
+        factors['Default']['ton hours'] = 12.00
         factors['Diesel']['Gallons (UK)'] = 165.03
         factors['Diesel']['Gallons (US)'] = 137.42
         factors['Diesel']['GJ'] = 947.82

--- a/seed/lib/superperms/orgs/models.py
+++ b/seed/lib/superperms/orgs/models.py
@@ -47,6 +47,7 @@ def _get_default_display_meter_units():
         'Coal (bituminous)': 'kBtu (thousand Btu)',
         'Coke': 'kBtu (thousand Btu)',
         'Diesel': 'kBtu (thousand Btu)',
+        'District Chilled Water': 'kBtu (thousand Btu)',
         'District Chilled Water - Absorption': 'kBtu (thousand Btu)',
         'District Chilled Water - Electric': 'kBtu (thousand Btu)',
         'District Chilled Water - Engine': 'kBtu (thousand Btu)',
@@ -65,7 +66,8 @@ def _get_default_display_meter_units():
         'Natural Gas': 'kBtu (thousand Btu)',
         'Other:': 'kBtu (thousand Btu)',
         'Propane': 'kBtu (thousand Btu)',
-        'Wood': 'kBtu (thousand Btu)'
+        'Wood': 'kBtu (thousand Btu)',
+        'Default': 'kBtu (thousand Btu)',
     }
 
 
@@ -145,6 +147,7 @@ class Organization(models.Model):
         'Coal (bituminous)': 'kBtu (thousand Btu)',
         'Coke': 'kBtu (thousand Btu)',
         'Diesel': 'kBtu (thousand Btu)',
+        'District Chilled Water': 'kBtu (thousand Btu)',
         'District Chilled Water - Absorption': 'kBtu (thousand Btu)',
         'District Chilled Water - Electric': 'kBtu (thousand Btu)',
         'District Chilled Water - Engine': 'kBtu (thousand Btu)',
@@ -163,7 +166,8 @@ class Organization(models.Model):
         'Natural Gas': 'kBtu (thousand Btu)',
         'Other:': 'kBtu (thousand Btu)',
         'Propane': 'kBtu (thousand Btu)',
-        'Wood': 'kBtu (thousand Btu)'
+        'Wood': 'kBtu (thousand Btu)',
+        'Default': 'kBtu (thousand Btu)',
     }
 
     class Meta:

--- a/seed/lib/superperms/orgs/permissions.py
+++ b/seed/lib/superperms/orgs/permissions.py
@@ -10,6 +10,8 @@ All rights reserved.
 Provides permissions classes for use in DRF views and viewsets to control
 access based on Organization and OrganizationUser.role_level.
 """
+from typing import Union
+
 from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from rest_framework.exceptions import PermissionDenied
@@ -37,12 +39,16 @@ def is_authenticated(user):
     return user.is_authenticated
 
 
-def get_org_or_id(dictlike):
+def get_org_or_id(dictlike: dict) -> Union[int, None]:
     """Get value of organization or organization_id"""
     # while documentation should encourage the use of one consistent key choice
     # for supplying an organization to query_params, we check all reasonable
     # permutations of organization id.
     org_query_strings = ['organization', 'organization_id', 'org_id', 'org']
+    if isinstance(dictlike, list):
+        return None
+
+    # Check if there are any assigned organization values
     org_id = None
     for org_str in org_query_strings:
         org_id = dictlike.get(org_str)

--- a/seed/serializers/meter_readings.py
+++ b/seed/serializers/meter_readings.py
@@ -46,10 +46,6 @@ class MeterReadingBulkCreateUpdateSerializer(serializers.ListSerializer):
 
 
 class MeterReadingSerializer(serializers.ModelSerializer):
-    def to_internal_value(self, data):
-        print(data)
-        return data
-
     def create(self, validated_data):
         instance = MeterReading(**validated_data)
 

--- a/seed/serializers/meter_readings.py
+++ b/seed/serializers/meter_readings.py
@@ -4,20 +4,41 @@
 :copyright (c) 2014 - 2022, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.
 :author
 """
+import dateutil.parser
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
+from django.utils.timezone import make_aware
+from pytz import timezone
 from rest_framework import serializers
 
+from config.settings.common import TIME_ZONE
 from seed.models import MeterReading
+
+# import logging
+# _log = logging.getLogger(__name__)
 
 
 class MeterReadingBulkCreateUpdateSerializer(serializers.ListSerializer):
+    def to_internal_value(self, data):
+        for datum in data:
+            datum['start_time'] = make_aware(dateutil.parser.parse(
+                datum['start_time']), timezone=timezone(TIME_ZONE))
+            datum['end_time'] = make_aware(dateutil.parser.parse(
+                datum['end_time']), timezone=timezone(TIME_ZONE))
+        return data
+
     def create(self, validated_data):
-        print(validated_data)
         meter_data = [MeterReading(**item) for item in validated_data]
 
         try:
-            result = MeterReading.objects.bulk_create(meter_data)
+            # Presently update_conflicts are not supported in Django 3.x.
+            # An older github patch has happened, but we need to evaluate
+            # it: https://github.com/martinphellwig/django-query-signals/commit/a3ed59614287f1ef9e7398d325a8bbcc11bf0b3c.
+            # For now, if there is a conflict with the date/times, then it will
+            # ignore the conflict and not update the reading values.
+            #   update_conflicts=True,
+            #   update_fields=['reading', 'source_unit', 'conversion_factor'],
+            result = MeterReading.objects.bulk_create(meter_data, ignore_conflicts=True)
         except IntegrityError as e:
             raise ValidationError(e)
 
@@ -25,6 +46,10 @@ class MeterReadingBulkCreateUpdateSerializer(serializers.ListSerializer):
 
 
 class MeterReadingSerializer(serializers.ModelSerializer):
+    def to_internal_value(self, data):
+        print(data)
+        return data
+
     def create(self, validated_data):
         instance = MeterReading(**validated_data)
 

--- a/seed/serializers/meter_readings.py
+++ b/seed/serializers/meter_readings.py
@@ -46,6 +46,13 @@ class MeterReadingBulkCreateUpdateSerializer(serializers.ListSerializer):
 
 
 class MeterReadingSerializer(serializers.ModelSerializer):
+    def to_internal_value(self, data):
+        data['start_time'] = make_aware(dateutil.parser.parse(
+            data['start_time']), timezone=timezone(TIME_ZONE))
+        data['end_time'] = make_aware(dateutil.parser.parse(
+            data['end_time']), timezone=timezone(TIME_ZONE))
+        return data
+
     def create(self, validated_data):
         instance = MeterReading(**validated_data)
 

--- a/seed/tests/test_meter_views.py
+++ b/seed/tests/test_meter_views.py
@@ -177,7 +177,7 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         response = self.client.post(url, data=json.dumps(payload), content_type='application/json')
         meter_pk = response.json()['id']
 
-        # create meter reading  property-meter-readings-list
+        # create meter readings
         url = reverse('api:v3:property-meter-readings-list', kwargs={'property_pk': property_view.id, 'meter_pk': meter_pk})
 
         # write a few values to the database
@@ -196,6 +196,47 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
             response = self.client.post(url, data=json.dumps(payload), content_type='application/json')
             self.assertEqual(response.status_code, 201)
             self.assertEqual(response.json()['reading'], values[2])
+
+        # read all the values from the meter and check the results
+        response = self.client.get(url, content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 3)
+
+    def test_bulk_import(self):
+        # create property
+        property_view = self.property_view_factory.get_property_view()
+        url = reverse('api:v3:property-meters-list', kwargs={'property_pk': property_view.id})
+
+        payload = {
+            'type': 'Electric',
+            'source': 'Manual Entry',
+            'source_id': '1234567890',
+        }
+
+        response = self.client.post(url, data=json.dumps(payload), content_type='application/json')
+        meter_pk = response.json()['id']
+
+        url = reverse('api:v3:property-meter-readings-list', kwargs={'property_pk': property_view.id, 'meter_pk': meter_pk})
+
+        # prepare the data in bulk format
+        payload = []
+        for values in [("2022-01-05T05:00:00Z", "2022-01-05T06:00:00Z", 22.2),
+                       ("2022-01-05T06:00:00Z", "2022-01-05T07:00:00Z", 44.4),
+                       ("2022-01-05T07:00:00Z", "2022-01-05T08:00:00Z", 88.8), ]:
+            payload.append({
+                "start_time": values[0],
+                "end_time": values[1],
+                "reading": values[2],
+                "source_unit": "Wh (Watt-hours)",
+                # conversion factor is required and is the conversion from the source unit to kBTU (1 Wh = 0.00341 kBtu)
+                "conversion_factor": 0.00341,
+            })
+
+        response = self.client.post(url, data=json.dumps(payload), content_type='application/json')
+        print(response)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()[0]['reading'], 22.2)
+        self.assertEqual(response.json()[1]['reading'], 44.4)
 
         # read all the values from the meter and check the results
         response = self.client.get(url, content_type='application/json')

--- a/seed/tests/test_meter_views.py
+++ b/seed/tests/test_meter_views.py
@@ -181,9 +181,9 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         url = reverse('api:v3:property-meter-readings-list', kwargs={'property_pk': property_view.id, 'meter_pk': meter_pk})
 
         # write a few values to the database
-        for values in [("2022-01-05T05:00:00Z", "2022-01-05T06:00:00Z", 6.0),
-                       ("2022-01-05T06:00:00Z", "2022-01-05T07:00:00Z", 12.0),
-                       ("2022-01-05T07:00:00Z", "2022-01-05T08:00:00Z", 18.0), ]:
+        for values in [("2022-01-05 05:00:00", "2022-01-05 06:00:00", 6.0),
+                       ("2022-01-05 06:00:00", "2022-01-05 07:00:00", 12.0),
+                       ("2022-01-05 07:00:00", "2022-01-05 08:00:00", 18.0), ]:
             payload = {
                 "start_time": values[0],
                 "end_time": values[1],
@@ -220,9 +220,9 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
 
         # prepare the data in bulk format
         payload = []
-        for values in [("2022-01-05T05:00:00Z", "2022-01-05T06:00:00Z", 22.2),
-                       ("2022-01-05T06:00:00Z", "2022-01-05T07:00:00Z", 44.4),
-                       ("2022-01-05T07:00:00Z", "2022-01-05T08:00:00Z", 88.8), ]:
+        for values in [("2022-01-05 05:00:00", "2022-01-05 06:00:00", 22.2),
+                       ("2022-01-05 06:00:00", "2022-01-05 07:00:00", 44.4),
+                       ("2022-01-05 07:00:00", "2022-01-05 08:00:00", 88.8), ]:
             payload.append({
                 "start_time": values[0],
                 "end_time": values[1],
@@ -261,8 +261,8 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         url = reverse('api:v3:property-meter-readings-list', kwargs={'property_pk': property_view.id, 'meter_pk': meter_pk})
 
         payload = {
-            "start_time": "2022-01-05T05:00:00Z",
-            "end_time": "2022-01-05T06:00:00Z",
+            "start_time": "2022-01-05 05:00:00",
+            "end_time": "2022-01-05 06:00:00",
             "reading": 10,
             "source_unit": "kBtu (Thousand BTU)",
             # conversion factor is required and is the conversion from the source unit to kBTU (1 Wh = 0.00341 kBtu)
@@ -274,7 +274,7 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         self.assertEqual(response.json()['reading'], 10)
 
         # now delete the item and verify that there are no more readings in the database
-        detail_url = reverse('api:v3:property-meter-readings-detail', kwargs={'property_pk': property_view.id, 'meter_pk': meter_pk, 'pk': '2022-01-05T05:00:00Z'})
+        detail_url = reverse('api:v3:property-meter-readings-detail', kwargs={'property_pk': property_view.id, 'meter_pk': meter_pk, 'pk': '2022-01-05 05:00:00'})
         response = self.client.get(detail_url, content_type='application/json')
         self.assertEqual(response.status_code, 200)
 

--- a/seed/utils/meters.py
+++ b/seed/utils/meters.py
@@ -230,8 +230,12 @@ class PropertyMeterReadingsExporter():
             display_unit = "{} Dollars".format(self._org_country)
             conversion_factor = 1.00
         else:
-            display_unit = self.org_meter_display_settings[type_text]
-            conversion_factor = self.factors[type_text][display_unit]
+            if type_text in self.org_meter_display_settings:
+                display_unit = self.org_meter_display_settings[type_text]
+                conversion_factor = self.factors[type_text][display_unit]
+            else:
+                display_unit = self.org_meter_display_settings['Default']
+                conversion_factor = self.factors['Default'][display_unit]
 
         column_defs[field_name] = {
             'field': field_name,

--- a/seed/views/v3/meter_readings.py
+++ b/seed/views/v3/meter_readings.py
@@ -6,10 +6,10 @@ from rest_framework.renderers import JSONRenderer
 
 from seed.models import MeterReading, PropertyView
 from seed.serializers.meter_readings import MeterReadingSerializer
-from seed.utils.viewsets import SEEDOrgNoPatchOrOrgCreateModelViewSet
+from seed.utils.viewsets import SEEDOrgModelViewSet
 
 
-class MeterReadingViewSet(SEEDOrgNoPatchOrOrgCreateModelViewSet):
+class MeterReadingViewSet(SEEDOrgModelViewSet):
     """API endpoint for managing meters."""
 
     serializer_class = MeterReadingSerializer
@@ -43,6 +43,12 @@ class MeterReadingViewSet(SEEDOrgNoPatchOrOrgCreateModelViewSet):
         return MeterReading.objects.filter(
             meter__property__organization_id=org_id, meter__property=self.property_pk, meter_id=meter_pk
         )
+
+    def get_serializer(self, *args, **kwargs):
+        if isinstance(kwargs.get("data", {}), list):
+            kwargs["many"] = True
+
+        return super(MeterReadingViewSet, self).get_serializer(*args, **kwargs)
 
     def perform_create(self, serializer):
         """On create, make sure to add in the property id which comes from the URL kwargs."""


### PR DESCRIPTION
#### Any background context you want to provide?
Meter readers only supported one-at-a-time style import.

#### What's this PR do?
* Add in a Bulk Meter Reading Create

#### How should this be manually tested?
* Should be tested in part of the Meter Viewset PR
* API only updates

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
