### PR TITLE
Fix showing derived column values on the inventory list page

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -1166,7 +1166,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
         // finally, update the data to include the calculated values
         $scope.data.forEach((row) => {
           Object.entries(aggregated_results).forEach(([derived_column_id, results]) => {
-            const derived_column = attached_derived_columns.find((col) => col.id === derived_column_id);
+            const derived_column = attached_derived_columns.find((col) => col.id === Number(derived_column_id));
             const result = results.find((res) => res.id === row.id) || {};
             row[column_name_lookup[derived_column.name]] = result.value;
           });


### PR DESCRIPTION
#### What's this PR do?
Fixes showing derived column values.  The issue was a strict type comparison between a string and a number, that should've both been numbers

#### How should this be manually tested?
Check that derived column values appear on the inventory list page