### PR TITLE
Update the default dates on data quality rules

### DIFF
--- a/seed/models/data_quality.py
+++ b/seed/models/data_quality.py
@@ -203,7 +203,7 @@ class Rule(models.Model):
             'data_type': TYPE_DATE,
             'rule_type': RULE_TYPE_DEFAULT,
             'min': 18890101,
-            'max': 20201231,
+            'max': 20241231,
             'severity': SEVERITY_ERROR,
             'condition': RULE_RANGE,
         }, {
@@ -232,7 +232,7 @@ class Rule(models.Model):
             'data_type': TYPE_DATE,
             'rule_type': RULE_TYPE_DEFAULT,
             'min': 18890101,
-            'max': 20201231,
+            'max': 20241231,
             'severity': SEVERITY_ERROR,
             'condition': RULE_RANGE,
         }, {
@@ -241,7 +241,7 @@ class Rule(models.Model):
             'data_type': TYPE_DATE,
             'rule_type': RULE_TYPE_DEFAULT,
             'min': 18890101,
-            'max': 20201231,
+            'max': 20241231,
             'severity': SEVERITY_ERROR,
             'condition': RULE_RANGE,
         }, {
@@ -308,7 +308,7 @@ class Rule(models.Model):
             'data_type': TYPE_YEAR,
             'rule_type': RULE_TYPE_DEFAULT,
             'min': 1700,
-            'max': 2019,
+            'max': 2024,
             'severity': SEVERITY_ERROR,
             'condition': RULE_RANGE,
         }, {
@@ -317,7 +317,7 @@ class Rule(models.Model):
             'data_type': TYPE_DATE,
             'rule_type': RULE_TYPE_DEFAULT,
             'min': 18890101,
-            'max': 20201231,
+            'max': 20241231,
             'severity': SEVERITY_ERROR,
             'condition': RULE_RANGE,
         }


### PR DESCRIPTION
#### Any background context you want to provide?
When creating a new org, the default dates for a few of the rules (e.g., sale_date, release_date, year_built) where from 2020 or 2019.

#### What's this PR do?
* Update so when creating a new org, the default rules will be 2024.

#### How should this be manually tested?
* Create a new organization
* Go to the Data Quality page
* Verify that the fields with dates and years are now 2024.

#### What are the relevant tickets?
n/a


