### PR TITLE
AH UI Fixes for access level modals

### DIFF
--- a/seed/static/seed/js/controllers/organization_add_access_level_instance_modal_controller.js
+++ b/seed/static/seed/js/controllers/organization_add_access_level_instance_modal_controller.js
@@ -25,7 +25,7 @@ angular.module('BE.seed.controller.organization_add_access_level_instance_modal'
       $scope.level_names = level_names;
       $scope.selected_level_index = null;
       $scope.parent = null;
-      $scope.potental_parents = [];
+      $scope.potential_parents = [];
       $scope.new_level_instance_name = '';
 
 
@@ -42,8 +42,8 @@ angular.module('BE.seed.controller.organization_add_access_level_instance_modal'
       calculate_access_level_instances_by_depth(access_level_tree, 1);
 
       $scope.change_selected_level_index = function () {
-        const new_level_instance_depth = parseInt($scope.selected_level_index);
-        $scope.potental_parents = access_level_instances_by_depth[new_level_instance_depth];
+        const new_level_instance_depth = parseInt($scope.selected_level_index, 10);
+        $scope.potential_parents = access_level_instances_by_depth[new_level_instance_depth];
         $scope.parent = null;
       };
 

--- a/seed/static/seed/js/controllers/organization_add_access_level_instance_modal_controller.js
+++ b/seed/static/seed/js/controllers/organization_add_access_level_instance_modal_controller.js
@@ -28,6 +28,7 @@ angular.module('BE.seed.controller.organization_add_access_level_instance_modal'
       $scope.potental_parents = [];
       $scope.new_level_instance_name = '';
 
+
       /* Build out access_level_instances_by_depth recursively */
       const access_level_instances_by_depth = {};
       const calculate_access_level_instances_by_depth = function (tree, depth = 1) {
@@ -45,6 +46,12 @@ angular.module('BE.seed.controller.organization_add_access_level_instance_modal'
         $scope.potental_parents = access_level_instances_by_depth[new_level_instance_depth];
         $scope.parent = null;
       };
+
+      // attempt to default the access level
+      if ($scope.level_names.length > 1){
+        $scope.selected_level_index = 1;
+        $scope.change_selected_level_index();
+      }
 
       $scope.create_new_level_instance = function () {
         organization_service.create_organization_access_level_instance(org_id, $scope.parent.id, $scope.new_level_instance_name)

--- a/seed/static/seed/partials/accounts.html
+++ b/seed/static/seed/partials/accounts.html
@@ -28,7 +28,7 @@
                 <a ui-sref="organization_members(::{organization_id: org.id})">{$:: org.name $}</a>
               </td>
               <td class="account_org right">
-                <a ui-sref="organization_access_level_tree(::{organization_id: org.id})"><i class="fa fa-users"></i>{$:: 'Access Level Tree' | translate $}</a>
+                <a ui-sref="organization_access_level_tree(::{organization_id: org.id})"><i class="fa-solid fa-users"></i>{$:: 'Access Level Tree' | translate $}</a>
                 <a ui-sref="organization_column_mappings(::{organization_id: org.id, inventory_type: 'properties'})" ng-if="::org.is_parent"
                   ><i class="fa-solid fa-sitemap"></i>{$:: 'Column Mappings' | translate $}</a
                 >

--- a/seed/static/seed/partials/accounts.html
+++ b/seed/static/seed/partials/accounts.html
@@ -28,6 +28,7 @@
                 <a ui-sref="organization_members(::{organization_id: org.id})">{$:: org.name $}</a>
               </td>
               <td class="account_org right">
+                <a ui-sref="organization_access_level_tree(::{organization_id: org.id})"><i class="fa fa-users"></i>{$:: 'Access Level Tree' | translate $}</a>
                 <a ui-sref="organization_column_mappings(::{organization_id: org.id, inventory_type: 'properties'})" ng-if="::org.is_parent"
                   ><i class="fa-solid fa-sitemap"></i>{$:: 'Column Mappings' | translate $}</a
                 >
@@ -45,7 +46,6 @@
                 <a ui-sref="organization_settings(::{organization_id: org.id})"><i class="fa-solid fa-gears"></i>Settings</a>
                 <a ui-sref="organization_sharing(::{organization_id: org.id})" ng-if="::org.is_parent"><i class="fa-solid fa-share-from-square"></i>{$:: 'Sharing' | translate $}</a>
                 <a ui-sref="organization_sub_orgs(::{organization_id: org.id})" ng-if="::org.is_parent"><i class="fa-solid fa-users"></i>{$:: 'Sub-Organizations' | translate $}</a>
-                <a ui-sref="organization_access_level_tree(::{organization_id: org.id})"><i class="fa fa-users"></i>{$:: 'Access Level Tree' | translate $}</a>
                 <i class="fa-solid fa-gear"></i>
               </td>
             </tr>

--- a/seed/static/seed/partials/accounts_nav.html
+++ b/seed/static/seed/partials/accounts_nav.html
@@ -1,3 +1,4 @@
+<a ui-sref="organization_access_level_tree(::{organization_id: org.id})" ui-sref-active="active" translate>Access Level Tree</a>
 <a
   ui-sref="organization_column_mappings(::{organization_id: org.id, inventory_type: 'properties'})"
   ng-if="::auth.requires_owner"
@@ -33,4 +34,3 @@
 <a ui-sref="organization_settings(::{organization_id: org.id})" ng-if="::auth.requires_owner" ui-sref-active="active" translate>Settings</a>
 <a ui-sref="organization_sharing(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sharing</a>
 <a ui-sref="organization_sub_orgs(::{organization_id: org.id})" ng-if="::org.is_parent && auth.requires_owner" ui-sref-active="active" translate>Sub-Organizations</a>
-<a ui-sref="organization_access_level_tree(::{organization_id: org.id})" ui-sref-active="active" translate>Access Level Tree</a>

--- a/seed/static/seed/partials/data_upload_modal.html
+++ b/seed/static/seed/partials/data_upload_modal.html
@@ -466,7 +466,6 @@
   <!-- Step 15:  Upload PM Meter Readings -->
   <div class="data_upload_steps" ng-switch-when="15">
     <div class="alert alert-danger" ng-show="pm_meter_import_error" translate>{$:: pm_meter_import_error $}</div>
-
     <div class="progress_bar_container" ng-show="uploader.in_progress">
       <div class="progress_bar_copy_top" translate="UPLOADING_PROGRESS" translate-values="{ dataset_filename: dataset.filename , cycle_name: selectedCycle.name }"></div>
 

--- a/seed/static/seed/partials/data_upload_modal_progress.html
+++ b/seed/static/seed/partials/data_upload_modal_progress.html
@@ -2,7 +2,7 @@
   <div class="progress_bar_copy_top" ng-if="step.number!==17 && step.number!==20" ng-attr-translate="{$ multipleCycleUpload ? 'UPLOADING_PROGRESS_MULTIPLE_CYCLE' : 'UPLOADING_PROGRESS' $}" translate-values="{ dataset_filename: dataset.filename , cycle_name: selectedCycle.name }"></div>
   <div
     class="progress_bar_copy_top"
-    ng-if="step.number !== 20"
+    ng-if="step.number == 20"
     ng-attr-translate="{$ multipleCycleUpload ? 'UPLOADING_PROGRESS_MULTIPLE_CYCLE' : 'UPLOADING_PROGRESS' $}"
     translate-values="{ dataset_filename: dataset.filename , cycle_name: selectedCycle.name }"
   ></div>

--- a/seed/static/seed/partials/data_upload_modal_progress.html
+++ b/seed/static/seed/partials/data_upload_modal_progress.html
@@ -1,12 +1,12 @@
 <div class="progress_bar_container">
-  <div class="progress_bar_copy_top" ng-if="step.number!==17 && step.number!==20" ng-attr-translate="{$ multipleCycleUpload ? 'UPLOADING_PROGRESS_MULTIPLE_CYCLE' : 'UPLOADING_PROGRESS' $}" translate-values="{ dataset_filename: dataset.filename , cycle_name: selectedCycle.name }"></div>
+  <div class="progress_bar_copy_top" ng-if="step.number !== 17 && step.number !== 20" ng-attr-translate="{$ multipleCycleUpload ? 'UPLOADING_PROGRESS_MULTIPLE_CYCLE' : 'UPLOADING_PROGRESS' $}" translate-values="{ dataset_filename: dataset.filename , cycle_name: selectedCycle.name }"></div>
   <div
     class="progress_bar_copy_top"
-    ng-if="step.number == 20"
+    ng-if="step.number === 20"
     ng-attr-translate="{$ multipleCycleUpload ? 'UPLOADING_PROGRESS_MULTIPLE_CYCLE' : 'UPLOADING_PROGRESS' $}"
     translate-values="{ dataset_filename: dataset.filename , cycle_name: selectedCycle.name }"
   ></div>
   <uib-progressbar class="progress-striped active" value="uploader.progress" type="success"></uib-progressbar>
   <div ng-if="step.number !== 20" class="progress_bar_copy_bottom">{$ uploader.progress | number:0 $}% {$:: 'Complete' | translate $} {$ uploader.status_message ? ': ' + uploader.status_message : '' $}</div>
-  <div ng-if="step.number == 20" class="progress_bar_copy_bottom" translate>ACCESS_LEVEL_UPLOAD_PROGRESS_MSG</div>
+  <div ng-if="step.number === 20" class="progress_bar_copy_bottom" translate>ACCESS_LEVEL_UPLOAD_PROGRESS_MSG</div>
 </div>

--- a/seed/static/seed/partials/organization_add_access_level_instance_modal.html
+++ b/seed/static/seed/partials/organization_add_access_level_instance_modal.html
@@ -10,7 +10,7 @@
                 id="selected_level_index"
                 ng-model="selected_level_index"
                 ng-change="change_selected_level_index()"
-                ng-options="level_names.indexOf(level_name)  as ('Level ' + (level_names.indexOf(level_name) + 1) + ' - ' + level_name) for (i, level_name) in level_names.slice(1)">
+                ng-options="level_names.indexOf(level_name) as ('Level ' + (level_names.indexOf(level_name) + 1) + ' - ' + level_name) for (i, level_name) in level_names.slice(1)">
             </select>
         </div>
     </div>
@@ -21,14 +21,14 @@
                 class="form-control"
                 id="potential_parents"
                 ng-model="parent"
-                ng-options="potental_parent as potental_parent.name for potental_parent in potental_parents">
+                ng-options="potential_parent as potential_parent.name for potential_parent in potential_parents">
             </select>
         </div>
     </div>
     <div class="row pad-bot-10">
         <div class="form-group col-sm-12">
             <label for="name" translate>Enter a Name for the new Access Level Instance</label>
-            <input id="name" style="margin: 10px 0px;" type="text" class="form-control" ng-model="new_level_instance_name">
+            <input id="name" style="margin: 10px 0;" type="text" class="form-control" ng-model="new_level_instance_name">
         </div>
     </div>
 </div>

--- a/seed/static/seed/partials/organization_add_access_level_instance_modal.html
+++ b/seed/static/seed/partials/organization_add_access_level_instance_modal.html
@@ -10,7 +10,7 @@
                 id="selected_level_index"
                 ng-model="selected_level_index"
                 ng-change="change_selected_level_index()"
-                ng-options="i as ('Level ' + i + ' - ' + level_name) for (i, level_name) in level_names">
+                ng-options="level_names.indexOf(level_name)  as ('Level ' + (level_names.indexOf(level_name) + 1) + ' - ' + level_name) for (i, level_name) in level_names.slice(1)">
             </select>
         </div>
     </div>

--- a/seed/templates/seed/_header.html
+++ b/seed/templates/seed/_header.html
@@ -37,6 +37,7 @@
       <ul uib-dropdown-menu class="dropdown-menu pull-right justify-left" role="menu" aria-labelledby="btnCreateNew">
         <li class="dropdown-header" translate>Organization Settings</li>
         <li class="divider"></li>
+        <li><a ui-sref="organization_access_level_tree({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Access Level Tree</a></li>
         <li>
           <a ui-sref="organization_column_mappings({organization_id: menu.user.organization.id, inventory_type: 'properties'})" ng-if="auth.requires_owner" ui-sref-active="active" translate
             >Column Mappings</a
@@ -73,8 +74,6 @@
             >Sub-Organizations</a
           >
         </li>
-        <li><a ui-sref="organization_access_level_tree({organization_id: menu.user.organization.id})" ui-sref-active="active" translate>Access Level Tree</a></li>
-
         <!--<li>
                     <a data-toggle="modal" data-target="#newProjectModalIndex" ng-click="open_create_project_modal()">Project</a>
                 </li>


### PR DESCRIPTION
1. Moved Access Level Tree option so the menu is correctly alphabetized:

<img width="1455" alt="Screenshot 2024-01-23 at 3 53 21 PM" src="https://github.com/SEED-platform/seed/assets/2205659/85281693-9177-436e-b7aa-c285ba578e41">

2. Fixed the upload dialog so it no longer shows 2 lines saying "uploading xxxx to cycle yyyy":
<img width="642" alt="Screenshot 2024-01-23 at 4 36 35 PM" src="https://github.com/SEED-platform/seed/assets/2205659/67e99ed9-b0c9-40c2-863b-5d8a3a5126f5">

3. Fixed the level numbering on the "Add access level instance" modal.  Levels used to be listed as 0-based. Now only listing levels where you can actually add an instance (level 2 and up):
<img width="637" alt="Screenshot 2024-01-23 at 4 47 18 PM" src="https://github.com/SEED-platform/seed/assets/2205659/9bd6a5dd-f8c5-4c4a-9354-cfec8b3a1edc">
<img width="467" alt="Screenshot 2024-01-23 at 4 47 11 PM" src="https://github.com/SEED-platform/seed/assets/2205659/cfd426f1-6623-414d-8d67-75d7b8d1fc4f">
