### PR TITLE
Fix inventory loading if no previous sort settings exist in localStorage

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -1800,8 +1800,8 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
       $scope.restore_status = RESTORE_SETTINGS;
       let state = inventory_service.loadGridSettings(`${localStorageKey}.sort`);
       // If save state has filters or sorts, ignore the grids first attempt to run filterChanged or sortChanged
-      const columns = JSON.parse(state).columns
-      $scope.ignore_filter_or_sort = !_.isEmpty(columns)
+      const { columns } = JSON.parse(state) ?? {};
+      $scope.ignore_filter_or_sort = !_.isEmpty(columns);
       if (!_.isNull(state)) {
         state = JSON.parse(state);
         $scope.gridApi.saveState.restore($scope, state).then(() => {
@@ -1826,14 +1826,13 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
     };
 
     const filterOrSortChanged = _.debounce(() => {
-        if ($scope.ignore_filter_or_sort) {
-          $scope.ignore_filter_or_sort = false;
-        } else if ($scope.restore_status === RESTORE_COMPLETE) {
-          updateColumnFilterSort();
-          $scope.load_inventory(1);
-        }
-      }, 1000)
-
+      if ($scope.ignore_filter_or_sort) {
+        $scope.ignore_filter_or_sort = false;
+      } else if ($scope.restore_status === RESTORE_COMPLETE) {
+        updateColumnFilterSort();
+        $scope.load_inventory(1);
+      }
+    }, 1000);
 
     $scope.gridOptions = {
       data: 'data',
@@ -1903,7 +1902,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
           saveSettings();
         });
         gridApi.core.on.columnVisibilityChanged($scope, saveSettings);
-        gridApi.core.on.filterChanged($scope, filterOrSortChanged)
+        gridApi.core.on.filterChanged($scope, filterOrSortChanged);
         gridApi.core.on.sortChanged($scope, filterOrSortChanged);
         gridApi.pinning.on.columnPinned($scope, (colDef, container) => {
           if (container) {


### PR DESCRIPTION
#### Any background context you want to provide?
PR #4480 introduced a bug that prevents inventory from loading if the user has never sorted a column for the current org (localStorage has no sort key)

#### What's this PR do?
Fixes showing the Inventory List data if there is no pre-existing sort rule

#### How should this be manually tested?
1. Create a new org
2. Import data
3. Go to the Inventory List page, ensure that data appears
