### PR TITLE
Fix editing a derived column without changing the name

### DIFF
--- a/seed/static/seed/js/controllers/derived_columns_admin_controller.js
+++ b/seed/static/seed/js/controllers/derived_columns_admin_controller.js
@@ -26,10 +26,12 @@ angular.module('BE.seed.controller.derived_columns_admin', [])
       organization_payload,
       derived_columns_payload
     ) {
-
+      $scope.state = $state.current;
       $scope.auth = auth_payload.auth;
       $scope.org = organization_payload.organization;
       $scope.derived_columns = derived_columns_payload.derived_columns;
+
+      $scope.inventory_type = $stateParams.inventory_type;
 
       // used to determine column sorting. 0 = no sort, 1 = ascending, 2 = descending
       $scope.column_sorting = 0;

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -1500,6 +1500,9 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
         url: '/accounts/{organization_id:int}/derived_columns/edit/:derived_column_id',
         templateUrl: static_url + 'seed/partials/derived_columns_editor.html',
         controller: 'derived_columns_editor_controller',
+        params: {
+          inventory_type: 'properties'
+        },
         resolve: {
           organization_payload: ['organization_service', '$stateParams', function (organization_service, $stateParams) {
             var organization_id = $stateParams.organization_id;

--- a/seed/static/seed/partials/accounts_nav.html
+++ b/seed/static/seed/partials/accounts_nav.html
@@ -2,7 +2,7 @@
      --><a ui-sref="organization_column_mappings(::{organization_id: org.id, inventory_type: 'properties'})" ng-if="::auth.requires_owner" ng-class="::{active: state.name === 'organization_column_mappings'}" translate>Column Mappings</a><!--
      --><a ui-sref="organization_cycles(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Cycles</a><!--
      --><a ui-sref="organization_data_quality(::{organization_id: org.id, inventory_type: 'properties'})" ng-if="::org.is_parent && auth.requires_owner" ng-class="::{active: state.name === 'organization_data_quality'}" translate>Data Quality</a><!--
-     --><a ui-sref="organization_derived_columns(::{organization_id: org.id, inventory_type: 'properties'})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Derived Columns</a><!--
+     --><a ui-sref="organization_derived_columns(::{organization_id: org.id, inventory_type: 'properties'})" ng-if="::auth.requires_owner" ng-class="::{active: ['organization_derived_columns', 'organization_derived_column_editor'].includes(state.name)}" translate>Derived Columns</a><!--
      --><a ui-sref="organization_email_templates(::{organization_id: org.id})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Email Templates</a><!--
      --><a ui-sref="organization_labels(::{organization_id: org.id})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Labels</a><!--
      --><a ui-sref="organization_members(::{organization_id: org.id})" ui-sref-active="active" translate>Members</a><!--

--- a/seed/static/seed/partials/derived_columns_admin.html
+++ b/seed/static/seed/partials/derived_columns_admin.html
@@ -22,7 +22,7 @@
                 <h2><i class="fa fa-calculator"></i> <span translate>Derived Columns</span></h2>
             </div>
             <div class="section_action_container right_40 section_action_btn pull-right">
-                <a ui-sref="organization_derived_column_editor(::{organization_id: org.id, derived_column_id: null})">
+                <a ui-sref="organization_derived_column_editor(::{organization_id: org.id, derived_column_id: null, inventory_type: inventory_type})">
                     <button type="button" class="btn btn-primary">
                         Create Derived Column
                     </button>


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### Any background context you want to provide?
Attempting to edit an already-saved column, without changing the name, always resulted in an error because _the name was already taken by itself_.

#### What's this PR do?
- Fixes updating an existing derived column when the name is unchanged
- Fixes `Derived Columns` active nav for all subpages
- Improves the `Create Derived Column` button to set the default type on the editor page based on whether it was clicked when viewing the Property or Tax Lot derived columns
- Improves the `Create`/`Save` button such that it takes you to the correct Property/Tax Lot derived column page on success

#### How should this be manually tested?
- Create a derived column, click Edit, then click Save.  It should now succeed
- Check that the `Derived Columns` nav shows as active while on any of the derived column pages
- Check that the `Create Derived Column` button initializes the Type field depending on which tab you were using when you clicked it
- Check that saving a derived column takes you to the correct tab where it appears
