### PR TITLE
Updated salesforce pg_restore docs

### DIFF
--- a/docs/source/developer_resources.rst
+++ b/docs/source/developer_resources.rst
@@ -341,8 +341,10 @@ Restoring a Database Dump
         --password=password \
         --organization=testorg
 
+If restoring a production backup to a different deployment update the site settings for password reset emails, and disable celerybeat Salesforce updates/emails:
 
-    # if restoring a production backup to a different deployment update the site settings for password reset emails
+.. code-block:: bash
+
     ./manage.py shell
 
     from django.contrib.sites.models import Site
@@ -350,6 +352,12 @@ Restoring a Database Dump
     site.domain = 'dev1.seed-platform.org'
     site.name = 'SEED Dev1'
     site.save()
+
+    from seed.models import Organization
+    Organization.objects.filter(salesforce_enabled=True).update(salesforce_enabled=False)
+
+    from django_celery_beat.models import PeriodicTask
+    PeriodicTask.objects.filter(enabled=True, name__startswith='salesforce_sync_org-').update(enabled=False)
 
 
 Migrating the Database

--- a/seed/utils/salesforce.py
+++ b/seed/utils/salesforce.py
@@ -86,12 +86,7 @@ def toggle_salesforce_sync(salesforce_enabled, org_id):
     tasks = PeriodicTask.objects.filter(name=AUTO_SYNC_NAME + str(org_id))
     if tasks:
         task = tasks.first()
-        if salesforce_enabled:
-            # look for task and make sure it's enabled
-            task.enabled = True
-        else:
-            # look for task and make sure it's disabled
-            task.enabled = False
+        task.enabled = bool(salesforce_enabled)
         task.save()
 
 


### PR DESCRIPTION
#### Any background context you want to provide?
Restoring a production database results in any scheduled tasks to inadvertently start running on the instance where the restore takes place

#### What's this PR do?
Updates the production database `pg_restore` documentation with steps to disable Salesforce syncing once the restore is completed

#### How should this be manually tested?
After restoring a production database follow the updated steps in the documentation and ensure that the celerybeat periodic tasks related to Salesforce are disabled