### PR TITLE
Get audit date and audit date type from buildingsync files

### DIFF
--- a/seed/building_sync/building_sync.py
+++ b/seed/building_sync/building_sync.py
@@ -9,6 +9,7 @@ import copy
 import logging
 import os
 import re
+from datetime import datetime
 from io import BytesIO, StringIO
 
 import xmlschema
@@ -356,6 +357,11 @@ class BuildingSync(object):
 
             scenarios.append(seed_scenario)
 
+        # get most recent audit date
+        audit_dates = result["audit_dates"]
+        audit_dates.sort(key=lambda x: datetime.strptime(x["date"], "%Y-%m-%d"))
+        most_recent_audit_date = {} if len(audit_dates) == 0 else audit_dates[-1]
+
         property_ = result['property']
         res = {
             'measures': measures,
@@ -378,6 +384,8 @@ class BuildingSync(object):
             'net_floor_area': property_['net_floor_area'],
             'footprint_floor_area': property_['footprint_floor_area'],
             'audit_template_building_id': property_['audit_template_building_id'],
+            'audit_date': most_recent_audit_date.get("date"),
+            'audit_date_type': most_recent_audit_date.get("custom_date_type"),
         }
 
         return res

--- a/seed/building_sync/mappings.py
+++ b/seed/building_sync/mappings.py
@@ -707,6 +707,27 @@ BASE_MAPPING_V2 = {
             }
         }
     },
+    'audit_dates': {
+        'xpath': '/auc:BuildingSync/auc:Facilities/auc:Facility/auc:Reports/auc:Report/auc:AuditDates/auc:AuditDate',
+        'type': 'list',
+        'items': {
+            "date": {
+                'xpath': './auc:Date',
+                'type': 'value',
+                'value': 'text',
+            },
+            "date_type": {
+                'xpath': './auc:DateType',
+                'type': 'value',
+                'value': 'text',
+            },
+            "custom_date_type": {
+                'xpath': './auc:CustomDateType',
+                'type': 'value',
+                'value': 'text',
+            },
+        }
+    },
     'scenarios': {
         'xpath': '/auc:BuildingSync/auc:Facilities/auc:Facility/auc:Reports/auc:Report/auc:Scenarios/auc:Scenario',
         'type': 'list',

--- a/seed/building_sync/tests/test_buildingsync.py
+++ b/seed/building_sync/tests/test_buildingsync.py
@@ -51,6 +51,8 @@ class TestBuildingFiles(TestCase):
         self.assertTrue(status)
         self.assertEqual(property_state.address_line_1, '123 Main St')
         self.assertEqual(property_state.property_type, 'Office')
+        self.assertEqual(property_state.extra_data.get("audit_date"), None)
+        self.assertEqual(property_state.extra_data.get("audit_date_type"), None)
         self.assertEqual(messages, {'errors': [], 'warnings': []})
 
     def test_buildingsync_constructor_diff_ns(self):
@@ -125,6 +127,8 @@ class TestBuildingFiles(TestCase):
         status, property_state, property_view, messages = bf.process(self.org.id, self.org.cycles.first())
         self.assertTrue(status, f'Expected process() to succeed; messages: {messages}')
         self.assertEqual(property_state.address_line_1, '123 Example Street')
+        self.assertEqual(property_state.extra_data.get("audit_date"), "2019-07-01")
+        self.assertEqual(property_state.extra_data.get("audit_date_type"), "Level 2: Energy Survey and Analysis")
         self.assertEqual(messages['errors'], [])
 
         # we expect warnings indicating skipped scenarios and meters


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### Any background context you want to provide?

#### What's this PR do?

#### How should this be manually tested?
upload a buildingsync file and see the new columns.

#### What are the relevant tickets?
https://github.com/SEED-platform/seed/issues/3774

#### Screenshots (if appropriate)
