### PR TITLE
replacing seed getting started guide for v2.18

### DIFF
--- a/seed/static/seed/partials/home.html
+++ b/seed/static/seed/partials/home.html
@@ -58,7 +58,7 @@
 
           <div>
             <div>
-              <a ng-href="{$ urls.static_url $}seed/pdf/SEED Platform V2_18_Getting_Started_Guide.pdf" target="_blank" rel="noopener noreferrer" title="SEED_v2.13_User_Guide" class="btn btn-warning btn-lg" role="button" style="white-space:normal !important;"><i class="fa fa-file-text"></i>&nbsp;&nbsp;{$:: 'Getting Started Guide' | translate $}</a>
+              <a ng-href="{$ urls.static_url $}seed/pdf/SEED_Platform_V2_18_Getting_Started_Guide.pdf" target="_blank" rel="noopener noreferrer" title="SEED_v2.13_User_Guide" class="btn btn-warning btn-lg" role="button" style="white-space:normal !important;"><i class="fa fa-file-text"></i>&nbsp;&nbsp;{$:: 'Getting Started Guide' | translate $}</a>
             </div>
 
             <div>

--- a/seed/static/seed/partials/home.html
+++ b/seed/static/seed/partials/home.html
@@ -58,7 +58,7 @@
 
           <div>
             <div>
-              <a ng-href="{$ urls.static_url $}seed/pdf/SEED_Platform_V2_13_Getting_Started_Guide.pdf" target="_blank" rel="noopener noreferrer" title="SEED_v2.13_User_Guide" class="btn btn-warning btn-lg" role="button" style="white-space:normal !important;"><i class="fa fa-file-text"></i>&nbsp;&nbsp;{$:: 'Getting Started Guide' | translate $}</a>
+              <a ng-href="{$ urls.static_url $}seed/pdf/SEED Platform V2_18_Getting_Started_Guide.pdf" target="_blank" rel="noopener noreferrer" title="SEED_v2.13_User_Guide" class="btn btn-warning btn-lg" role="button" style="white-space:normal !important;"><i class="fa fa-file-text"></i>&nbsp;&nbsp;{$:: 'Getting Started Guide' | translate $}</a>
             </div>
 
             <div>


### PR DESCRIPTION
Replaced getting started guide on front page for v2.18