### PR TITLE
Set default property if goal property is undefined

### DIFF
--- a/seed/static/seed/js/controllers/portfolio_summary_controller.js
+++ b/seed/static/seed/js/controllers/portfolio_summary_controller.js
@@ -422,8 +422,8 @@ angular.module('BE.seed.controller.portfolio_summary', [])
                 let combined_properties = []
                 unique_ids.forEach(id => {
                     // find matching properties
-                    let baseline = baseline_properties.find(p => p.id == id)
-                    let current = current_properties.find(p => p.id == id)
+                    let baseline = baseline_properties.find(p => p.id == id) || {}
+                    let current = current_properties.find(p => p.id == id) || {}
                     // set accumulator
                     let property = combine_properties(current, baseline)
                     // add baseline stats


### PR DESCRIPTION
#### Any background context you want to provide?
Empty properties in a cycle would prevent portfolio summary from loading

#### What's this PR do?
Sets default properties as `{}` if they are missing

#### How should this be manually tested?
Create goals with empty cycles or missing properties in one of the cycles

#### What are the relevant tickets?

#### Screenshots (if appropriate)
![Screenshot 2024-02-05 at 11 57 31 AM](https://github.com/SEED-platform/seed/assets/58446472/21e16862-6d56-4191-beec-b5b57eebad43)
