### PR TITLE
Retrieve all map data at once

### DIFF
--- a/seed/static/seed/js/controllers/inventory_map_controller.js
+++ b/seed/static/seed/js/controllers/inventory_map_controller.js
@@ -59,7 +59,7 @@ angular.module('BE.seed.controller.inventory_map', []).controller('inventory_map
         })
       })
 
-      return Promise.all(page_promises).then(pages => [].concat(pages))
+      return Promise.all(page_promises).then(pages => [].concat(...pages))
     }
 
 
@@ -73,6 +73,7 @@ angular.module('BE.seed.controller.inventory_map', []).controller('inventory_map
 
     const getInventoryFn = isPropertiesTab ? inventory_service.get_properties : inventory_service.get_taxlots;
     fetchRecords(getInventoryFn).then(async (data) => {
+      console.log(data);
       loadingModal.close();
 
       $scope.data = data;

--- a/seed/static/seed/js/controllers/inventory_map_controller.js
+++ b/seed/static/seed/js/controllers/inventory_map_controller.js
@@ -73,7 +73,6 @@ angular.module('BE.seed.controller.inventory_map', []).controller('inventory_map
 
     const getInventoryFn = isPropertiesTab ? inventory_service.get_properties : inventory_service.get_taxlots;
     fetchRecords(getInventoryFn).then(async (data) => {
-      console.log(data);
       loadingModal.close();
 
       $scope.data = data;

--- a/seed/static/seed/js/controllers/inventory_map_controller.js
+++ b/seed/static/seed/js/controllers/inventory_map_controller.js
@@ -44,17 +44,24 @@ angular.module('BE.seed.controller.inventory_map', []).controller('inventory_map
     };
 
     const chunk = 250;
-    const fetchRecords = (fn, page = 1) => fn(page, chunk, undefined, undefined).then((data) => {
-      $scope.progress = {
-        current: data.pagination.end,
-        total: data.pagination.total,
-        percent: Math.round((data.pagination.end / data.pagination.total) * 100)
-      };
-      if (data.pagination.has_next) {
-        return fetchRecords(fn, page + 1).then((newData) => data.results.concat(newData));
-      }
-      return data.results;
-    });
+    const fetchRecords = async (fn) => {
+      pagination = await fn(1, chunk, undefined, undefined).then(data => data.pagination);
+
+      $scope.progress = {current: 0, total: pagination.total, percent:0};
+
+      page_numbers = [...Array(pagination.num_pages).keys()]
+      page_promises = page_numbers.map(page => {
+        return fn(page, chunk, undefined, undefined).then(data => {
+          num_data = data.pagination.end - data.pagination.start + 1;
+          $scope.progress.current += num_data;
+          $scope.progress.percent += Math.round((num_data / data.pagination.total) * 100)
+          return data.results
+        })
+      })
+
+      return Promise.all(page_promises).then(pages => [].concat(pages))
+    }
+
 
     $scope.progress = {};
     const loadingModal = $uibModal.open({


### PR DESCRIPTION
maps use to get data pages  like this
<img width="1503" alt="image" src="https://github.com/SEED-platform/seed/assets/30241543/e9cacf54-2a53-4e51-a335-edf2ca6628cc">
now it does it like this
<img width="1503" alt="image" src="https://github.com/SEED-platform/seed/assets/30241543/e4f22cbe-c0b5-4f48-8cff-451dbb80a50d">
yay!

Best speed up for https://github.com/SEED-platform/seed/issues/4430 will be view-location based filtering, but this is nice to.
