### PR TITLE
Update error message on overlapping reading import

### DIFF
--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -987,7 +987,7 @@ def _save_sensor_readings_task(readings_tuples, data_logger_id, sensor_column_na
                     result[sensor_column_name] = {'count': len(cursor.fetchall())}
         except ProgrammingError as e:
             if 'ON CONFLICT DO UPDATE command cannot affect row a second time' in str(e):
-                result[sensor_column_name] = {'error': 'Import failed. Unable to import data with overlapping readings.'}
+                result[sensor_column_name] = {'error': 'Import failed. Unable to import data with duplicate start and end date pairs.'}
             else:
                 progress_data.finish_with_error('data failed to import')
                 raise e
@@ -1052,7 +1052,7 @@ def _save_greenbutton_data_task(readings, meter_id, meter_usage_point_id, progre
                 result[result_summary_key] = {'count': len(cursor.fetchall())}
     except ProgrammingError as e:
         if 'ON CONFLICT DO UPDATE command cannot affect row a second time' in str(e):
-            result[result_summary_key] = {'error': 'Import failed. Unable to import data with overlapping readings.'}
+            result[result_summary_key] = {'error': 'Import failed. Unable to import data with duplicate start and end date pairs.'}
         else:
             progress_data.finish_with_error('data failed to import')
             raise e
@@ -1121,7 +1121,7 @@ def _save_pm_meter_usage_data_task(meter_readings, file_pk, progress_key):
                 meter_readings.get('source_id'),
                 type_lookup[meter_readings['type']]
             )
-            result[key] = {'error': 'Import failed. Unable to import data with overlapping readings.'}
+            result[key] = {'error': 'Import failed. Unable to import data with duplicate start and end date pairs.'}
         else:
             progress_data.finish_with_error('data failed to import')
             raise e

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -987,7 +987,7 @@ def _save_sensor_readings_task(readings_tuples, data_logger_id, sensor_column_na
                     result[sensor_column_name] = {'count': len(cursor.fetchall())}
         except ProgrammingError as e:
             if 'ON CONFLICT DO UPDATE command cannot affect row a second time' in str(e):
-                result[sensor_column_name] = {'error': 'Overlapping readings.'}
+                result[sensor_column_name] = {'error': 'Import failed. Unable to import data with overlapping readings.'}
             else:
                 progress_data.finish_with_error('data failed to import')
                 raise e
@@ -1052,7 +1052,7 @@ def _save_greenbutton_data_task(readings, meter_id, meter_usage_point_id, progre
                 result[result_summary_key] = {'count': len(cursor.fetchall())}
     except ProgrammingError as e:
         if 'ON CONFLICT DO UPDATE command cannot affect row a second time' in str(e):
-            result[result_summary_key] = {'error': 'Overlapping readings.'}
+            result[result_summary_key] = {'error': 'Import failed. Unable to import data with overlapping readings.'}
         else:
             progress_data.finish_with_error('data failed to import')
             raise e
@@ -1121,7 +1121,7 @@ def _save_pm_meter_usage_data_task(meter_readings, file_pk, progress_key):
                 meter_readings.get('source_id'),
                 type_lookup[meter_readings['type']]
             )
-            result[key] = {'error': 'Overlapping readings.'}
+            result[key] = {'error': 'Import failed. Unable to import data with overlapping readings.'}
         else:
             progress_data.finish_with_error('data failed to import')
             raise e

--- a/seed/tests/test_greenbutton_import.py
+++ b/seed/tests/test_greenbutton_import.py
@@ -263,7 +263,7 @@ class GreenButtonImportTest(DataMappingBaseTestCase):
                 "type": "Electric - Grid",
                 "incoming": 1002,
                 "successfully_imported": 1000,
-                "errors": 'Overlapping readings.',
+                "errors": 'Import failed. Unable to import data with overlapping readings.',
             },
         ]
 

--- a/seed/tests/test_greenbutton_import.py
+++ b/seed/tests/test_greenbutton_import.py
@@ -263,7 +263,7 @@ class GreenButtonImportTest(DataMappingBaseTestCase):
                 "type": "Electric - Grid",
                 "incoming": 1002,
                 "successfully_imported": 1000,
-                "errors": 'Import failed. Unable to import data with overlapping readings.',
+                "errors": 'Import failed. Unable to import data with duplicate start and end date pairs.',
             },
         ]
 

--- a/seed/tests/test_meter_usage_import.py
+++ b/seed/tests/test_meter_usage_import.py
@@ -809,7 +809,7 @@ class MeterUsageImportTest(TestCase):
                 "type": "Electric - Grid",
                 "incoming": 4,
                 "successfully_imported": 0,
-                "errors": "Import failed. Unable to import data with overlapping readings.",
+                "errors": "Import failed. Unable to import data with duplicate start and end date pairs.",
             },
             {
                 "property_id": self.property_2.id,
@@ -819,7 +819,7 @@ class MeterUsageImportTest(TestCase):
                 "type": "Natural Gas",
                 "incoming": 4,
                 "successfully_imported": 0,
-                "errors": "Import failed. Unable to import data with overlapping readings.",
+                "errors": "Import failed. Unable to import data with duplicate start and end date pairs.",
             },
         ]
 

--- a/seed/tests/test_meter_usage_import.py
+++ b/seed/tests/test_meter_usage_import.py
@@ -809,7 +809,7 @@ class MeterUsageImportTest(TestCase):
                 "type": "Electric - Grid",
                 "incoming": 4,
                 "successfully_imported": 0,
-                "errors": "Overlapping readings.",
+                "errors": "Import failed. Unable to import data with overlapping readings.",
             },
             {
                 "property_id": self.property_2.id,
@@ -819,7 +819,7 @@ class MeterUsageImportTest(TestCase):
                 "type": "Natural Gas",
                 "incoming": 4,
                 "successfully_imported": 0,
-                "errors": "Overlapping readings.",
+                "errors": "Import failed. Unable to import data with overlapping readings.",
             },
         ]
 


### PR DESCRIPTION
#### What's this PR do?
Updates the error message to be more descriptive if incoming readings (meter, sensor, greenbutton) have duplicate date-pairs.

Old message: "Overlapping Readings."
~New message: "Import failed. Unable to import data with overlapping readings."~
New message: "Import failed. Unable to import data with duplicate start and end date pairs."

#### How should this be manually tested?

#### What are the relevant tickets?
#4253

#### Screenshots (if appropriate)
![Screenshot 2024-02-15 at 11 32 57 AM](https://github.com/SEED-platform/seed/assets/58446472/81f93dc1-0dc9-4306-b9c1-58159327d883)
