### PR TITLE
Fix Meters Without `source_id`

### DIFF
--- a/seed/static/seed/js/controllers/inventory_detail_meters_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_meters_controller.js
@@ -48,9 +48,7 @@ angular.module('BE.seed.controller.inventory_detail_meters', [])
         view_id: $stateParams.view_id
       };
 
-      var getMeterLabel = function (meter) {
-        return meter.type + ' - ' + meter.source + ' - ' + meter.source_id;
-      };
+      const getMeterLabel = ({source, source_id, type}) => `${type} - ${source} - ${source_id ?? 'None'}`;
 
       var resetSelections = function () {
         $scope.sorted_meters = _.sortBy(meters, ['source', 'source_id', 'type']);


### PR DESCRIPTION
#### What's this PR do?
Fixes showing meter readings for meters that don't have a `source_id` value

#### How should this be manually tested?
See the related ticket

#### What are the relevant tickets?
#4228 