### PR TITLE
Fix User Creation Bugs

### DIFF
--- a/seed/management/commands/create_default_user.py
+++ b/seed/management/commands/create_default_user.py
@@ -6,7 +6,7 @@ See also https://github.com/seed-platform/seed/main/LICENSE.md
 from django.core.management.base import BaseCommand
 
 from seed.landing.models import SEEDUser as User
-from seed.lib.superperms.orgs.models import Organization
+from seed.lib.superperms.orgs.models import ROLE_OWNER, Organization
 from seed.utils.organizations import create_organization
 
 
@@ -71,8 +71,9 @@ class Command(BaseCommand):
         if Organization.objects.filter(name=options['organization']).exists():
             org = Organization.objects.get(name=options['organization'])
             self.stdout.write(
-                'Org <%s> already exists' % options['organization'], ending='\n'
+                'Org <%s> already exists, adding user' % options['organization'], ending='\n'
             )
+            org.add_member(u, ROLE_OWNER)
         else:
             self.stdout.write(
                 'Creating org <%s> ...' % options['organization'],

--- a/seed/static/seed/js/controllers/admin_controller.js
+++ b/seed/static/seed/js/controllers/admin_controller.js
@@ -68,7 +68,7 @@ angular.module('BE.seed.controller.admin', [])
           get_organizations().then(function () {
             $scope.$emit('organization_list_updated');
           });
-          update_alert(true, 'Organization ' + org.name + ' created');
+          update_alert(true, `Organization ${org.name} created`);
 
         }).catch(function (response) {
           update_alert(false, 'error creating organization: ' + response.data.message);
@@ -77,16 +77,18 @@ angular.module('BE.seed.controller.admin', [])
       $scope.user_form.add = function (user) {
         user_service.add(user).then(function (data) {
 
-          var alert_message = 'User ' + user.email + ' created and added';
+          let alert_message = `User ${user.email} created and added`;
           if (data.org_created) {
-            alert_message = alert_message + ' as head of new org ' + data.org;
+            alert_message = `${alert_message} as head of new org ${data.org}`;
           } else {
-            alert_message = alert_message + ' to existing org ' + data.org;
+            alert_message = `${alert_message} to existing org ${data.org}`;
           }
 
           update_alert(true, alert_message);
           get_users();
-          get_organizations();
+          get_organizations().then(function () {
+            $scope.$emit('organization_list_updated');
+          });
           $scope.user_form.reset();
 
         }).catch(function (response) {

--- a/seed/views/v3/users.py
+++ b/seed/views/v3/users.py
@@ -177,7 +177,9 @@ class UserViewSet(viewsets.ViewSet, OrgMixin):
     @has_perm_class('requires_owner_or_superuser_without_org', False)
     def create(self, request):
         """
-        Creates a new SEED user.  One of 'organization_id' or 'org_name' is needed.
+        Creates a new SEED user.
+        Organization owners must specify the `organization_id` query param.
+        Superusers can add `org_name` to the body and create a new organization for the new user.
         Sends invitation email to the new user.
         """
         # WARNING: we aren't using the OrgMixin here to validate the organization

--- a/seed/views/v3/users.py
+++ b/seed/views/v3/users.py
@@ -174,7 +174,7 @@ class UserViewSet(viewsets.ViewSet, OrgMixin):
     )
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_owner')
+    @has_perm_class('requires_owner_or_superuser_without_org', False)
     def create(self, request):
         """
         Creates a new SEED user.  One of 'organization_id' or 'org_name' is needed.


### PR DESCRIPTION
#### What's this PR do?
Fixes multiple bugs:
1. It was not possible to use the Admin `Create a user` form when also specifying a new organization to create
2. The same `Create a user` form failed to update the organization list after creating a new organization
3. The `create_default_user` script failed to add new users to the specified organization if it already existed, leaving the new user orphaned

#### How should this be manually tested?
1. Check that the `Create a user` form works as expected when specifying a new organization name, and then check the organization dropdown at the top right for the newly created org
2. Check that an organization owner (non-superuser) can still invite new members to their organization
3. Run `manage.py create_default_user`, specifying and existing organization name, and check that the new user was added to the organization as an owner

#### What are the relevant tickets?
#4095 