### PR TITLE
Add more logging to the exception when a property state is missing an audit log

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->
+
 #### Any background context you want to provide?
 
 #### What's this PR do?

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - debug-auditlog
     tags:
       - "*"
   workflow_dispatch:
@@ -43,6 +44,8 @@ jobs:
           if [[ ${GITHUB_EVENT_NAME} == "push" ]]; then
             if [[ "${GITHUB_REF}" == "refs/heads/develop" ]]; then
               SEED_TAG=seedplatform/seed:develop
+            elif [[ "${GITHUB_REF}" == "refs/heads/debug-auditlog" ]]; then
+              SEED_TAG=seedplatform/seed:debug-auditlog
             elif [[ "${GITHUB_REF}" =~ "refs/tags/v" ]]; then
               # you can have multiple tags, separated by commas
               SEED_TAG=seedplatform/seed:${GITHUB_REF#refs/tags/v},seedplatform/seed:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - debug-auditlog
     tags:
       - "*"
   workflow_dispatch:
@@ -44,8 +43,6 @@ jobs:
           if [[ ${GITHUB_EVENT_NAME} == "push" ]]; then
             if [[ "${GITHUB_REF}" == "refs/heads/develop" ]]; then
               SEED_TAG=seedplatform/seed:develop
-            elif [[ "${GITHUB_REF}" == "refs/heads/debug-auditlog" ]]; then
-              SEED_TAG=seedplatform/seed:debug-auditlog
             elif [[ "${GITHUB_REF}" =~ "refs/tags/v" ]]; then
               # you can have multiple tags, separated by commas
               SEED_TAG=seedplatform/seed:${GITHUB_REF#refs/tags/v},seedplatform/seed:latest

--- a/config/urls.py
+++ b/config/urls.py
@@ -35,6 +35,10 @@ schema_view = get_schema_view(
     permission_classes=(permissions.AllowAny,),
 )
 
+def trigger_error(request):
+    """Endpoint for testing sentry with a divide by zero"""
+    1 / 0
+
 urlpatterns = [
     re_path(r'^accounts/password/reset/done/$', password_reset_done, name='password_reset_done'),
     re_path(
@@ -61,16 +65,14 @@ urlpatterns = [
     re_path(r'^api/swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     re_path(r'^api/version/$', version, name='version'),
     re_path(r'^api/', include((api, "seed"), namespace='api')),
-    re_path(r'^oauth/', include(('oauth2_jwt_provider.urls', 'oauth2_jwt_provider'), namespace='oauth2_provider'))
+    re_path(r'^oauth/', include(('oauth2_jwt_provider.urls', 'oauth2_jwt_provider'), namespace='oauth2_provider')),
+
+    # test sentry error
+    path('sentry-debug/', trigger_error)
 ]
 
 handler404 = 'seed.views.main.error404'
 handler500 = 'seed.views.main.error500'
-
-
-def trigger_error(request):
-    """Endpoint for testing sentry with a divide by zero"""
-    1 / 0
 
 
 if settings.DEBUG:
@@ -85,8 +87,5 @@ if settings.DEBUG:
         re_path(r'^angular_js_tests/$', angular_js_tests, name='angular_js_tests'),
 
         # admin
-        re_path(r'^admin/', admin.site.urls),
-
-        # test sentry error
-        path('sentry-debug/', trigger_error)
+        re_path(r'^admin/', admin.site.urls),        
     ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -35,9 +35,11 @@ schema_view = get_schema_view(
     permission_classes=(permissions.AllowAny,),
 )
 
+
 def trigger_error(request):
     """Endpoint for testing sentry with a divide by zero"""
     1 / 0
+
 
 urlpatterns = [
     re_path(r'^accounts/password/reset/done/$', password_reset_done, name='password_reset_done'),
@@ -87,5 +89,5 @@ if settings.DEBUG:
         re_path(r'^angular_js_tests/$', angular_js_tests, name='angular_js_tests'),
 
         # admin
-        re_path(r'^admin/', admin.site.urls),        
+        re_path(r'^admin/', admin.site.urls),
     ]

--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -519,6 +519,16 @@ def save_state_match(state1, state2, priorities):
 
     AuditLogClass = PropertyAuditLog if isinstance(merged_state, PropertyState) else TaxLotAuditLog
 
+    if AuditLogClass.objects.filter(state=state1).count() == 0:
+        # If there is no audit log for state1, then there is an error!
+        # get the info of the object that is causing the issue
+        raise Exception(f'No audit log for merging of (base) state: {state1.__dict__}')
+
+    if AuditLogClass.objects.filter(state=state2).count() == 0:
+        # If there is no audit log for state1, then there is an error!
+        # get the info of the object that is causing the issue
+        raise Exception(f'No audit log for merging of (incoming) state: {state2.__dict__}')
+
     assert AuditLogClass.objects.filter(state=state1).count() >= 1
     assert AuditLogClass.objects.filter(state=state2).count() >= 1
 

--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -522,15 +522,12 @@ def save_state_match(state1, state2, priorities):
     if AuditLogClass.objects.filter(state=state1).count() == 0:
         # If there is no audit log for state1, then there is an error!
         # get the info of the object that is causing the issue
-        raise Exception(f'No audit log for merging of (base) state: {state1.__dict__}')
+        raise Exception(f'No audit log for merging of (base) state. Base {state1.id}, Incoming {state2.id}')
 
     if AuditLogClass.objects.filter(state=state2).count() == 0:
         # If there is no audit log for state1, then there is an error!
         # get the info of the object that is causing the issue
-        raise Exception(f'No audit log for merging of (incoming) state: {state2.__dict__}')
-
-    assert AuditLogClass.objects.filter(state=state1).count() >= 1
-    assert AuditLogClass.objects.filter(state=state2).count() >= 1
+        raise Exception(f'No audit log for merging of (incoming) state. Base {state1.id}, Incoming {state2.id}')
 
     # NJACHECK - is this logic correct?
     state_1_audit_log = AuditLogClass.objects.filter(state=state1).first()


### PR DESCRIPTION
#### Any background context you want to provide?
SEED requires that a property state includes at least one audit log when completing a merge. SEED had code in the merging logic which simply called `assert` and for the first time that we know of, this assertion was called.

#### What's this PR do?
* add more information to the exception so that we can track down the state id's of the records that do not have audit logs
* move sentry-debug out of debug urls to allow for sentry testing.

#### How should this be manually tested?
n/a

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
