### PR TITLE
Optimize list analyses endpoint

### DIFF
--- a/seed/serializers/analysis_property_views.py
+++ b/seed/serializers/analysis_property_views.py
@@ -8,12 +8,11 @@ from rest_framework import serializers
 
 from seed.models import AnalysisPropertyView
 from seed.serializers.analysis_output_files import AnalysisOutputFileSerializer
-from seed.serializers.properties import PropertyStateSerializer
 
 
 class AnalysisPropertyViewSerializer(serializers.ModelSerializer):
     output_files = AnalysisOutputFileSerializer(source='analysisoutputfile_set', many=True)
-    property_state = PropertyStateSerializer()
+    display_name = serializers.CharField(required=False)
 
     class Meta:
         model = AnalysisPropertyView

--- a/seed/static/seed/js/controllers/analyses_controller.js
+++ b/seed/static/seed/js/controllers/analyses_controller.js
@@ -151,15 +151,6 @@ angular.module('BE.seed.controller.analyses', [])
 
       $scope.is_object = _.isObject;
 
-      $scope.get_display_name = function (inventory_state) {
-        return organization_service.get_inventory_display_value(
-          $scope.org,
-          // NOTE: hardcoding 'property' b/c you can only run analyses on properties
-          'property',
-          inventory_state
-        );
-      };
-
     }
   ])
   .filter('get_run_duration', function () {

--- a/seed/static/seed/partials/analyses.html
+++ b/seed/static/seed/partials/analyses.html
@@ -91,10 +91,10 @@
                             <td><a ui-sref="analysis_run(::{run_id: view.id, analysis_id: view.analysis, organization_id: org.id})" ui-sref-active="active">{$:: view.id $}</a></td>
                             <td>
                                 <a ng-if="original_views[view.id]" ui-sref="inventory_detail({inventory_type: 'properties', view_id: original_views[view.id]})">
-                                    {$:: get_display_name(view.property_state) || 'Property ' + original_views[view.id] $}
+                                    {$:: view.display_name || 'Property ' + original_views[view.id] $}
                                 </a>
                                 <span ng-if="!original_views[view.id]" uib-tooltip="Property no longer exists">
-                                    {$:: get_display_name(view.property_state) || 'Unknown' $}
+                                    {$:: view.display_name || 'Unknown' $}
                                 </span>
                             </td>
                             <td>

--- a/seed/views/v3/analyses.py
+++ b/seed/views/v3/analyses.py
@@ -164,7 +164,7 @@ class AnalysisViewSet(viewsets.ViewSet, OrgMixin):
                 display_column_field = "extra_data__" + display_column_field
 
             views_queryset = AnalysisPropertyView.objects.filter(analysis__organization_id=organization_id).order_by('-id')
-            views_queryset = views_queryset.annotate(display_name=F(f'property_state__{display_column_field}'))
+            views_queryset = views_queryset.annotate(display_name=F(f'property_state__{display_column_field}')).prefetch_related("analysisoutputfile_set")
             property_views_by_apv_id = AnalysisPropertyView.get_property_views(views_queryset)
 
             results["views"] = AnalysisPropertyViewSerializer(list(views_queryset), many=True).data

--- a/seed/views/v3/analyses.py
+++ b/seed/views/v3/analyses.py
@@ -7,7 +7,8 @@ See also https://github.com/seed-platform/seed/main/LICENSE.md
 import json
 import logging
 
-from django.db.models import Count
+from django.contrib.postgres.aggregates import ArrayAgg
+from django.db.models import Count, F, Q
 from django.http import JsonResponse
 from drf_yasg.utils import swagger_auto_schema
 from pint import Quantity
@@ -34,9 +35,6 @@ from seed.models import (
     PropertyView
 )
 from seed.serializers.analyses import AnalysisSerializer
-from seed.serializers.analysis_property_views import (
-    AnalysisPropertyViewSerializer
-)
 from seed.utils.api import OrgMixin, api_endpoint_class
 from seed.utils.api_schema import AutoSchemaHelper
 
@@ -160,13 +158,28 @@ class AnalysisViewSet(viewsets.ViewSet, OrgMixin):
             views_queryset = AnalysisPropertyView.objects.filter(analysis__organization_id=organization_id).order_by('-id')
             property_views_by_apv_id = AnalysisPropertyView.get_property_views(views_queryset)
 
-            results["views"] = AnalysisPropertyViewSerializer(list(views_queryset), many=True).data
+            results["views"] = self._format_views(views_queryset, organization_id)
             results["original_views"] = {
                 apv_id: property_view.id if property_view is not None else None
                 for apv_id, property_view in property_views_by_apv_id.items()
             }
 
         return JsonResponse(results)
+
+    def _format_views(self, views_queryset, organization_id):
+        """"
+            add view display_name and output files to queryset
+        """
+        org = Organization.objects.get(pk=organization_id)
+        display_column = Column.objects.filter(organization=org, column_name=org.property_display_field).first()
+        display_column_field = display_column.column_name
+        if display_column.is_extra_data:
+            display_column_field = "extra_data__" + display_column_field
+
+        views_queryset = views_queryset.annotate(display_name=F(f'property_state__{display_column_field}'))
+        views_queryset = views_queryset.annotate(output_files=ArrayAgg("analysisoutputfile", filter=Q(analysisoutputfile__isnull=False)))
+
+        return list(views_queryset.values("id", "output_files", "parsed_results", "analysis", "property", "cycle", "property_state", "display_name"))
 
     @swagger_auto_schema(manual_parameters=[AutoSchemaHelper.query_org_id_field(True)])
     @require_organization_id_class

--- a/seed/views/v3/analyses.py
+++ b/seed/views/v3/analyses.py
@@ -155,7 +155,14 @@ class AnalysisViewSet(viewsets.ViewSet, OrgMixin):
         results = {'status': 'success', 'analyses': analyses}
 
         if analyses and include_views:
+            org = Organization.objects.get(pk=organization_id)
+            display_column = Column.objects.filter(organization=org, column_name=org.property_display_field).first()
+            display_column_field = display_column.column_name
+            if display_column.is_extra_data:
+                display_column_field = "extra_data__" + display_column_field
+
             views_queryset = AnalysisPropertyView.objects.filter(analysis__organization_id=organization_id).order_by('-id')
+            views_queryset = views_queryset.annotate(display_name=F(f'property_state__{display_column_field}'))
             property_views_by_apv_id = AnalysisPropertyView.get_property_views(views_queryset)
 
             results["views"] = self._format_views(views_queryset, organization_id)


### PR DESCRIPTION
Previously, `GET /api/v3/analyses/` returned a whole propertystate per `AnalysisPropertyViews` of which there are many. We did this the compute view display_name client side. now we compute that in the backend, greatly decreasing the amount of fetched and sent data. 

We were also querying for each `AnalysisPropertyViews`'s outputfiles one at a time. We are now prefetching them with the `AnalysisPropertyViews`

on a test db with 400 `AnalysisPropertyViews`, `GET /api/v3/analyses/` used to take ~4.5 secs and returns ~75 KB. It now returns < .4 secs and returns ~10KB.  I believe both of these performance gain will scale linearly with the number of `AnalysisPropertyViews`.