### PR TITLE
fix 403 error for viewer role

### DIFF
--- a/seed/views/v3/organizations.py
+++ b/seed/views/v3/organizations.py
@@ -812,18 +812,25 @@ class OrganizationViewSet(viewsets.ViewSet):
         # set x
         if x_var == "Count":
             result["x"] = 1
-
-        elif not getattr(state, x_var):
-            return {}
-
         else:
-            result["x"] = getattr(state, x_var)
+            try:
+                result["x"] = getattr(state, x_var)
+            except AttributeError:
+                # check extra data
+                try:
+                    result["x"] = state.extra_data.get(x_var)
+                except AttributeError:
+                    return {}
 
         # set y
-        if not getattr(state, y_var, None):
-            return {}
-        else:
+        try:
             result["y"] = getattr(state, y_var)
+        except AttributeError:
+            # check extra data
+            try:
+                result["y"] = state.extra_data.get(y_var)
+            except AttributeError:
+                return {}
 
         return result
 
@@ -888,7 +895,7 @@ class OrganizationViewSet(viewsets.ViewSet):
     )
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_member')
+    @has_perm_class('requires_viewer')
     @action(detail=True, methods=['GET'])
     def report(self, request, pk=None):
         """Retrieve a summary report for charting x vs y
@@ -945,7 +952,7 @@ class OrganizationViewSet(viewsets.ViewSet):
     )
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_member')
+    @has_perm_class('requires_viewer')
     @action(detail=True, methods=['GET'])
     def report_aggregated(self, request, pk=None):
         """Retrieve a summary report for charting x vs y aggregated by y_var
@@ -1113,7 +1120,7 @@ class OrganizationViewSet(viewsets.ViewSet):
     )
     @api_endpoint_class
     @ajax_request_class
-    @has_perm_class('requires_member')
+    @has_perm_class('requires_viewer')
     @action(detail=True, methods=['GET'])
     def report_export(self, request, pk=None):
         """


### PR DESCRIPTION
- Adjust permissions for default reports page.  Allow viewers to load the default reports page (was set to require_members).
- Also fixed retrieving extra_data x and y columns.

#### What are the relevant tickets?
#4123 

#### Screenshots (if appropriate)
![Screenshot 2024-02-12 at 5 05 36 PM](https://github.com/SEED-platform/seed/assets/2205659/ea47ef57-9f1f-4e5c-b2cd-8a52f5027c1d)
