### PR TITLE
Catch create column error correctly

### DIFF
--- a/seed/static/seed/js/controllers/create_column_modal_controller.js
+++ b/seed/static/seed/js/controllers/create_column_modal_controller.js
@@ -37,7 +37,7 @@ angular.module('BE.seed.controller.create_column_modal', [])
         then(() => {
           $uibModalInstance.close();
           $state.reload();
-        }).error((err) => {
+        }).catch((err) => {
           Notification.error('error: ' + err);
         }).finally(() => {
           spinner_utility.hide()


### PR DESCRIPTION
#### Any background context you want to provide?
@axelstudios this'll give us a actual error message, but is there a way to figure out what the error underneath is before this hits dev1? locally, I get no errors. 

#### What's this PR do?

#### How should this be manually tested?

#### What are the relevant tickets?
[Column Settings: getting 520 error when making a new column but column is created#3780](https://github.com/SEED-platform/seed/issues/3780)

#### Screenshots (if appropriate)
<img width="1485" alt="image" src="https://user-images.githubusercontent.com/30241543/214693281-2f8f630e-3e47-43cf-966f-035c5191beae.png">

