### PR TITLE
Move program setup to modal on insights pages

### DIFF
--- a/seed/static/seed/js/controllers/insights_property_controller.js
+++ b/seed/static/seed/js/controllers/insights_property_controller.js
@@ -11,20 +11,42 @@ angular.module('BE.seed.controller.insights_property', []).controller('insights_
   'compliance_metrics',
   'compliance_metric_service',
   'organization_payload',
+  'filter_groups',
+  'property_columns',
+  'cycles',
   'spinner_utility',
   'auth_payload',
   // eslint-disable-next-line func-names
-  function ($scope, $state, $stateParams, $uibModal, urls, compliance_metrics, compliance_metric_service, organization_payload, spinner_utility, auth_payload) {
+  function (
+    $scope,
+    $state,
+    $stateParams,
+    $uibModal,
+    urls,
+    compliance_metrics,
+    compliance_metric_service,
+    organization_payload,
+    filter_groups,
+    property_columns,
+    cycles,
+    spinner_utility,
+    auth_payload
+  ) {
     $scope.id = $stateParams.id;
     $scope.static_url = urls.static_url;
     $scope.organization = organization_payload.organization;
     $scope.auth = auth_payload.auth;
 
+    // used by modal
+    $scope.filter_groups = filter_groups;
+    $scope.property_columns = property_columns;
+    $scope.all_cycles = cycles.cycles;
+
     // toggle help
     $scope.show_help = false;
     $scope.toggle_help = () => {
       $scope.show_help = !$scope.show_help;
-    }
+    };
 
     // configs ($scope.configs set to saved_configs where still applies.
     // for example, if saved_configs.compliance_metric is 1, but 1 has been deleted, it does apply.)
@@ -73,6 +95,65 @@ angular.module('BE.seed.controller.insights_property', []).controller('insights_
     $scope.y_axis_options = [];
     $scope.x_categorical = false;
 
+    // Program Setup Modal
+    $scope.open_program_setup_modal = () => {
+      const modalInstance = $uibModal.open({
+        templateUrl: `${urls.static_url}seed/partials/program_setup.html`,
+        controller: 'program_setup_controller',
+        size: 'lg',
+        backdrop: 'static',
+        resolve: {
+          cycles: () => $scope.all_cycles,
+          compliance_metrics: () => $scope.compliance_metrics,
+          organization_payload: () => $scope.organization,
+          filter_groups: () => $scope.filter_groups,
+          property_columns: () => $scope.property_columns,
+          id: () => $scope.selected_metric
+        }
+      });
+      // on modal close
+      modalInstance.result.then((program) => {
+        // 1) change selection if no programs existed before
+        // 2) change selection if the selected one in insights no longer exists
+        // 3) reload if the selected one still exists (just in case)
+        // 4) do nothing
+        compliance_metric_service.get_compliance_metrics($scope.organization.id).then((data) => {
+          $scope.compliance_metrics = data;
+          const metric_ids = _.map($scope.compliance_metrics, 'id');
+          if ($scope.selected_metric === null && $scope.compliance_metrics.length > 0) {
+            // case 1
+            if (program != null) {
+              $scope.configs.compliance_metric = $scope.compliance_metrics.find((cm) => cm.id === program.id);
+              $scope.selected_metric = program.id;
+            } else {
+              // this should not happen, but just in case use the 1st one
+              $scope.configs.compliance_metric = $scope.compliance_metrics[0];
+              $scope.selected_metric = $scope.configs.compliance_metric.id;
+            }
+          } else if ($scope.selected_metric && metric_ids.indexOf($scope.selected_metric) === -1) {
+            // case 2
+            if (program != null) {
+              $scope.configs.compliance_metric = $scope.compliance_metrics.find((cm) => cm.id === program.id);
+              $scope.selected_metric = program.id;
+            } else if ($scope.compliance_metrics.length > 0) {
+              // this should not happen, but just in case use the 1st one
+              $scope.configs.compliance_metric = $scope.compliance_metrics[0];
+              $scope.selected_metric = $scope.configs.compliance_metric.id;
+            } else {
+              // load nothing
+              $scope.configs.compliance_metric = {};
+              $scope.selected_metric = null;
+            }
+          } else if ($scope.selected_metric) {
+            // case 3
+            // otherwise reload the data for selected one in case it changed
+            $scope.configs.compliance_metric = $scope.compliance_metrics.find((cm) => cm.id === $scope.selected_metric);
+          }
+          $scope.update_metric();
+        });
+      });
+    };
+
     $scope.$watch(
       'configs',
       (new_configs) => {
@@ -89,6 +170,7 @@ angular.module('BE.seed.controller.insights_property', []).controller('insights_
     const _load_data = () => {
       if (_.isEmpty($scope.configs.compliance_metric)) {
         spinner_utility.hide();
+        $scope.data = null;
         return;
       }
       spinner_utility.show();
@@ -189,7 +271,10 @@ angular.module('BE.seed.controller.insights_property', []).controller('insights_
       spinner_utility.show();
 
       // compliance metric
-      $scope.configs.compliance_metric = _.find($scope.compliance_metrics, (o) => o.id === $scope.selected_metric);
+      $scope.configs.compliance_metric = {};
+      if ($scope.selected_metric != null) {
+        $scope.configs.compliance_metric = _.find($scope.compliance_metrics, (o) => o.id === $scope.selected_metric);
+      }
 
       // reload data for selected metric
       _load_data();

--- a/seed/static/seed/js/controllers/program_setup_controller.js
+++ b/seed/static/seed/js/controllers/program_setup_controller.js
@@ -5,39 +5,49 @@
 angular.module('BE.seed.controller.program_setup', []).controller('program_setup_controller', [
   '$scope',
   '$state',
-  '$stateParams',
-  'compliance_metrics',
+  '$uibModalInstance',
   'compliance_metric_service',
-  'filter_groups',
   'Notification',
-  'organization_payload',
-  'cycles_payload',
-  'property_columns',
   'spinner_utility',
-  'x_axis_columns',
+  'naturalSort',
+  'cycles',
+  'compliance_metrics',
+  'organization_payload',
+  'filter_groups',
+  'property_columns',
+  'id',
   // eslint-disable-next-line func-names
   function (
     $scope,
     $state,
-    $stateParams,
-    compliance_metrics,
+    $uibModalInstance,
     compliance_metric_service,
-    filter_groups,
     Notification,
-    organization_payload,
-    cycles_payload,
-    property_columns,
     spinner_utility,
-    x_axis_columns
+    naturalSort,
+    cycles,
+    compliance_metrics,
+    organization_payload,
+    filter_groups,
+    property_columns,
+    id
   ) {
-    spinner_utility.show();
+    // spinner_utility.show();
     $scope.state = $state.current;
-    $scope.id = $stateParams.id;
-    $scope.org = organization_payload.organization;
-    $scope.cycles = cycles_payload.cycles;
+    $scope.org = organization_payload;
+    $scope.cycles = cycles;
+    $scope.id = id;
+    $scope.filter_groups = filter_groups;
     // order cycles by start date
-    $scope.cycles = _.orderBy($scope.cycles, ['start'],
-    ['asc']);
+    $scope.cycles = _.orderBy($scope.cycles, ['start'], ['asc']);
+    $scope.filter_groups = filter_groups;
+    $scope.valid_column_data_types = ['number', 'float', 'integer', 'ghg', 'ghg_intensity', 'area', 'eui', 'boolean'];
+    $scope.valid_x_axis_data_types = ['number', 'string', 'float', 'integer', 'ghg', 'ghg_intensity', 'area', 'eui', 'boolean'];
+
+    $scope.property_columns = _.reject(property_columns, (item) => item.related || !$scope.valid_column_data_types.includes(item.data_type)).sort((a, b) => naturalSort(a.displayName, b.displayName));
+    $scope.x_axis_columns = _.reject(property_columns, (item) => item.related || !$scope.valid_x_axis_data_types.includes(item.data_type)).sort((a, b) => naturalSort(a.displayName, b.displayName));
+    $scope.x_axis_selection = '';
+    $scope.cycle_selection = '';
     $scope.compliance_metrics_error = [];
     $scope.program_settings_not_changed = true;
     $scope.program_settings_changed = () => {
@@ -45,12 +55,35 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
     };
     $scope.compliance_metrics = compliance_metrics;
     $scope.has_compliance_metrics = $scope.compliance_metrics.length > 0;
+    $scope.selected_compliance_metric = null;
 
-    if ($scope.id) {
-      $scope.selected_compliance_metric = $scope.compliance_metrics.find((item) => item.id === $scope.id);
-    }
-    $scope.property_columns = property_columns;
-    $scope.x_axis_columns = x_axis_columns;
+    // init_selected_compliance_metric (handle case where there are none)
+    $scope.init_selected_metric = (id) => {
+      $scope.has_compliance_metrics = $scope.compliance_metrics.length > 0;
+      $scope.selected_compliance_metric = null;
+      $scope.available_cycles = [];
+      $scope.available_x_axis_columns = [];
+      $scope.compliance_metrics_error = [];
+      $scope.program_settings_not_changed = true;
+      $scope.x_axis_selection = '';
+      $scope.cycle_selection = '';
+      $scope.available_x_axis_columns = () => [];
+      $scope.available_cycles = () => [];
+
+      if (id === null) {
+        if ($scope.has_compliance_metrics) {
+          // this is after a delete. choose the first metric?
+          id = $scope.compliance_metrics[0].id;
+        }
+      }
+      if (id != null) {
+        $scope.selected_compliance_metric = $scope.compliance_metrics.find((item) => item.id === id);
+        $scope.available_x_axis_columns = () => $scope.x_axis_columns.filter(({ id }) => !$scope.selected_compliance_metric?.x_axis_columns.includes(id));
+        $scope.available_cycles = () => $scope.cycles.filter(({ id }) => !$scope.selected_compliance_metric?.cycles.includes(id));
+      }
+    };
+
+    $scope.init_selected_metric($scope.id);
 
     $scope.get_column_display = (id) => {
       const record = _.find($scope.property_columns, { id });
@@ -60,15 +93,12 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
     };
 
     // cycles
-    $scope.cycle_selection = '';
     $scope.get_cycle_display = (id) => {
       const record = _.find($scope.cycles, { id });
       if (record) {
         return record.name;
       }
     };
-
-    $scope.available_cycles = () => $scope.cycles.filter(({ id }) => !$scope.selected_compliance_metric?.cycles.includes(id));
 
     $scope.select_cycle = () => {
       $scope.program_settings_changed();
@@ -79,7 +109,6 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
       }
       $scope.selected_compliance_metric.cycles.push(selection);
       $scope.order_selected_cycles();
-
     };
 
     $scope.order_selected_cycles = () => {
@@ -100,10 +129,6 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
       }
     };
 
-    $scope.available_x_axis_columns = () => $scope.x_axis_columns.filter(({ id }) => !$scope.selected_compliance_metric?.x_axis_columns.includes(id));
-
-    $scope.x_axis_selection = '';
-
     $scope.select_x_axis = () => {
       $scope.program_settings_changed();
       const selection = $scope.x_axis_selection;
@@ -120,7 +145,6 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
     };
 
     // Filter Groups
-    $scope.filter_groups = filter_groups;
     $scope.get_filter_group_display = (id) => {
       const record = _.find($scope.filter_groups, { id });
       if (record) {
@@ -128,8 +152,19 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
       }
     };
 
+    $scope.set_program = (id) => {
+      // check to ensure there are no unsaved changes
+      if ($scope.program_settings_not_changed) {
+        // switch it out / re-init
+        $scope.init_selected_metric(id);
+      } else {
+        // warn user to save first
+        Notification.warning({ message: 'You have unsaved changes to the current program. Save your changes first before selecting a different program to update.', delay: 5000 });
+      }
+    };
+
     /**
-     * saves the updates settings
+     * saves the updated settings
      */
     $scope.save_settings = () => {
       spinner_utility.show();
@@ -184,22 +219,23 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
             $scope.compliance_metrics_error.push(`${key}: ${error}`);
           }
         } else {
+          // success. the ID would already be saved so this block seems unnecesary
           if (!$scope.selected_compliance_metric.id) {
-            window.location = `#/accounts/${$scope.org.id}/program_setup/${data.id}`;
+            $scope.selected_compliance_metric.id = data.id;
           }
-
-          // replace data into compliance metric? needed?
+          // replace data into compliance metric
           const index = _.findIndex($scope.compliance_metrics, ['id', data.id]);
-          $scope.compliance_metrics[index] = data;
-
+          if (index >= 0) {
+            $scope.compliance_metrics[index] = data;
+          } else {
+            $scope.compliance_metrics.push(data);
+          }
           $scope.selected_compliance_metric = data;
-
-          window.location = `#/accounts/${$scope.org.id}/program_setup`;
         }
       });
 
       // display messages
-      Notification.primary({ message: '<a href="#/insights" style="color: #337ab7;">Click here to view your Program Overview</a>', delay: 5000 });
+      // Notification.primary({ message: '<a href="#/insights" style="color: #337ab7;">Click here to view your Program Overview</a>', delay: 5000 });
       Notification.success({ message: 'Program Setup Saved!', delay: 5000 });
 
       $scope.program_settings_not_changed = true;
@@ -207,7 +243,7 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
     };
 
     $scope.click_new_compliance_metric = () => {
-      spinner_utility.show();
+      //spinner_utility.show();
 
       // create a new metric using api and then assign it to selected_compliance_metric that
       // way it will have an id
@@ -224,16 +260,14 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
         x_axis_columns: []
       };
       compliance_metric_service.new_compliance_metric(template_compliance_metric, $scope.org.id).then((data) => {
-        $scope.selected_compliance_metric = data;
-        window.location = `#/accounts/${$scope.org.id}/program_setup/${data.id}`;
+        $scope.compliance_metrics.push(data);
+        $scope.init_selected_metric(data.id);
       });
-      $scope.program_settings_not_changed = true;
-
-      spinner_utility.hide();
-    };
+      //spinner_utility.hide();
+    }
 
     $scope.click_delete = (compliance_metric = null) => {
-      spinner_utility.show();
+      // spinner_utility.show();
       if (!compliance_metric) {
         compliance_metric = $scope.selected_compliance_metric;
       }
@@ -243,12 +277,21 @@ angular.module('BE.seed.controller.program_setup', []).controller('program_setup
           if (data.status === 'success') {
             $scope.compliance_metrics = $scope.compliance_metrics.filter((compliance_metric) => compliance_metric.id !== delete_id);
             if ($scope.selected_compliance_metric.id === delete_id) {
-              window.location = `#/accounts/${$scope.org.id}/program_setup`;
+              // notification
+              Notification.success({ message: 'Compliance metric deleted successfully!', delay: 5000 });
+              // reset selection
+              $scope.selected_compliance_metric = {};
+              $scope.init_selected_metric(null);
             }
           }
         });
       }
-      spinner_utility.hide();
+      // spinner_utility.hide();
+    };
+
+    $scope.close = () => {
+      // close and return selected compliance metric
+      $uibModalInstance.close($scope.selected_compliance_metric);
     };
   }
 ]);

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -1236,148 +1236,6 @@ SEED_app.config([
         }
       })
       .state({
-        name: 'programs',
-        url: '/accounts/{organization_id:int}/program_setup',
-        templateUrl: `${static_url}seed/partials/program_setup.html`,
-        controller: 'program_setup_controller',
-        resolve: {
-          valid_column_data_types: [
-            () => ['number', 'float', 'integer', 'ghg', 'ghg_intensity', 'area', 'eui', 'boolean']
-          ],
-          valid_x_axis_data_types: [
-            () => ['number', 'string', 'float', 'integer', 'ghg', 'ghg_intensity', 'area', 'eui', 'boolean']
-          ],
-          compliance_metrics: [
-            '$stateParams',
-            'compliance_metric_service',
-            ($stateParams, compliance_metric_service) => compliance_metric_service.get_compliance_metrics($stateParams.organization_id)
-          ],
-          organization_payload: [
-            'organization_service',
-            '$stateParams',
-            (organization_service, $stateParams) => organization_service.get_organization($stateParams.organization_id)
-          ],
-          cycles_payload: [
-            'cycle_service',
-            '$stateParams',
-            (cycle_service, $stateParams) => cycle_service.get_cycles_for_org($stateParams.organization_id)
-          ],
-          property_columns: [
-            'valid_column_data_types',
-            '$stateParams',
-            'inventory_service',
-            'naturalSort',
-            (valid_column_data_types, $stateParams, inventory_service, naturalSort) => inventory_service.get_property_columns_for_org($stateParams.organization_id).then((columns) => {
-              columns = _.reject(columns, (item) => item.related || !valid_column_data_types.includes(item.data_type)).sort((a, b) => naturalSort(a.displayName, b.displayName));
-              return columns;
-            })
-          ],
-          x_axis_columns: [
-            'valid_x_axis_data_types',
-            '$stateParams',
-            'inventory_service',
-            'naturalSort',
-            (valid_x_axis_data_types, $stateParams, inventory_service, naturalSort) => inventory_service.get_property_columns_for_org($stateParams.organization_id).then((columns) => {
-              columns = _.reject(columns, (item) => item.related || !valid_x_axis_data_types.includes(item.data_type)).sort((a, b) => naturalSort(a.displayName, b.displayName));
-              return columns;
-            })
-          ],
-          filter_groups: [
-            '$stateParams',
-            'filter_groups_service',
-            ($stateParams, filter_groups_service) => {
-              const inventory_type = 'Property'; // just properties for now
-              return filter_groups_service.get_filter_groups(inventory_type, $stateParams.organization_id);
-            }
-          ],
-          auth_payload: [
-            'auth_service',
-            '$stateParams',
-            '$q',
-            (auth_service, $stateParams, $q) => auth_service.is_authorized($stateParams.organization_id, ['requires_member']).then(
-              (data) => {
-                if (data.auth.requires_member) {
-                  return data;
-                }
-                return $q.reject('not authorized');
-              },
-              (data) => $q.reject(data.message)
-            )
-          ]
-        }
-      })
-      .state({
-        name: 'program_setup',
-        url: '/accounts/{organization_id:int}/program_setup/{id:int}',
-        templateUrl: `${static_url}seed/partials/program_setup.html`,
-        controller: 'program_setup_controller',
-        resolve: {
-          valid_column_data_types: [
-            () => ['number', 'float', 'integer', 'ghg', 'ghg_intensity', 'area', 'eui', 'boolean']
-          ],
-          valid_x_axis_data_types: [
-            () => ['number', 'string', 'float', 'integer', 'ghg', 'ghg_intensity', 'area', 'eui', 'boolean']
-          ],
-          compliance_metrics: [
-            '$stateParams',
-            'compliance_metric_service',
-            ($stateParams, compliance_metric_service) => compliance_metric_service.get_compliance_metrics($stateParams.organization_id)
-          ],
-          organization_payload: [
-            'organization_service',
-            '$stateParams',
-            (organization_service, $stateParams) => organization_service.get_organization($stateParams.organization_id)
-          ],
-          cycles_payload: [
-            'cycle_service',
-            '$stateParams',
-            (cycle_service, $stateParams) => cycle_service.get_cycles_for_org($stateParams.organization_id)
-          ],
-          property_columns: [
-            'valid_column_data_types',
-            '$stateParams',
-            'inventory_service',
-            'naturalSort',
-            (valid_column_data_types, $stateParams, inventory_service, naturalSort) => inventory_service.get_property_columns_for_org($stateParams.organization_id).then((columns) => {
-              columns = _.reject(columns, (item) => item.related || !valid_column_data_types.includes(item.data_type)).sort((a, b) => naturalSort(a.displayName, b.displayName));
-              return columns;
-            })
-          ],
-          x_axis_columns: [
-            'valid_x_axis_data_types',
-            '$stateParams',
-            'inventory_service',
-            'naturalSort',
-            (valid_x_axis_data_types, $stateParams, inventory_service, naturalSort) => inventory_service.get_property_columns_for_org($stateParams.organization_id).then((columns) => {
-              columns = _.reject(columns, (item) => item.related || !valid_x_axis_data_types.includes(item.data_type)).sort((a, b) => naturalSort(a.displayName, b.displayName));
-              return columns;
-            })
-          ],
-          filter_groups: [
-            '$stateParams',
-            'filter_groups_service',
-            ($stateParams, filter_groups_service) => {
-              const inventory_type = 'Property'; // just properties for now
-              return filter_groups_service.get_filter_groups(inventory_type, $stateParams.organization_id);
-            }
-          ],
-          auth_payload: [
-            'auth_service',
-            '$stateParams',
-            '$q',
-            (auth_service, $stateParams, $q) => auth_service.is_authorized($stateParams.organization_id, ['requires_member']).then(
-              (data) => {
-                if (data.auth.requires_member) {
-                  return data;
-                }
-                return $q.reject('not authorized');
-              },
-              (data) => $q.reject(data.message)
-            )
-          ]
-        }
-      })
-      .state({
         name: 'organization_column_settings',
         url: '/accounts/{organization_id:int}/column_settings/{inventory_type:properties|taxlots}',
         templateUrl: `${static_url}seed/partials/column_settings.html`,
@@ -2646,10 +2504,26 @@ SEED_app.config([
             'cycle_service',
             (cycle_service) => cycle_service.get_cycles()
           ],
+          property_columns: [
+            'inventory_service',
+            'user_service',
+            (inventory_service, user_service) => {
+              const organization_id = user_service.get_organization().id;
+              return inventory_service.get_property_columns_for_org(organization_id);
+            }
+          ],
           organization_payload: [
             'user_service',
             'organization_service',
             (user_service, organization_service) => organization_service.get_organization(user_service.get_organization().id)
+          ],
+          filter_groups: [
+            '$stateParams',
+            'filter_groups_service',
+            ($stateParams, filter_groups_service) => {
+              const inventory_type = 'Property'; // just properties for now
+              return filter_groups_service.get_filter_groups(inventory_type, $stateParams.organization_id);
+            }
           ]
         }
       })
@@ -2675,6 +2549,26 @@ SEED_app.config([
             'user_service',
             'organization_service',
             (user_service, organization_service) => organization_service.get_organization(user_service.get_organization().id)
+          ],
+          filter_groups: [
+            '$stateParams',
+            'filter_groups_service',
+            ($stateParams, filter_groups_service) => {
+              const inventory_type = 'Property'; // just properties for now
+              return filter_groups_service.get_filter_groups(inventory_type, $stateParams.organization_id);
+            }
+          ],
+          property_columns: [
+            'inventory_service',
+            'user_service',
+            (inventory_service, user_service) => {
+              const organization_id = user_service.get_organization().id;
+              return inventory_service.get_property_columns_for_org(organization_id);
+            }
+          ],
+          cycles: [
+            'cycle_service',
+            (cycle_service) => cycle_service.get_cycles()
           ]
         }
       })

--- a/seed/static/seed/partials/accounts.html
+++ b/seed/static/seed/partials/accounts.html
@@ -42,7 +42,6 @@
                 <a ui-sref="organization_email_templates(::{organization_id: org.id})"><i class="fa-solid fa-envelope"></i>{$:: 'Email Templates' | translate $}</a>
                 <a ui-sref="organization_labels(::{organization_id: org.id})"><i class="fa-solid fa-tags"></i>{$:: 'Labels' | translate $}</a>
                 <a ui-sref="organization_members(::{organization_id: org.id})"><i class="fa-solid fa-user"></i>{$:: 'Members' | translate $}</a>
-                <a ui-sref="programs(::{organization_id: org.id})"><i class="fa-solid fa-gauge-high"></i>{$:: 'Program Setup' | translate $}</a>
                 <a ui-sref="organization_settings(::{organization_id: org.id})"><i class="fa-solid fa-gears"></i>Settings</a>
                 <a ui-sref="organization_sharing(::{organization_id: org.id})" ng-if="::org.is_parent"><i class="fa-solid fa-share-from-square"></i>{$:: 'Sharing' | translate $}</a>
                 <a ui-sref="organization_sub_orgs(::{organization_id: org.id})" ng-if="::org.is_parent"><i class="fa-solid fa-users"></i>{$:: 'Sub-Organizations' | translate $}</a>

--- a/seed/static/seed/partials/accounts_nav.html
+++ b/seed/static/seed/partials/accounts_nav.html
@@ -30,7 +30,6 @@
 <a ui-sref="organization_email_templates(::{organization_id: org.id})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Email Templates</a>
 <a ui-sref="organization_labels(::{organization_id: org.id})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Labels</a>
 <a ui-sref="organization_members(::{organization_id: org.id})" ui-sref-active="active" translate>Members</a>
-<a ui-sref="programs(::{organization_id: org.id})" ng-class="::{active: ['program_setup', 'programs'].includes(state.name)}" translate>Program Setup</a>
 <a ui-sref="organization_settings(::{organization_id: org.id})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Settings</a>
 <a ui-sref="organization_sharing(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sharing</a>
 <a ui-sref="organization_sub_orgs(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sub-Organizations</a>

--- a/seed/static/seed/partials/insights_program.html
+++ b/seed/static/seed/partials/insights_program.html
@@ -19,7 +19,10 @@
             <h2 style="font-size: 18px">{$:: 'Program Overview' | translate $}</h2>
           </div>
           <div ng-if="auth.requires_member" class="compliance-setup">
-            <p>If you are not seeing a chart on this page, visit the <a ui-sref="programs(::{organization_id: organization.id})">Program</a> page to configure your program's metrics.</p>
+            <p>Configure your program's metrics:</p>
+            <button class="btn btn-primary" type="submit" ng-click="open_program_setup_modal()">
+              Program Configuration
+            </button>
           </div>
         </div>
       </div>
@@ -31,7 +34,11 @@
           </div>
           <!-- compliance setup -->
           <div ng-if="auth.requires_member" class="compliance-setup">
-            <p>Need to configure your Program? <a ui-sref="programs(::{organization_id: organization.id})">Program Configuration page</a>.</p>
+            <p>Need to configure your Program?
+              <button class="btn btn-primary" type="submit" ng-click="open_program_setup_modal()">
+                Program Configuration
+            </button>
+            </p>
           </div>
           <div class="form-group margin-top-20">
             <label for="program">Program</label>

--- a/seed/static/seed/partials/insights_property.html
+++ b/seed/static/seed/partials/insights_property.html
@@ -15,12 +15,19 @@
     <div class="content_block row insights-header">
         <div ng-show="!data">
           <div ng-if="auth.requires_member" class="compliance-setup">
-            <p>If you are not seeing a chart on this page, visit the <a ui-sref="programs(::{organization_id: organization.id})">Program</a> page to configure your program's metrics.</p>
+            <p>Configure your program's metrics:</p>
+            <button class="btn btn-primary" type="submit" ng-click="open_program_setup_modal()">
+              Program Configuration
+            </button>
           </div>
         </div>
         <div ng-show="data">
           <div ng-if="auth.requires_member" class="compliance-setup">
-            <p><span translate>CONFIGURE_PROGRAM</span> <a ui-sref="programs(::{organization_id: organization.id})" translate>Program Configuration page</a>.</p>
+            <p>Need to configure your Program?
+              <button class="btn btn-primary" type="submit" ng-click="open_program_setup_modal()">
+                Program Configuration
+              </button>
+            </p>
           </div>
         </div>
     </div>
@@ -28,10 +35,14 @@
       <div ng-show="data">
         <div class="col-md-2">
           <div class="chart-options">
-            <div class="title"><span translate>Chart Options</span><span class="help-text-icon" ng-click="toggle_help()"><i class="fa-solid fa-circle-question" aria-label="display help text"></i></span></div>
-              <div ng-show="show_help">
-                <p class="small-text" translate>INSIGHTS_HELP_TEXT</p>
-              </div>
+            <div class="title">
+              <span translate>Chart Options</span>
+              <span class="help-text-icon" ng-click="toggle_help()">
+                <i class="fa-solid fa-circle-question" aria-label="display help text"></i>
+              </span>
+            </div>
+            <div ng-show="show_help">
+              <p class="small-text" translate>INSIGHTS_HELP_TEXT</p>
             </div>
 
             <div class="form-group">

--- a/seed/static/seed/partials/program_setup.html
+++ b/seed/static/seed/partials/program_setup.html
@@ -1,30 +1,16 @@
-<div class="page_header_container">
-  <div class="page_header">
-    <div class="left page_action_container">
-      <a ui-sref="organizations" class="page_action"><i class="fa-solid fa-chevron-left"></i> {$:: 'Organizations' | translate $}</a>
-    </div>
-    <div class="page_title">
-      <h1>{$:: org.name $}</h1>
-    </div>
-    <div class="right page_action_container"></div>
-  </div>
-</div>
-
-<div class="section_nav_container">
-  <div class="section_nav" ng-include="::urls.static_url + 'seed/partials/accounts_nav.html'"></div>
-</div>
-
-<div class="section">
-  <div class="section_header_container">
-    <div class="section_header has_no_padding fixed_height_short">
-      <div class="section_action_container left">
-        <h2><i class="fa-solid fa-gauge-high"></i> {$:: 'Program Setup' | translate $}</h2>
-      </div>
-      <div ng-show="selected_compliance_metric" class="section_action_container right_40 section_action_btn pull-right">
-        <button class="btn btn-info r-margin-right-5" ng-click="click_delete()" translate>Delete</button>
-        <button class="btn btn-primary" ng-disabled="program_settings_not_changed" ng-click="save_settings()">
-          {$:: 'Save Changes' | translate $} <i class="fa-solid fa-check" ng-show="settings_updated"></i>
-        </button>
+<div class="modal-content">
+  <div class="modal-header section">
+    <div class="section_header_container">
+      <div class="section_header has_no_padding fixed_height_short">
+        <div class="section_action_container left">
+          <h2><i class="fa-solid fa-gauge-high"></i> {$:: 'Program Setup' | translate $}</h2>
+        </div>
+        <div ng-show="selected_compliance_metric" class="section_action_container right_40 section_action_btn pull-right">
+          <button class="btn btn-info r-margin-right-5" ng-click="click_delete()" translate>Delete</button>
+          <button class="btn btn-primary" ng-disabled="program_settings_not_changed" ng-click="save_settings()">
+            {$:: 'Save Changes' | translate $} <i class="fa-solid fa-check" ng-show="settings_updated"></i>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -46,7 +32,7 @@
             ng-repeat-end
             class="r-row r-row-centered"
           >
-            <a ui-sref="program_setup(::{organization_id: org.id, id: compliance_metric.id})" class="r-grow">{$:: compliance_metric.name $}</a>
+            <a ng-click="set_program(compliance_metric.id)" class="r-grow">{$:: compliance_metric.name $}</a>
             <i class="fa-solid fa-xmark r-margin-left-5" ng-click="click_delete(compliance_metric)"></i>
           </li>
         </ul>
@@ -104,27 +90,6 @@
                       <select class="form-control" ng-model="selected_compliance_metric.filter_group" ng-change="program_settings_changed()">
                         <option value=""></option>
                         <option ng-repeat="filter_group in filter_groups" ng-value="filter_group.id">{$:: filter_group.name $}</option>
-                      </select>
-                    </li>
-                  </ul>
-                </div>
-                <div class="r-panel">
-                  <div class="r-small-header">
-                    <p class="r-small-header" translate>Visualization Settings</p>
-                  </div>
-                  <div class="r-panel r-info r-margin-top-10 r-margin-bottom-10">
-                    Select at least one field which will serve as the x-axis for visualizations on the
-                    <b><a ui-sref="insights_property(::{organization_id: org.id})" ui-sref-active="active" translate>property insights</a></b> page. Multiple fields can be selected.
-                  </div>
-                  <ul class="r-list">
-                    <li class="r-list-header" translate>X-Axis Field Options</li>
-                    <li ng-repeat="item in selected_compliance_metric.x_axis_columns" class="r-row r-row-centered">
-                      <span class="r-grow">{$:: get_x_axis_display(item) $}</span>
-                      <i class="fa-solid fa-xmark r-margin-left-5" ng-click="click_remove_x_axis(item)"></i>
-                    </li>
-                    <li class="r-row r-row-centered">
-                      <select id="select-x-axis" class="form-control" ng-change="select_x_axis()" ng-model="x_axis_selection">
-                        <option ng-repeat="x_axis_column in available_x_axis_columns()" ng-value="x_axis_column.id">{$:: x_axis_column.displayName $}</option>
                       </select>
                     </li>
                   </ul>
@@ -192,6 +157,27 @@
                     </ul>
                   </div>
                 </div>
+                <div class="r-panel">
+                  <div class="r-small-header">
+                    <p class="r-small-header" translate>Visualization Settings</p>
+                  </div>
+                  <div class="r-panel r-info r-margin-top-10 r-margin-bottom-10">
+                    Select at least one field which will serve as the x-axis for visualizations on the
+                    <b><a ui-sref="insights_property(::{organization_id: org.id})" ui-sref-active="active" translate>property insights</a></b> page. Multiple fields can be selected.
+                  </div>
+                  <ul class="r-list">
+                    <li class="r-list-header" translate>X-Axis Field Options</li>
+                    <li ng-repeat="item in selected_compliance_metric.x_axis_columns" class="r-row r-row-centered">
+                      <span class="r-grow">{$:: get_x_axis_display(item) $}</span>
+                      <i class="fa-solid fa-xmark r-margin-left-5" ng-click="click_remove_x_axis(item)"></i>
+                    </li>
+                    <li class="r-row r-row-centered">
+                      <select id="select-x-axis" class="form-control" ng-change="select_x_axis()" ng-model="x_axis_selection">
+                        <option ng-repeat="x_axis_column in available_x_axis_columns()" ng-value="x_axis_column.id">{$:: x_axis_column.displayName $}</option>
+                      </select>
+                    </li>
+                  </ul>
+                </div>
                 <div ng-show="compliance_metrics_error.length > 0" class="r-panel r-error r-margin-bottom-10">
                   <ul class="r-list">
                     <li ng-repeat="error in compliance_metrics_error">{$ error $}</li>
@@ -205,5 +191,9 @@
     </div>
 
     <div class="section_content_container"></div>
+  </div>
+
+  <div class="modal-footer">
+    <button class="btn btn-default r-margin-right-5" ng-click="close()">Close</button>
   </div>
 </div>

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -59,7 +59,6 @@
         <li><a ui-sref="organization_email_templates({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Email Templates</a></li>
         <li><a ui-sref="organization_labels({organization_id: menu.user.organization.id})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Labels</a></li>
         <li><a ui-sref="organization_members({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Members</a></li>
-        <li><a ui-sref="programs({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Program Setup</a></li>
         <li><a ui-sref="organization_settings({organization_id: menu.user.organization.id})" ng-if="auth.requires_owner" ui-sref-active="active" translate>Settings</a></li>
         <li>
           <a ui-sref="organization_sharing({organization_id: menu.user.organization.id})" ng-if="menu.user.organization.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sharing</a>


### PR DESCRIPTION
To prepare for the portfolio (cross cycle) summary coming soon to the insights tab, the program setup page was moved to a modal accessible from both the property insights and program insight pages. 

<img width="1473" alt="Screen Shot 2024-01-08 at 4 31 10 PM" src="https://github.com/SEED-platform/seed/assets/2205659/f02caa85-4e29-4ced-bdfb-bf0552d50718">

<img width="1491" alt="Screen Shot 2024-01-08 at 4 31 21 PM" src="https://github.com/SEED-platform/seed/assets/2205659/2b47d1d1-1e73-4245-a226-44ed54dbb5d4">

<img width="256" alt="Screen Shot 2024-01-08 at 4 30 53 PM" src="https://github.com/SEED-platform/seed/assets/2205659/c908c70c-9ed2-49de-ad75-22ed2c20f18f">

To test:
ensure that you can still CRUD programs from both the insights pages and that the page behaves property when dismissing the modal (for example, if you delete the program that is currently displayed on the page, it should select another program to display)