### PR TITLE
Fix mapping of BETTER's measures with empty strings to false

### DIFF
--- a/seed/analysis_pipelines/better/pipeline.py
+++ b/seed/analysis_pipelines/better/pipeline.py
@@ -544,7 +544,11 @@ def _process_results(self, analysis_id):
         for data_path in column_data_paths:
             value = get_json_path(data_path.json_path, raw_better_results)
             if value is not None:
-                value = float(value) * data_path.unit_multiplier
+                # some of the ee_measures return an empty string, which should be falsey
+                if 'ee_measures' in data_path.json_path and value == '':
+                    value = 0.0 * data_path.unit_multiplier  # to be consistent
+                else:
+                    value = float(value) * data_path.unit_multiplier
             simplified_results[data_path.column_name] = value
 
         electricity_model_is_valid = bool(simplified_results[BETTER_VALID_MODEL_E_COL])


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### Any background context you want to provide?
There appears to have been an update with BETTER's API where measure recommendations are either `''` or `True`. 

#### What's this PR do?
Hande the case where the measure recommendation is an empty string

#### How should this be manually tested?
Run a property with better (I used `better.lbl.gov`)

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
