### PR TITLE
Fix user creation bug

### DIFF
--- a/seed/static/seed/js/controllers/admin_controller.js
+++ b/seed/static/seed/js/controllers/admin_controller.js
@@ -99,10 +99,10 @@ angular.module('BE.seed.controller.admin', [])
         $scope.user.access_level_instance_id = undefined
         $scope.level_name_index = undefined
 
-        organization_service.get_organization_access_level_tree($scope.user.organization.id).then(access_level_instance => {
-          $scope.level_names = access_level_instance.access_level_names
+        organization_service.get_organization_access_level_tree($scope.user.organization.id).then(access_level_tree => {
+          $scope.level_names = access_level_tree.access_level_names
           access_level_instances_by_depth = {}
-          calculate_access_level_instances_by_depth(access_level_instance.access_level_tree, 1)
+          calculate_access_level_instances_by_depth(access_level_tree.access_level_tree, 1)
         })
       };
       $scope.org_form.reset = function () {

--- a/seed/static/seed/js/controllers/admin_controller.js
+++ b/seed/static/seed/js/controllers/admin_controller.js
@@ -33,7 +33,6 @@ angular.module('BE.seed.controller.admin', [])
       Notification,
       $window,
       $translate,
-      access_level_tree
     ) {
       $scope.is_superuser = auth_payload.auth.requires_superuser;
       $scope.user = {};

--- a/seed/static/seed/js/controllers/admin_controller.js
+++ b/seed/static/seed/js/controllers/admin_controller.js
@@ -98,7 +98,7 @@ angular.module('BE.seed.controller.admin', [])
       $scope.org_form.existing_org = () => {
         $scope.user.org_name = undefined
         $scope.user.access_level_instance_id = undefined
-        $scope.level_name_index = undefined 
+        $scope.level_name_index = undefined
 
         organization_service.get_organization_access_level_tree($scope.user.organization.id).then(access_level_instance => {
           $scope.level_names = access_level_instance.access_level_names

--- a/seed/static/seed/js/controllers/new_member_modal_controller.js
+++ b/seed/static/seed/js/controllers/new_member_modal_controller.js
@@ -56,7 +56,7 @@ angular.module('BE.seed.controller.new_member_modal', [])
       }];
       $scope.user = {
         organization,
-        role: $scope.roles[1]
+        role: $scope.roles[1].value
       };
 
       /**
@@ -65,7 +65,6 @@ angular.module('BE.seed.controller.new_member_modal', [])
       $scope.submit_form = function () {
         // make `role` a string
         const u = _.cloneDeep($scope.user);
-        u.role = u.role.value;
 
         user_service.add(u).then(function () {
           $uibModalInstance.close();

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -442,7 +442,11 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           users_payload: ['auth_payload', 'user_service', function (auth_payload, user_service) {
             // Require auth_payload to successfully complete before attempting
             return user_service.get_users();
-          }]
+          }],
+          access_level_tree: ['organization_service', 'user_service', function (organization_service, user_service) {
+            var organization_id = user_service.get_organization().id;;
+            return organization_service.get_organization_access_level_tree(organization_id);
+          }],
         }
       })
       .state({

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -442,7 +442,7 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
           users_payload: ['auth_payload', 'user_service', function (auth_payload, user_service) {
             // Require auth_payload to successfully complete before attempting
             return user_service.get_users();
-          }],
+          }]
         }
       })
       .state({

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -443,10 +443,6 @@ SEED_app.config(['stateHelperProvider', '$urlRouterProvider', '$locationProvider
             // Require auth_payload to successfully complete before attempting
             return user_service.get_users();
           }],
-          access_level_tree: ['organization_service', 'user_service', function (organization_service, user_service) {
-            var organization_id = user_service.get_organization().id;;
-            return organization_service.get_organization_access_level_tree(organization_id);
-          }],
         }
       })
       .state({

--- a/seed/static/seed/partials/admin.html
+++ b/seed/static/seed/partials/admin.html
@@ -74,13 +74,13 @@
                         <div class="form-group">
                             <label class="col-sm-2 control-label" for="new_user_org_select" translate>Choose Existing Organization:</label>
                             <div class="col-sm-4">
-                                <select name="new_user_orgs" class="form-control" id="new_user_org_select" ng-options="o as o.name for o in org_user.organizations" ng-model="user.organization" ng-change="user.org_name = undefined"></select>
+                                <select name="new_user_orgs" class="form-control" id="new_user_org_select" ng-options="o as o.name for o in org_user.organizations" ng-model="user.organization" ng-change="org_form.existing_org()"></select>
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label" for="org_name_from_user" translate>Or Create New (With User as Head):</label>
                             <div class="col-sm-4">
-                                <input type="text" class="form-control" id="org_name_from_user" ng-model="user.org_name" ng-change="user.organization = undefined" placeholder="{$:: 'Organization Name' | translate $}">
+                                <input type="text" class="form-control" id="org_name_from_user" ng-model="user.org_name" ng-change="org_form.new_org()" placeholder="{$:: 'Organization Name' | translate $}">
                             </div>
                         </div>
                         <div class="form-group">
@@ -93,7 +93,7 @@
                         <div class="form-group">
                             <label class="col-sm-2 control-label" for="access_level_name" translate>Access Level:</label>
                             <div class="col-sm-4">
-                                <select class="form-control" id="access_level_name" ng-model="level_name_index" ng-change="change_selected_level_index()"
+                                <select class="form-control" id="access_level_name" ng-model="level_name_index" ng-change="change_selected_level_index()" ng-disabled="user.org_name"
                                     ng-options="i as name for (i, name) in level_names">
                                 </select>
                             </div>
@@ -102,7 +102,7 @@
                             <label class="col-sm-2 control-label" for="access_level_instance" translate>Access Level Instance:</label>
                             <div class="col-sm-4">
                                 <select class="form-control" id="access_level_instance" ng-model="user.access_level_instance_id"
-                                    ng-options="potential_level_instance.id as potential_level_instance.name for potential_level_instance in potential_level_instances">
+                                    ng-options="potential_level_instance.id as potential_level_instance.name for potential_level_instance in potential_level_instances" ng-disabled="user.org_name">
                                 </select>
                             </div>
                         </div>

--- a/seed/static/seed/partials/admin.html
+++ b/seed/static/seed/partials/admin.html
@@ -84,6 +84,29 @@
                             </div>
                         </div>
                         <div class="form-group">
+                            <label class="col-sm-2 control-label" for="user_role" translate>Role:</label>
+                            <div class="col-sm-4">
+                                <select class="form-control" id="user_role" ng-model="user.role" ng-options="role.value as role.name for role in roles">
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-2 control-label" for="access_level_name" translate>Access Level:</label>
+                            <div class="col-sm-4">
+                                <select class="form-control" id="access_level_name" ng-model="level_name_index" ng-change="change_selected_level_index()"
+                                    ng-options="i as name for (i, name) in level_names">
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-2 control-label" for="access_level_instance" translate>Access Level Instance:</label>
+                            <div class="col-sm-4">
+                                <select class="form-control" id="access_level_instance" ng-model="user.access_level_instance_id"
+                                    ng-options="potential_level_instance.id as potential_level_instance.name for potential_level_instance in potential_level_instances">
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-group">
                             <div class="col-sm-offset-2 col-sm-10">
                                 <button class="btn btn-default" type="reset" ng-click="user_form.reset()" translate>Reset</button>
                                 <button class="btn btn-primary" type="submit" ng-click="user_form.add(user)" ng-disabled="userForm.$invalid || user_form.not_ready()" translate>Create</button>

--- a/seed/static/seed/partials/new_member_modal.html
+++ b/seed/static/seed/partials/new_member_modal.html
@@ -13,35 +13,35 @@
         <div class="form-group"  ng-class="{ 'has-error' : new_member_form.last_name.$invalid && !new_member_form.last_name.$pristine }">
             <label class="control-label col-sm-3" for="newMemberLastName" translate>Last Name:</label>
             <div class="col-sm-8">
-                <input type="text" class="form-control" name="last_name" placeholder="{$:: 'Enter last name' | translate $}" ng-model="user.last_name" required>
+                <input type="text" class="form-control" id="newMemberLastName" name="last_name" placeholder="{$:: 'Enter last name' | translate $}" ng-model="user.last_name" required>
                  <p ng-show="new_member_form.last_name.$invalid && !new_member_form.last_name.$pristine" class="help-block" translate>Last name is required.</p>
             </div>
         </div>
         <div class="form-group"  ng-class="{ 'has-error' : new_member_form.email.$invalid && !new_member_form.email.$pristine }">
             <label class="control-label col-sm-3" for="newMemberEmail" translate>Email Address:</label>
             <div class="col-sm-8">
-                <input type="email" class="form-control" name="email" placeholder="{$:: 'Enter email address' | translate $}" ng-model="user.email" required>
+                <input type="email" class="form-control" id="newMemberEmail" name="email" placeholder="{$:: 'Enter email address' | translate $}" ng-model="user.email" required>
                 <p ng-show="new_member_form.email.$invalid && !new_member_form.email.$pristine" class="help-block" translate>Enter a valid email address.</p>
             </div>
         </div>
         <div class="form-group">
-            <label class="control-label col-sm-3" for="newMemberEmail" translate>Role:</label>
+            <label class="control-label col-sm-3" for="newMemberRole" translate>Role:</label>
             <div class="col-sm-8">
-                <select class="form-control" ng-model="user.role" ng-options="role as role.name for role in roles">
+                <select class="form-control" id="newMemberRole" ng-model="user.role" ng-options="role.value as role.name for role in roles">
                 </select>
             </div>
         </div>
         <div class="form-group">
             <label class="control-label col-sm-3" for="newMemberAccessLevel" translate>Access Level:</label>
             <div class="col-sm-8">
-                <select class="form-control" ng-model="level_name_index" ng-change="change_selected_level_index()" ng-options="i as name for (i, name) in level_names">
+                <select class="form-control" id="newMemberAccessLevel" ng-model="level_name_index" ng-change="change_selected_level_index()" ng-options="i as name for (i, name) in level_names">
                 </select>
             </div>
         </div>
         <div class="form-group">
-            <label class="control-label col-sm-3" for="newMemberAccessLevel" translate>Access Level Instance:</label>
+            <label class="control-label col-sm-3" for="newMemberAccessLevelInstance" translate>Access Level Instance:</label>
             <div class="col-sm-8">
-                <select class="form-control" ng-model="user.access_level_instance_id" ng-options="potential_level_instance.id as potential_level_instance.name for potential_level_instance in potential_level_instances">
+                <select class="form-control" id="newMemberAccessLevelInstance" ng-model="user.access_level_instance_id" ng-options="potential_level_instance.id as potential_level_instance.name for potential_level_instance in potential_level_instances">
                 </select>
             </div>
         </div>

--- a/seed/static/seed/tests/new_member_modal_controller.spec.js
+++ b/seed/static/seed/tests/new_member_modal_controller.spec.js
@@ -63,7 +63,7 @@ describe('controller: new_member_modal_controller', function () {
     ctrl_scope.$digest();
 
     // assertions
-    expect(ctrl_scope.user.role.value).toEqual('member');
+    expect(ctrl_scope.user.role).toEqual('member');
   });
 
   it('should call the user service to add a new user to the org',

--- a/seed/tests/test_admin_views.py
+++ b/seed/tests/test_admin_views.py
@@ -136,7 +136,7 @@ class AdminViewsTest(TestCase):
             'first_name': 'New',
             'last_name': 'User',
             'email': 'new_user@testserver',
-            'role': 'member',
+            'role': 'owner',
             'access_level_instance_id': child.id,
         }
 

--- a/seed/tests/test_admin_views.py
+++ b/seed/tests/test_admin_views.py
@@ -110,7 +110,7 @@ class AdminViewsTest(TestCase):
             'first_name': 'New',
             'last_name': 'User',
             'email': 'new_user@testserver',
-            'role_level': 'ROLE_MEMBER',
+            'role': 'member',
             'access_level_instance_id': org.root.id,
         }
 
@@ -136,7 +136,7 @@ class AdminViewsTest(TestCase):
             'first_name': 'New',
             'last_name': 'User',
             'email': 'new_user@testserver',
-            'role_level': 'ROLE_MEMBER',
+            'role': 'member',
             'access_level_instance_id': child.id,
         }
 
@@ -154,7 +154,6 @@ class AdminViewsTest(TestCase):
                 'organization_id': org.id,
                 'email': 'new_owner@testserver'}
         res = self._post_json(self.add_user_url, data)
-
         self.assertEqual(res.body['status'], 'success')
         user = User.objects.get(username=data['email'])
         self.assertEqual(user.email, data['email'])

--- a/seed/views/v3/users.py
+++ b/seed/views/v3/users.py
@@ -197,8 +197,9 @@ class UserViewSet(viewsets.ViewSet, OrgMixin):
         try:
             role = get_role_from_js(role)
         except Exception:
-                return JsonResponse({'status': 'error', 'message': 'valid arguments for role are [viewer, member, owner]'},
-                                    status=status.HTTP_400_BAD_REQUEST)
+            return JsonResponse({
+                'status': 'error', 'message': 'valid arguments for role are [viewer, member, owner]'
+            }, status=status.HTTP_400_BAD_REQUEST)
         if not org.is_member(user):
             try:
                 org.add_member(user, access_level_instance_id, role)

--- a/seed/views/v3/users.py
+++ b/seed/views/v3/users.py
@@ -174,6 +174,7 @@ class UserViewSet(viewsets.ViewSet, OrgMixin):
         email = body['email']
         username = body['email']
         access_level_instance_id = body.get("access_level_instance_id")
+        role = body.get('role')
         user, created = User.objects.get_or_create(username=username.lower())
 
         if org_id:
@@ -192,30 +193,20 @@ class UserViewSet(viewsets.ViewSet, OrgMixin):
         # Add the user to the org.  If this is the org's first user,
         # the user becomes the owner/admin automatically.
         # see Organization.add_member()
+
+        try:
+            role = get_role_from_js(role)
+        except Exception:
+                return JsonResponse({'status': 'error', 'message': 'valid arguments for role are [viewer, member, owner]'},
+                                    status=status.HTTP_400_BAD_REQUEST)
         if not org.is_member(user):
             try:
-                org.add_member(user, access_level_instance_id)
+                org.add_member(user, access_level_instance_id, role)
             except IntegrityError as e:
                 return JsonResponse({
                     'status': 'error',
                     'message': str(e)
                 }, status=status.HTTP_400_BAD_REQUEST)
-
-        if body.get('role'):
-            # check if this is a dict, if so, grab the value out of 'value'
-            role = body['role']
-            try:
-                get_role_from_js(role)
-            except Exception:
-                return JsonResponse({'status': 'error', 'message': 'valid arguments for role are [viewer, member, '
-                                                                   'owner]'},
-                                    status=status.HTTP_400_BAD_REQUEST)
-
-            OrganizationUser.objects.filter(
-                organization_id=org.pk,
-                user_id=user.pk,
-                access_level_instance_id=access_level_instance_id,
-            ).update(role_level=get_role_from_js(role))
 
         if created:
             user.set_unusable_password()

--- a/seed/views/v3/users.py
+++ b/seed/views/v3/users.py
@@ -174,7 +174,7 @@ class UserViewSet(viewsets.ViewSet, OrgMixin):
         email = body['email']
         username = body['email']
         access_level_instance_id = body.get("access_level_instance_id")
-        role = body.get('role')
+        role = body.get('role', 'owner')
         user, created = User.objects.get_or_create(username=username.lower())
 
         if org_id:
@@ -200,6 +200,7 @@ class UserViewSet(viewsets.ViewSet, OrgMixin):
             return JsonResponse({
                 'status': 'error', 'message': 'valid arguments for role are [viewer, member, owner]'
             }, status=status.HTTP_400_BAD_REQUEST)
+
         if not org.is_member(user):
             try:
                 org.add_member(user, access_level_instance_id, role)

--- a/seed/views/v3/users.py
+++ b/seed/views/v3/users.py
@@ -183,7 +183,7 @@ class UserViewSet(viewsets.ViewSet, OrgMixin):
                 return JsonResponse({
                     'status': 'error',
                     'message': 'if using an existing org, you must provide a `access_level_instance_id`'
-                }, status=status._BAD_REQUEST)
+                }, status=status.HTTP_400_BAD_REQUEST)
         else:
             org, _, _ = create_organization(user, org_name)
             access_level_instance_id = AccessLevelInstance.objects.get(organization=org, depth=1).id


### PR DESCRIPTION
#### Any background context you want to provide?
There are 2 locations new users can be created
1. /app/#/accounts/{org_id}/members > invite new member
2. /app/#/profile/admin (only if current user is a superuser)

#### What's this PR do?
Adds ALI info to the superuser 'create a user' form. If a new organization is selected the ALI fields are set to undefined and disabled. The result user will be assigned to the root of the new org.

#### How should this be manually tested?
As a superuser create a new user from both members and admin pages.

#### What are the relevant tickets?

#### Screenshots (if appropriate)
![Screenshot 2023-09-22 at 3 29 57 PM](https://github.com/SEED-platform/seed/assets/58446472/b356d49c-17dd-4589-a9ff-680c49c4ac2b)
