### PR TITLE
Fix importing diesel meter readings

### DIFF
--- a/seed/data_importer/meters_parser.py
+++ b/seed/data_importer/meters_parser.py
@@ -461,11 +461,11 @@ class MetersParser(object):
         # check which (if any) meter readings are provided
         # there can be more than one reading type per row (e.g., both electricity
         # and natural gas in the same row)
-        provided_reading_types = []
+        provided_reading_types = set()
         for field in raw_data[0].keys():
             for header_string in Meter.ENERGY_TYPE_BY_HEADER_STRING.keys():
                 if field.startswith(header_string):
-                    provided_reading_types.append(field)
+                    provided_reading_types.add(field)
                     continue
 
         if not provided_reading_types:


### PR DESCRIPTION
#### Any background context you want to provide?
See comments in the issue for added context

#### What's this PR do?
Prevents ESPM meters from being imported twice (and failing) due to multiple energy types matching a single meter column

#### How should this be manually tested?
Import ESPM meter data using a meter column name that starts with `Diesel #2 Use`

#### What are the relevant tickets?
#4474 

#### Screenshots (if appropriate)
Importing a diesel energy type after the fix:
![diesel](https://github.com/SEED-platform/seed/assets/411466/786ee7d4-a1db-4976-bba6-b7ce6e52dc39)