### PR TITLE
update modal step ID

### DIFF
--- a/seed/static/seed/js/controllers/organization_access_level_tree_controller.js
+++ b/seed/static/seed/js/controllers/organization_access_level_tree_controller.js
@@ -64,7 +64,7 @@ angular.module('BE.seed.controller.organization_access_level_tree', [])
       };
 
       $scope.open_upload_al_instances_modal = function () {
-        const step = 17; // this is the step that corresponds to uploading access levels
+        const step = 20; // this is the step that corresponds to uploading access levels
         $uibModal.open({
           templateUrl: `${urls.static_url}seed/partials/data_upload_modal.html`,
           controller: 'data_upload_modal_controller',


### PR DESCRIPTION
Correct the data import modal id that points to the access level import file (corrupted during a merge).

To verify: ensure that when going to this page, and clicking on "upload access level instances" button and ensure the correct modal pops up.

<img width="926" alt="Screen Shot 2023-10-19 at 11 26 53 AM" src="https://github.com/SEED-platform/seed/assets/2205659/365854b8-a3cb-472e-9282-7bef6f2df10a">
