### PR TITLE
Sort the dropdown of meter units

### DIFF
--- a/seed/views/v3/organizations.py
+++ b/seed/views/v3/organizations.py
@@ -142,7 +142,7 @@ def _dict_org(request, organizations):
             'better_host_url': settings.BETTER_HOST,
             'property_display_field': o.property_display_field,
             'taxlot_display_field': o.taxlot_display_field,
-            'display_meter_units': o.display_meter_units,
+            'display_meter_units': dict(sorted(o.display_meter_units.items(), key=lambda item: (item[0], item[1]))),
             'thermal_conversion_assumption': o.thermal_conversion_assumption,
             'comstock_enabled': o.comstock_enabled,
             'new_user_email_from': o.new_user_email_from,


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### Any background context you want to provide?
In a user's settings page, the list of meter units can be pretty long and as new meters are added, the order of the list needs to be sorted.

#### What's this PR do?
* sort the backend/django return of the org data's meter unit display 

#### How should this be manually tested?
* go to an org
* select setting -> units
* Look at the meter energy units drop down and make sure the values are sorted.



#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
Before:
<img width="419" alt="image" src="https://user-images.githubusercontent.com/1907354/216670536-5ac2269e-fec9-494d-a4fe-0e1425699ad6.png">


After:
<img width="623" alt="image" src="https://user-images.githubusercontent.com/1907354/216669965-82e3a9fd-9ba3-4d88-a5cd-ab3d6c8ef6bb.png">

