### PR TITLE
Mark icebox-labeled issues as stale after 180 days

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -11,6 +11,6 @@ jobs:
       - name: Verify PR label action
         uses: mheap/github-action-required-labels@v1
         with:
-          mode: exactly
+          mode: minimum
           count: 1
           labels: "Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish"

--- a/.github/workflows/stale-ice-box.yml
+++ b/.github/workflows/stale-ice-box.yml
@@ -1,0 +1,19 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/stale@v4
+        with:
+          days-before-stale: 180
+          any-of-labels: Icebox
+          stale-issue-message: "This issue has been automatically marked as stale because it has been in the icebox for more than 180 days. It will be closed if no further activity occurs. Thank you for your contributions."
+          close-issue-message: "This issue has been in the icebox for over 180 days and has been closed automatically. If this still affects you please re-open this issue with a comment or contact us so we can look into resolving it."
+          exempt-all-milestones: true
+          operations-per-run: 500

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
+          days-before-stale: 60
           stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity within 60 days. It will be closed if no further activity occurs. Thank you for your contributions."
           close-issue-message: "This issue has been closed automatically. If this still affects you please re-open this issue with a comment or contact us so we can look into resolving it."
           exempt-all-milestones: true


### PR DESCRIPTION
#### Any background context you want to provide?
Developers only -- issues that are labeled icebox will be marked stale after 180 days.
