### PR TITLE
Fixes text alignment following FontAwesome changes

### DIFF
--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -3745,7 +3745,7 @@ $pairedCellWidth: 60px;
   div {
     position: relative;
     text-align: right;
-    top: -2px;
+    top: -6px;
     width: 20px;
   }
 }


### PR DESCRIPTION
#### Any background context you want to provide?
FontAwesome recently released a minor update that included several positioning changes

#### What's this PR do?
Fixes the note-count text alignment

#### How should this be manually tested?
Browse to the Inventory List view, look at the the notes-count column for rows with >0 notes

#### Screenshots (if appropriate)
<table>
<tr><td>Before:</td><td>After:</td></tr>
<tr>
<td><img src="https://github.com/SEED-platform/seed/assets/411466/51e37db5-7085-420f-95d0-5340633d8fab"></td>
<td><img src="https://github.com/SEED-platform/seed/assets/411466/d138867e-1392-4929-bc46-f9387f1c6e3a"></td>
</tr>
</table>
