### PR TITLE
http request type

### DIFF
--- a/seed/views/v3/users.py
+++ b/seed/views/v3/users.py
@@ -183,7 +183,7 @@ class UserViewSet(viewsets.ViewSet, OrgMixin):
                 return JsonResponse({
                     'status': 'error',
                     'message': 'if using an existing org, you must provide a `access_level_instance_id`'
-                }, status=status._BAD_REQUEST)
+                }, status=status.HTTP_400_BAD_REQUEST)
         else:
             org, _, _ = create_organization(user, org_name)
             access_level_instance_id = AccessLevelInstance.objects.get(organization=org, depth=1).id


### PR DESCRIPTION
#### Any background context you want to provide?
Typo in user creation endpoint. `_BAD_REQUEST` -> `HTTP_400_BAD_REQUEST`

```
seed_web       |   File "/seed/seed/views/v3/users.py", line 186, in create
seed_web       |     }, status=status._BAD_REQUEST)
seed_web       | AttributeError: module 'rest_framework.status' has no attribute '_BAD_REQUEST'
```