### PR TITLE
Move analyses endpoint

### DIFF
--- a/seed/static/seed/js/services/analyses_service.js
+++ b/seed/static/seed/js/services/analyses_service.js
@@ -36,7 +36,7 @@ angular.module('BE.seed.service.analyses', [])
 
       const get_analyses_for_canonical_property = function (property_id) {
         const org = user_service.get_organization().id;
-        return $http.get('/api/v3/analyses/?&include_views=false&organization_id=' + org + '&property_id=' + property_id).then(function (response) {
+        return $http.get('/api/v3/properties/' + property_id + '/analyses/?organization_id=' + org).then(function (response) {
           return response.data;
         });
       };

--- a/seed/tests/test_analyses_views.py
+++ b/seed/tests/test_analyses_views.py
@@ -148,10 +148,7 @@ class TestAnalysesView(TestCase):
 
     def test_list_with_property(self):
         response = self.client.get("".join([
-            '/api/v3/analyses/?organization_id=',
-            str(self.org.pk),
-            '&property_id=',
-            str(self.property_a.pk)
+            '/api/v3/properties/', str(self.property_a.pk), '/analyses/?organization_id=', str(self.org.pk),
         ]))
         self.assertEqual(response.status_code, 200)
         result = json.loads(response.content)

--- a/seed/views/v3/analyses.py
+++ b/seed/views/v3/analyses.py
@@ -133,25 +133,17 @@ class AnalysisViewSet(viewsets.ViewSet, OrgMixin):
     @has_perm_class('requires_member')
     def list(self, request):
         organization_id = self.get_organization(request)
-        property_id = request.query_params.get('property_id', None)
         include_views = json.loads(request.query_params.get('include_views', 'true'))
 
         analyses = []
-        if property_id is not None:
-            analyses_queryset = (
-                Analysis.objects.filter(organization=organization_id, analysispropertyview__property=property_id)
-                .distinct()
-                .order_by('-id')
-            )
-        else:
-            analyses_queryset = (
-                Analysis.objects.filter(organization=organization_id)
-                .order_by('-id')
-            )
+        analyses_queryset = (
+            Analysis.objects.filter(organization=organization_id)
+            .order_by('-id')
+        )
         for analysis in analyses_queryset:
             serialized_analysis = AnalysisSerializer(analysis).data
-            serialized_analysis.update(analysis.get_property_view_info(property_id))
-            serialized_analysis.update({'highlights': analysis.get_highlights(property_id)})
+            serialized_analysis.update(analysis.get_property_view_info())
+            serialized_analysis.update({'highlights': analysis.get_highlights()})
             analyses.append(serialized_analysis)
 
         results = {'status': 'success', 'analyses': analyses}

--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -27,6 +27,7 @@ from seed.models import (
     MERGE_STATE_DELETE,
     MERGE_STATE_MERGED,
     MERGE_STATE_NEW,
+    Analysis,
     BuildingFile,
     Column,
     ColumnMappingProfile,
@@ -45,6 +46,7 @@ from seed.models import (
 )
 from seed.models import StatusLabel as Label
 from seed.models import TaxLotProperty, TaxLotView
+from seed.serializers.analyses import AnalysisSerializer
 from seed.serializers.pint import PintJSONEncoder
 from seed.serializers.properties import (
     PropertySerializer,
@@ -281,6 +283,26 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
         exporter = PropertyMeterReadingsExporter(property_id, org_id, excluded_meter_ids, scenario_ids=scenario_ids)
 
         return exporter.readings_and_column_defs(interval)
+
+    @ajax_request_class
+    @has_perm_class('requires_viewer')
+    @action(detail=True, methods=['GET'])
+    def analyses(self, request, pk):
+        organization_id = self.get_organization(request)
+
+        analyses_queryset = (
+            Analysis.objects.filter(organization=organization_id, analysispropertyview__property=pk)
+            .distinct().order_by('-id')
+        )
+
+        analyses = []
+        for analysis in analyses_queryset:
+            serialized_analysis = AnalysisSerializer(analysis).data
+            serialized_analysis.update(analysis.get_property_view_info(pk))
+            serialized_analysis.update({'highlights': analysis.get_highlights(pk)})
+            analyses.append(serialized_analysis)
+
+        return {'status': 'success', 'analyses': analyses}
 
     @ajax_request_class
     @has_perm_class('requires_member')


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### Any background context you want to provide?

#### What's this PR do?

#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

The endpoint to get all a properties analyses used to be `/v3/analyses/{id}?property_id={id}`, same as the regular "list analyses" endpoint but with an arg. I've removed the arg, and created the endpoint `/v3/properties/{id}/analyses`. This vibes better with the AH permissions. 

I keeped the `v3/analyses/{id}/views/` endpoints in place tho. What do you think of that choice?

