### PR TITLE
Fix Nginx Security

### DIFF
--- a/docker/nginx-seed.conf
+++ b/docker/nginx-seed.conf
@@ -102,6 +102,8 @@ http {
     # Includes virtual hosts configs.
     # include /etc/nginx/http.d/*.conf;
 
+    add_header Referrer-Policy 'same-origin';
+
     # https://gist.github.com/plentz/6737338
     # config to disallow the browser to render the page inside a frame or iframe
     # and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
@@ -125,6 +127,47 @@ http {
 
     # HSTS
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+
+    # Content Security Policy (CSP)
+    # https://www.html5rocks.com/en/tutorials/security/content-security-policy/
+    # https://www.owasp.org/index.php/Content_Security_Policy
+    # https://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
+    set $DEFAULT "default-src 'self'";
+
+    set $SCRIPT "script-src 'self' 'unsafe-inline' 'unsafe-eval'";
+    set $SCRIPT "${SCRIPT} https://better-lbnl-development.herokuapp.com";
+    set $SCRIPT "${SCRIPT} https://better.lbl.gov";
+    set $SCRIPT "${SCRIPT} https://cdn.jsdelivr.net";
+    set $SCRIPT "${SCRIPT} https://cdn.plot.ly";
+    set $SCRIPT "${SCRIPT} https://cdnjs.cloudflare.com";
+    set $SCRIPT "${SCRIPT} https://code.jquery.com";
+    set $SCRIPT "${SCRIPT} https://stackpath.bootstrapcdn.com";
+    set $SCRIPT "${SCRIPT} https://www.google.com/recaptcha/";
+    set $SCRIPT "${SCRIPT} https://www.gstatic.com/recaptcha/";
+
+    set $STYLE "style-src 'self' 'unsafe-inline'";
+    set $STYLE "${STYLE} https://cdn.jsdelivr.net";
+    set $STYLE "${STYLE} https://cdnjs.cloudflare.com";
+    set $STYLE "${STYLE} https://maxcdn.bootstrapcdn.com";
+    set $STYLE "${STYLE} https://stackpath.bootstrapcdn.com";
+
+    set $FONT "font-src 'self' 'unsafe-inline'";
+    set $FONT "${FONT} https://cdnjs.cloudflare.com";
+    set $FONT "${FONT} https://maxcdn.bootstrapcdn.com";
+
+    set $FRAME "frame-src 'self'";
+    set $FRAME "${FRAME} https://recaptcha.google.com/recaptcha/";
+    set $FRAME "${FRAME} https://www.google.com/recaptcha/";
+
+    set $IMG "img-src 'self' data:";
+    set $IMG "${IMG} https://*.a.ssl.fastly.net";
+    set $IMG "${IMG} https://better-lbnl-development.herokuapp.com";
+    set $IMG "${IMG} https://better.lbl.gov";
+    set $IMG "${IMG} https://validator.swagger.io";
+
+    set $OBJECT "object-src 'none'";
+
+    add_header Content-Security-Policy "${DEFAULT}; ${SCRIPT}; ${STYLE}; ${FONT}; ${FRAME}; ${IMG}; ${OBJECT}";
 
     # the upstream component nginx needs to connect to
     upstream seed_upstream {
@@ -150,47 +193,6 @@ http {
 
         # max upload size
         client_max_body_size 75M;   # adjust to taste
-
-        # Content Security Policy (CSP)
-        # https://www.html5rocks.com/en/tutorials/security/content-security-policy/
-        # https://www.owasp.org/index.php/Content_Security_Policy
-        # https://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
-        set $DEFAULT "default-src 'self'";
-
-        set $SCRIPT "script-src 'self' 'unsafe-inline' 'unsafe-eval'";
-        set $SCRIPT "${SCRIPT} https://better-lbnl-development.herokuapp.com";
-        set $SCRIPT "${SCRIPT} https://better.lbl.gov";
-        set $SCRIPT "${SCRIPT} https://cdn.jsdelivr.net";
-        set $SCRIPT "${SCRIPT} https://cdn.plot.ly";
-        set $SCRIPT "${SCRIPT} https://cdnjs.cloudflare.com";
-        set $SCRIPT "${SCRIPT} https://code.jquery.com";
-        set $SCRIPT "${SCRIPT} https://stackpath.bootstrapcdn.com";
-        set $SCRIPT "${SCRIPT} https://www.google.com/recaptcha/";
-        set $SCRIPT "${SCRIPT} https://www.gstatic.com/recaptcha/";
-
-        set $STYLE "style-src 'self' 'unsafe-inline'";
-        set $STYLE "${STYLE} https://cdn.jsdelivr.net";
-        set $STYLE "${STYLE} https://cdnjs.cloudflare.com";
-        set $STYLE "${STYLE} https://maxcdn.bootstrapcdn.com";
-        set $STYLE "${STYLE} https://stackpath.bootstrapcdn.com";
-
-        set $FONT "font-src 'self' 'unsafe-inline'";
-        set $FONT "${FONT} https://cdnjs.cloudflare.com";
-        set $FONT "${FONT} https://maxcdn.bootstrapcdn.com";
-
-        set $FRAME "frame-src 'self'";
-        set $FRAME "${FRAME} https://recaptcha.google.com/recaptcha/";
-        set $FRAME "${FRAME} https://www.google.com/recaptcha/";
-
-        set $IMG "img-src 'self' data:";
-        set $IMG "${IMG} https://*.a.ssl.fastly.net";
-        set $IMG "${IMG} https://better-lbnl-development.herokuapp.com";
-        set $IMG "${IMG} https://better.lbl.gov";
-        set $IMG "${IMG} https://validator.swagger.io";
-
-        set $OBJECT "object-src 'none'";
-
-        add_header Content-Security-Policy "${DEFAULT}; ${SCRIPT}; ${STYLE}; ${FONT}; ${FRAME}; ${IMG}; ${OBJECT}";
 
         # configure maintenance page redirect
         if (-f /seed/collected_static/maintenance.html) {


### PR DESCRIPTION
#### Any background context you want to provide?
In our Nginx config we have `add_header` directives at multiple levels, which is BAD - the directives are inherited from the previous level only if there are no `add_header` directives defined on the current level, so our higher level headers were being ignored

#### What's this PR do?
Moves all `add_header`s to the same level

#### How should this be manually tested?
Serve via Nginx, look for all headers