### PR TITLE
AH - Fix label creation UI

### DIFF
--- a/seed/static/seed/js/controllers/update_item_labels_modal_controller.js
+++ b/seed/static/seed/js/controllers/update_item_labels_modal_controller.js
@@ -60,7 +60,7 @@ angular.module('BE.seed.controller.update_item_labels_modal', []).controller('up
           // in this modal...
           createdLabel.is_checked_add = true;
 
-          $scope.newLabelForm.$setPristine();
+          form.$setPristine();
           $scope.labels.unshift(createdLabel);
           $scope.initialize_new_label();
         },

--- a/seed/static/seed/js/services/simple_modal_service.js
+++ b/seed/static/seed/js/services/simple_modal_service.js
@@ -75,7 +75,7 @@ angular.module('BE.seed.service.simple_modal', []).factory('simple_modal_service
       // Map modal.html $scope custom properties to defaults defined in service
       angular.extend(tempModalOptions, modalOptions, customModalOptions);
 
-      tempModalDefaults.controller = ($scope, $uibModalInstance) => {
+      tempModalDefaults.controller = ['$scope', '$uibModalInstance', ($scope, $uibModalInstance) => {
         $scope.modalOptions = tempModalOptions;
         $scope.modalOptions.ok = () => {
           $uibModalInstance.close(tempModalOptions.okResult);
@@ -83,8 +83,7 @@ angular.module('BE.seed.service.simple_modal', []).factory('simple_modal_service
         $scope.modalOptions.cancel = () => {
           $uibModalInstance.dismiss('cancel');
         };
-      };
-
+      }];
       return $uibModal.open(tempModalDefaults).result;
     };
 
@@ -96,6 +95,7 @@ angular.module('BE.seed.service.simple_modal', []).factory('simple_modal_service
        */
     function showModal(customModalOptions, customModalDefaults) {
       if (customModalOptions && customModalOptions.type !== null) {
+
         if (!_.includes(validModalTypes, customModalOptions.type)) {
           throw new Error('Invalid modal type');
         }

--- a/seed/static/seed/partials/update_item_labels_modal.html
+++ b/seed/static/seed/partials/update_item_labels_modal.html
@@ -3,7 +3,7 @@
     <h4 class="modal-title" id="manageLabelsModalLabel" translate>Add/Remove Labels</h4>
   </div>
   <div class="modal-body">
-    <div class="newLabelInput" ng-if="is_ali_root" style="margin-top: 0">
+    <div class="newLabelInput" ng-if="is_ali_root" style="margin-top: 0" ng-if="is_ali_root">
       <form name="newLabelForm" class="form-inline" role="form" ng-submit="submitNewLabelForm(newLabelForm)" novalidate>
         <label class="control-label sectionLabel" style="padding-right: 20px" translate>Create new label</label>
         <div class="form-group" ng-class="{'has-error': newLabelForm.name.$invalid && newLabelForm.name.$dirty }">

--- a/seed/static/seed/partials/update_item_labels_modal.html
+++ b/seed/static/seed/partials/update_item_labels_modal.html
@@ -3,7 +3,7 @@
     <h4 class="modal-title" id="manageLabelsModalLabel" translate>Add/Remove Labels</h4>
   </div>
   <div class="modal-body">
-    <div class="newLabelInput" ng-if="is_ali_root" style="margin-top: 0" ng-if="is_ali_root">
+    <div class="newLabelInput" ng-if="is_ali_root" style="margin-top: 0">
       <form name="newLabelForm" class="form-inline" role="form" ng-submit="submitNewLabelForm(newLabelForm)" novalidate>
         <label class="control-label sectionLabel" style="padding-right: 20px" translate>Create new label</label>
         <div class="form-group" ng-class="{'has-error': newLabelForm.name.$invalid && newLabelForm.name.$dirty }">


### PR DESCRIPTION
This PR resolves the bug described in #4502

As an org owner: user can create a new label and assign it to properties:
![Screenshot 2024-01-26 at 12 36 07 PM](https://github.com/SEED-platform/seed/assets/2205659/31c9430e-1c59-40a1-b1d8-64b15bb1b5d3)
![Screenshot 2024-01-26 at 12 36 13 PM](https://github.com/SEED-platform/seed/assets/2205659/32d4b02e-e5c8-430c-8c7e-5cc4546c1a29)

As an org owner: user can assign labels to the properties they have access to, but not create new labels:
![Screenshot 2024-01-26 at 1 14 47 PM](https://github.com/SEED-platform/seed/assets/2205659/2e653916-f94e-46a0-8810-fbc433e74152)
