### PR TITLE
Add export to meters and meter readings

### DIFF
--- a/seed/static/seed/js/controllers/inventory_detail_meters_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_meters_controller.js
@@ -16,7 +16,6 @@ angular.module('BE.seed.controller.inventory_detail_meters', [])
     'urls',
     'user_service',
     'organization_payload',
-    '$log',
     function (
       $state,
       $scope,
@@ -33,8 +32,7 @@ angular.module('BE.seed.controller.inventory_detail_meters', [])
       spinner_utility,
       urls,
       user_service,
-      organization_payload,
-      $log
+      organization_payload
     ) {
       spinner_utility.show();
       $scope.item_state = inventory_payload.state;
@@ -79,10 +77,11 @@ angular.module('BE.seed.controller.inventory_detail_meters', [])
         enableSelectAll: true,
         exporterMenuPdf: false,
         exporterMenuExcel: false,
-        exporterCsvFilename: 'meters.csv',
+        exporterCsvFilename: () => `${$scope.inventory_name ? $scope.inventory_name : $stateParams.view_id} meter.csv`,
         enableColumnResizing: true,
         flatEntityAccess: true,
         fastWatch: true,
+        gridMenuShowHideColumns: false,
         rowIdentity: (meter) => {return meter.id},
         minRowsToShow: Math.min($scope.sorted_meters.length, 10),
         onRegisterApi: function (meterGridApi) {
@@ -117,11 +116,12 @@ angular.module('BE.seed.controller.inventory_detail_meters', [])
         enableSelectAll: true,
         exporterMenuPdf: false,
         exporterMenuExcel: false,
-        exporterCsvFilename: 'meter_readings.csv',
+        exporterCsvFilename: () => `${$scope.inventory_name ? $scope.inventory_name : $stateParams.view_id} meter_readings.csv`,
         enableColumnResizing: true,
         enableFiltering: true,
         flatEntityAccess: true,
         fastWatch: true,
+        gridMenuShowHideColumns: false,
         minRowsToShow: Math.min($scope.data.length, 15),
         onRegisterApi: function (readingGridApi) {
           $scope.readingGridApi = readingGridApi;
@@ -288,21 +288,22 @@ angular.module('BE.seed.controller.inventory_detail_meters', [])
         });
       };
 
-      $scope.inventory_display_name = function (property_type) {
+      const get_inventory_display_name = function (property_type) {
         let error = '';
-        let field = property_type == 'property' ? $scope.organization.property_display_field : $scope.organization.taxlot_display_field;
+        let field = property_type === 'property' ? $scope.organization.property_display_field : $scope.organization.taxlot_display_field;
         if (!(field in $scope.item_state)) {
-          error = field + ' does not exist';
+          error = `${field} does not exist`;
           field = 'address_line_1';
         }
         if (!$scope.item_state[field]) {
-          error += (error == '' ? '' : ' and default ') + field + ' is blank';
+          error += `${error === '' ? '' : ' and default '}${field} is blank`;
         }
-        $scope.inventory_name = $scope.item_state[field] ? $scope.item_state[field] : '(' + error + ') <i class="glyphicon glyphicon-question-sign" title="This can be changed from the organization settings page."></i>';
+        $scope.inventory_name_error = error;
+        $scope.inventory_name = $scope.item_state[field] ? $scope.item_state[field] : '';
       };
 
       $scope.updateHeight = function () {
-        var height = 0;
+        let height = 0;
         _.forEach(['.header', '.page_header_container', '.section_nav_container', '.inventory-list-controls'], function (selector) {
           var element = angular.element(selector)[0];
           if (element) height += element.offsetHeight;
@@ -312,4 +313,6 @@ angular.module('BE.seed.controller.inventory_detail_meters', [])
         $scope.readingGridApi.core.handleWindowResize();
         $scope.meterGridApi.core.handleWindowResize();
       };
+
+      get_inventory_display_name($scope.inventory_type === 'properties' ? 'property' : 'taxlot');
     }]);

--- a/seed/static/seed/js/controllers/inventory_detail_meters_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_meters_controller.js
@@ -75,10 +75,15 @@ angular.module('BE.seed.controller.inventory_detail_meters', [])
           {field: "scenario_name"},
           {field: "actions", cellTemplate: deleteButton},
         ],
+        enableGridMenu: true,
+        enableSelectAll: true,
+        exporterMenuPdf: false,
+        exporterMenuExcel: false,
+        exporterCsvFilename: 'meters.csv',
         enableColumnResizing: true,
         flatEntityAccess: true,
-        rowIdentity: (meter) => {return meter.id},
         fastWatch: true,
+        rowIdentity: (meter) => {return meter.id},
         minRowsToShow: Math.min($scope.sorted_meters.length, 10),
         onRegisterApi: function (meterGridApi) {
           $scope.meterGridApi = meterGridApi;
@@ -108,11 +113,16 @@ angular.module('BE.seed.controller.inventory_detail_meters', [])
       $scope.meterReadGridOptions = {
         data: 'data',
         columnDefs: property_meter_usage.column_defs,
+        enableGridMenu: true,
+        enableSelectAll: true,
+        exporterMenuPdf: false,
+        exporterMenuExcel: false,
+        exporterCsvFilename: 'meter_readings.csv',
         enableColumnResizing: true,
         enableFiltering: true,
         flatEntityAccess: true,
         fastWatch: true,
-        minRowsToShow: Math.min($scope.data.length, 10),
+        minRowsToShow: Math.min($scope.data.length, 15),
         onRegisterApi: function (readingGridApi) {
           $scope.readingGridApi = readingGridApi;
 

--- a/seed/static/seed/partials/home.html
+++ b/seed/static/seed/partials/home.html
@@ -5,7 +5,7 @@
       <div uib-alert class="alert-danger http_error" ng-if="http_error == 500" close="closeAlert()" ><span translate>HTTP Error! Status Code: 500. Internal Server Error.</span></div>
 
 
-      <div class="jumbotron">
+      <div class="bg jumbotron">
         <div class="home_hero_content_container">
           <h1 translate>The SEED Platform™</h1>
           <div translate>The DOE developed the Standard Energy Efficiency Data (SEED) Platform™ as a free software tool that provides a standardized format for collecting, storing and analyzing building energy performance information about large portfolios.

--- a/seed/static/seed/partials/inventory_detail_meters.html
+++ b/seed/static/seed/partials/inventory_detail_meters.html
@@ -60,7 +60,7 @@
     <div class="section_content">
         <h4> Meters </div>
         <div id="meters-grid-container" ng-show="has_meters">
-            <div ui-grid="meterGridOptions" ui-grid-selection ui-grid-resize-columns></div>
+            <div ui-grid="meterGridOptions" ui-grid-selection ui-grid-resize-columns ui-grid-exporter></div>
         </div>
         <div ng-hide="has_meters">
             <div class="jumbotron text-center" translate>No Data</div>
@@ -68,7 +68,7 @@
 
         <h4> Readings </h4>
         <div id="meters-readings-grid-container" ng-show="has_readings">
-            <div ui-grid="meterReadGridOptions" ui-grid-resize-columns></div>
+            <div ui-grid="meterReadGridOptions" ui-grid-selection ui-grid-resize-columns ui-grid-exporter></div>
         </div>
         <div ng-hide="has_readings">
             <div class="jumbotron text-center" translate>No Data</div>

--- a/seed/static/seed/partials/inventory_detail_meters.html
+++ b/seed/static/seed/partials/inventory_detail_meters.html
@@ -19,20 +19,21 @@
         <div class="section_action_container left" style="width: 50%;">
             <span>
                 <h2>
-                    <span ng-if="::inventory_type==='properties'">
+                    <span ng-if="::inventory_type === 'properties'">
                         <i class="fa fa-building-o"></i><span translate>Property</span> :
                     </span>
-                    <span ng-if="::inventory_type==='taxlots'">
+                    <span ng-if="::inventory_type === 'taxlots'">
                         <i class="fa fa-map-o"></i><span translate>Tax Lot</span> :
                     </span>
-                    <span ng-bind-html="inventory_name">{$ inventory_display_name(inventory_type==='properties' ? 'property' : 'taxlot') | translate $}</span>
+                    <span ng-if="inventory_name">{$:: inventory_name | translate $}</span>
+                    <span ng-if="!inventory_name">({$:: inventory_name_error $}) <i class="glyphicon glyphicon-question-sign" title="This can be changed from the organization settings page."></i></span>
                 </h2>
             </span>
         </div>
     </div>
 </div>
 
-<div class="section_content_container" ng-cloak>
+<div class="section_content_container meters-detail" ng-cloak>
     <div class="inventory-list-controls columns">
 
         <div class="column">
@@ -58,7 +59,7 @@
     </div>
 
     <div class="section_content">
-        <h4> Meters </div>
+        <h4>Meters</h4>
         <div id="meters-grid-container" ng-show="has_meters">
             <div ui-grid="meterGridOptions" ui-grid-selection ui-grid-resize-columns ui-grid-exporter></div>
         </div>
@@ -66,7 +67,7 @@
             <div class="jumbotron text-center" translate>No Data</div>
         </div>
 
-        <h4> Readings </h4>
+        <h4>Readings</h4>
         <div id="meters-readings-grid-container" ng-show="has_readings">
             <div ui-grid="meterReadGridOptions" ui-grid-selection ui-grid-resize-columns ui-grid-exporter></div>
         </div>

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -890,7 +890,7 @@ a:not([href]) {
       }
     }
 
-    .jumbotron {
+    .bg.jumbotron {
       background: url("../../seed/images/kc_2.jpg") no-repeat center bottom;
       background-size: cover;
       min-height: 402px;
@@ -4646,4 +4646,9 @@ ul.r-list {
 
 .strikethrough {
   text-decoration: line-through;
+}
+
+.meters-detail .ui-grid-menu-button .ui-grid-menu .ui-grid-menu-mid {
+  overflow: auto;
+  max-height: 112px;
 }


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### Any background context you want to provide?
Needed an easy way to export meter data. 

#### What's this PR do?
Simply adds the un grid export to the meter and meter readings tables. This supports the basic use case. It also allows us to export the monthly or yearly data without having to make an additional API call.

#### How should this be manually tested?
* import meter data (via building sync or espm)
* Go to a meter 
* Click on the hamburger on the top right of the meter and then on the meter_reading page
* Verify data exported correctly

#### What are the relevant tickets?
#2946 

#### Screenshots (if appropriate)
