### PR TITLE
Fixed Issues with Scenario/Measure CRUD Operations

### DIFF
--- a/seed/models/property_measures.py
+++ b/seed/models/property_measures.py
@@ -157,7 +157,9 @@ class PropertyMeasure(models.Model):
             return None
 
         if isinstance(impl_status, int):
-            return impl_status
+            if impl_status in [(t[0]) for t in cls.IMPLEMENTATION_TYPES]:
+                return impl_status
+            return None
 
         value = [y[0] for x, y in enumerate(cls.IMPLEMENTATION_TYPES) if y[1] == impl_status]
         if len(value) == 1:
@@ -171,7 +173,9 @@ class PropertyMeasure(models.Model):
             return None
 
         if isinstance(category, int):
-            return category
+            if category in [(t[0]) for t in cls.CATEGORY_AFFECTED_TYPE]:
+                return category
+            return None
 
         value = [y[0] for x, y in enumerate(cls.CATEGORY_AFFECTED_TYPE) if y[1] == category]
         if len(value) == 1:
@@ -185,7 +189,9 @@ class PropertyMeasure(models.Model):
             return None
 
         if isinstance(app_scale, int):
-            return app_scale
+            if app_scale in [(t[0]) for t in cls.APPLICATION_SCALE_TYPES]:
+                return app_scale
+            return None
 
         value = [y[0] for x, y in enumerate(cls.APPLICATION_SCALE_TYPES) if y[1] == app_scale]
         if len(value) == 1:

--- a/seed/models/scenarios.py
+++ b/seed/models/scenarios.py
@@ -102,3 +102,19 @@ class Scenario(models.Model):
             meter.property = property_
             meter.save()  # save to get new id / association
             meter.copy_readings(source_meter, overlaps_possible=False)
+
+    @classmethod
+    def str_to_temporal_status(cls, status):
+        if not status:
+            return None
+
+        if isinstance(status, int):
+            if status in [(t[0]) for t in cls.TEMPORAL_STATUS_TYPES]:
+                return status
+            return None
+
+        value = [y[0] for x, y in enumerate(cls.TEMPORAL_STATUS_TYPES) if y[1] == status]
+        if len(value) == 1:
+            return value[0]
+        else:
+            return None

--- a/seed/tests/test_property_measures.py
+++ b/seed/tests/test_property_measures.py
@@ -80,9 +80,10 @@ class TestPropertyMeasures(DeleteModelsTestCase):
             args=[property_view.id, 1234567]
         )
         response = self.client.get(url, **self.headers)
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.json()['message'], "No Measures found for given pks")
-        self.assertEqual(response.json()['status'], 'error')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['status'], 'success')
+        data = response.json()['data']
+        self.assertEqual(len(data), 0)
 
         url = reverse_lazy(
             'api:v3:property-measures-list',

--- a/seed/utils/api_schema.py
+++ b/seed/utils/api_schema.py
@@ -139,7 +139,7 @@ class AutoSchemaHelper(SwaggerAutoSchema):
     def schema_factory(cls, obj, **kwargs):
         """Translates an object into an openapi Schema
 
-        This can handle nested objects (lists, dicts), and "types" defined as strings
+        This can handle nested objects (lists, dicts, enum tuples), and "types" defined as strings
         For example:
         {
             'hello': ['string'],
@@ -153,6 +153,13 @@ class AutoSchemaHelper(SwaggerAutoSchema):
         :param obj: str, list, dict[str, obj]
         :return: drf_yasg.openapi.Schema
         """
+        if isinstance(obj, tuple):
+            return openapi.Schema(
+                type=openapi.TYPE_STRING,
+                enum=[t[1] for t in obj],
+                **kwargs
+            )
+
         if isinstance(obj, str):
             openapi_type = cls._openapi_type(obj)
             return openapi.Schema(
@@ -179,14 +186,6 @@ class AutoSchemaHelper(SwaggerAutoSchema):
                 },
                 **kwargs
             )
-
-        if isinstance(obj, tuple):
-            k, v = obj
-            if k == 'enum':
-                return openapi.Schema(
-                    type=openapi.TYPE_STRING,
-                    enum=[enum_lookup[1] for enum_lookup in v]
-                )
 
         raise Exception(f'Unhandled type "{type(obj)}" for {obj}')
 

--- a/seed/views/v3/meters.py
+++ b/seed/views/v3/meters.py
@@ -28,9 +28,9 @@ from seed.utils.viewsets import SEEDOrgNoPatchOrOrgCreateModelViewSet
         ],
         request_body=AutoSchemaHelper.schema_factory(
             {
-                'type': ('enum', Meter.ENERGY_TYPES),
+                'type': Meter.ENERGY_TYPES,
                 'alias': 'string',
-                'source': ('enum', Meter.SOURCES),
+                'source': Meter.SOURCES,
                 'source_id': 'string',
                 'scenario_id': 'integer',
                 'is_virtual': 'boolean'

--- a/seed/views/v3/property_measures.py
+++ b/seed/views/v3/property_measures.py
@@ -4,6 +4,7 @@
 SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and other contributors.
 See also https://github.com/seed-platform/seed/main/LICENSE.md
 """
+from django.core.exceptions import ValidationError
 from django.http import JsonResponse
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
@@ -22,7 +23,14 @@ class PropertyMeasureViewSet(SEEDOrgNoPatchNoCreateModelViewSet):
     """
     serializer_class = PropertyMeasureSerializer
     model = PropertyMeasure
+    pagination_class = None
     orgfilter = 'property_state__organization_id'
+
+    enum_validators = {
+        'application_scale': PropertyMeasure.str_to_application_scale,
+        'category_affected': PropertyMeasure.str_to_category_affected,
+        'implementation_status': PropertyMeasure.str_to_impl_status
+    }
 
     @api_endpoint_class
     @ajax_request_class
@@ -35,15 +43,10 @@ class PropertyMeasureViewSet(SEEDOrgNoPatchNoCreateModelViewSet):
         except PropertyView.DoesNotExist:
             return JsonResponse({
                 "status": 'error',
-                "message": 'No Measures found for given pks'
+                "message": 'No PropertyView found for given pks'
             }, status=status.HTTP_404_NOT_FOUND)
 
         measure_set = PropertyMeasure.objects.filter(scenario=scenario_pk, property_state=property_state.id)
-        if not measure_set:
-            return JsonResponse({
-                "status": 'error',
-                "message": 'No Measures found for given pks'
-            }, status=status.HTTP_404_NOT_FOUND)
 
         serialized_measures = []
         for measure in measure_set:
@@ -81,8 +84,8 @@ class PropertyMeasureViewSet(SEEDOrgNoPatchNoCreateModelViewSet):
     @swagger_auto_schema(
         request_body=AutoSchemaHelper.schema_factory(
             {
-                "application_scale": "integer",
-                "category_affected": "integer",
+                "application_scale": PropertyMeasure.APPLICATION_SCALE_TYPES,
+                "category_affected": PropertyMeasure.CATEGORY_AFFECTED_TYPE,
                 "cost_capital_replacement": "integer",
                 "cost_installation": "integer",
                 "cost_material": "integer",
@@ -90,9 +93,9 @@ class PropertyMeasureViewSet(SEEDOrgNoPatchNoCreateModelViewSet):
                 "cost_residual_value": "integer",
                 "cost_total_first": "integer",
                 "description": "string",
-                "implementation_status": "integer",
+                "implementation_status": PropertyMeasure.IMPLEMENTATION_TYPES,
                 "property_measure_name": "string",
-                "recommended": "string",
+                "recommended": "boolean",
                 "useful_life": "integer",
             }
         )
@@ -116,6 +119,15 @@ class PropertyMeasureViewSet(SEEDOrgNoPatchNoCreateModelViewSet):
 
         for key, value in request.data.items():
             if key in possible_fields:
+                # Handle enums
+                if key in self.enum_validators.keys():
+                    value = self.enum_validators[key](value)
+                    if value is None:
+                        return JsonResponse({
+                            "Success": False,
+                            "Message": f"Invalid {key} value"
+                        }, status=status.HTTP_400_BAD_REQUEST)
+
                 setattr(property_measure, key, value)
             else:
                 return JsonResponse({
@@ -123,7 +135,13 @@ class PropertyMeasureViewSet(SEEDOrgNoPatchNoCreateModelViewSet):
                     "message": f'"{key}" is not a valid property measure field'
                 }, status=status.HTTP_400_BAD_REQUEST)
 
-        property_measure.save()
+        try:
+            property_measure.save()
+        except ValidationError as e:
+            return JsonResponse({
+                "Success": False,
+                "Message": str(e)
+            }, status=status.HTTP_400_BAD_REQUEST)
 
         result = {
             "status": "success",

--- a/seed/views/v3/property_scenarios.py
+++ b/seed/views/v3/property_scenarios.py
@@ -4,6 +4,7 @@
 SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and other contributors.
 See also https://github.com/seed-platform/seed/main/LICENSE.md
 """
+from django.core.exceptions import ValidationError
 from django.http import JsonResponse
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
@@ -28,6 +29,10 @@ class PropertyScenarioViewSet(SEEDOrgNoPatchNoCreateModelViewSet):
     pagination_class = None
     orgfilter = 'property_state__organization_id'
 
+    enum_validators = {
+        'temporal_status': Scenario.str_to_temporal_status
+    }
+
     def get_queryset(self):
         # Authorization is partially implicit in that users can't try to query
         # on an org_id for an Organization that they are not a member of.
@@ -42,23 +47,6 @@ class PropertyScenarioViewSet(SEEDOrgNoPatchNoCreateModelViewSet):
     @swagger_auto_schema(
         request_body=AutoSchemaHelper.schema_factory(
             {
-                "measures": [
-                    {
-                        "application_scale": "integer",
-                        "category_affected": "integer",
-                        "cost_capital_replacement": "integer",
-                        "cost_installation": "integer",
-                        "cost_material": "integer",
-                        "cost_mv": "integer",
-                        "cost_residual_value": "integer",
-                        "cost_total_first": "integer",
-                        "description": "string",
-                        "implementation_status": "integer",
-                        "property_measure_name": "string",
-                        "recommended": "string",
-                        "useful_life": "integer",
-                    }
-                ],
                 "annual_cost_savings": "integer",
                 "annual_electricity_energy": "integer",
                 "annual_electricity_savings": "integer",
@@ -78,10 +66,8 @@ class PropertyScenarioViewSet(SEEDOrgNoPatchNoCreateModelViewSet):
                 "hdd": "integer",
                 "hdd_base_temperature": "integer",
                 "name": "string",
-                "property_state": "integer",
-                "reference_case": "integer",
                 "summer_peak_load_reduction": "integer",
-                "temporal_status": "integer",
+                "temporal_status": Scenario.TEMPORAL_STATUS_TYPES,
                 "winter_peak_load_reduction": "integer",
             }
         )
@@ -92,11 +78,27 @@ class PropertyScenarioViewSet(SEEDOrgNoPatchNoCreateModelViewSet):
         """
         Where property_pk is the associated PropertyView.id
         """
-        scenario = Scenario.objects.get(pk=pk)
-        possible_fields = [f.name for f in scenario._meta.get_fields()]
+        try:
+            scenario = Scenario.objects.get(pk=pk)
+        except Scenario.DoesNotExist:
+            return JsonResponse({
+                "status": "error",
+                "message": 'No scenario found with given pks'
+            }, status=status.HTTP_404_NOT_FOUND)
+
+        possible_fields = [f.name for f in scenario._meta.get_fields() if f.name not in ['measures', 'property_state', 'reference_case']]
 
         for key, value in request.data.items():
             if key in possible_fields:
+                # Handle enums
+                if key in self.enum_validators.keys():
+                    value = self.enum_validators[key](value)
+                    if value is None:
+                        return JsonResponse({
+                            "Success": False,
+                            "Message": f"Invalid {key} value"
+                        }, status=status.HTTP_400_BAD_REQUEST)
+
                 setattr(scenario, key, value)
             else:
                 return JsonResponse({
@@ -104,7 +106,13 @@ class PropertyScenarioViewSet(SEEDOrgNoPatchNoCreateModelViewSet):
                     "Message": f'"{key}" is not a valid scenario field'
                 }, status=status.HTTP_400_BAD_REQUEST)
 
-        scenario.save()
+        try:
+            scenario.save()
+        except ValidationError as e:
+            return JsonResponse({
+                "Success": False,
+                "Message": str(e)
+            }, status=status.HTTP_400_BAD_REQUEST)
 
         result = {
             "status": "success",


### PR DESCRIPTION
#### Any background context you want to provide?
These changes are cherry picked from a64092639fcb4647d0d5d4c257a56858561f2f46 on the `bps-feature-develop` branch that was never merged to develop (but all of the BPS changes were merged in with https://github.com/SEED-platform/seed/pull/3899/)

#### What's this PR do?
- Fixed 500 errors when the input datatypes did not match the expected model types
- Fixed 500 error when using PUT with a nonexistent scenario
- Removed 3 fields from the scenario input model that always resulted in 500 errors: `measures`, `property_state`, and `reference_case`
- Removed unused pagination inputs on measures endpoints
- Fixed listing measures for a scenario, if the scenario exists with zero measures it now returns an empty array rather than a 404
- Fixed measure input model, `recommended` is a boolean rather than a string
- Updated schema generation to allow OpenAPI enum types and document the enum options
- Added enum validation to scenario/measure endpoints. Strings and ints are both accepted and validated
  - Before, this was resulting in 500 errors if invalid options were sent, like `false` or `0` or other invalid enum integers.  Subsequently, any endpoint that pulled in another model with an invalid integer would start returning 500 errors.