### PR TITLE
Enable background progress for uploading AH levels

### DIFF
--- a/seed/lib/progress_data/progress_data.py
+++ b/seed/lib/progress_data/progress_data.py
@@ -180,8 +180,8 @@ class ProgressData(object):
 
     def increment_value(self):
         """
-        Return the value to increment the progress back. Currently this is always assume that that
-        size of the step is 1 to the self.total count.
+        Return the value used to increment the progress. Currently, this always assumes that the
+        size of the step is 1 / self.total count.
 
         :return: float, value to increment the step by
         """

--- a/seed/lib/superperms/orgs/models.py
+++ b/seed/lib/superperms/orgs/models.py
@@ -386,7 +386,7 @@ class Organization(models.Model):
 
         return new_access_level_instance
 
-    def get_access_tree(self, from_ali=None) -> dict:
+    def get_access_tree(self, from_ali=None) -> list:
         if from_ali is None:
             from_ali = self.root
 


### PR DESCRIPTION
#### Any background context you want to provide?
The `Upload Access Level Instances` functionality was correctly set up as a background task, but wasn't running in the background

#### What's this PR do?
Updates that task to run in Celery, and adds progress status

#### How should this be manually tested?
Upload a hierarchy on the Access Level Tree page, and observe the progress bar status

#### Screenshots (if appropriate)
![image](https://github.com/SEED-platform/seed/assets/411466/a4659bcd-9ec0-4be9-a470-8e1a089031f1)