### PR TITLE
add better error messaging that includes the property view ID

### DIFF
--- a/seed/utils/salesforce.py
+++ b/seed/utils/salesforce.py
@@ -229,7 +229,7 @@ def update_salesforce_property(org_id, property_id, salesforce_client=None, conf
 
     # print(f"benchmark ID is: {benchmark_id}")
     if not benchmark_id:
-        message = 'SEED Unique Benchmark ID Column data is undefined. Update your property record with this information.'
+        message = f"SEED Unique Benchmark ID Column data on property id {property_view.id} is undefined. Update your property record with this information."
         return status, message
 
     """ CONTACT/ACCOUNT CREATION """


### PR DESCRIPTION
Minor enhancement to include the property view ID in a salesforce error message for better troubleshooting.

@axelstudios, if you could get this fix onto dev1 when you have a chance that would be great and would help out users testing out the functionality. thanks!