### PR TITLE
Compliance metrics

### DIFF
--- a/seed/lib/superperms/orgs/decorators.py
+++ b/seed/lib/superperms/orgs/decorators.py
@@ -63,8 +63,9 @@ def requires_superuser(org_user):
 
 def requires_root_member_access(org_user):
     """ User must be an owner or member at the root access level"""
-    ali = org_user.access_level_instance
+    org_user.access_level_instance
     return org_user.access_level_instance.depth == 1 and org_user.role_level >= ROLE_MEMBER
+
 
 def can_create_sub_org(org_user):
     return requires_parent_org_owner(org_user)
@@ -214,28 +215,29 @@ def has_perm_class(perm_name: str, requires_org: bool = True):
 
 
 def assert_hiarchary_access(request, property_view_id_kwarg=None, taxlot_view_id_kwarg=None, body_ali_id=None, *args, **kwargs):
-        print("++ assert_hiarchary_access ++")
-        if property_view_id_kwarg:
-            property_view = PropertyView.objects.get(pk=kwargs[property_view_id_kwarg])
-            requests_ali = property_view.property.access_level_instance
+    print("++ assert_hiarchary_access ++")
+    if property_view_id_kwarg:
+        property_view = PropertyView.objects.get(pk=kwargs[property_view_id_kwarg])
+        requests_ali = property_view.property.access_level_instance
 
-        elif taxlot_view_id_kwarg:
-            taxlot_view = TaxLotView.objects.get(pk=kwargs[taxlot_view_id_kwarg])
-            requests_ali = taxlot_view.taxlot.access_level_instance
+    elif taxlot_view_id_kwarg:
+        taxlot_view = TaxLotView.objects.get(pk=kwargs[taxlot_view_id_kwarg])
+        requests_ali = taxlot_view.taxlot.access_level_instance
 
-        elif body_ali_id:
-            requests_ali =  AccessLevelInstance.objects.get(pk=request.data[body_ali_id])
+    elif body_ali_id:
+        requests_ali = AccessLevelInstance.objects.get(pk=request.data[body_ali_id])
 
-        else:
-            property_view = PropertyView.objects.get(pk=request.GET['property_view_id'])
-            requests_ali = property_view.property.access_level_instance
+    else:
+        property_view = PropertyView.objects.get(pk=request.GET['property_view_id'])
+        requests_ali = property_view.property.access_level_instance
 
-        user_ali = AccessLevelInstance.objects.get(pk=request.access_level_instance_id)
-        if not (user_ali == requests_ali or requests_ali.is_descendant_of(user_ali)):
-            return JsonResponse({
-                'status': 'error',
-                'message': 'No such resource.'
-            }, status=status.HTTP_404_NOT_FOUND)
+    user_ali = AccessLevelInstance.objects.get(pk=request.access_level_instance_id)
+    if not (user_ali == requests_ali or requests_ali.is_descendant_of(user_ali)):
+        return JsonResponse({
+            'status': 'error',
+            'message': 'No such resource.'
+        }, status=status.HTTP_404_NOT_FOUND)
+
 
 def has_hiarchary_access(property_view_id_kwarg=None, taxlot_view_id_kwarg=None, body_ali_id=None):
     """Must be called after has_perm_class"""

--- a/seed/lib/superperms/orgs/decorators.py
+++ b/seed/lib/superperms/orgs/decorators.py
@@ -61,6 +61,11 @@ def requires_superuser(org_user):
     return org_user.user.is_superuser
 
 
+def requires_root_member_access(org_user):
+    """ User must be an owner or member at the root access level"""
+    ali = org_user.access_level_instance
+    return org_user.access_level_instance.depth == 1 and org_user.role_level >= ROLE_MEMBER
+
 def can_create_sub_org(org_user):
     return requires_parent_org_owner(org_user)
 
@@ -124,6 +129,7 @@ PERMS = {
     'requires_owner': requires_owner,
     'requires_member': requires_member,
     'requires_viewer': requires_viewer,
+    'requires_root_member_access': requires_root_member_access,
     'can_create_sub_org': can_create_sub_org,
     'can_remove_org': can_remove_org,
     'can_invite_member': can_invite_member,
@@ -172,7 +178,6 @@ def _validate_permissions(perm_name, request, requires_org):
         org = Organization.objects.get(pk=org_id)
     except Organization.DoesNotExist:
         return _make_resp('org_dne')
-
     # Skip perms checks if settings allow super_users to bypass.
     if request.user.is_superuser and ALLOW_SUPER_USER_PERMS:
         request.access_level_instance_id = org.root.id
@@ -193,7 +198,6 @@ def _validate_permissions(perm_name, request, requires_org):
 
 def has_perm_class(perm_name: str, requires_org: bool = True):
     """Proceed if user from request has ``perm_name``."""
-
     def decorator(fn):
         if 'self' in signature(fn).parameters:
             @wraps(fn)

--- a/seed/lib/superperms/orgs/decorators.py
+++ b/seed/lib/superperms/orgs/decorators.py
@@ -63,7 +63,6 @@ def requires_superuser(org_user):
 
 def requires_root_member_access(org_user):
     """ User must be an owner or member at the root access level"""
-    org_user.access_level_instance
     return org_user.access_level_instance.depth == 1 and org_user.role_level >= ROLE_MEMBER
 
 
@@ -215,7 +214,6 @@ def has_perm_class(perm_name: str, requires_org: bool = True):
 
 
 def assert_hiarchary_access(request, property_view_id_kwarg=None, taxlot_view_id_kwarg=None, body_ali_id=None, *args, **kwargs):
-    print("++ assert_hiarchary_access ++")
     if property_view_id_kwarg:
         property_view = PropertyView.objects.get(pk=kwargs[property_view_id_kwarg])
         requests_ali = property_view.property.access_level_instance

--- a/seed/models/compliance_metrics.py
+++ b/seed/models/compliance_metrics.py
@@ -44,7 +44,7 @@ class ComplianceMetric(models.Model):
     def __str__(self):
         return 'Program Metric - %s' % self.name
 
-    def evaluate(self):
+    def evaluate(self, user_ali):
         response = {
             'meta': {
                 'organization': self.organization.id,
@@ -61,7 +61,6 @@ class ComplianceMetric(models.Model):
         query_dict = QueryDict(mutable=True)
         if self.filter_group and self.filter_group.query_dict:
             query_dict.update(self.filter_group.query_dict)
-        # print(f"query dict: {query_dict}")
 
         # grab cycles
         cycle_ids = self.cycles.values_list('pk', flat=True).order_by('start')
@@ -95,6 +94,7 @@ class ComplianceMetric(models.Model):
 
         property_response = properties_across_cycles_with_filters(
             self.organization_id,
+            user_ali,
             cycle_ids,
             query_dict,
             column_ids

--- a/seed/test_helpers/fake.py
+++ b/seed/test_helpers/fake.py
@@ -134,15 +134,18 @@ class FakeColumnFactory(BaseFake):
                    table_name='PropertyState', **kw):
         """Get column details."""
         column_details = {
-            'organization': organization if organization else self.organization,
+            'organization_id': organization.pk if organization else self.organization.pk,
             'column_name': name,
             'table_name': table_name,
+            'is_extra_data': is_extra_data if is_extra_data else False,
         }
-        if is_extra_data:
-            column_details.update({
-                'is_extra_data': is_extra_data,
-            })
         column_details.update(kw)
+
+        # If the column isn't extra data, then it should be a native column
+        # which dynamically populates when a new org is created.
+        if Column.objects.filter(**column_details).exists():
+            return Column.objects.get(**column_details)
+
         return Column.objects.create(**column_details)
 
 
@@ -183,15 +186,19 @@ class FakePropertyFactory(BaseFake):
     Factory Class for producing Property instances.
     """
 
-    def __init__(self, organization=None):
+    def __init__(self, organization=None, access_level_instance=None):
         super().__init__()
         self.organization = organization
+        self.access_level_instance = access_level_instance
 
-    def get_property(self, organization=None, **kw):
+    def get_property(self, organization=None, access_level_instance=None, **kw):
         """Get property instance."""
         property_details = {
             'organization': self._get_attr('organization', organization),
+            'access_level_instance': self._get_attr('access_level_instance', access_level_instance),
         }
+        # add in the access level if passed, otherwise it will be null.
+
         property_details.update(kw)
         return Property.objects.create(**property_details)
 

--- a/seed/tests/test_compliance_metrics_views.py
+++ b/seed/tests/test_compliance_metrics_views.py
@@ -10,10 +10,10 @@ from django.core import serializers
 from django.urls import reverse
 
 from seed.models import ComplianceMetric, FilterGroup
-from seed.tests.util import AccessLevelTestCase
+from seed.tests.util import AccessLevelBaseTestCase
 
 
-class ComplianceMetricViewTests(AccessLevelTestCase):
+class ComplianceMetricViewTests(AccessLevelBaseTestCase):
     """
     Test ComplianceMetric model
     """
@@ -45,7 +45,7 @@ class ComplianceMetricViewTests(AccessLevelTestCase):
         self.filter_group = FilterGroup.objects.create(
             name='filter group 1',
             organization_id=self.org.id,
-            inventory_type=1,  # Property
+            inventory_type=0,  # Property
             query_dict={'year_built__lt': ['1980']},
         )
         self.filter_group.save()
@@ -247,7 +247,7 @@ class ComplianceMetricViewTests(AccessLevelTestCase):
         self.assertEqual('ComplianceMetric with id 99999 does not exist', data['message'])
 
 
-class ComplianceMetricEvaluationTests(AccessLevelTestCase):
+class ComplianceMetricEvaluationTests(AccessLevelBaseTestCase):
     """
     Test ComplianceMetric model's ability to evaluate propertyview values
     """
@@ -273,7 +273,7 @@ class ComplianceMetricEvaluationTests(AccessLevelTestCase):
         self.filter_group = FilterGroup.objects.create(
             name='filter group 1',
             organization_id=self.org.id,
-            inventory_type=1,  # Property
+            inventory_type=0,  # Property
             query_dict={'year_built__lt': ['1980']},
         )
         self.filter_group.save()

--- a/seed/tests/test_compliance_metrics_views.py
+++ b/seed/tests/test_compliance_metrics_views.py
@@ -7,16 +7,10 @@ See also https://github.com/seed-platform/seed/main/LICENSE.md
 import json
 
 from django.core import serializers
-from django.test import TestCase
 from django.urls import reverse
 
-from seed.models import (
-    ComplianceMetric,
-    FilterGroup,
-    User
-)
+from seed.models import ComplianceMetric, FilterGroup
 from seed.tests.util import AccessLevelTestCase
-from seed.utils.organizations import create_organization
 
 
 class ComplianceMetricViewTests(AccessLevelTestCase):
@@ -51,7 +45,7 @@ class ComplianceMetricViewTests(AccessLevelTestCase):
         self.filter_group = FilterGroup.objects.create(
             name='filter group 1',
             organization_id=self.org.id,
-            inventory_type=1, # Property
+            inventory_type=1,  # Property
             query_dict={'year_built__lt': ['1980']},
         )
         self.filter_group.save()
@@ -132,7 +126,7 @@ class ComplianceMetricViewTests(AccessLevelTestCase):
             content_type='application/json'
         )
         data = json.loads(response.content)
-        assert(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         self.assertEqual('compliance metric 3', data['compliance_metric']['name'])
         self.assertEqual(self.org.id, data['compliance_metric']['organization_id'])
@@ -175,7 +169,7 @@ class ComplianceMetricViewTests(AccessLevelTestCase):
             data=json.dumps(test_metric_details),
             content_type='application/json'
         )
-        assert(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # CANNOT CREATE AS CHILD-LEVEL MEMBER:
         self.login_as_child_member()
@@ -185,8 +179,7 @@ class ComplianceMetricViewTests(AccessLevelTestCase):
             data=json.dumps(test_metric_details),
             content_type='application/json'
         )
-        assert(response.status_code, 403)
-
+        self.assertEqual(response.status_code, 403)
 
     def test_compliance_metric_create_bad_data(self):
         response = self.client.post(
@@ -253,6 +246,7 @@ class ComplianceMetricViewTests(AccessLevelTestCase):
         self.assertEqual('error', data['status'])
         self.assertEqual('ComplianceMetric with id 99999 does not exist', data['message'])
 
+
 class ComplianceMetricEvaluationTests(AccessLevelTestCase):
     """
     Test ComplianceMetric model's ability to evaluate propertyview values
@@ -306,7 +300,7 @@ class ComplianceMetricEvaluationTests(AccessLevelTestCase):
         self.view12 = self.property_view_factory.get_property_view(prprty=self.retail3, cycle=self.cycle1, site_eui=65, source_eui=62, total_ghg_emissions=300)
         self.view13 = self.property_view_factory.get_property_view(prprty=self.retail4, cycle=self.cycle1, site_eui=72, source_eui=62, total_ghg_emissions=350)
 
-        data = serializers.serialize('json', [self.view10])
+        serializers.serialize('json', [self.view10])
 
         self.view20 = self.property_view_factory.get_property_view(prprty=self.office1, cycle=self.cycle2, site_eui=58, source_eui=59, total_ghg_emissions=480)
         self.view21 = self.property_view_factory.get_property_view(prprty=self.office2, cycle=self.cycle2, site_eui=68, source_eui=59, total_ghg_emissions=380)

--- a/seed/tests/test_data_view_views.py
+++ b/seed/tests/test_data_view_views.py
@@ -502,7 +502,6 @@ class DataViewEvaluationTests(TestCase):
         self.view10.property = property
         self.view10.save()
 
-
     def test_evaluation_endpoint_canonical_col_permissions(self):
         self.client.login(**self.user_with_nothing_details)
         response = self.client.put(

--- a/seed/tests/test_meter_views.py
+++ b/seed/tests/test_meter_views.py
@@ -71,7 +71,6 @@ class TestMeterCRUD(DeleteModelsTestCase):
         self.their_property_view_factory = FakePropertyViewFactory(organization=self.their_org)
         self.property_factory = FakePropertyFactory(organization=self.org)
 
-
         # create user wih nothing
         self.user_with_nothing_details = {
             'username': 'nothing@demo.com',
@@ -238,7 +237,7 @@ class TestMeterCRUD(DeleteModelsTestCase):
         # create meter
         property = self.property_factory.get_property()
         property_view = self.property_view_factory.get_property_view(property)
-        meter = Meter.objects.create(property=property)
+        Meter.objects.create(property=property)
 
         meter_url = reverse('api:v3:property-meters-list', kwargs={'property_pk': property_view.id}) + "?organization_id=" + str(self.org.id)
         response = self.client.get(meter_url)

--- a/seed/tests/test_property_measures.py
+++ b/seed/tests/test_property_measures.py
@@ -75,7 +75,6 @@ class TestPropertyMeasures(DeleteModelsTestCase):
         response = self.client.get(url, **self.headers)
         self.assertEqual(response.status_code, 404)
 
-
     def test_get_property_measure(self):
         """
         Test PropertyMeasure view can retrieve all or individual ProperyMeasure model instances

--- a/seed/tests/test_property_views.py
+++ b/seed/tests/test_property_views.py
@@ -556,7 +556,7 @@ class PropertyViewTests(DataMappingBaseTestCase):
         url += f'?organization_id={self.org.pk}'
 
         result = self.client.post(url, params, content_type='application/json')
-        assert json.loads(result.content) == False
+        assert json.loads(result.content) is False
 
         self.client.login(**self.user_with_nothing_details)
         result = self.client.post(url, params, content_type='application/json')
@@ -1426,7 +1426,6 @@ class PropertySensorViewTests(DataMappingBaseTestCase):
         result = self.client.get(url, {"property_view_id": self.property_view_1.id, "org_id": self.org.pk})
         assert result.status_code == 404
 
-
     def test_sensors_list_permissions(self):
         url = reverse('api:v3:properties-sensors', kwargs={'pk': self.property_view_1.id})
         url += f'?organization_id={self.org.pk}'
@@ -1454,7 +1453,6 @@ class PropertySensorViewTests(DataMappingBaseTestCase):
 
         result = self.client.post(url, post_params, content_type="application/json")
         assert result.status_code == 404
-
 
     def test_property_sensors_endpoint_returns_a_list_of_sensors_of_a_view(self):
         dl_a = DataLogger.objects.create(**{

--- a/seed/tests/test_views.py
+++ b/seed/tests/test_views.py
@@ -158,7 +158,6 @@ class GetDatasetsViewsTests(TestCase):
         )
         self.assertEqual('success', response.json()['status'])
 
-
     def test_get_dataset_permissions(self):
         import_record = ImportRecord.objects.create(owner=self.user, access_level_instance=self.org.root)
         import_record.super_organization = self.org
@@ -277,6 +276,7 @@ class GetDatasetsViewsTests(TestCase):
         assert response.status_code == 200
         import_record = ImportRecord.objects.get(pk=response.json()["id"])
         assert import_record.access_level_instance.id == self.child.id
+
 
 class ImportFileViewsTests(TestCase):
     def setUp(self):

--- a/seed/tests/util.py
+++ b/seed/tests/util.py
@@ -98,7 +98,7 @@ class DeleteModelsTestCase(TestCase):
         self._delete_models()
 
 
-class AccessLevelTestCase(TestCase):
+class AccessLevelBaseTestCase(TestCase):
     """Base Test Case Class to handle Access Levels
        Creates a root owner user, a root member user,
        and a child member user

--- a/seed/tests/util.py
+++ b/seed/tests/util.py
@@ -12,7 +12,12 @@ from django.utils import timezone
 
 from seed.data_importer.models import ImportFile, ImportRecord
 from seed.landing.models import SEEDUser as User
-from seed.lib.superperms.orgs.models import Organization, OrganizationUser
+from seed.lib.superperms.orgs.models import (
+    Organization,
+    OrganizationUser,
+    ROLE_MEMBER,
+    ROLE_OWNER
+)
 from seed.models import (
     ASSESSED_RAW,
     DATA_STATE_IMPORT,
@@ -41,6 +46,13 @@ from seed.models import (
 from seed.models.data_quality import DataQualityCheck
 from seed.utils.organizations import create_organization
 
+from seed.test_helpers.fake import (
+    FakeColumnFactory,
+    FakeCycleFactory,
+    FakePropertyFactory,
+    FakePropertyStateFactory,
+    FakePropertyViewFactory
+)
 
 class DeleteModelsTestCase(TestCase):
     def _delete_models(self):
@@ -84,6 +96,86 @@ class DeleteModelsTestCase(TestCase):
 
     def tearDown(self):
         self._delete_models()
+
+
+class AccessLevelTestCase(TestCase):
+    """Base Test Case Class to handle Access Levels
+       Creates a root owner user, a root member user,
+       and a child member user
+       Useful for testing "setup" API endpoints
+       as well as "data" endpoints
+       Provides methods for logging in as different
+       users
+       Sets up the factories
+    """
+    def setUp(self):
+        """ SUPERUSER """
+        self.superuser_details = {
+            'username': 'test_superuser@demo.com',
+            'password': 'test_pass',
+            'email': 'test_superuser@demo.com',
+            'first_name': 'Johnny',
+            'last_name': 'Energy',
+        }
+        self.superuser = User.objects.create_superuser(**self.superuser_details)
+        self.org, _, _ = create_organization(self.superuser, "test-organization-a")
+        # add ALI to org (2 levels)
+        self.org.access_level_names = ["root", "child"]
+        self.root_level_instance = self.org.root
+        self.child_level_instance = self.org.add_new_access_level_instance(self.org.root.id, "child")
+
+        # default login as superuser/org owner
+        self.client.login(**self.superuser_details)
+
+        """ ROOT-LEVEL OWNER USER """
+        self.root_owner_user_details = {
+            'username': 'test_user@demo.com',
+            'password': 'test_pass',
+            'email': 'test_user@demo.com',
+            'first_name': 'Jane',
+            'last_name': 'Energy',
+        }
+        self.root_owner_user = User.objects.create_user(**self.root_owner_user_details)
+        self.org.add_member(self.root_owner_user, self.org.root.id, ROLE_OWNER)
+        self.org.save()
+
+        """ ROOT-LEVEL MEMBER USER """
+        self.root_member_user_details = {
+            'username': 'root_member@demo.com',
+            'password': 'test_pass',
+        }
+        self.root_member_user = User.objects.create_user(**self.root_member_user_details)
+        self.org.add_member(self.root_member_user, self.org.root.id, ROLE_MEMBER)
+        self.org.save()
+
+        """ CHILD-LEVEL MEMBER USER """
+        self.child_member_user_details = {
+            'username': 'child_member@demo.com',
+            'password': 'test_pass',
+        }
+        self.child_member_user = User.objects.create_user(**self.child_member_user_details)
+        # add user to org
+        self.org.add_member(self.child_member_user, self.child_level_instance.pk, ROLE_MEMBER)
+        self.org.save()
+
+        # setup factories
+        self.cycle_factory = FakeCycleFactory(organization=self.org, user=self.root_owner_user)
+        self.column_factory = FakeColumnFactory(organization=self.org)
+        self.property_factory = FakePropertyFactory(organization=self.org)
+        self.property_state_factory = FakePropertyStateFactory(organization=self.org)
+        self.property_view_factory = FakePropertyViewFactory(organization=self.org)
+
+    def login_as_root_owner(self):
+        """ Login to client as Root-Level owner user """
+        self.client.login(**self.root_owner_user_details)
+
+    def login_as_root_member(self):
+        """ Login to client as Root-Level member user """
+        self.client.login(**self.root_member_user_details)
+
+    def login_as_child_member(self):
+        """ Login to client as Child-Level member user """
+        self.client.login(**self.child_member_user_details)
 
 
 class DataMappingBaseTestCase(DeleteModelsTestCase):

--- a/seed/tests/util.py
+++ b/seed/tests/util.py
@@ -13,10 +13,10 @@ from django.utils import timezone
 from seed.data_importer.models import ImportFile, ImportRecord
 from seed.landing.models import SEEDUser as User
 from seed.lib.superperms.orgs.models import (
-    Organization,
-    OrganizationUser,
     ROLE_MEMBER,
-    ROLE_OWNER
+    ROLE_OWNER,
+    Organization,
+    OrganizationUser
 )
 from seed.models import (
     ASSESSED_RAW,
@@ -44,8 +44,6 @@ from seed.models import (
     TaxLotView
 )
 from seed.models.data_quality import DataQualityCheck
-from seed.utils.organizations import create_organization
-
 from seed.test_helpers.fake import (
     FakeColumnFactory,
     FakeCycleFactory,
@@ -53,6 +51,8 @@ from seed.test_helpers.fake import (
     FakePropertyStateFactory,
     FakePropertyViewFactory
 )
+from seed.utils.organizations import create_organization
+
 
 class DeleteModelsTestCase(TestCase):
     def _delete_models(self):

--- a/seed/views/v3/compliance_metrics.py
+++ b/seed/views/v3/compliance_metrics.py
@@ -80,7 +80,7 @@ class ComplianceMetricViewSet(viewsets.ViewSet, OrgMixin):
     @require_organization_id_class
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_member')
+    @has_perm_class('requires_root_member_access')
     def destroy(self, request, pk):
         organization_id = self.get_organization(request)
 
@@ -177,7 +177,7 @@ class ComplianceMetricViewSet(viewsets.ViewSet, OrgMixin):
     @require_organization_id_class
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_member')
+    @has_perm_class('requires_root_member_access')
     def update(self, request, pk):
         org_id = self.get_organization(request)
 

--- a/seed/views/v3/compliance_metrics.py
+++ b/seed/views/v3/compliance_metrics.py
@@ -13,8 +13,8 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 
 from seed.decorators import ajax_request_class, require_organization_id_class
-from seed.lib.superperms.orgs.decorators import has_perm_class
-from seed.lib.superperms.orgs.models import Organization
+from seed.lib.superperms.orgs.decorators import has_perm_class, has_hiarchary_access
+from seed.lib.superperms.orgs.models import Organization, AccessLevelInstance
 from seed.models.compliance_metrics import ComplianceMetric
 from seed.serializers.compliance_metrics import ComplianceMetricSerializer
 from seed.utils.api import OrgMixin, api_endpoint_class
@@ -118,7 +118,7 @@ class ComplianceMetricViewSet(viewsets.ViewSet, OrgMixin):
     @require_organization_id_class
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_member')
+    @has_perm_class('requires_root_member_access')
     def create(self, request):
 
         org_id = int(self.get_organization(request))
@@ -239,7 +239,8 @@ class ComplianceMetricViewSet(viewsets.ViewSet, OrgMixin):
                 'message': 'ComplianceMetric does not exist'
             }, status=status.HTTP_404_NOT_FOUND)
 
-        response = compliance_metric.evaluate()
+        user_ali = AccessLevelInstance.objects.get(pk=request.access_level_instance_id)
+        response = compliance_metric.evaluate(user_ali)
 
         return JsonResponse({
             'status': 'success',

--- a/seed/views/v3/compliance_metrics.py
+++ b/seed/views/v3/compliance_metrics.py
@@ -13,8 +13,8 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 
 from seed.decorators import ajax_request_class, require_organization_id_class
-from seed.lib.superperms.orgs.decorators import has_perm_class, has_hiarchary_access
-from seed.lib.superperms.orgs.models import Organization, AccessLevelInstance
+from seed.lib.superperms.orgs.decorators import has_perm_class
+from seed.lib.superperms.orgs.models import AccessLevelInstance, Organization
 from seed.models.compliance_metrics import ComplianceMetric
 from seed.serializers.compliance_metrics import ComplianceMetricSerializer
 from seed.utils.api import OrgMixin, api_endpoint_class

--- a/seed/views/v3/data_logger.py
+++ b/seed/views/v3/data_logger.py
@@ -5,9 +5,8 @@ See also https://github.com/seed-platform/seed/main/LICENSE.md
 from datetime import datetime, timedelta
 
 from django.db.utils import IntegrityError
-from django.http import JsonResponse
 from pytz import timezone as pytztimezone
-from rest_framework import status, viewsets
+from rest_framework import viewsets
 
 from config.settings.common import TIME_ZONE
 from seed.decorators import ajax_request_class
@@ -15,7 +14,6 @@ from seed.lib.superperms.orgs.decorators import (
     has_hiarchary_access,
     has_perm_class
 )
-from seed.lib.superperms.orgs.models import AccessLevelInstance
 from seed.models import DataLogger, PropertyView
 from seed.utils.api import OrgMixin
 from seed.utils.api_schema import swagger_auto_schema_org_query_param

--- a/seed/views/v3/data_views.py
+++ b/seed/views/v3/data_views.py
@@ -219,7 +219,7 @@ class DataViewViewSet(viewsets.ViewSet, OrgMixin):
                 'message': f'Columns with ids {data["columns"]} do not exist'
             }, status=status.HTTP_404_NOT_FOUND)
 
-        user_ali= AccessLevelInstance.objects.get(pk=request.access_level_instance_id)
+        user_ali = AccessLevelInstance.objects.get(pk=request.access_level_instance_id)
         response = data_view.evaluate(columns, user_ali)
         return JsonResponse({
             'status': 'success',

--- a/seed/views/v3/labels.py
+++ b/seed/views/v3/labels.py
@@ -13,7 +13,6 @@ from rest_framework.renderers import JSONRenderer
 
 from seed.decorators import DecoratorMixin
 from seed.filters import LabelFilterBackend
-from seed.lib.superperms.orgs.models import AccessLevelInstance
 from seed.models import StatusLabel as Label
 from seed.serializers.labels import LabelSerializer
 from seed.utils.api import drf_api_endpoint

--- a/seed/views/v3/measures.py
+++ b/seed/views/v3/measures.py
@@ -12,7 +12,7 @@ from rest_framework.decorators import action
 from rest_framework.parsers import FormParser, JSONParser
 from rest_framework.renderers import JSONRenderer
 
-from seed.lib.superperms.orgs.decorators import has_perm_class, has_hiarchary_access
+from seed.lib.superperms.orgs.decorators import has_perm_class
 from seed.models import Measure
 from seed.serializers.measures import MeasureSerializer
 from seed.utils.api import OrgMixin

--- a/seed/views/v3/meters.py
+++ b/seed/views/v3/meters.py
@@ -4,14 +4,18 @@
 SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and other contributors.
 See also https://github.com/seed-platform/seed/main/LICENSE.md
 """
+from django.utils.decorators import method_decorator
 from rest_framework.parsers import FormParser, JSONParser
 from rest_framework.renderers import JSONRenderer
 
+from seed.lib.superperms.orgs.decorators import (
+    has_hiarchary_access,
+    has_perm_class
+)
 from seed.models import Meter, PropertyView
 from seed.serializers.meters import MeterSerializer
 from seed.utils.viewsets import SEEDOrgNoPatchOrOrgCreateModelViewSet
-from django.utils.decorators import method_decorator
-from seed.lib.superperms.orgs.decorators import has_perm_class, has_hiarchary_access
+
 
 @method_decorator(
     name='list',

--- a/seed/views/v3/property_measures.py
+++ b/seed/views/v3/property_measures.py
@@ -8,17 +8,15 @@ from django.http import JsonResponse
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 
-from seed.lib.superperms.orgs.models import AccessLevelInstance
 from seed.decorators import ajax_request_class
+from seed.lib.superperms.orgs.decorators import has_perm_class
+from seed.lib.superperms.orgs.models import AccessLevelInstance
 from seed.models import PropertyMeasure, PropertyView
 from seed.serializers.scenarios import PropertyMeasureSerializer
 from seed.utils.api import api_endpoint_class
 from seed.utils.api_schema import AutoSchemaHelper
 from seed.utils.viewsets import SEEDOrgNoPatchNoCreateModelViewSet
-from seed.lib.superperms.orgs.decorators import (
-    has_hiarchary_access,
-    has_perm_class
-)
+
 
 class PropertyMeasureViewSet(SEEDOrgNoPatchNoCreateModelViewSet):
     """
@@ -43,7 +41,7 @@ class PropertyMeasureViewSet(SEEDOrgNoPatchNoCreateModelViewSet):
             property_state = PropertyView.objects.get(
                 pk=property_pk,
                 property__access_level_instance__lft__gte=ali.lft,
-                property__access_level_instance__rgt__lte=ali.rgt,          
+                property__access_level_instance__rgt__lte=ali.rgt,
             ).state
             print(PropertyView.objects.get(pk=property_pk).property.access_level_instance)
         except PropertyView.DoesNotExist:

--- a/seed/views/v3/property_scenarios.py
+++ b/seed/views/v3/property_scenarios.py
@@ -5,19 +5,23 @@ SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and othe
 See also https://github.com/seed-platform/seed/main/LICENSE.md
 """
 from django.http import JsonResponse
+from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.parsers import FormParser, JSONParser
 from rest_framework.renderers import JSONRenderer
 
 from seed.decorators import ajax_request_class
+from seed.lib.superperms.orgs.decorators import (
+    has_hiarchary_access,
+    has_perm_class
+)
 from seed.models import Scenario
 from seed.serializers.scenarios import ScenarioSerializer
 from seed.utils.api import api_endpoint_class
 from seed.utils.api_schema import AutoSchemaHelper
 from seed.utils.viewsets import SEEDOrgNoPatchNoCreateModelViewSet
-from django.utils.decorators import method_decorator
-from seed.lib.superperms.orgs.decorators import has_perm_class, has_hiarchary_access
+
 
 @method_decorator(
     name='retrieve',

--- a/seed/views/v3/taxlots.py
+++ b/seed/views/v3/taxlots.py
@@ -13,11 +13,11 @@ from rest_framework.parsers import JSONParser
 from rest_framework.renderers import JSONRenderer
 
 from seed.decorators import ajax_request_class
-from seed.lib.superperms.orgs.models import AccessLevelInstance
 from seed.lib.superperms.orgs.decorators import (
     has_hiarchary_access,
     has_perm_class
 )
+from seed.lib.superperms.orgs.models import AccessLevelInstance
 from seed.models import (
     AUDIT_USER_EDIT,
     DATA_STATE_MATCHING,


### PR DESCRIPTION
Add helper methods for testing ALI-related permissions
Add decorator @has_perm_class('requires_root_member_access') that can be used to test "setup" type API endpoints
Update compliance_metrics endpoints and tests