### PR TITLE
Provide environment variable to disable wait-for-it condition in deployments

### DIFF
--- a/docker/start_celery_docker.sh
+++ b/docker/start_celery_docker.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Check if 'STRATUS_MANAGED_SERVICES_ENABLED' is not set or if its value is 'TRUE'
-if [[ "${STRATUS_MANAGED_SERVICES_ENABLED}" == "on" ]]; then
-    echo "'STRATUS_MANAGED_SERVICES_ENABLED' is set and not equal to 'on'. Skipping wait-for-it.sh execution."
+# Check if 'DISABLE_SERVICE_CHECKS_ON_START' is not set or if its value is 'TRUE'
+if [[ "${DISABLE_SERVICE_CHECKS_ON_START}" == "on" ]]; then
+    echo "'DISABLE_SERVICE_CHECKS_ON_START' is set and equal to 'on'. Skipping wait-for-it.sh execution."
 else
     cd /seed
 

--- a/docker/start_celery_docker.sh
+++ b/docker/start_celery_docker.sh
@@ -1,35 +1,35 @@
 #!/bin/bash
 
-cd /seed
-
-echo "Waiting for postgres to start"
-if [ -v POSTGRES_HOST ];
-then
-   POSTGRES_ACTUAL_HOST=$POSTGRES_HOST
+# Check if 'STRATUS_MANAGED_SERVICES_ENABLED' is not set or if its value is 'TRUE'
+if [[ "${STRATUS_MANAGED_SERVICES_ENABLED}" == "on" ]]; then
+    echo "'STRATUS_MANAGED_SERVICES_ENABLED' is set and not equal to 'on'. Skipping wait-for-it.sh execution."
 else
-   POSTGRES_ACTUAL_HOST=db-postgres
+    cd /seed
+
+    echo "Waiting for postgres to start"
+    if [ -v POSTGRES_HOST ]; then
+        POSTGRES_ACTUAL_HOST=$POSTGRES_HOST
+    else
+        POSTGRES_ACTUAL_HOST=db-postgres
+    fi
+    /usr/local/wait-for-it.sh --strict -t 0 $POSTGRES_ACTUAL_HOST:$POSTGRES_PORT
+
+    echo "Waiting for redis to start"
+    if [ -v REDIS_HOST ]; then
+        REDIS_ACTUAL_HOST=$REDIS_HOST
+    else
+        REDIS_ACTUAL_HOST=db-redis
+    fi
+    /usr/local/wait-for-it.sh --strict -t 0 $REDIS_ACTUAL_HOST:6379
+
+    echo "Waiting for web to start"
+    if [ -v WEB_HOST ]; then
+        WEB_ACTUAL_HOST=$WEB_HOST
+    else
+        WEB_ACTUAL_HOST=web
+    fi
+    /usr/local/wait-for-it.sh --strict -t 0 $WEB_ACTUAL_HOST:80
 fi
-/usr/local/wait-for-it.sh --strict -t 0 $POSTGRES_ACTUAL_HOST:$POSTGRES_PORT
-
-echo "Waiting for redis to start"
-if [ -v REDIS_HOST ];
-then
-    REDIS_ACTUAL_HOST=$REDIS_HOST
-else
-    REDIS_ACTUAL_HOST=db-redis
-fi
-
-/usr/local/wait-for-it.sh --strict -t 0 $REDIS_ACTUAL_HOST:6379
-
-echo "Waiting for web to start"
-if [ -v WEB_HOST ];
-then
-    WEB_ACTUAL_HOST=$WEB_HOST
-else
-    WEB_ACTUAL_HOST=web
-fi
-
-/usr/local/wait-for-it.sh --strict -t 0 $WEB_ACTUAL_HOST:80
 
 # check if the number of workers is set in the env
 if [ -z ${NUMBER_OF_WORKERS} ]; then

--- a/docker/start_uwsgi_docker.sh
+++ b/docker/start_uwsgi_docker.sh
@@ -2,24 +2,29 @@
 
 cd /seed
 
-echo "Waiting for postgres to start"
-if [ -v POSTGRES_HOST ];
-then
-   POSTGRES_ACTUAL_HOST=$POSTGRES_HOST
+# Check if 'STRATUS_MANAGED_SERVICES_ENABLED' is not set or if its value is 'TRUE'
+if [[ "${STRATUS_MANAGED_SERVICES_ENABLED}" == "on" ]]; then
+    echo "'STRATUS_MANAGED_SERVICES_ENABLED' is set and not equal to 'on'. Skipping wait-for-it.sh execution."
 else
-   POSTGRES_ACTUAL_HOST=db-postgres
-fi
-/usr/local/wait-for-it.sh --strict $POSTGRES_ACTUAL_HOST:$POSTGRES_PORT
+    cd /seed
 
-echo "Waiting for redis to start"
-if [ -v REDIS_HOST ];
-then
-    REDIS_ACTUAL_HOST=$REDIS_HOST
-else
-    REDIS_ACTUAL_HOST=db-redis
-fi
+    echo "Waiting for postgres to start"
+    if [ -v POSTGRES_HOST ]; then
+        POSTGRES_ACTUAL_HOST=$POSTGRES_HOST
+    else
+        POSTGRES_ACTUAL_HOST=db-postgres
+    fi
+    /usr/local/wait-for-it.sh --strict $POSTGRES_ACTUAL_HOST:$POSTGRES_PORT
 
-/usr/local/wait-for-it.sh --strict $REDIS_ACTUAL_HOST:6379
+    echo "Waiting for redis to start"
+    if [ -v REDIS_HOST ]; then
+        REDIS_ACTUAL_HOST=$REDIS_HOST
+    else
+        REDIS_ACTUAL_HOST=db-redis
+    fi
+
+    /usr/local/wait-for-it.sh --strict $REDIS_ACTUAL_HOST:6379
+fi
 
 # collect static resources before starting and compress the assets
 ./manage.py collectstatic --no-input -i package.json -i npm-shrinkwrap.json -i node_modules/openlayers-ext/index.html

--- a/docker/start_uwsgi_docker.sh
+++ b/docker/start_uwsgi_docker.sh
@@ -2,9 +2,9 @@
 
 cd /seed
 
-# Check if 'STRATUS_MANAGED_SERVICES_ENABLED' is not set or if its value is 'TRUE'
-if [[ "${STRATUS_MANAGED_SERVICES_ENABLED}" == "on" ]]; then
-    echo "'STRATUS_MANAGED_SERVICES_ENABLED' is set and not equal to 'on'. Skipping wait-for-it.sh execution."
+# Check if 'DISABLE_SERVICE_CHECKS_ON_START' is not set or if its value is 'TRUE'
+if [[ "${DISABLE_SERVICE_CHECKS_ON_START}" == "on" ]]; then
+    echo "'DISABLE_SERVICE_CHECKS_ON_START' is set and equal to 'on'. Skipping wait-for-it.sh execution."
 else
     cd /seed
 


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### This is to fix bug in stratus where celery container halted as wait-for-it script couldn't make socket connection to main connection.

#### What's this PR do?

This fix disables wait-for-it scripts that are not needed as managed services such as Postgres, Redis are not in docker and are already running.  So wait-for-it scrips are not needed in Stratus environment.

#### How should this be manually tested?

Build Docker image of seed and deploy to Stratus.

#### What are the relevant tickets?

#### Screenshots (if appropriate)
