### PR TITLE
Add Open Street Map to CSP rules

### DIFF
--- a/docker/nginx/seed-csp.conf
+++ b/docker/nginx/seed-csp.conf
@@ -34,7 +34,9 @@ set $FRAME "${FRAME} https://better.lbl.gov/";
 
 set $IMG "img-src 'self' data:";
 set $IMG "${IMG} https://*.a.ssl.fastly.net";
+set $IMG "${IMG} https://*.tile.openstreetmap.org";
 set $IMG "${IMG} https://better-lbnl-development.herokuapp.com";
+set $IMG "${IMG} https://better-lbnl-staging.herokuapp.com";
 set $IMG "${IMG} https://better.lbl.gov";
 set $IMG "${IMG} https://validator.swagger.io";
 


### PR DESCRIPTION
#### What's this PR do?
Adds `https://*.tile.openstreetmap.org` and `https://better-lbnl-staging.herokuapp.com` to the allowed domains for loading images (to fix the map view)

#### How should this be manually tested?
Run the web container in production with nginx, then load a map view

#### What are the relevant tickets?
#4168 
