### PR TITLE
Health check endpoint

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -19,7 +19,7 @@ from seed.landing.views import (
     password_reset_confirm,
     password_reset_done
 )
-from seed.views.main import angular_js_tests, version
+from seed.views.main import angular_js_tests, health_check, version
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -63,6 +63,7 @@ urlpatterns = [
     re_path(r'^robots\.txt', robots_txt, name='robots_txt'),
 
     # API
+    re_path(r'^api/health_check/$', health_check, name='health_check'),
     re_path(r'^api/swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     re_path(r'^api/version/$', version, name='version'),
     re_path(r'^api/', include((api, "seed"), namespace='api')),


### PR DESCRIPTION
#### Any background context you want to provide?
Tools like Docker can better integrate with containers if they offer a method for checking the health status of the container and its dependencies.

#### What's this PR do?
Adds a new, undocumented API endpoint that does not require authentication to check the status of the various systems necessary for SEED to function properly
- Endpoint: `/api/health_check/`
- 200 response code if everything is healthy, 418 otherwise

Example response:

**_HTTP 200_**
```json
{
  "status": "healthy",
  "postgres": "success",
  "celery": "success",
  "redis": "success"
}
```

#### How should this be manually tested?
1. Run SEED, check that the status is healthy
2. Stop celery, check that status has updated
3. Restart celery, stop redis. Check that both celery and redis are unhealthy
4. Restart redis, stop postgres. Check that only postgres is unhealthy
5. Restart postgres, check that the status is healthy