### PR TITLE
Prevent Automatically Serving Static `index.html` Files

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -145,6 +145,12 @@ http {
 
         location /static {
             alias /seed/collected_static;
+            types {
+                text/css css;
+                application/javascript js;
+                image/svg+xml svg;
+            }
+            default_type application/octet-stream;
             index nonextistent;
             autoindex off;
             expires 1d;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -145,6 +145,7 @@ http {
 
         location /static {
             alias /seed/collected_static;
+            index nonextistent;
             autoindex off;
             expires 1d;
             include seed-security-headers.conf;


### PR DESCRIPTION
#### What's this PR do?
1. Prevents automatically serving `/static/**/index.html` files
2. Treats every `/static/**` file, except for js/css/svg, as binary files

#### How should this be manually tested?
1. Browse to `/static/node_modules/angular-dragula/` and make sure the dragula readme page doesn't appear (403 error)
2. Browse to `/static/node_modules/angular-dragula/index.html` and make sure the file downloads rather than rendering and loading js files that we don't want executing
3. Monkey test, make sure the app itself still works as expected and that images load and such

#### What are the relevant tickets?
#4039 