### PR TITLE
Feature to enable Redis for ElastiCache

### DIFF
--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -150,7 +150,7 @@ LOGGING = {
     'loggers': {
         'django': {
             'handlers': ['console'],
-            'level': os.getenv('DJANGO_LOG_LEVEL', 'DEBUG'),
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'ERROR'),
         },
     },
 }

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -81,6 +81,7 @@ if 'REDIS_AWS_ELASTICACHE' in os.environ:
                 'DB': 1,
                 "CLIENT_CLASS": "django_redis.client.DefaultClient",
                 'PASSWORD': os.environ.get('REDIS_PASSWORD')
+                "SSL": True  # If your AWS Elasticache is set up for SSL, set this to True
             },
             'TIMEOUT': 300
         }

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -86,7 +86,7 @@ if 'REDIS_AWS_ELASTICACHE' in os.environ:
             'TIMEOUT': 300
         }
     }
-    CELERY_BROKER_URL = 'rediss://:%s@%s:6379/%s' % (
+    CELERY_BROKER_URL = 'rediss://:%s@%s:6379/%s?ssl_cert_reqs=required' % (
         CACHES['default']['OPTIONS']['PASSWORD'],
         os.environ.get('REDIS_HOST'),
         CACHES['default']['OPTIONS']['DB']

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -34,14 +34,14 @@ for loc in ENV_VARS:
     if not locals().get(loc):
         raise Exception("%s Not defined as env variables" % loc)
 
-DEBUG = os.environ.get('Debug', 'False')
+DEBUG = os.environ.get('Debug', False)
 COMPRESS_ENABLED = False
 # COMPRESS_STORAGE = 'compressor.storage.GzipCompressorFileStorage'
 # COMPRESS_OFFLINE = True
 
 # Make sure to disable secure cookies and csrf when using Cloudflare
-SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE', 'False')
-CSRF_COOKIE_SECURE = os.environ.get('CSRF_COOKIE_SECURE', 'False')
+SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE', False)
+CSRF_COOKIE_SECURE = os.environ.get('CSRF_COOKIE_SECURE', False)
 
 ALLOWED_HOSTS_ENV = os.environ.get('ALLOWED_HOSTS')
 if ALLOWED_HOSTS_ENV:

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -80,7 +80,7 @@ if 'REDIS_AWS_ELASTICACHE' in os.environ:
             'OPTIONS': {
                 'DB': 1,
                 "CLIENT_CLASS": "django_redis.client.DefaultClient",
-                'PASSWORD': os.environ.get('REDIS_PASSWORD')
+                'PASSWORD': os.environ.get('REDIS_PASSWORD'),
                 "SSL": True  # If your AWS Elasticache is set up for SSL, set this to True
             },
             'TIMEOUT': 300

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -86,9 +86,9 @@ if 'REDIS_AWS_ELASTICACHE' in os.environ:
             'TIMEOUT': 300
         }
     }
-    CELERY_BROKER_URL = 'rediss://:%s@%s/%s' % (
+    CELERY_BROKER_URL = 'rediss://:%s@%s:6379/%s' % (
         CACHES['default']['OPTIONS']['PASSWORD'],
-        CACHES['default']['LOCATION'],
+        os.environ.get('REDIS_HOST'),
         CACHES['default']['OPTIONS']['DB']
     )
 elif 'REDIS_PASSWORD' in os.environ:

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -40,8 +40,8 @@ COMPRESS_ENABLED = False
 # COMPRESS_OFFLINE = True
 
 # Make sure to disable secure cookies and csrf when using Cloudflare
-SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE', 'True')
-CSRF_COOKIE_SECURE = os.environ.get('CSRF_COOKIE_SECURE', 'True')
+SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE', 'False')
+CSRF_COOKIE_SECURE = os.environ.get('CSRF_COOKIE_SECURE', 'False')
 
 ALLOWED_HOSTS_ENV = os.environ.get('ALLOWED_HOSTS')
 if ALLOWED_HOSTS_ENV:

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -34,16 +34,20 @@ for loc in ENV_VARS:
     if not locals().get(loc):
         raise Exception("%s Not defined as env variables" % loc)
 
-DEBUG = False
+DEBUG = os.environ.get('Debug', 'False')
 COMPRESS_ENABLED = False
 # COMPRESS_STORAGE = 'compressor.storage.GzipCompressorFileStorage'
 # COMPRESS_OFFLINE = True
 
 # Make sure to disable secure cookies and csrf when using Cloudflare
-SESSION_COOKIE_SECURE = False
-CSRF_COOKIE_SECURE = False
+SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE', 'True')
+CSRF_COOKIE_SECURE = os.environ.get('CSRF_COOKIE_SECURE', 'True')
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS_ENV = os.environ.get('ALLOWED_HOSTS')
+if ALLOWED_HOSTS_ENV:
+    ALLOWED_HOSTS = ALLOWED_HOSTS_ENV.split(',')
+else:
+    ALLOWED_HOSTS = ['*']
 
 # By default we are using SES as our email client. If you would like to use
 # another backend (e.g., SMTP), then please update this model to support both and


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### Any background context you want to provide?

#### What's this PR do?

Fixes bug with CELERY BROKER connection string to Elasticache Redis

#### How should this be manually tested?

In Django shell, print CELERY_BROKER_URL to make sure it is correct when using Docker.py settings.

#### What are the relevant tickets?

No

#### Screenshots (if appropriate)
