### PR TITLE
Fix Redis compatibility with boto3

### DIFF
--- a/requirements/aws.txt
+++ b/requirements/aws.txt
@@ -1,5 +1,5 @@
 -r base.txt
-boto3==1.17.36
+boto3==1.34.42
 django-redis==5.2.0
 django-sslify==0.2.7
 django-ses==3.5.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ psycopg2-binary==2.9.6
 # background process management
 celery==5.2.2
 django-celery-beat==2.2.1
-django-redis==5.4.0
+django-redis==5.2.0  # Version is tied to compatibility with boto3
 hiredis==2.3.2
 
 django-compressor==4.4


### PR DESCRIPTION
#### What's this PR do?
Downgrades `django-redis` for compatibility with boto3 to resolve this error:
```
Requirement already satisfied: boto3==1.34.42 in c:\nrel\seed.clean2\.venv\lib\site-packages (from -r requirements/aws.txt (line 2)) (1.34.42)
ERROR: Cannot install django-redis==5.2.0 and django-redis==5.4.0 because these package versions have conflicting dependencies.
```

#### How should this be manually tested?
`pip install -r requirements/aws.txt` should succeed