### PR TITLE
ArcGIS CSP rule

### DIFF
--- a/docker/nginx/seed-csp.conf
+++ b/docker/nginx/seed-csp.conf
@@ -4,6 +4,8 @@
 # https://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
 set $DEFAULT "default-src 'self'";
 
+set $CONNECT "connect-src 'self' https://services.arcgis.com/";
+
 set $SCRIPT "script-src 'self' 'unsafe-inline' 'unsafe-eval'";
 set $SCRIPT "${SCRIPT} https://better-lbnl-development.herokuapp.com";
 set $SCRIPT "${SCRIPT} https://better.lbl.gov";
@@ -42,4 +44,4 @@ set $IMG "${IMG} https://validator.swagger.io";
 
 set $OBJECT "object-src 'none'";
 
-set $CSP "${DEFAULT}; ${SCRIPT}; ${STYLE}; ${FONT}; ${FRAME}; ${IMG}; ${OBJECT}";
+set $CSP "${DEFAULT}; ${CONNECT}; ${SCRIPT}; ${STYLE}; ${FONT}; ${FRAME}; ${IMG}; ${OBJECT}";


### PR DESCRIPTION
#### What's this PR do?
Allows modern network requests (via fetch) to be made to ArcGIS for displaying census tracts

#### How should this be manually tested?
1. Run seed through nginx
2. Zoom in on the map page and check that census tracts are visible