### PR TITLE
Fixed saving Program Setup data for non-active orgs

### DIFF
--- a/seed/static/seed/js/controllers/program_setup_controller.js
+++ b/seed/static/seed/js/controllers/program_setup_controller.js
@@ -162,7 +162,7 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
 
       // update the compliance metric
       console.log("about to update the metric");
-      compliance_metric_service.update_compliance_metric($scope.selected_compliance_metric.id, $scope.selected_compliance_metric).then(data => {
+      compliance_metric_service.update_compliance_metric($scope.selected_compliance_metric.id, $scope.selected_compliance_metric, $scope.org.id).then(data => {
         if ('status' in data && data.status == 'error') {
           for (const [key, error] of Object.entries(data.compliance_metrics_error)) {
             $scope.compliance_metrics_error.push(key + ': ' + error);
@@ -217,7 +217,7 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
         filter_group: null,
         x_axis_columns: []
       };
-      compliance_metric_service.new_compliance_metric(template_compliance_metric).then(data => {
+      compliance_metric_service.new_compliance_metric(template_compliance_metric, $scope.org.id).then(data => {
         $scope.selected_compliance_metric = data;
         window.location =
         '#/accounts/' +
@@ -237,7 +237,7 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
       }
       if (confirm('Are you sure you want to delete the Program Metric "' + compliance_metric.name + '"?')) {
         let delete_id = compliance_metric.id;
-        compliance_metric_service.delete_compliance_metric(delete_id).then((data) => {
+        compliance_metric_service.delete_compliance_metric(delete_id, $scope.org.id).then((data) => {
           if (data.status == 'success') {
             $scope.compliance_metrics = $scope.compliance_metrics.filter(compliance_metric => compliance_metric.id != delete_id);
             if ($scope.selected_compliance_metric.id == delete_id) {

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -1031,8 +1031,8 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           valid_x_axis_data_types: [function () {
             return ['number', 'string', 'float', 'integer', 'ghg', 'ghg_intensity', 'area', 'eui', 'boolean'];
           }],
-          compliance_metrics: ['compliance_metric_service', function (compliance_metric_service) {
-            return compliance_metric_service.get_compliance_metrics();
+          compliance_metrics: ['$stateParams', 'compliance_metric_service', function ($stateParams, compliance_metric_service) {
+            return compliance_metric_service.get_compliance_metrics($stateParams.organization_id);
           }],
           organization_payload: ['organization_service', '$stateParams', function (organization_service, $stateParams) {
             return organization_service.get_organization($stateParams.organization_id);
@@ -1060,13 +1060,12 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
                 return columns;
               });
           }],
-          filter_groups: ['filter_groups_service', function (filter_groups_service) {
+          filter_groups: ['$stateParams', 'filter_groups_service', function ($stateParams, filter_groups_service) {
             var inventory_type = 'Property'; // just properties for now
-            return filter_groups_service.get_filter_groups(inventory_type, brief=true);
+            return filter_groups_service.get_filter_groups(inventory_type, $stateParams.organization_id);
           }],
           auth_payload: ['auth_service', '$stateParams', '$q', function (auth_service, $stateParams, $q) {
-            var organization_id = $stateParams.organization_id;
-            return auth_service.is_authorized(organization_id, ['requires_member'])
+            return auth_service.is_authorized($stateParams.organization_id, ['requires_member'])
               .then(function (data) {
                 if (data.auth.requires_member) {
                   return data;
@@ -1091,8 +1090,8 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           valid_x_axis_data_types: [function () {
             return ['number', 'string', 'float', 'integer', 'ghg', 'ghg_intensity', 'area', 'eui', 'boolean'];
           }],
-          compliance_metrics: ['compliance_metric_service', function (compliance_metric_service) {
-            return compliance_metric_service.get_compliance_metrics();
+          compliance_metrics: ['$stateParams', 'compliance_metric_service', function ($stateParams, compliance_metric_service) {
+            return compliance_metric_service.get_compliance_metrics($stateParams.organization_id);
           }],
           organization_payload: ['organization_service', '$stateParams', function (organization_service, $stateParams) {
             return organization_service.get_organization($stateParams.organization_id);
@@ -1120,13 +1119,12 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
                 return columns;
               });
           }],
-          filter_groups: ['filter_groups_service', function (filter_groups_service) {
+          filter_groups: ['$stateParams', 'filter_groups_service', function ($stateParams, filter_groups_service) {
             var inventory_type = 'Property'; // just properties for now
-            return filter_groups_service.get_filter_groups(inventory_type, brief=true);
+            return filter_groups_service.get_filter_groups(inventory_type, $stateParams.organization_id);
           }],
           auth_payload: ['auth_service', '$stateParams', '$q', function (auth_service, $stateParams, $q) {
-            var organization_id = $stateParams.organization_id;
-            return auth_service.is_authorized(organization_id, ['requires_member'])
+            return auth_service.is_authorized($stateParams.organization_id, ['requires_member'])
               .then(function (data) {
                 if (data.auth.requires_member) {
                   return data;
@@ -1594,7 +1592,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           }],
           profiles: ['$stateParams', 'inventory_service', function ($stateParams, inventory_service) {
             var inventory_type = $stateParams.inventory_type === 'properties' ? 'Property' : 'Tax Lot';
-            return inventory_service.get_column_list_profiles('List View Profile', inventory_type, brief=true);
+            return inventory_service.get_column_list_profiles('List View Profile', inventory_type, true);
           }],
           current_profile: ['$stateParams', 'inventory_service', 'profiles', function ($stateParams, inventory_service, profiles) {
             var validProfileIds = _.map(profiles, 'id');
@@ -1611,7 +1609,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           }],
           filter_groups: ['$stateParams', 'filter_groups_service', function ($stateParams, filter_groups_service) {
             var inventory_type = $stateParams.inventory_type === 'properties' ? 'Property' : 'Tax Lot';
-            return filter_groups_service.get_filter_groups(inventory_type, brief=true);
+            return filter_groups_service.get_filter_groups(inventory_type);
           }],
           current_filter_group: ['$stateParams', 'filter_groups_service', 'filter_groups', function ($stateParams, filter_groups_service, filter_groups) {
             var validFilterGroupIds = _.map(filter_groups, 'id');
@@ -1681,7 +1679,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           }],
           profiles: ['$stateParams', 'inventory_service', function ($stateParams, inventory_service) {
             var inventory_type = $stateParams.inventory_type === 'properties' ? 'Property' : 'Tax Lot';
-            return inventory_service.get_column_list_profiles('List View Profile', inventory_type, brief=true);
+            return inventory_service.get_column_list_profiles('List View Profile', inventory_type, true);
           }],
           current_profile: ['$stateParams', 'inventory_service', 'profiles', function ($stateParams, inventory_service, profiles) {
             var validProfileIds = _.map(profiles, 'id');
@@ -2082,7 +2080,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           }],
           filter_groups: ['filter_groups_service', function (filter_groups_service) {
             var inventory_type = 'Property'; // just properties for now
-            return filter_groups_service.get_filter_groups(inventory_type, brief=true);
+            return filter_groups_service.get_filter_groups(inventory_type);
           }]
         }
       })
@@ -2127,7 +2125,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           }],
           filter_groups: ['filter_groups_service', function (filter_groups_service) {
             var inventory_type = 'Property'; // just properties for now
-            return filter_groups_service.get_filter_groups(inventory_type, brief=true);
+            return filter_groups_service.get_filter_groups(inventory_type);
           }]
         }
       });

--- a/seed/static/seed/js/services/compliance_metric_service.js
+++ b/seed/static/seed/js/services/compliance_metric_service.js
@@ -9,10 +9,10 @@ angular.module('BE.seed.service.compliance_metric', []).factory('compliance_metr
   ) {
 
   	// get all compliance metrics defined
-  	const get_compliance_metrics = function () {
+  	const get_compliance_metrics = function (organization_id = user_service.get_organization().id) {
       return $http.get('/api/v3/compliance_metrics/', {
         params: {
-          'organization_id': user_service.get_organization().id
+          organization_id
         }
       }).then(function (response) {
         return response.data.compliance_metrics;
@@ -22,10 +22,10 @@ angular.module('BE.seed.service.compliance_metric', []).factory('compliance_metr
     };
 
     // retrieve compliance metric
-    const get_compliance_metric = function (metric_id) {
+    const get_compliance_metric = function (metric_id, organization_id = user_service.get_organization().id) {
       return $http.get('/api/v3/compliance_metrics/' + metric_id + '/', {
         params: {
-          'organization_id': user_service.get_organization().id
+          organization_id
         }
       }).then(function (response) {
         return response.data.compliance_metric;
@@ -35,14 +35,14 @@ angular.module('BE.seed.service.compliance_metric', []).factory('compliance_metr
     };
 
     // delete
-    const delete_compliance_metric = function (metric_id) {
+    const delete_compliance_metric = function (metric_id, organization_id = user_service.get_organization().id) {
       if (_.isNil(metric_id)) {
         $log.error('#compliance_metric_service.get_compliance_metric(): metric_id is undefined');
         throw new Error('Invalid Parameter');
       }
       return $http.delete('/api/v3/compliance_metrics/' + metric_id + '/', {
         params: {
-          'organization_id': user_service.get_organization().id
+          organization_id
         }
       }).then(function (response) {
         return response.data;
@@ -52,10 +52,10 @@ angular.module('BE.seed.service.compliance_metric', []).factory('compliance_metr
     };
 
     // evaluate
-    const evaluate_compliance_metric = function (metric_id) {
+    const evaluate_compliance_metric = function (metric_id, organization_id = user_service.get_organization().id) {
       return $http.get('/api/v3/compliance_metrics/' + metric_id + '/evaluate/', {
         params: {
-          'organization_id': user_service.get_organization().id
+          organization_id
         }
       }).then(function (response) {
         return response.data.data;
@@ -65,10 +65,10 @@ angular.module('BE.seed.service.compliance_metric', []).factory('compliance_metr
     };
 
     // update
-    const update_compliance_metric = function (metric_id, data) {
+    const update_compliance_metric = function (metric_id, data, organization_id = user_service.get_organization().id) {
       return $http.put('/api/v3/compliance_metrics/' + metric_id + '/', data, {
         params: {
-          'organization_id': user_service.get_organization().id
+          organization_id
         }
       }).then(function (response) {
         return response.data.compliance_metric;
@@ -78,10 +78,10 @@ angular.module('BE.seed.service.compliance_metric', []).factory('compliance_metr
     };
 
     // create
-    const new_compliance_metric = function (data) {
+    const new_compliance_metric = function (data, organization_id = user_service.get_organization().id) {
       return $http.post('/api/v3/compliance_metrics/', data, {
         params: {
-          'organization_id': user_service.get_organization().id
+          organization_id
         }
       }).then(function (response) {
         return response.data.compliance_metric;
@@ -90,14 +90,12 @@ angular.module('BE.seed.service.compliance_metric', []).factory('compliance_metr
       });
     };
 
-    const compliance_metric_factory = {
-      'get_compliance_metrics': get_compliance_metrics,
-      'get_compliance_metric': get_compliance_metric,
-      'delete_compliance_metric': delete_compliance_metric,
-      'evaluate_compliance_metric': evaluate_compliance_metric,
-      'update_compliance_metric': update_compliance_metric,
-      'new_compliance_metric': new_compliance_metric
+    return {
+      get_compliance_metrics,
+      get_compliance_metric,
+      delete_compliance_metric,
+      evaluate_compliance_metric,
+      update_compliance_metric,
+      new_compliance_metric
     };
-
-	return compliance_metric_factory;
   }]);

--- a/seed/static/seed/js/services/filter_groups_service.js
+++ b/seed/static/seed/js/services/filter_groups_service.js
@@ -11,11 +11,11 @@ angular.module('BE.seed.service.filter_groups', []).factory('filter_groups_servi
 
     var filter_groups_factory = {};
 
-    filter_groups_factory.get_filter_groups = function (inventory_type) {
+    filter_groups_factory.get_filter_groups = function (inventory_type, organization_id = user_service.get_organization().id) {
       return $http.get('/api/v3/filter_groups/', {
         params: {
-          organization_id: user_service.get_organization().id,
-          inventory_type: inventory_type,
+          organization_id,
+          inventory_type,
         }
       }).then(function (response) {
         var filter_groups = response.data.data.sort(function (a, b) {

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -4478,7 +4478,7 @@ ul.r-list {
 
   &.r-scrollable {
     max-height: 200px;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 }
 


### PR DESCRIPTION
#### What's this PR do?
This PR fixes the ability to save Program Setup programs for a different organization than the currently active one.

Additionally, it fixes many unnecessary scrollbars and removes invalid `brief=true` arguments from seed.js

#### How should this be manually tested?
1. Go to the Program Setup settings of an organization other than the active one in the top right corner
2. Attempt to create/save/update/delete a Program
3. Confirm that the data was saved to the correct org, and not the active one

#### What are the relevant tickets?
#3919