### PR TITLE
Fixed FontAwesome v6.5 alignment

### DIFF
--- a/seed/static/seed/partials/home.html
+++ b/seed/static/seed/partials/home.html
@@ -14,36 +14,24 @@
           <div class="row">
             <div class="content_col col-md-4">
               <div class="content_col_header">
-                <div class="content_col_header_left">
-                  <span><i class="fa-solid fa-cloud-arrow-up"></i></span>
-                </div>
-                <div class="content_col_header_right">
-                  <h3 translate>Upload your data</h3>
-                </div>
+                <i class="fa-solid fa-cloud-arrow-up"></i>
+                <h3 translate>Upload your data</h3>
               </div>
               <div class="copy" translate>MARKETING_BULLET_1</div>
             </div>
 
             <div class="content_col col-md-4">
               <div class="content_col_header">
-                <div class="content_col_header_left">
-                  <span><i class="fa-solid fa-arrow-right-arrow-left"></i></span>
-                </div>
-                <div class="content_col_header_right">
-                  <h3 translate>Match your data</h3>
-                </div>
+                <i class="fa-solid fa-arrow-right-arrow-left"></i>
+                <h3 translate>Match your data</h3>
               </div>
               <div class="copy" translate>MARKETING_BULLET_2</div>
             </div>
 
             <div class="content_col col-md-4">
               <div class="content_col_header">
-                <div class="content_col_header_left">
-                  <span><i class="fa-solid fa-square-check"></i></span>
-                </div>
-                <div class="content_col_header_right">
-                  <h3 translate>Manage compliance</h3>
-                </div>
+                <i class="fa-solid fa-square-check"></i>
+                <h3 translate>Manage compliance</h3>
               </div>
               <div class="copy" translate>MARKETING_BULLET_3</div>
             </div>

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -202,6 +202,7 @@ a:not([href]) {
 }
 
 .sidebar {
+  font-size: 14px;
   margin-left: 0;
   position: fixed;
   float: none;
@@ -220,15 +221,15 @@ a:not([href]) {
     }
 
     .item {
-      position: relative;
-      overflow: hidden;
-      display: block;
-      padding: 16px;
-      width: 100%;
-      height: 53px;
+      height: 54px;
       color: $white;
       cursor: pointer;
+      display: flex;
       text-decoration: none;
+      justify-content: start;
+      overflow: hidden;
+      align-items: center;
+      position: relative;
 
       &:hover,
       &.active {
@@ -258,15 +259,8 @@ a:not([href]) {
 
       .icon {
         display: flex;
-        align-items: center;
-        position: relative;
-        float: left;
-        width: 20px;
-        text-align: center;
-
-        i {
-          width: 100%;
-        }
+        justify-content: center;
+        min-width: 55px;
 
         .toggle {
           display: flex;
@@ -274,19 +268,13 @@ a:not([href]) {
         }
       }
 
-      i:not(.fa-sm) {
-        font-size: 18px;
-      }
-
       .item_name {
-        position: relative;
-        top: 1px;
-        margin-top: 0;
-        margin-left: 16px;
-        line-height: 0;
         text-transform: uppercase;
         font-weight: bold;
         letter-spacing: 2px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 204px;
       }
 
       .badge {
@@ -859,8 +847,6 @@ a:not([href]) {
     h3 {
       font-size: 14px;
       font-weight: bold;
-      margin-top: 26px;
-      margin-bottom: 6px;
     }
 
     .content_block {
@@ -909,42 +895,34 @@ a:not([href]) {
 
       .content_col {
         .content_col_header {
-          position: relative;
-          overflow: auto;
+          display: flex;
+          flex-direction: row;
 
-          .content_col_header_left {
-            position: relative;
-            float: left;
+          i {
+            padding-top: 7px;
+            padding-right: 10px;
+            font-size: 48px;
 
-            i {
-              padding-top: 7px;
-              padding-right: 10px;
-              font-size: 48px;
+            &.fa-cloud-arrow-up {
+              color: $lightBlue;
+            }
 
-              &.fa-cloud-arrow-up {
-                color: $lightBlue;
-              }
+            &.fa-arrow-right-arrow-left {
+              color: lighten($purple, 25%);
+            }
 
-              &.fa-arrow-right-arrow-left {
-                color: lighten($purple, 25%);
-              }
-
-              &.fa-square-check {
-                color: lighten($green, 20%);
-              }
+            &.fa-square-check {
+              color: lighten($green, 20%);
             }
           }
 
-          .content_col_header_right {
-            h3 {
-              font-size: 20px;
-              font-weight: bold;
-            }
+          h3 {
+            font-size: 20px;
+            font-weight: bold;
           }
         }
 
         .copy {
-          clear: both;
           padding: 5px 30px 0 0;
           font-size: 16px;
         }

--- a/seed/templates/seed/_sidebar.html
+++ b/seed/templates/seed/_sidebar.html
@@ -3,7 +3,7 @@
     <div class="menu">
         <a id="sidebar-menu" class="item" ng-click="toggle_menu()">
             <div class="icon">
-                <i class="fa-solid fa-bars"></i>
+                <i class="fa-solid fa-lg fa-bars"></i>
                 <span ng-switch="expanded_controller" class="toggle">
                   <i ng-switch-when="true" id="sidebar-menu-close" class="fa-solid fa-chevron-left fa-sm"></i>
                   <i ng-switch-when="false" id="sidebar-menu-open" class="fa-solid fa-chevron-right fa-sm"></i>
@@ -11,54 +11,54 @@
             </div>
         </a>
         <a id="sidebar-profile" class="item" ng-class="{active: is_active('/profile'), 'disabled-item': !logged_in}" href="{% url "seed:home" %}#/profile">
-            <div class="icon"><i class="fa-solid fa-gear"></i></div>
+            <div class="icon"><i class="fa-solid fa-lg fa-gear"></i></div>
             <div class="item_name">{$ username $}</div>
         </a>
         <div class="divider"></div>
         <a id="sidebar-inventory" ng-class="{item: true, active: is_active('/properties') || is_active('/taxlots'), 'disabled-item': !logged_in}" href="{% url "seed:home" %}#/properties">
-            <div class="icon"><i class="fa-solid fa-building"></i></div>
+            <div class="icon"><i class="fa-solid fa-lg fa-building"></i></div>
             <div class="item_name" translate>Inventory</div>
         </a>
         <a id="sidebar-data" ng-class="{item: true, active: is_active('/data'), 'disabled-item': !logged_in}" title="{$:: 'Data' | translate $}" href="{% url "seed:home" %}#/data" ng-show="menu.user.organization.user_role !== 'viewer'">
-            <div class="icon"><i class="fa-solid fa-sitemap"></i></div>
+            <div class="icon"><i class="fa-solid fa-lg fa-sitemap"></i></div>
             <div class="item_name" translate>Data</div>
             <div ng-show="logged_in" class="badge badge_menu">{$ datasets_count | number:0 $}</div>
         </a>
         <a id="sidebar-accounts" ng-class="{item: true, active: is_active('/accounts'), 'disabled-item': !logged_in}" title="{$:: 'Organizations' | translate $}" href="{% url "seed:home" %}#/accounts">
-            <div class="icon"><i class="fa-solid fa-users"></i></div>
+            <div class="icon"><i class="fa-solid fa-lg fa-users"></i></div>
             <div class="item_name" translate>Organizations</div>
             <div ng-show="logged_in" class="badge badge_menu">{$ organizations_count | number:0 $}</div>
         </a>
         <a id="sidebar-accounts" ng-class="{item: true, active: is_active('/insights'), 'disabled-item': !logged_in}" title="{$:: 'Insights' | translate $}" href="{% url "seed:home" %}#/insights">
-            <div class="icon"><i class="fa-solid fa-gauge-high"></i></div>
+            <div class="icon"><i class="fa-solid fa-lg fa-gauge-high"></i></div>
             <div class="item_name" translate>Insights</div>
         </a>
 
         <a id="sidebar-accounts" ng-class="{item: true, active: is_active('/analyses'), 'disabled-item': !logged_in}" title="{$:: 'Analyses' | translate $}" href="{% url "seed:home" %}#/analyses">
-            <div class="icon"><i class="fa-solid fa-bar-chart"></i></div>
+            <div class="icon"><i class="fa-solid fa-lg fa-bar-chart"></i></div>
             <div class="item_name" translate>Analyses</div>
         </a>
 
         <div class="divider"></div>
 
         <a id="sidebar-api" ng-class="{item: true, active: is_active('/api/swagger'), 'disabled-item': !logged_in}" title="{$:: 'API Documentation' | translate $}" href="{% url "seed:home" %}#/api/swagger">
-            <div class="icon"><i class="fa-solid fa-code"></i></div>
+            <div class="icon"><i class="fa-solid fa-lg fa-code"></i></div>
             <div class="item_name" translate>API Documentation</div>
         </a>
         <a id="sidebar-contact" ng-class="{item: true, active: is_active('/contact'), 'disabled-item': !logged_in}" title="{$:: 'Contact' | translate $}" href="{% url "seed:home" %}#/contact">
-            <div class="icon"><i class="fa-solid fa-question-circle"></i></div>
+            <div class="icon"><i class="fa-solid fa-lg fa-question-circle"></i></div>
             <div class="item_name" translate>Contact</div>
         </a>
         <a id="sidebar-about" ng-class="{item: true, active: is_active('/about'), 'disabled-item': !logged_in}" title="{$:: 'About' | translate $}" href="{% url "seed:home" %}#/about">
-            <div class="icon"><i class="fa-solid fa-info-circle"></i></div>
+            <div class="icon"><i class="fa-solid fa-lg fa-info-circle"></i></div>
             <div class="item_name" translate>About</div>
         </a>
         <a id="sidebar-docs" ng-class="{item: true, active: is_active('/documentation/', true)}" title="{$:: 'Documentation' | translate $}" href="{% url "docs:documentation" %}#/">
-            <div class="icon"><i class="fa-solid fa-book"></i></div>
+            <div class="icon"><i class="fa-solid fa-lg fa-book"></i></div>
             <div class="item_name" translate>Documentation</div>
         </a>
         <a id="sidebar-logout" class="item" ng-class="{'disabled-item': !logged_in}" title="{$:: 'Logout' | translate $}" href="{% url "landing:logout" %}">
-            <div class="icon"><i class="fa-solid fa-sign-out"></i></div>
+            <div class="icon"><i class="fa-solid fa-lg fa-sign-out"></i></div>
             <div class="item_name" translate>Logout</div>
         </a>
     </div>

--- a/vendors/package-lock.json
+++ b/vendors/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fontsource/pt-sans": "^5.0.8",
         "@fontsource/pt-sans-narrow": "^5.0.15",
-        "@fortawesome/fontawesome-free": "^6.4.2",
+        "@fortawesome/fontawesome-free": "^6.5.1",
         "angular": "^1.8.3",
         "angular-animate": "^1.8.3",
         "angular-aria": "^1.8.3",
@@ -400,9 +400,9 @@
       "integrity": "sha512-jsECczOyWn+r4QqzLGY8FxVhecjbt+8mHk77VxOR/0IWWhO6BtQqJRPPirtn+E5nx6y71HDJaZac3ufXCzth+g=="
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.2.tgz",
-      "integrity": "sha512-m5cPn3e2+FDCOgi1mz0RexTUvvQibBebOUlUlW0+YrMjDTPkiJ6VTKukA1GRsvRw+12KyJndNjj0O4AgTxm2Pg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.1.tgz",
+      "integrity": "sha512-CNy5vSwN3fsUStPRLX7fUYojyuzoEMSXPl7zSLJ8TgtRfjv24LOnOWKT2zYwaHZCJGkdyRnTmstR0P+Ah503Gw==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"

--- a/vendors/package.json
+++ b/vendors/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@fontsource/pt-sans": "^5.0.8",
     "@fontsource/pt-sans-narrow": "^5.0.15",
-    "@fortawesome/fontawesome-free": "^6.4.2",
+    "@fortawesome/fontawesome-free": "^6.5.1",
     "angular": "^1.8.3",
     "angular-animate": "^1.8.3",
     "angular-aria": "^1.8.3",


### PR DESCRIPTION
#### Any background context you want to provide?
FontAwesome automatically updated from `v6.4.2` to `v6.5.0`, which caused alignment issues and visible scrollbars:
![image](https://github.com/SEED-platform/seed/assets/411466/a95c31c3-95b5-4915-b155-4c2a7ba8ec0f)

#### What's this PR do?
Fixes the alignment for the latest version of FontAwesome

#### How should this be manually tested?
1. Run `npm install`
2. Check that tiny scrollbars no longer appear on the homepage