### PR TITLE
Fix 179d ESPM update endpoint to run in foreground with Celery enabled

### DIFF
--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -596,6 +596,52 @@ def _data_quality_check_create_tasks(org_id, property_state_ids, taxlot_state_id
     return tasks
 
 
+def map_data_synchronous(import_file_id: int) -> dict:
+    """This method is used to map data synchronously and intended for only mapping a
+    small set of data. It is used in the Update with ESPM workflow, which runs on a
+    single property. Further, this method is a copy of the `map_data` method but simplified
+    to run only in the foreground.
+
+    Args:
+        import_file_id (int): Database ID of the import file record
+
+    Returns:
+        dict: Result of the progress data.
+    """
+    import_file = ImportFile.objects.get(pk=import_file_id)
+
+    # create a key, but this is just used to communicate the result
+    progress_data = ProgressData(func_name='map_data_only', unique_id=import_file_id)
+    progress_data.delete()
+
+    # Check for duplicate column headers
+    column_headers = import_file.first_row_columns or []
+    duplicate_tracker = collections.defaultdict(lambda: 0)
+    for header in column_headers:
+        duplicate_tracker[header] += 1
+        if duplicate_tracker[header] > 1:
+            raise Exception("Duplicate column found in file: %s" % (header))
+
+    source_type = SEED_DATA_SOURCES_MAPPING.get(import_file.source_type, ASSESSED_RAW)
+
+    qs = PropertyState.objects.filter(
+        import_file=import_file,
+        source_type=source_type,
+        data_state=DATA_STATE_IMPORT,
+    ).only('id').iterator()
+
+    # This version of the `map_data` should only be run when the data
+    # set is reasonably small because it will block operations and prevent
+    # reporting status updates.
+    id_chunks = [[obj.id for obj in chunk] for chunk in batch(qs, 100)]
+    for ids in id_chunks:
+        map_row_chunk(ids, import_file_id, source_type, progress_data.key)
+
+    finish_mapping(import_file_id, True, progress_data.key)
+
+    return progress_data.result()
+
+
 def map_data(import_file_id, remap=False, mark_as_done=True):
     """
     Map data task. By default this method will run through the mapping and mark it as complete.
@@ -603,7 +649,7 @@ def map_data(import_file_id, remap=False, mark_as_done=True):
     :param remap: bool, if remapping, then delete previous objects from the database
     :param mark_as_done: bool, if skip review then the mapping_done flag will be set to true at the
     end.
-    :return: JSON
+    :return: dict
     """
     import_file = ImportFile.objects.get(pk=import_file_id)
 
@@ -1254,6 +1300,67 @@ def _save_raw_data_create_tasks(file_pk, progress_key):
         tasks.append(_save_raw_data_chunk.s(chunk, file_pk, progress_data.key))
 
     return chord(tasks, interval=15)(finish_raw_save.s(file_pk, progress_data.key))
+
+
+def save_raw_espm_data_synchronous(file_pk: int) -> dict:
+    """This method is a one-off method for saving ESPM the raw data synchronously. This
+    is needed for the ESPM update method that runs on a single property. The `save_raw_data`
+    method is not used because it is asynchronous and the pieces of that method were
+    copied here. Technically, this method will work with a CSV or XLSX spreadsheet too,
+    but was only intended for ESPM.
+
+    Args:
+        file_pk (int): Import file ID to import
+
+    Returns:
+        dict: returns the result of the progress data
+    """
+    progress_data = ProgressData(func_name='save_raw_data_synchronous', unique_id=file_pk)
+    try:
+        # Go get the tasks that need to be created, then call them in the chord here.
+        import_file = ImportFile.objects.get(pk=file_pk)
+        if import_file.raw_save_done:
+            return progress_data.finish_with_warning('Raw data already saved')
+
+        try:
+            parser = reader.MCMParser(import_file.local_file)
+        except Exception as e:
+            _log.debug(f'Error reading XLSX file: {str(e)}')
+            return progress_data.finish_with_error('Failed to parse XLSX file. Please review your import file - all headers should be present and non-numeric.')
+
+        import_file.has_generated_headers = False
+        if hasattr(parser, 'has_generated_headers'):
+            import_file.has_generated_headers = parser.has_generated_headers
+
+        cache_first_rows(import_file, parser)
+        import_file.num_rows = 0
+        import_file.num_columns = parser.num_columns()
+
+        chunks = []
+        for batch_chunk in batch(parser.data, 100):
+            import_file.num_rows += len(batch_chunk)
+            chunks.append(batch_chunk)
+        import_file.save()
+
+        progress_data.total = len(chunks)
+        progress_data.save()
+
+        # Save the raw data chunks. This should only happen
+        # on a small amount of data since it is running in the foreground
+        for chunk in chunks:
+            _save_raw_data_chunk(chunk, file_pk, progress_data.key)
+
+        finish_raw_save(file_pk, progress_data.key)
+    except Error as e:
+        progress_data.finish_with_error('File Content Error: ' + str(e), traceback.format_exc())
+    except KeyError as e:
+        progress_data.finish_with_error('Invalid Column Name: "' + str(e) + '"', traceback.format_exc())
+    except TypeError:
+        progress_data.finish_with_error('TypeError Exception', traceback.format_exc())
+    except Exception as e:
+        progress_data.finish_with_error('Unhandled Error: ' + str(e), traceback.format_exc())
+
+    return progress_data.result()
 
 
 def save_raw_data(file_pk):

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -616,7 +616,7 @@ def map_data_synchronous(import_file_id: int) -> dict:
 
     # Check for duplicate column headers
     column_headers = import_file.first_row_columns or []
-    duplicate_tracker = collections.defaultdict(lambda: 0)
+    duplicate_tracker: dict = collections.defaultdict(lambda: 0)
     for header in column_headers:
         duplicate_tracker[header] += 1
         if duplicate_tracker[header] > 1:

--- a/seed/lib/xml_mapping/mapper.py
+++ b/seed/lib/xml_mapping/mapper.py
@@ -56,20 +56,24 @@ def get_bae_mappings():
     # units field name is the same with " Units" appended.
 
     bsync_assets = BAE.get_default_asset_defs()
-    for item in bsync_assets:
+    for asset in bsync_assets:
+        if isinstance(asset, dict):
+            asset_type, export_name, export_units = asset['type'], asset['export_name'], asset['export_units']
+        else:
+            asset_type, export_name, export_units = asset.type, asset.export_name, asset.export_units
 
-        if item.type == 'sqft':
+        if asset_type == 'sqft':
             # these types need 2 different entries: 1 for "primary" and 1 for "secondary"
             for i in ['Primary', 'Secondary']:
-                results.append(make_bae_hash(i + ' ' + item.export_name))
-                if item.export_units is True:
+                results.append(make_bae_hash(i + ' ' + export_name))
+                if export_units is True:
                     # also export units field
-                    results.append(make_bae_hash(i + ' ' + item.export_name + " Units"))
+                    results.append(make_bae_hash(i + ' ' + export_name + " Units"))
 
         else:
-            results.append(make_bae_hash(item.export_name))
-            if item.export_units is True:
-                results.append(make_bae_hash(item.export_name + " Units"))
+            results.append(make_bae_hash(export_name))
+            if export_units is True:
+                results.append(make_bae_hash(export_name + " Units"))
 
     return results
 

--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -1654,8 +1654,8 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
             source_program_version='1.0',
         )
 
-        # save the raw data
-        tasks.save_raw_data(import_file.pk)
+        # save the raw data, but do it synchronously in the foreground
+        tasks.save_raw_espm_data_synchronous(import_file.pk)
 
         # verify that there is only one property in the file
         import_file.refresh_from_db()
@@ -1671,8 +1671,8 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
         # assign the mappings to the import file id
         Column.create_mappings(column_mapping_profile.mappings, org_inst, request.user, import_file.pk)
 
-        # call the mapping process
-        tasks.map_data(import_file.pk)
+        # call the mapping process - but do this in the foreground, not asynchronously.
+        tasks.map_data_synchronous(import_file.pk)
 
         # The data should now be mapped, but since we called the task, we have the IDs of the
         # mapped files, so query for the files.


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### Any background context you want to provide?
The import process relies heavily on cascading delay/background tasks. To allow a full path through the existing background tasks in the foreground on a system that has celery enabled is complicated. 

#### What's this PR do?
* creates two new methods for saving raw data and mapping in the foreground. 

There is definitely some areas of improvement with the entire Celery workflow, but this will not be done until the AH work is complete.

#### How should this be manually tested?
* locally start SEED with the always eager flag set to false. 
* test the `Update from ESPM` method. It should now return successfully and update the SEED property

#### What are the relevant tickets?
n/a
#### Screenshots (if appropriate)
