### PR TITLE
AH - Fix level 1 Access Level display in Inventory Details Page table

### DIFF
--- a/seed/static/seed/js/controllers/inventory_detail_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_controller.js
@@ -127,8 +127,6 @@ angular.module('BE.seed.controller.inventory_detail', []).controller('inventory_
     $scope.ali_path = {};
     if (typeof (ali) === 'object') {
       $scope.ali_path = ali.path;
-      // the first key in the path (<org name>: 'root') is not necessary to display
-      delete $scope.ali_path[$scope.organization.name];
     }
 
     $scope.order_historical_items_with_scenarios = () => {


### PR DESCRIPTION
Tiniest bug to display access levels table on inventory details page: fix for level 1 instance not showing up in the table.