### PR TITLE
Reject import file if it contains braces

### DIFF
--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1277,6 +1277,9 @@ def _save_raw_data_create_tasks(file_pk, progress_key):
             _log.debug(f'Error reading XLSX file: {str(e)}')
             return progress_data.finish_with_error('Failed to parse XLSX file. Please review your import file - all headers should be present and non-numeric.')
 
+    if any('{' in header or '}' in header for header in parser.headers):
+        return progress_data.finish_with_error('Failed to import. Please review your import file - headers cannot contain braces: { }')
+
     import_file.has_generated_headers = False
     if hasattr(parser, 'has_generated_headers'):
         import_file.has_generated_headers = parser.has_generated_headers


### PR DESCRIPTION
#### Background
Curly braces `{ }` are an angular reserved operator used to pass variables from js to html, if braces are included in incoming file headers angular becomes confused and misrepresents data.

#### What's this PR do?
Rejects import files if the headers contain curly braces `{ }`. 
Invalid files will be rejected before the mapping screen.

#### How should this be manually tested?
example invalid header file (any file with braces in a header will do)
[12props_special_characters.xlsx](https://github.com/SEED-platform/seed/files/14312847/12props_special_characters.xlsx)


#### What are the relevant tickets?
#4511

#### Screenshots (if appropriate)
![Screenshot 2024-02-15 at 3 59 16 PM](https://github.com/SEED-platform/seed/assets/58446472/45fbe2b9-ba1a-450b-bebe-4cbd18a12c37)
