### PR TITLE
Remove add column in mapping page

### DIFF
--- a/seed/static/seed/partials/column_mappings.html
+++ b/seed/static/seed/partials/column_mappings.html
@@ -181,9 +181,6 @@
                   </tbody>
               </table>
             </div>
-            <button class="btn btn-success" type="button" ng-click="add_new_column()" ng-disabled="!profiles.length" tooltip-placement="bottom" uib-tooltip="New" ng-hide="!profile_action_ok('add_new_column')" translate>
-                Add Column
-            </button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
I didn't remove the function `add_new_column` cause it's used in `copy_csv_headers`. idk if _that_ function works, but that's not what this ticket is about. 🤷 

#### How should this be manually tested?

#### What are the relevant tickets?
[Organization: Column Mapping: What does Add Column do?#3809](https://github.com/SEED-platform/seed/issues/3809)
#### Screenshots (if appropriate)
