### PR TITLE
Additional analyses performance improvement

### DIFF
--- a/seed/models/analysis_property_views.py
+++ b/seed/models/analysis_property_views.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
+from django.db.models import QuerySet
 
 from seed.models import Analysis, Cycle, Property, PropertyState, PropertyView
 
@@ -84,11 +85,11 @@ class AnalysisPropertyView(models.Model):
         return analysis_property_view_ids, failures
 
     @classmethod
-    def get_property_views(cls, analysis_property_views):
+    def get_property_views(cls, analysis_property_views: QuerySet):
         """Get PropertyViews related to the AnalysisPropertyViews. If no PropertyView
         is found for an AnalysisPropertyView, the value will be None for that key.
 
-        :param analysis_property_views: list[AnalysisPropertyView]
+        :param analysis_property_views: QuerySet[AnalysisPropertyView]
         :return: dict{int: PropertyView}, PropertyViews keyed by the related AnalysisPropertyView id
         """
         # Fast query to find all potentially-necessary propertyViews

--- a/seed/views/v3/analysis_views.py
+++ b/seed/views/v3/analysis_views.py
@@ -11,7 +11,7 @@ from rest_framework.status import HTTP_409_CONFLICT
 
 from seed.decorators import ajax_request_class, require_organization_id_class
 from seed.lib.superperms.orgs.decorators import has_perm_class
-from seed.models import AnalysisPropertyView
+from seed.models import AnalysisPropertyView, PropertyView
 from seed.serializers.analysis_property_views import (
     AnalysisPropertyViewSerializer
 )
@@ -68,8 +68,7 @@ class AnalysisPropertyViewViewSet(viewsets.ViewSet, OrgMixin):
                 'message': "Requested analysis property view doesn't exist in this organization and/or analysis."
             }, status=HTTP_409_CONFLICT)
 
-        property_view_by_apv_id = AnalysisPropertyView.get_property_views([view])
-        original_view = property_view_by_apv_id[view.id]
+        original_view = PropertyView.objects.filter(property=view.property, cycle=view.cycle).first()
 
         return JsonResponse({
             'status': 'success',


### PR DESCRIPTION
#### What's this PR do?
Improves a very long, slow query, by ~17x

Previously, `GET /api/v3/analyses/` took `~13.52s`, now it takes `910ms` - `4.19s` for the same large dataset

#### How should this be manually tested?
Request the above URL and check the response timing

#### What are the relevant tickets?
#4433