### PR TITLE
Show all navs in org

### DIFF
--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -1150,7 +1150,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           }],
           auth_payload: ['auth_service', '$stateParams', '$q', function (auth_service, $stateParams, $q) {
             var organization_id = $stateParams.organization_id;
-            return auth_service.is_authorized(organization_id, ['requires_viewer'])
+            return auth_service.is_authorized(organization_id, ['requires_viewer', 'requires_owner'])
               .then(function (data) {
                 if (data.auth.requires_viewer) {
                   return data;
@@ -1191,7 +1191,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           }],
           auth_payload: ['auth_service', '$stateParams', '$q', function (auth_service, $stateParams, $q) {
             var organization_id = $stateParams.organization_id;
-            return auth_service.is_authorized(organization_id, ['requires_viewer'])
+            return auth_service.is_authorized(organization_id, ['requires_viewer', 'requires_owner'])
               .then(function (data) {
                 if (data.auth.requires_viewer) {
                   return data;


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
the nav of the org pages needs `auth.owner_requried`, which not every controller had. Now it does.

#### How should this be manually tested?
go to the org page and click around. 

#### What are the relevant tickets?
 Organization: Not all links appear at the top on all screens #3808 

#### Screenshots (if appropriate)
before:
![image](https://user-images.githubusercontent.com/30241543/215588487-9294a898-c59d-4279-a6c9-8049b8e6012e.png)

after:
<img width="1493" alt="image" src="https://user-images.githubusercontent.com/30241543/215588437-46edb5df-4200-46e5-b4ee-b07c12987bac.png">
