### PR TITLE
Restore column filters when unpinning

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -11,6 +11,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
   '$state',
   '$stateParams',
   '$q',
+  '$timeout',
   'inventory_service',
   'label_service',
   'data_quality_service',
@@ -45,6 +46,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
     $state,
     $stateParams,
     $q,
+    $timeout,
     inventory_service,
     label_service,
     data_quality_service,
@@ -1829,7 +1831,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
       fastWatch: true,
       flatEntityAccess: true,
       gridMenuShowHideColumns: false,
-      showTreeExpandNoChildren: false,
+      hidePinRight: true,
       saveFocus: false,
       saveGrouping: false,
       saveGroupingExpandedStates: false,
@@ -1840,6 +1842,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
       saveTreeView: false,
       saveVisible: false,
       saveWidths: false,
+      showTreeExpandNoChildren: false,
       useExternalFiltering: true,
       useExternalSorting: true,
       columnDefs: $scope.columns,
@@ -1903,7 +1906,24 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
             }
           }, 1000)
         );
-        gridApi.pinning.on.columnPinned($scope, saveSettings);
+        gridApi.pinning.on.columnPinned($scope, (colDef, container) => {
+          if (container) {
+            saveSettings();
+          } else {
+            // Hack to fix disappearing filter after unpinning a column
+            const gridCol = gridApi.grid.columns.find(({ colDef: { name } }) => name === colDef.name);
+            if (gridCol) {
+              gridCol.colDef.visible = false;
+              gridApi.grid.refresh();
+
+              $timeout(() => {
+                gridCol.colDef.visible = true;
+                gridApi.grid.refresh();
+                saveSettings();
+              }, 0);
+            }
+          }
+        });
 
         const selectionChanged = () => {
           const selected = gridApi.selection.getSelectedRows();

--- a/vendors/package-lock.json
+++ b/vendors/package-lock.json
@@ -24,7 +24,7 @@
         "angular-translate-interpolation-messageformat": "^2.19.0",
         "angular-translate-loader-static-files": "^2.19.0",
         "angular-ui-bootstrap": "^2.5.6",
-        "angular-ui-grid": "^4.12.2",
+        "angular-ui-grid": "^4.12.4",
         "angular-ui-notification": "^0.3.6",
         "angular-ui-router": "^1.0.30",
         "angular-ui-router.statehelper": "^1.3.1",
@@ -1985,9 +1985,9 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "funding": [
         {
           "type": "individual",

--- a/vendors/package.json
+++ b/vendors/package.json
@@ -20,7 +20,7 @@
     "angular-translate-interpolation-messageformat": "^2.19.0",
     "angular-translate-loader-static-files": "^2.19.0",
     "angular-ui-bootstrap": "^2.5.6",
-    "angular-ui-grid": "^4.12.2",
+    "angular-ui-grid": "^4.12.4",
     "angular-ui-notification": "^0.3.6",
     "angular-ui-router": "^1.0.30",
     "angular-ui-router.statehelper": "^1.3.1",


### PR DESCRIPTION
#### Any background context you want to provide?
UI Grid has a known bug where unpinning a pinned column causes the filter box to disappear (until you either scroll away from the column and back, or refresh the page).

#### What's this PR do?
- Adds a workaround to handle a preexisting bug in UI grid by unpinning, hiding the column, and restoring the column. This is necessary because the underlying issue is a race condition with the filter destructor, and the column has to be recreated.
- This PR also hides the `Pin Right` menu option, since we don't respect that option

#### How should this be manually tested?
1. On the Inventory List page, pin a column
2. Unpin the same column, check that the filter box is still present

If there are other grids in SEED that allow pinning _and_ filtering they should be updated as well.

#### What are the relevant tickets?
#3760