### PR TITLE
Inventor List - Ignore incomplete filters containing just an operator

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -1691,6 +1691,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
       gte: '>=',
       icontains: ''
     };
+    const operatorArr = [">", "<", "=", "!", "!=", "<=", ">="]
 
     $scope.delete_filter = (filterToDelete) => {
       const column = $scope.gridApi.grid.getColumn(filterToDelete.name);
@@ -1797,6 +1798,12 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
           const subFilters = _.map(_.split(filter.term, ','), _.trim);
           for (const subFilter of subFilters) {
             if (subFilter) {
+
+              // ignore filters with only an operator. user is not done typing
+              if (operatorArr.includes(subFilter)) {
+                continue
+              }
+
               const { string, operator, value } = parseFilter(subFilter);
               const index = all_columns.findIndex((p) => p.name === column_name);
               const display = [$scope.columnDisplayByName[name], string, value].join(' ');


### PR DESCRIPTION
Do not display an error to user when a filter only contains an operator (>, <, =, etc.). Assume that the user is still typing.

#### How should this be manually tested?
Type an operator in a filter field on the inventory list page and ensure there is no red notification that pops up.

#### What are the relevant tickets?
#3970, #4106