### PR TITLE
Pin urllib3

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,9 +12,11 @@ psutil==5.6.7
 Faker==0.9.3
 mock==2.0.0
 coveralls-merge==0.0.3
-vcrpy==4.0.0
+vcrpy==4.2.1
 pytest==7.2.0
 pytest-django==4.5.2
+# Lock urllib3 to v1 until vcrpy supports it
+urllib3<2
 
 # static code analysis
 flake8==3.8.1


### PR DESCRIPTION
#### Any background context you want to provide?
Dependabot updated `requests`, and requests v2.30.0 added support for urllib3 v2.0.

> https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#attributeerror-module-urllib3-connectionpool-has-no-attribute-verifiedhttpsconnection

> https://github.com/kevin1024/vcrpy/issues/688

#### What's this PR do?
Pins urllib3 to v1 to fix the one CI test failure until vcrpy fixes their broken imports

#### How should this be manually tested?
CI success