### PR TITLE
Change "Program Configuration" to "Program Setup"

### DIFF
--- a/seed/static/seed/js/controllers/program_setup_controller.js
+++ b/seed/static/seed/js/controllers/program_setup_controller.js
@@ -186,7 +186,7 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
       // display messages
           setTimeout(() => {
             Notification.primary({message: '<a href="#/insights" style="color: #337ab7;">Click here to view your Program Overview</a>', delay: 5000});
-            Notification.success({message: 'Program Metric Configuration Saved!', delay: 5000});
+            Notification.success({message: 'Program Setup Saved!', delay: 5000});
           }, 1000);
       $scope.program_settings_not_changed = true;
       spinner_utility.hide();

--- a/seed/static/seed/partials/program_setup.html
+++ b/seed/static/seed/partials/program_setup.html
@@ -20,7 +20,7 @@
     <div class="section_header_container">
         <div class="section_header has_no_padding fixed_height_short">
             <div class="section_action_container left">
-                <h2><i class="fa fa-tachometer"></i> {$:: 'Program Configuration' | translate $}</h2>
+                <h2><i class="fa fa-tachometer"></i> {$:: 'Program Setup' | translate $}</h2>
             </div>
             <div ng-show="selected_compliance_metric && (auth.requires_owner || auth.requires_member)" class="section_action_container right_40 section_action_btn pull-right">
                 <button class="btn btn-info r-margin-right-5" ng-click="click_delete()" translate>Delete</button>


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### Any background context you want to provide?
The Program Setup page in the organization settings used a heading of "Program Configuration" at the top of the page. Where as all of the other organization settings pages had the header consistent with the name of the page.

#### What's this PR do?
Revise Program Configuration to be Program Setup.

#### How should this be manually tested?
Load the Program Setup page and make sure that the header has been revised as indicated.

#### What are the relevant tickets?
#3831 
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/6326294/217080781-e5fdf54c-969c-46f9-91be-28fd50b85b49.png)