### PR TITLE
Redis backend update

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -394,6 +394,7 @@
     "unmerge",
     "unmerges",
     "unpair",
+    "Unpickles",
     "unresolvable",
     "untracked",
     "uom",

--- a/.cspell.json
+++ b/.cspell.json
@@ -116,6 +116,7 @@
     "edgecase",
     "eeej",
     "ejscreen",
+    "ELASTICACHE",
     "energystar",
     "enums",
     "env",

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -83,10 +83,6 @@ if 'REDIS_AWS_ELASTICACHE' in os.environ:
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': CELERY_BROKER_URL,
-            'OPTIONS': {
-                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-            },
-            'TIMEOUT': 300
         }
     }
 elif 'REDIS_PASSWORD' in os.environ:
@@ -96,10 +92,6 @@ elif 'REDIS_PASSWORD' in os.environ:
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': CELERY_BROKER_URL,
-            'OPTIONS': {
-                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-            },
-            'TIMEOUT': 300
         }
     }
 else:
@@ -109,14 +101,9 @@ else:
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': CELERY_BROKER_URL,
-            'OPTIONS': {
-                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-            },
-            'TIMEOUT': 300
         }
     }
 
-CELERY_BROKER_TRANSPORT = 'redis'
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 CELERY_TASK_DEFAULT_QUEUE = 'seed-docker'
 CELERY_TASK_QUEUES = (

--- a/config/settings/docker_dev.py
+++ b/config/settings/docker_dev.py
@@ -81,14 +81,9 @@ else:
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': CELERY_BROKER_URL,
-            'OPTIONS': {
-                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-            },
-            'TIMEOUT': 300
         }
     }
 
-    CELERY_BROKER_TRANSPORT = 'redis'
     CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 
 CELERY_TASK_DEFAULT_QUEUE = 'seed-docker'

--- a/config/settings/docker_dev.py
+++ b/config/settings/docker_dev.py
@@ -72,21 +72,21 @@ if SEED_TESTING:
     TESTING_MAPQUEST_API_KEY = os.environ.get('TESTING_MAPQUEST_API_KEY', '<your_key_here>')
 else:
     # Redis / Celery config
+    if 'REDIS_PASSWORD' in os.environ:
+        CELERY_BROKER_URL = f"redis://:{os.environ.get('REDIS_PASSWORD')}@{os.environ.get('REDIS_HOST', 'db-redis')}:6379/1"
+    else:
+        CELERY_BROKER_URL = f"redis://{os.environ.get('REDIS_HOST', 'db-redis')}:6379/1"
+
     CACHES = {
         'default': {
-            'BACKEND': 'redis_cache.cache.RedisCache',
-            'LOCATION': f"{os.environ.get('REDIS_HOST', 'db-redis')}:6379",
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': CELERY_BROKER_URL,
             'OPTIONS': {
-                'DB': 1
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
             },
-            'TIMEOUT': 300,
+            'TIMEOUT': 300
         }
     }
-    if 'REDIS_PASSWORD' in os.environ:
-        CACHES['OPTIONS']['PASSWORD'] = os.environ.get('REDIS_PASSWORD')
-        CELERY_BROKER_URL = f"redis://:{CACHES['default']['OPTIONS']['PASSWORD']}@{CACHES['default']['LOCATION']}/{CACHES['default']['OPTIONS']['DB']}"
-    else:
-        CELERY_BROKER_URL = f"redis://{CACHES['default']['LOCATION']}/{CACHES['default']['OPTIONS']['DB']}"
 
     CELERY_BROKER_TRANSPORT = 'redis'
     CELERY_RESULT_BACKEND = CELERY_BROKER_URL

--- a/config/settings/local_untracked.py.dist
+++ b/config/settings/local_untracked.py.dist
@@ -95,18 +95,19 @@ DATABASES = {
 }
 
 # =============================== Celery/Redis Cache Settings (No Password) =========
+CELERY_BROKER_URL = 'redis://redis-hostname:6379/1'
+
 CACHES = {
     'default': {
-        'BACKEND': 'redis_cache.cache.RedisCache',
-        'LOCATION': 'your-cache-url:your-cache-port',
-        'OPTIONS': {'DB': 1},
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': CELERY_BROKER_URL,
+        'OPTIONS': {
+            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+        },
         'TIMEOUT': 300
     }
 }
 
-CELERY_BROKER_URL = 'redis://%s/%s' % (
-    CACHES['default']['LOCATION'], CACHES['default']['OPTIONS']['DB']
-)
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 CELERY_TASK_DEFAULT_QUEUE = 'seed-local'
 CELERY_TASK_QUEUES = (
@@ -118,32 +119,28 @@ CELERY_TASK_QUEUES = (
 )
 
 # =============================== Celery/Redis Cache Settings (w/Password) =========
-#CACHES = {
+# CELERY_BROKER_URL = 'redis://:your-redis-password@your-cache-url:6379/1'
+#
+# CACHES = {
 #   'default': {
-#        'BACKEND': 'redis_cache.cache.RedisCache',
-#        'LOCATION': 'your-cache-url:your-cache-port',
+#        'BACKEND': 'django_redis.cache.RedisCache',
+#        'LOCATION': CELERY_BROKER_URL,
 #        'OPTIONS': {
-#            'DB': 1,
-#             'PASSWORD': 'your-redis-password',
+#            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
 #        },
 #        'TIMEOUT': 300
 #    }
-#}
+# }
 #
-#CELERY_BROKER_URL = 'redis://:%s@%s/%s' % (
-#    CACHES['default']['OPTIONS']['PASSWORD'],
-#    CACHES['default']['LOCATION'],
-#    CACHES['default']['OPTIONS']['DB']
-#)
-#CELERY_RESULT_BACKEND = CELERY_BROKER_URL
-#CELERY_TASK_DEFAULT_QUEUE = 'seed-local'
-#CELERY_TASK_QUEUES = (
+# CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+# CELERY_TASK_DEFAULT_QUEUE = 'seed-local'
+# CELERY_TASK_QUEUES = (
 #    Queue(
 #        CELERY_TASK_DEFAULT_QUEUE,
 #        Exchange(CELERY_TASK_DEFAULT_QUEUE),
 #        routing_key=CELERY_TASK_DEFAULT_QUEUE
 #    ),
-#)
+# )
 
 
 # =================================== Logging =======================================

--- a/config/settings/local_untracked.py.dist
+++ b/config/settings/local_untracked.py.dist
@@ -101,10 +101,6 @@ CACHES = {
     'default': {
         'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': CELERY_BROKER_URL,
-        'OPTIONS': {
-            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-        },
-        'TIMEOUT': 300
     }
 }
 
@@ -125,10 +121,6 @@ CELERY_TASK_QUEUES = (
 #   'default': {
 #        'BACKEND': 'django_redis.cache.RedisCache',
 #        'LOCATION': CELERY_BROKER_URL,
-#        'OPTIONS': {
-#            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-#        },
-#        'TIMEOUT': 300
 #    }
 # }
 #

--- a/config/settings/test_local_untracked.py
+++ b/config/settings/test_local_untracked.py
@@ -32,8 +32,8 @@ DATABASES = {
 }
 
 # redis cache config
-# with AWS ElastiCache redis, the LOCATION setting looks something like:
-# 'xx-yy-zzrr0aax9a.ntmprk.0001.usw2.cache.amazonaws.com:6379'
+# with AWS ElastiCache redis, the CELERY_BROKER_URL setting looks something like:
+# 'rediss://:password@xx-yy-zzrr0aax9a.ntmprk.0001.usw2.cache.amazonaws.com:6379/1?ssl_cert_reqs=required'
 
 EAGER = os.environ.get('CELERY_ALWAYS_EAGER', 'True') == 'True'
 if EAGER:
@@ -41,18 +41,18 @@ if EAGER:
     CELERY_TASK_ALWAYS_EAGER = True
     CELERY_TASK_EAGER_PROPAGATES = True
 else:
-    print("Using redis database")
+    print('Using redis database')
+    CELERY_BROKER_URL = 'redis://localhost:6379/1'
     CACHES = {
         'default': {
-            'BACKEND': 'redis_cache.cache.RedisCache',
-            'LOCATION': "localhost:6379",
-            'OPTIONS': {'DB': 1},
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': CELERY_BROKER_URL,
+            'OPTIONS': {
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+            },
             'TIMEOUT': 300
         }
     }
-    CELERY_BROKER_URL = 'redis://%s/%s' % (
-        CACHES['default']['LOCATION'], CACHES['default']['OPTIONS']['DB']
-    )
     CELERY_RESULT_BACKEND = CELERY_BROKER_URL
     CELERY_TASK_DEFAULT_QUEUE = 'seed-local'
     CELERY_TASK_QUEUES = (

--- a/config/settings/test_local_untracked.py
+++ b/config/settings/test_local_untracked.py
@@ -47,10 +47,6 @@ else:
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': CELERY_BROKER_URL,
-            'OPTIONS': {
-                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-            },
-            'TIMEOUT': 300
         }
     }
     CELERY_RESULT_BACKEND = CELERY_BROKER_URL

--- a/docs/source/aws.rst
+++ b/docs/source/aws.rst
@@ -166,10 +166,6 @@ settings.
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': CELERY_BROKER_URL,
-            'OPTIONS': {
-                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-            },
-            'TIMEOUT': 300
         }
     }
 

--- a/docs/source/aws.rst
+++ b/docs/source/aws.rst
@@ -161,15 +161,17 @@ settings.
 
 .. code-block:: python
 
+    CELERY_BROKER_URL = 'redis://seed-core-cache.ntmprk.0001.usw2.cache.amazonaws.com:6379/1'
     CACHES = {
         'default': {
-            'BACKEND': 'redis_cache.cache.RedisCache',
-            'LOCATION': "seed-core-cache.ntmprk.0001.usw2.cache.amazonaws.com:6379",
-            'OPTIONS': { 'DB': 1 },
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': CELERY_BROKER_URL,
+            'OPTIONS': {
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+            },
             'TIMEOUT': 300
         }
     }
-    CELERY_BROKER_URL = 'redis://seed-core-cache.ntmprk.0001.usw2.cache.amazonaws.com:6379/1'
 
 Running Celery the Background Task Worker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/linux.rst
+++ b/docs/source/linux.rst
@@ -148,10 +148,6 @@ settings.
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': CELERY_BROKER_URL,
-            'OPTIONS': {
-                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-            },
-            'TIMEOUT': 300
         }
     }
 
@@ -327,10 +323,6 @@ local_untracked.py
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': CELERY_BROKER_URL,
-            'OPTIONS': {
-                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-            },
-            'TIMEOUT': 300
         }
     }
 

--- a/docs/source/linux.rst
+++ b/docs/source/linux.rst
@@ -143,15 +143,17 @@ settings.
 
 .. code-block:: python
 
+    CELERY_BROKER_URL = 'redis://127.0.0.1:6379/1'
     CACHES = {
         'default': {
-            'BACKEND': 'redis_cache.cache.RedisCache',
-            'LOCATION': '127.0.0.1:6379',
-            'OPTIONS': {'DB': 1},
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': CELERY_BROKER_URL,
+            'OPTIONS': {
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+            },
             'TIMEOUT': 300
         }
     }
-    CELERY_BROKER_URL = 'redis://127.0.0.1:6379/1'
 
 
 Creating the initial user
@@ -320,15 +322,17 @@ local_untracked.py
     # config for local storage backend
     DOMAIN_URLCONFS = {'default': 'config.urls'}
 
+    CELERY_BROKER_URL = 'redis://127.0.0.1:6379/1'
     CACHES = {
         'default': {
-            'BACKEND': 'redis_cache.cache.RedisCache',
-            'LOCATION': '127.0.0.1:6379',
-            'OPTIONS': {'DB': 1},
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': CELERY_BROKER_URL,
+            'OPTIONS': {
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+            },
             'TIMEOUT': 300
         }
     }
-    CELERY_BROKER_URL = 'redis://127.0.0.1:6379/1'
 
     # SMTP config
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/docs/source/migrations.rst
+++ b/docs/source/migrations.rst
@@ -15,28 +15,23 @@ Docker then you will not need to do this.
     CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 
 If you are using a password, then in your local_untracked.py configuration, add the password to
-the CACHES configuration option. Your final configuration should look like the following in your
+the CELERY_BROKER_URL. Your final configuration should look like the following in your
 local_untracked.py file
 
 .. code-block:: python
 
+    CELERY_BROKER_URL = 'redis://:password@127.0.0.1:6379/1'
     CACHES = {
         'default': {
-            'BACKEND': 'redis_cache.cache.RedisCache',
-            'LOCATION': "127.0.0.1:6379",
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': CELERY_BROKER_URL,
             'OPTIONS': {
-                'DB': 1,
-                'PASSWORD': 'password',
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
             },
             'TIMEOUT': 300
         }
     }
 
-    CELERY_BROKER_URL = 'redis://:%s@%s/%s' % (
-        CACHES['default']['OPTIONS']['PASSWORD'],
-        CACHES['default']['LOCATION'],
-        CACHES['default']['OPTIONS']['DB']
-    )
     CELERY_RESULT_BACKEND = CELERY_BROKER_URL
     CELERY_TASK_DEFAULT_QUEUE = 'seed-local'
     CELERY_TASK_QUEUES = (

--- a/docs/source/migrations.rst
+++ b/docs/source/migrations.rst
@@ -25,10 +25,6 @@ local_untracked.py file
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': CELERY_BROKER_URL,
-            'OPTIONS': {
-                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-            },
-            'TIMEOUT': 300
         }
     }
 

--- a/docs/source/setup_osx.rst
+++ b/docs/source/setup_osx.rst
@@ -270,15 +270,17 @@ For Redis, edit the `CACHES` and `CELERY_BROKER_URL` values to look like this:
 
 .. code-block:: python
 
+    CELERY_BROKER_URL = 'redis://127.0.0.1:6379/1'
     CACHES = {
         'default': {
-            'BACKEND': 'redis_cache.cache.RedisCache',
-            'LOCATION': "127.0.0.1:6379",
-            'OPTIONS': {'DB': 1},
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': CELERY_BROKER_URL,
+            'OPTIONS': {
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+            },
             'TIMEOUT': 300
         }
     }
-    CELERY_BROKER_URL = 'redis://127.0.0.1:6379/1'
 
 MapQuest API Key
 ----------------

--- a/docs/source/setup_osx.rst
+++ b/docs/source/setup_osx.rst
@@ -275,10 +275,6 @@ For Redis, edit the `CACHES` and `CELERY_BROKER_URL` values to look like this:
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': CELERY_BROKER_URL,
-            'OPTIONS': {
-                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-            },
-            'TIMEOUT': 300
         }
     }
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,11 +11,13 @@ psycopg2-binary==2.9.6
 
 # background process management
 celery==5.2.2
-django-redis-cache==3.0.0
+django-celery-beat==2.2.1
 django-compressor==4.4
 django-extensions==3.1.3
 django-model-utils==4.3.1
-django-celery-beat==2.2.1
+django-redis==5.4.0
+hiredis==2.2.3
+redis==5.0.1
 
 # Time zones support - Do not update these without doing significant testing!
 pytz==2018.7

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,12 +12,12 @@ psycopg2-binary==2.9.6
 # background process management
 celery==5.2.2
 django-celery-beat==2.2.1
+django-redis==5.4.0
+hiredis==2.3.2
+
 django-compressor==4.4
 django-extensions==3.1.3
 django-model-utils==4.3.1
-django-redis==5.4.0
-hiredis==2.2.3
-redis==5.0.1
 
 # Time zones support - Do not update these without doing significant testing!
 pytz==2018.7


### PR DESCRIPTION
#### Any background context you want to provide?
The dependency we were using to leverage Redis as the Django/Celery cache (`django-redis-cache`) effectively hasn't been updated since 2020, and requires `redis-py < v4.0`. Redis-py introduced cluster-mode in v4.1.0.

#### What's this PR do?
Drops the `django-redis-cache` dependency in favor of `django-redis`, which is compatible with current versions of `redis-py`. This PR also adds `hiredis` for performance.

Once we migrate to Django v4 we can use Django's built-in Redis support going forward.

#### How should this be manually tested?
1. `pip install -r requirements/base.txt`
2. Update your local config (usually `local_untracked.py`), **see the migration steps below** to understand what to change
3. Test that SEED and Celery work as expected

#### What are the relevant tickets?
#4375

## BREAKING CHANGE
This updated dependency requires users and deployments to modify their `CACHES` config. [Django v4 uses the same syntax](https://docs.djangoproject.com/en/4.2/topics/cache/#redis), so this is a necessary step regardless.

### Migration Steps
1. Update your dependencies with `pip install -r requirements/base.txt`
2. Update the CACHES `BACKEND` property to `django_redis.cache.RedisCache`
3. Update the CACHES `LOCATION` property to match the redis-py native URL notation for connection strings, including the `redis` protocol and database number. e.g. `redis://localhost:6379/1`
    1. Since the `CELERY_BROKER_URL` setting must also be in the same format, it may be helpful to configure that setting first and then reference it in the caches `LOCATION` parameter.

#### Example migration
In your Django settings file, replace existing code that looks like this:
```python
CACHES = {
    'default': {
        'BACKEND': 'redis_cache.cache.RedisCache',
        'LOCATION': 'localhost:6379',
        'OPTIONS': {'DB': 1},
        'TIMEOUT': 300
    }
}

CELERY_BROKER_URL = 'redis://%s/%s' % (
    CACHES['default']['LOCATION'], CACHES['default']['OPTIONS']['DB']
)
```

with this:

```python
CELERY_BROKER_URL = 'redis://localhost:6379/1'

CACHES = {
    'default': {
        'BACKEND': 'django_redis.cache.RedisCache',
        'LOCATION': CELERY_BROKER_URL,
    }
}
```

For advanced connections, the connection string can also specify SSL, username, and password, e.g. `rediss://username:password@localhost:6379/1`