### PR TITLE
Fix clickable header

### DIFF
--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -403,11 +403,10 @@ a:not([href]) {
 
       .logo_container {
         .logo {
-          display: block;
+          display: inline-block;
           color: black;
 
           .logo_text {
-            width: 234px;
             padding: 11px 20px 10px 18px;
             font-size: 24px;
             font-family: $font-family-base-narrow;


### PR DESCRIPTION
#### What's this PR do?
Fixes the top header so that the whitespace isn't clickable, inadvertently redirecting the user to the home page

#### How should this be manually tested?
Click the header area that doesn't include the logo

#### Screenshots
![image](https://user-images.githubusercontent.com/411466/219816316-ca50b67b-48e0-4161-9df9-02a3e8d06014.png)
