### PR TITLE
Set the MEDIA_ROOT path back to original value during test

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -31,10 +31,12 @@ bedes
 Bool
 boolean
 BrowserDefinition
+bsync
 bsyncr
 buildingsnapshot
 BuildingSnapshot
 BuildingSnapshots
+BUILDINGSYNC
 bytestring
 calendarize
 canonicalbuilding
@@ -261,6 +263,7 @@ strftime
 subclasses
 subdirectory
 Submodules
+suborg
 Subpackages
 subtask
 sudo

--- a/seed/tests/test_media.py
+++ b/seed/tests/test_media.py
@@ -50,6 +50,7 @@ class TestMeasures(TestCase):
     @classmethod
     def setUpClass(cls):
         # Override MEDIA_ROOT as the temporary dir (kind of a bad way to do this but ya know)
+        cls.previous_media_root = settings.MEDIA_ROOT
         cls.temp_media_dir = tempfile.TemporaryDirectory()
         settings.MEDIA_ROOT = cls.temp_media_dir.name
 
@@ -87,6 +88,8 @@ class TestMeasures(TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        # set the media directory back
+        settings.MEDIA_ROOT = cls.previous_media_root
         cls.temp_media_dir.cleanup()
 
     def test_successfully_get_uploads_file_when_user_is_org_member(self):

--- a/seed/tests/test_media.py
+++ b/seed/tests/test_media.py
@@ -62,7 +62,7 @@ class TestMeasures(TestCase):
         with open(cls.absolute_uploads_file, 'w') as f:
             f.write('Hello world')
 
-        # buildingsync file
+        # BuildingSync file
         upload_to = BuildingFile._meta.get_field('file').upload_to
         cls.absolute_bsync_file = os.path.join(settings.MEDIA_ROOT, upload_to, 'test_bsync.xml')
         os.makedirs(os.path.dirname(cls.absolute_bsync_file), exist_ok=True)
@@ -313,7 +313,7 @@ class TestMeasures(TestCase):
         # Assert
         self.assertFalse(is_permitted)
 
-    def test_fails_when_path_doesnt_match(self):
+    def test_fails_when_path_does_not_match(self):
         # test import files
         with self.assertRaises(ModelForFileNotFound):
             check_file_permission(


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### Any background context you want to provide?
The `test_media.py` file mucks with the location of the MEDIA_ROOT. If there is a test that runs after this that write data to the MEDIA_ROOT, then it will still be pointing to the updated location (which is the `/tmp` dir). If the subsequent test needs to read out of MEDIA_ROOT it will fail due to the "file not in django working path" error.

#### What's this PR do?
After running the test, in the tearDown, set the MEDIA_ROOT back to the previous value.

#### How should this be manually tested?
CI only

#### What are the relevant tickets?
N/A
#### Screenshots (if appropriate)
