### PR TITLE
Fixed issue with filtering Property columns from Tax Lot tab of Inventory

### DIFF
--- a/seed/utils/inventory_filter.py
+++ b/seed/utils/inventory_filter.py
@@ -131,8 +131,8 @@ def get_filtered_results(request: Request, inventory_type: Literal['property', '
         if len(filters) > 0 or len(annotations) > 0:
             other_inventory_type_class: Union[Type[TaxLotView], Type[PropertyView]] = TaxLotView if inventory_type == "property" else PropertyView
             other_views_list = (
-                other_inventory_type_class.objects.select_related('taxlot', 'state', 'cycle')
-                .filter(taxlot__organization_id=org_id, cycle=cycle)
+                other_inventory_type_class.objects.select_related(other_inventory_type, 'state', 'cycle')
+                .filter(**{f'{other_inventory_type}__organization_id': org_id, 'cycle': cycle})
             )
 
             other_views_list = other_views_list.annotate(**annotations).filter(filters)


### PR DESCRIPTION
#### Any background context you want to provide?
Previously cross filtering was added for the Property tab of Inventory, but it wasn't also working for the Tax Lot tab.

#### What's this PR do?
Makes the code work in both scenarios.

#### How should this be manually tested?
Import data that includes both properties and tax lots, such as San Jose sample test data, and try filtering a Property column in the Tax Lot tab of the inventory.

#### What are the relevant tickets?
#3942 

#### Screenshots (if appropriate)
