### PR TITLE
Add healthcheck to docker web container

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -83,6 +83,12 @@ services:
       - seed_media:/seed/media
     ports:
       - "80:80"
+    healthcheck:
+      test: curl -f http://localhost/api/health_check/ || exit 1
+      interval: 1m
+      timeout: 10s
+      retries: 1
+      start_period: 45s
     logging:
       options:
         max-size: 50m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,12 @@ services:
       - seed_media:/seed/media
     ports:
       - "80:80"
+    healthcheck:
+      test: curl -f http://localhost/api/health_check/ || exit 1
+      interval: 1m
+      timeout: 10s
+      retries: 1
+      start_period: 45s
     logging:
       options:
         max-size: 50m


### PR DESCRIPTION
#### What's this PR do?
Adds `healthcheck` to the `seed_web` container so that Docker understands the health status of the dependencies.

#### How should this be manually tested?
1. Run SEED using `docker compose`
2. Wait for the health status of the `seed_web` container to transition from `Starting` to `Healthy`
3. Stop the `seed_celery` container
4. Wait at most 60 seconds, and check that the container status is now `Unhealthy`
5. Start the `seed_celery` container
6. Wait at most 60 seconds, and check that the container status is now back to `Healthy`

#### Screenshots
![image](https://github.com/SEED-platform/seed/assets/411466/a1f3d672-d55f-4e4f-b586-81dd1c7bf8bc)
