### PR TITLE
Ah/develop data upload modal fix

### DIFF
--- a/seed/static/seed/js/controllers/organization_access_level_tree_controller.js
+++ b/seed/static/seed/js/controllers/organization_access_level_tree_controller.js
@@ -64,7 +64,7 @@ angular.module('BE.seed.controller.organization_access_level_tree', [])
       };
 
       $scope.open_upload_al_instances_modal = function () {
-        const step = 17; // this is the step that corresponds to uploading access levels
+        const step = 20; // this is the step that corresponds to uploading access levels
         $uibModal.open({
           templateUrl: `${urls.static_url}seed/partials/data_upload_modal.html`,
           controller: 'data_upload_modal_controller',


### PR DESCRIPTION
#### Any background context you want to provide?
The data upload modal had a step mismatch when the AT import/export work was merged that caused the 'Upload Access Level Instances' button to open the AT export modal.

#### What's this PR do?
updates step number from 17 (AT export) to 20 (ALI upload)

#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
