### PR TITLE
Add year built to goal table

### DIFF
--- a/seed/static/seed/js/controllers/portfolio_summary_controller.js
+++ b/seed/static/seed/js/controllers/portfolio_summary_controller.js
@@ -423,7 +423,7 @@ angular.module('BE.seed.controller.portfolio_summary', [])
                     let baseline = baseline_properties.find(p => p.id == id)
                     let current = current_properties.find(p => p.id == id)
                     // set accumulator
-                    let property = current || baseline
+                    let property = combine_properties(current, baseline)
                     // add baseline stats
                     if (baseline) {
                         property.baseline_cycle = baseline_cycle_name
@@ -440,6 +440,13 @@ angular.module('BE.seed.controller.portfolio_summary', [])
                     combined_properties.push(property)
                 })
                 return combined_properties
+            }
+
+            const combine_properties = (a, b) => {
+                // Given 2 properties, find non null values and combine into a single property
+                let c = {};
+                Object.keys(a).forEach(key => c[key] = a[key] !== null ? a[key] : b[key])
+                return c
             }
 
             const apply_defaults = (cols, ...defaults) => { _.map(cols, (col) => _.defaults(col, ...defaults)) }

--- a/seed/static/seed/js/controllers/portfolio_summary_controller.js
+++ b/seed/static/seed/js/controllers/portfolio_summary_controller.js
@@ -60,7 +60,7 @@ angular.module('BE.seed.controller.portfolio_summary', [])
                     const matching = c.is_matching_criteria;
                     const area = c.data_type === 'area';
                     const eui = c.data_type === 'eui';
-                    const other = ['property_name', 'property_type'].includes(c.column_name);
+                    const other = ['property_name', 'property_type', 'year_built'].includes(c.column_name);
 
                     if (default_display || matching || eui || area || other ) table_column_ids.push(c.id);
                     if (eui) $scope.eui_columns.push(c);
@@ -450,6 +450,7 @@ angular.module('BE.seed.controller.portfolio_summary', [])
                     ...matching_column_names,
                     'property_name',
                     'property_type',
+                    'year_built'
                 ]
             )]
             // handle cycle specific columns


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
- adds "Year Built" to table
- adds a logic to find non null columns given 2 property views from different cycles.

#### How should this be manually tested?
- Year Built column should appear in the table. 
- Columns that are constant between cycles (property name, pm property id, year built) should appear if values exist in either baseline or current, with a default to current.

#### What are the relevant tickets?

#### Screenshots (if appropriate)
![Screenshot 2024-02-01 at 9 48 59 AM](https://github.com/SEED-platform/seed/assets/58446472/5ba3bcbe-ec63-4919-b4c6-c630eafa79c4)

