### PR TITLE
Decrease BETTER polling rate 5x, increase timeout 5x

### DIFF
--- a/seed/analysis_pipelines/better/client.py
+++ b/seed/analysis_pipelines/better/client.py
@@ -402,8 +402,8 @@ class BETTERClient:
             response = polling.poll(
                 lambda: requests.request("GET", url, headers=headers),
                 check_success=is_ready,
-                timeout=60,
-                step=1)
+                timeout=300,
+                step=5)
         except TimeoutError:
             return None, ['BETTER analysis timed out']
 


### PR DESCRIPTION
#### Any background context you want to provide?
BETTER's API can begin limiting API requests for long periods of time once a certain threshold of requests have been sent for a specific API key.

#### What's this PR do?
Reduces the polling rate for BETTER results from every second to every 5 seconds, and increases the timeout from 1 minute to 5 minutes.

#### How should this be manually tested?
Monitor backend network requests when performing a BETTER analysis.