### PR TITLE
Restrict leaf user permissions for goals

### DIFF
--- a/seed/docs/views.py
+++ b/seed/docs/views.py
@@ -64,7 +64,7 @@ def faq_page(request):
                 faq_data[category_name].append(parsed_faq._asdict())
 
     if not request.user.is_anonymous:
-        initial_org_id, initial_org_name, initial_org_user_role, access_level_instance_name, access_level_instance_id, is_ali_root = _get_default_org(
+        initial_org_id, initial_org_name, initial_org_user_role, access_level_instance_name, access_level_instance_id, is_ali_root, is_ali_leaf = _get_default_org(
             request.user
         )
     debug = settings.DEBUG

--- a/seed/lib/superperms/orgs/decorators.py
+++ b/seed/lib/superperms/orgs/decorators.py
@@ -82,6 +82,10 @@ def requires_root_member_access(org_user):
     """ User must be an owner or member at the root access level"""
     return org_user.access_level_instance.depth == 1 and org_user.role_level >= ROLE_MEMBER
 
+def requires_non_leaf_access(org_user):
+    """ User must be a non leaf member. Exception when user is both root and leaf. """
+    return org_user.access_level_instance.is_root() or not org_user.access_level_instance.is_leaf()
+
 
 def can_create_sub_org(org_user):
     return requires_parent_org_owner(org_user)
@@ -148,6 +152,7 @@ PERMS = {
     'requires_member': requires_member,
     'requires_viewer': requires_viewer,
     'requires_root_member_access': requires_root_member_access,
+    'requires_non_leaf_access': requires_non_leaf_access,
     'can_create_sub_org': can_create_sub_org,
     'can_remove_org': can_remove_org,
     'can_invite_member': can_invite_member,

--- a/seed/lib/superperms/orgs/decorators.py
+++ b/seed/lib/superperms/orgs/decorators.py
@@ -82,6 +82,7 @@ def requires_root_member_access(org_user):
     """ User must be an owner or member at the root access level"""
     return org_user.access_level_instance.depth == 1 and org_user.role_level >= ROLE_MEMBER
 
+
 def requires_non_leaf_access(org_user):
     """ User must be a non leaf member. Exception when user is both root and leaf. """
     return org_user.access_level_instance.is_root() or not org_user.access_level_instance.is_leaf()

--- a/seed/static/seed/js/controllers/goal_editor_modal_controller.js
+++ b/seed/static/seed/js/controllers/goal_editor_modal_controller.js
@@ -37,7 +37,6 @@ angular.module('BE.seed.controller.goal_editor_modal', [])
             $scope.auth = auth_payload.auth;
             $scope.organization = organization;
             $scope.write_permission = write_permission;
-            console.log('write permission', $scope.write_permission)
             $scope.goal = goal || {};
             $scope.access_level_tree = access_level_tree.access_level_tree;
             $scope.all_level_names = []

--- a/seed/static/seed/js/controllers/goal_editor_modal_controller.js
+++ b/seed/static/seed/js/controllers/goal_editor_modal_controller.js
@@ -10,13 +10,14 @@ angular.module('BE.seed.controller.goal_editor_modal', [])
         '$uibModalInstance',
         'Notification',
         'goal_service',
-        'auth_payload',
-        'organization',
-        'cycles',
-        'area_columns',
-        'eui_columns',
         'access_level_tree',
+        'area_columns',
+        'auth_payload',
+        'cycles',
+        'eui_columns',
         'goal',
+        'organization',
+        'write_permission',
         function (
             $scope,
             $state,
@@ -24,16 +25,19 @@ angular.module('BE.seed.controller.goal_editor_modal', [])
             $uibModalInstance,
             Notification,
             goal_service,
-            auth_payload,
-            organization,
-            cycles,
-            area_columns,
-            eui_columns,
             access_level_tree,
+            area_columns,
+            auth_payload,
+            cycles,
+            eui_columns,
             goal,
+            organization,
+            write_permission,
         ) {
             $scope.auth = auth_payload.auth;
             $scope.organization = organization;
+            $scope.write_permission = write_permission;
+            console.log('write permission', $scope.write_permission)
             $scope.goal = goal || {};
             $scope.access_level_tree = access_level_tree.access_level_tree;
             $scope.all_level_names = []

--- a/seed/static/seed/js/controllers/menu_controller.js
+++ b/seed/static/seed/js/controllers/menu_controller.js
@@ -241,6 +241,7 @@ angular.module('BE.seed.controller.menu', []).controller('menu_controller', [
             $scope.menu.user.organization = _.find(data.organizations, { id: _.toInteger(user_service.get_organization().id) });
             $scope.menu.user.access_level_instance_name = user_service.get_access_level_instance().name;
             $scope.menu.user.is_ali_root = user_service.get_access_level_instance().is_ali_root;
+            $scope.menu.user.is_ali_leaf = user_service.get_access_level_instance().is_ali_leaf;
             set_auth($scope.menu.user.organization.id);
           })
           .catch((error) => {

--- a/seed/static/seed/js/controllers/portfolio_summary_controller.js
+++ b/seed/static/seed/js/controllers/portfolio_summary_controller.js
@@ -39,6 +39,7 @@ angular.module('BE.seed.controller.portfolio_summary', [])
             spinner_utility,
         ) {
             $scope.organization = organization_payload.organization;
+            $scope.write_permission = $scope.menu.user.is_ali_root || !$scope.menu.user.is_ali_leaf
             // Ii there a better way to convert string units to displayUnits?
             const area_units = $scope.organization.display_units_area.replace('**2', '²');
             const eui_units = $scope.organization.display_units_eui.replace('**2', '²');
@@ -158,13 +159,14 @@ angular.module('BE.seed.controller.portfolio_summary', [])
                     size: 'lg',
                     backdrop: 'static',
                     resolve: {
-                        auth_payload: () => auth_payload,
-                        organization: () => $scope.organization,
-                        cycles: () => $scope.cycles,
-                        area_columns: () => $scope.area_columns,
-                        eui_columns: () => $scope.eui_columns,
                         access_level_tree: () => access_level_tree,
+                        area_columns: () => $scope.area_columns,
+                        auth_payload: () => auth_payload,
+                        cycles: () => $scope.cycles,
+                        eui_columns: () => $scope.eui_columns,
                         goal: () => $scope.goal,
+                        organization: () => $scope.organization,
+                        write_permission: () => $scope.write_permission,
                     },
                 });
 

--- a/seed/static/seed/js/services/user_service.js
+++ b/seed/static/seed/js/services/user_service.js
@@ -33,6 +33,7 @@ angular.module('BE.seed.service.user', []).factory('user_service', [
       id: window.BE.access_level_instance_id,
       name: window.BE.access_level_instance_name,
       is_ali_root: window.BE.is_ali_root == "True",
+      is_ali_leaf: window.BE.is_ali_leaf == "True"
     };
 
     /**

--- a/seed/static/seed/partials/goal_editor_modal.html
+++ b/seed/static/seed/partials/goal_editor_modal.html
@@ -35,7 +35,7 @@
                                 <span class="r-grow goal-name" uib-tooltip="{$ goal.name.length > 40 ? goal.name : '' $}" tooltip-class="tooltip-long" style="height:18px;"
                                 >{$ goal.name $}
                                 </span>
-                                <i class="fa-solid fa-xmark r-margin-left-5" ng-if="goal.id" ng-click="delete_goal(goal.id)" ></i>
+                                <i class="fa-solid fa-xmark r-margin-left-5" ng-if="goal.id && write_permission" ng-click="delete_goal(goal.id)" ></i>
                             </li>
                         </ul>
                         <ul class="r-list r-scrollable" id="goal-list">
@@ -44,10 +44,10 @@
                                 ng-show="goal_option.id != goal.id"
                                 class="r-row r-row-centered">
                                 <span class="r-grow goal-name" uib-tooltip="{$ goal_option.name.length > 40 ? goal_option.name : '' $}" tooltip-class="tooltip-long" style="cursor: pointer" ng-click="set_goal(goal_option)">{$ goal_option.name $}</span>
-                                <i class="fa-solid fa-xmark r-margin-left-5" ng-click="delete_goal(goal_option.id)"></i>
+                                <i class="fa-solid fa-xmark r-margin-left-5" ng-if="write_permission" ng-click="delete_goal(goal_option.id)"></i>
                             </li>
                         </ul>
-                        <ul class="r-list">
+                        <ul class="r-list" ng-if="write_permission">
                             <li>
                                 <button class="btn btn-success r-grow" ng-click="new_goal()">
                                     <i class="fa-solid fa-circle-plus r-pad-right-5"></i>{$:: 'New Goal' | translate $}
@@ -221,7 +221,7 @@
             </div>
         </div>
         <div class="section_action_container right_40 section_action_btn pull-right">
-            <button class="btn btn-primary" ng-click="save_goal()" ng-disabled="goal_form.$invalid || !goal_changed" translate>
+            <button class="btn btn-primary" ng-click="save_goal()" ng-disabled="goal_form.$invalid || !goal_changed" ng-if="write_permission" translate>
                 Save Changes<i class="fa-solid fa-check" ng-show="settings_updated" ></i>
             </button>
             <button class="btn btn-default r-margin-right-5" ng-click="close()" translate>Dismiss</button>

--- a/seed/static/seed/partials/portfolio_summary.html
+++ b/seed/static/seed/partials/portfolio_summary.html
@@ -13,7 +13,7 @@
 </div>
 <div class="portfolio-summary-wrapper">
     <div class="goals-header-text" >
-        {$:: 'The portfolio summary page compares 2 cycles to calculate progress toward an Energy Use Intensity reduction goal.' | translate $} 
+        {$:: 'The portfolio summary page compares 2 cycles to calculate progress toward an Energy Use Intensity reduction goal.' | translate $}
         <span ng-if="write_permission">{$:: 'Cycle selection and goal details can be customized by clicking the Configure Goals button below.' | translate $}</span>
     </div>
     <div class="goal-actions-wrapper">

--- a/seed/static/seed/partials/portfolio_summary.html
+++ b/seed/static/seed/partials/portfolio_summary.html
@@ -12,8 +12,9 @@
     <div class="section_nav" ng-include="::urls.static_url + 'seed/partials/insights_nav.html'"></div>
 </div>
 <div class="portfolio-summary-wrapper">
-    <div class="goals-header-text" translate>
-        PORTFOLIO_SUMMARY_HEADER_TEXT
+    <div class="goals-header-text" >
+        {$:: 'The portfolio summary page compares 2 cycles to calculate progress toward an Energy Use Intensity reduction goal.' | translate $} 
+        <span ng-if="write_permission">{$:: 'Cycle selection and goal details can be customized by clicking the Configure Goals button below.' | translate $}</span>
     </div>
     <div class="goal-actions-wrapper">
         <div class="goal-select-wrapper">
@@ -25,7 +26,7 @@
                     ng-options="goal as goal.name for goal in goals" ng-model="goal">
                 </select>
             </div>
-            <button class="btn btn-primary portfolio-summary-btn" type="submit" ng-click="open_goal_editor_modal()">
+            <button class="btn btn-primary portfolio-summary-btn" type="submit" ng-click="open_goal_editor_modal()" ng-if="write_permission">
                 {$:: 'Configure Goals' | translate $}
             </button>
         </div>

--- a/seed/templates/seed/base.html
+++ b/seed/templates/seed/base.html
@@ -76,6 +76,7 @@
       window.BE.access_level_instance_id = "{{ access_level_instance_id }}";
       window.BE.access_level_instance_name = "{{ access_level_instance_name }}";
       window.BE.is_ali_root = "{{ is_ali_root }}";
+      window.BE.is_ali_leaf = "{{ is_ali_leaf }}";
 
       {# js CSRF config #}
       window.BE.csrf_token = "{{ csrf_token }}";

--- a/seed/tests/test_account_views.py
+++ b/seed/tests/test_account_views.py
@@ -1052,7 +1052,7 @@ class AuthViewTests(TestCase):
 
     def test__get_default_org(self):
         """test seed.views.main._get_default_org"""
-        org_id, org_name, org_role, ali_name, ali_id, is_ali_root = _get_default_org(self.user)
+        org_id, org_name, org_role, ali_name, ali_id, is_ali_root, is_ali_leaf = _get_default_org(self.user)
 
         # check standard case
         self.assertEqual(org_id, self.org.id)
@@ -1070,7 +1070,7 @@ class AuthViewTests(TestCase):
             username='tester@be.com',
             email='tester@be.com',
         )
-        org_id, org_name, org_role, ali_name, ali_id, is_ali_root = _get_default_org(other_user)
+        org_id, org_name, org_role, ali_name, ali_id, is_ali_root, is_ali_leaf = _get_default_org(other_user)
         self.assertEqual(org_id, '')
         self.assertEqual(org_name, '')
         self.assertEqual(org_role, '')
@@ -1082,7 +1082,7 @@ class AuthViewTests(TestCase):
         self.assertEqual(other_user.default_organization, self.org)
         # _get_default_org should remove the user from the org and set the
         # next available org as default or set to ''
-        org_id, org_name, org_role, ali_name, ali_id, is_ali_root = _get_default_org(other_user)
+        org_id, org_name, org_role, ali_name, ali_id, is_ali_root, is_ali_leaf = _get_default_org(other_user)
         self.assertEqual(org_id, '')
         self.assertEqual(org_name, '')
         self.assertEqual(org_role, '')

--- a/seed/tests/test_goals.py
+++ b/seed/tests/test_goals.py
@@ -171,14 +171,20 @@ class GoalViewTests(AccessLevelBaseTestCase):
     def test_goal_destroy(self):
         goal_count = Goal.objects.count()
 
-        # invalid permission
+        # cannot delete parent goal
         self.login_as_child_member()
         url = reverse_lazy('api:v3:goals-detail', args=[self.root_goal.id]) + '?organization_id=' + str(self.org.id)
         response = self.client.delete(url, content_type='application/json')
-        assert response.status_code == 404
+        assert response.status_code == 403
         assert Goal.objects.count() == goal_count
 
-        # valid
+        # leaf alis cannot delete any goal
+        url = reverse_lazy('api:v3:goals-detail', args=[self.child_goal.id]) + '?organization_id=' + str(self.org.id)
+        response = self.client.delete(url, content_type='application/json')
+        assert response.status_code == 403
+        assert Goal.objects.count() == goal_count
+
+        self.login_as_root_member()
         url = reverse_lazy('api:v3:goals-detail', args=[self.child_goal.id]) + '?organization_id=' + str(self.org.id)
         response = self.client.delete(url, content_type='application/json')
         assert response.status_code == 204
@@ -210,8 +216,26 @@ class GoalViewTests(AccessLevelBaseTestCase):
             }
         goal_data = reset_goal_data('child_goal 2')
 
-        # success
+        # leaf have invalid permissions
         self.login_as_child_member()
+        response = self.client.post(
+            url,
+            data=json.dumps(goal_data),
+            content_type='application/json'
+        )
+        assert response.status_code == 403
+        assert Goal.objects.count() == goal_count
+
+        goal_data['access_level_instance'] = self.root_ali.id
+        response = self.client.post(
+            url,
+            data=json.dumps(goal_data),
+            content_type='application/json'
+        )
+        assert response.status_code == 403
+        assert Goal.objects.count() == goal_count
+
+        self.login_as_root_member()
         response = self.client.post(
             url,
             data=json.dumps(goal_data),
@@ -220,16 +244,6 @@ class GoalViewTests(AccessLevelBaseTestCase):
         assert response.status_code == 201
         assert Goal.objects.count() == goal_count + 1
         goal_count = Goal.objects.count()
-
-        # invalid permission
-        goal_data['access_level_instance'] = self.root_ali.id
-        response = self.client.post(
-            url,
-            data=json.dumps(goal_data),
-            content_type='application/json'
-        )
-        assert response.status_code == 404
-        assert Goal.objects.count() == goal_count
 
         # invalid data
         goal_data['access_level_instance'] = self.child_ali.id
@@ -291,6 +305,7 @@ class GoalViewTests(AccessLevelBaseTestCase):
     def test_goal_update(self):
         original_goal = Goal.objects.get(id=self.child_goal.id)
 
+        # invalid permission
         self.login_as_child_member()
         url = reverse_lazy('api:v3:goals-detail', args=[self.child_goal.id]) + '?organization_id=' + str(self.org.id)
         goal_data = {
@@ -298,18 +313,16 @@ class GoalViewTests(AccessLevelBaseTestCase):
             'target_percentage': 99,
         }
         response = self.client.put(url, data=json.dumps(goal_data), content_type='application/json')
+        assert response.status_code == 403
+
+        # valid permissions
+        self.login_as_root_member()
+        response = self.client.put(url, data=json.dumps(goal_data), content_type='application/json')
         assert response.status_code == 200
         assert response.json()['target_percentage'] == 99
         assert response.json()['baseline_cycle'] == self.cycle2.id
         assert response.json()['eui_column1'] == original_goal.eui_column1.id
 
-        # invalid permission
-        goal_data = {
-            'access_level_instance': self.root_ali.id
-        }
-        response = self.client.put(url, data=json.dumps(goal_data), content_type='application/json')
-        assert response.status_code == 404
-        assert response.json()['message'] == 'No such resource.'
 
         # unexpected fields are ignored
         goal_data = {

--- a/seed/tests/test_goals.py
+++ b/seed/tests/test_goals.py
@@ -323,7 +323,6 @@ class GoalViewTests(AccessLevelBaseTestCase):
         assert response.json()['baseline_cycle'] == self.cycle2.id
         assert response.json()['eui_column1'] == original_goal.eui_column1.id
 
-
         # unexpected fields are ignored
         goal_data = {
             'name': 'child_goal y',

--- a/seed/tests/test_goals.py
+++ b/seed/tests/test_goals.py
@@ -171,19 +171,19 @@ class GoalViewTests(AccessLevelBaseTestCase):
     def test_goal_destroy(self):
         goal_count = Goal.objects.count()
 
-        # cannot delete parent goal
+        # invalid permission
         self.login_as_child_member()
         url = reverse_lazy('api:v3:goals-detail', args=[self.root_goal.id]) + '?organization_id=' + str(self.org.id)
         response = self.client.delete(url, content_type='application/json')
         assert response.status_code == 403
         assert Goal.objects.count() == goal_count
 
-        # leaf alis cannot delete any goal
         url = reverse_lazy('api:v3:goals-detail', args=[self.child_goal.id]) + '?organization_id=' + str(self.org.id)
         response = self.client.delete(url, content_type='application/json')
         assert response.status_code == 403
         assert Goal.objects.count() == goal_count
 
+        # valid
         self.login_as_root_member()
         url = reverse_lazy('api:v3:goals-detail', args=[self.child_goal.id]) + '?organization_id=' + str(self.org.id)
         response = self.client.delete(url, content_type='application/json')
@@ -216,7 +216,7 @@ class GoalViewTests(AccessLevelBaseTestCase):
             }
         goal_data = reset_goal_data('child_goal 2')
 
-        # leaf have invalid permissions
+        # leaves have invalid permissions
         self.login_as_child_member()
         response = self.client.post(
             url,

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -57,7 +57,7 @@ def _get_default_org(user):
         ali_name = ou.access_level_instance.name
         ali_id = ou.access_level_instance.id
         is_ali_root = ou.access_level_instance == ou.organization.root
-        is_ali_leaf = ou.access_level_instance.depth == len(org.access_level_names)
+        is_ali_leaf = ou.access_level_instance.is_leaf()
         return org_id, org_name, org_user_role, ali_name, ali_id, is_ali_root, is_ali_leaf
     else:
         return "", "", "", "", "", "", ""

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -57,9 +57,10 @@ def _get_default_org(user):
         ali_name = ou.access_level_instance.name
         ali_id = ou.access_level_instance.id
         is_ali_root = ou.access_level_instance == ou.organization.root
-        return org_id, org_name, org_user_role, ali_name, ali_id, is_ali_root
+        is_ali_leaf = ou.access_level_instance.depth == len(org.access_level_names)
+        return org_id, org_name, org_user_role, ali_name, ali_id, is_ali_root, is_ali_leaf
     else:
-        return "", "", "", "", "", ""
+        return "", "", "", "", "", "", ""
 
 
 @login_required
@@ -71,7 +72,7 @@ def home(request):
         * **username**: the request user's username (first and last name)
     """
     username = request.user.first_name + " " + request.user.last_name
-    initial_org_id, initial_org_name, initial_org_user_role, access_level_instance_name, access_level_instance_id, is_ali_root = _get_default_org(
+    initial_org_id, initial_org_name, initial_org_user_role, access_level_instance_name, access_level_instance_id, is_ali_root, is_ali_leaf = _get_default_org(
         request.user
     )
     debug = settings.DEBUG

--- a/seed/views/v3/goals.py
+++ b/seed/views/v3/goals.py
@@ -36,6 +36,7 @@ from seed.utils.viewsets import ModelViewSetWithoutPatch
     decorator=[
         swagger_auto_schema_org_query_param,
         has_perm_class('requires_member'),
+        has_perm_class('requires_non_leaf_access'),
         has_hierarchy_access(goal_id_kwarg="pk")
     ]
 )
@@ -44,6 +45,7 @@ from seed.utils.viewsets import ModelViewSetWithoutPatch
     decorator=[
         swagger_auto_schema_org_query_param,
         has_perm_class('requires_member'),
+        has_perm_class('requires_non_leaf_access'),
         has_hierarchy_access(body_ali_id="access_level_instance")
     ]
 )
@@ -70,6 +72,7 @@ class GoalViewSet(ModelViewSetWithoutPatch, OrgMixin):
 
     @swagger_auto_schema_org_query_param
     @has_perm_class('requires_member')
+    @has_perm_class('requires_non_leaf_access')
     @has_hierarchy_access(goal_id_kwarg='pk')
     def update(self, request, pk):
         try:


### PR DESCRIPTION
#### Any background context you want to provide?
Per Sydney, partners should only have read access to goals.

#### What's this PR do?
- Adds frontend logic to prevent leaf users from accessing goal configs 
- Adds a backend decorator to prevent leaf users from performing write actions on goal views (create, update, delete)

#### How should this be manually tested?
- As root user create/update/delete goals 
- As a middle tree user (not root or leaf) create/update/delete goals
- As a leaf (partner) user attept to create/update/delete goals. Your permission should be denied.

- In a new org with a single user with an access level tree depth of 1, create/update/delete goals

#### What are the relevant tickets?

#### Screenshots (if appropriate)
Leaf
![Screenshot 2024-01-31 at 12 41 03 PM](https://github.com/SEED-platform/seed/assets/58446472/6d3a7426-53e9-4361-9da2-7b24766bca81)
Root
![Screenshot 2024-01-31 at 12 41 36 PM](https://github.com/SEED-platform/seed/assets/58446472/ce4d637a-cd54-4fe3-b8b8-038a787581c6)
Middle
![Screenshot 2024-01-31 at 12 40 21 PM](https://github.com/SEED-platform/seed/assets/58446472/c111c6c7-ee27-4abc-8c30-27106f842a29)
Root & Leaf
![Screenshot 2024-01-31 at 12 49 05 PM](https://github.com/SEED-platform/seed/assets/58446472/eff0c0fd-9453-4372-9f73-4f009ec975a5)
