### PR TITLE
Fix co2 analysis column naming

### DIFF
--- a/seed/analysis_pipelines/co2.py
+++ b/seed/analysis_pipelines/co2.py
@@ -357,8 +357,8 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
         table_name='PropertyState',
     )
     if created:
-        column.display_name = 'Average Annual CO2 (kgCO2e)',
-        column.column_description = 'Average Annual CO2 (kgCO2e)',
+        column.display_name = 'Average Annual CO2 (kgCO2e)'
+        column.column_description = 'Average Annual CO2 (kgCO2e)'
         column.save()
 
     column, created = Column.objects.get_or_create(


### PR DESCRIPTION
Very tiny bug fix - when creating a column during the CO2 analysis, it was naming the column with a tuple instead of a string.