### PR TITLE
AH - Revise analysis permissions for creating columns

### DIFF
--- a/seed/analysis_pipelines/better/pipeline.py
+++ b/seed/analysis_pipelines/better/pipeline.py
@@ -536,7 +536,7 @@ def _process_results(self, analysis_id):
                 organization=analysis.organization,
                 table_name='PropertyState',
             )
-        except:
+        except Exception:
             if analysis.can_create:
                 column, created = Column.objects.create(
                     is_extra_data=True,
@@ -549,7 +549,6 @@ def _process_results(self, analysis_id):
                 column.save()
             else:
                 missing_columns = True
-
 
     # Update the original PropertyView's PropertyState with analysis results of interest
     analysis_property_views = analysis.analysispropertyview_set.prefetch_related('property', 'cycle').all()

--- a/seed/analysis_pipelines/better/pipeline.py
+++ b/seed/analysis_pipelines/better/pipeline.py
@@ -418,12 +418,6 @@ def _process_results(self, analysis_id):
     # if user is at root level and has role member or owner, columns can be created
     # otherwise set the 'missing_columns' flag for later
     missing_columns = False
-    can_create = False
-    if (
-        analysis.organization.is_user_ali_root(analysis.user.id)
-        and (analysis.organization.is_owner(analysis.user.id) or analysis.organization.has_role_member(analysis.user.id))
-       ):
-        can_create = True
 
     column_data_paths = [
         # Combined Savings
@@ -543,7 +537,7 @@ def _process_results(self, analysis_id):
                 table_name='PropertyState',
             )
         except:
-            if can_create:
+            if analysis.can_create:
                 column, created = Column.objects.create(
                     is_extra_data=True,
                     column_name=column_data_path.column_name,

--- a/seed/analysis_pipelines/better/pipeline.py
+++ b/seed/analysis_pipelines/better/pipeline.py
@@ -415,9 +415,15 @@ def _process_results(self, analysis_id):
     BETTER_VALID_MODEL_E_COL = 'better_valid_model_electricity'
     BETTER_VALID_MODEL_F_COL = 'better_valid_model_fuel'
 
-    # if user is org owner, columns can be created, otherwise set the 'missing_columns' flag for later
-    can_create = analysis.organization.is_owner(analysis.user.id)
+    # if user is at root level and has role member or owner, columns can be created
+    # otherwise set the 'missing_columns' flag for later
     missing_columns = False
+    can_create = False
+    if (
+        analysis.organization.is_user_ali_root(analysis.user.id)
+        and (analysis.organization.is_owner(analysis.user.id) or analysis.organization.has_role_member(analysis.user.id))
+       ):
+        can_create = True
 
     column_data_paths = [
         # Combined Savings

--- a/seed/analysis_pipelines/better/pipeline.py
+++ b/seed/analysis_pipelines/better/pipeline.py
@@ -537,7 +537,7 @@ def _process_results(self, analysis_id):
                 table_name='PropertyState',
             )
         except Exception:
-            if analysis.can_create:
+            if analysis.can_create():
                 column, created = Column.objects.create(
                     is_extra_data=True,
                     column_name=column_data_path.column_name,

--- a/seed/analysis_pipelines/co2.py
+++ b/seed/analysis_pipelines/co2.py
@@ -375,7 +375,7 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
                 table_name='PropertyState',
             )
         except Exception:
-            if analysis.can_create:
+            if analysis.can_create():
                 column = Column.objects.create(
                     is_extra_data=True,
                     column_name=col["column_name"],

--- a/seed/analysis_pipelines/co2.py
+++ b/seed/analysis_pipelines/co2.py
@@ -356,7 +356,8 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
     missing_columns = False
 
     column_meta = [
-        {   'column_name': 'analysis_co2',
+        {
+            'column_name': 'analysis_co2',
             'display_name': 'Average Annual CO2 (kgCO2e)',
             'description': 'Average Annual CO2 (kgCO2e)'
         }, {
@@ -373,7 +374,7 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
                 organization=analysis.organization,
                 table_name='PropertyState',
             )
-        except:
+        except Exception:
             if analysis.can_create:
                 column = Column.objects.create(
                     is_extra_data=True,

--- a/seed/analysis_pipelines/co2.py
+++ b/seed/analysis_pipelines/co2.py
@@ -354,12 +354,6 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
     # if user is at root level and has role member or owner, columns can be created
     # otherwise set the 'missing_columns' flag for later
     missing_columns = False
-    can_create = False
-    if (
-        analysis.organization.is_user_ali_root(analysis.user.id)
-        and (analysis.organization.is_owner(analysis.user.id) or analysis.organization.has_role_member(analysis.user.id))
-       ):
-        can_create = True
 
     column_meta = [
         {   'column_name': 'analysis_co2',
@@ -380,7 +374,7 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
                 table_name='PropertyState',
             )
         except:
-            if can_create:
+            if analysis.can_create:
                 column = Column.objects.create(
                     is_extra_data=True,
                     column_name=col["column_name"],

--- a/seed/analysis_pipelines/co2.py
+++ b/seed/analysis_pipelines/co2.py
@@ -350,27 +350,41 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
     # displayname and description if the column already exists because
     # the user might have changed them which would re-create new columns
     # here.
-    column, created = Column.objects.get_or_create(
-        is_extra_data=True,
-        column_name='analysis_co2',
-        organization=analysis.organization,
-        table_name='PropertyState',
-    )
-    if created:
-        column.display_name = 'Average Annual CO2 (kgCO2e)'
-        column.column_description = 'Average Annual CO2 (kgCO2e)'
-        column.save()
+    # if user is org owner, columns can be created, otherwise set the 'missing_columns' flag for later
+    can_create = analysis.organization.is_owner(analysis.user.id)
+    missing_columns = False
 
-    column, created = Column.objects.get_or_create(
-        is_extra_data=True,
-        column_name='analysis_co2_coverage',
-        organization=analysis.organization,
-        table_name='PropertyState',
-    )
-    if created:
-        column.display_name = 'Average Annual CO2 Coverage (% of the year)'
-        column.column_description = 'Average Annual CO2 Coverage (% of the year)'
-        column.save()
+    column_meta = [
+        {   'column_name': 'analysis_co2',
+            'display_name': 'Average Annual CO2 (kgCO2e)',
+            'description': 'Average Annual CO2 (kgCO2e)'
+        }, {
+            'column_name': 'analysis_co2_coverage',
+            'display_name': 'Average Annual CO2 Coverage (% of the year)',
+            'description': 'Average Annual CO2 Coverage (% of the year)'
+        }
+    ]
+
+    for col in column_meta:
+        try:
+            Column.objects.get(
+                column_name=col["column_name"],
+                organization=analysis.organization,
+                table_name='PropertyState',
+            )
+        except:
+            if can_create:
+                column = Column.objects.create(
+                    is_extra_data=True,
+                    column_name=col["column_name"],
+                    organization=analysis.organization,
+                    table_name='PropertyState',
+                )
+                column.display_name = col["display_name"]
+                column.column_description = col["description"]
+                column.save()
+            else:
+                missing_columns = True
 
     # fix the meter readings dict b/c celery messes with it when serializing
     meter_readings_by_analysis_property_view = {
@@ -431,10 +445,12 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
         }
         analysis_property_view.save()
         if save_co2_results:
-            # Convert the analysis results which reports in kgCO2e to MtCO2e which is the canonical database field units
-            property_view.state.total_ghg_emissions = co2['average_annual_kgco2e'] / 1000
-            property_view.state.total_ghg_emissions_intensity = co2['average_annual_kgco2e'] / property_view.state.gross_floor_area.magnitude
-            property_view.state.save()
+            # only save to property view if columns exist
+            if not missing_columns:
+                # Convert the analysis results which reports in kgCO2e to MtCO2e which is the canonical database field units
+                property_view.state.total_ghg_emissions = co2['average_annual_kgco2e'] / 1000
+                property_view.state.total_ghg_emissions_intensity = co2['average_annual_kgco2e'] / property_view.state.gross_floor_area.magnitude
+                property_view.state.save()
 
     # all done!
     pipeline.set_analysis_status_to_completed()

--- a/seed/analysis_pipelines/eeej.py
+++ b/seed/analysis_pipelines/eeej.py
@@ -403,9 +403,15 @@ def _run_analysis(self, loc_data_by_analysis_property_view, analysis_id):
     progress_data = pipeline.set_analysis_status_to_running()
     progress_data.step('Calculating EEEJ Indicators')
     analysis = Analysis.objects.get(id=analysis_id)
-    # if user is org owner, columns can be created, otherwise set the 'missing_columns' flag for later
+    # if user is at root level and has role member or owner, columns can be created
+    # otherwise set the 'missing_columns' flag for later
     missing_columns = False
-    can_create = analysis.organization.is_owner(analysis.user.id)
+    can_create = False
+    if (
+        analysis.organization.is_user_ali_root(analysis.user.id)
+        and (analysis.organization.is_owner(analysis.user.id) or analysis.organization.has_role_member(analysis.user.id))
+       ):
+        can_create = True
 
     # make sure we have the extra data columns we need
     column_meta = [

--- a/seed/analysis_pipelines/eeej.py
+++ b/seed/analysis_pipelines/eeej.py
@@ -18,6 +18,7 @@ from seed.analysis_pipelines.pipeline import (
     analysis_pipeline_task,
     task_create_analysis_property_views
 )
+
 from seed.models import (
     Analysis,
     AnalysisMessage,
@@ -51,29 +52,38 @@ TRACT_FIELDNAME = 'analysis_census_tract'
 EJSCREEN_URL_STUB = 'https://ejscreen.epa.gov/mapper/EJscreen_SOE_report.aspx?namestr=&geometry={"spatialReference":{"wkid":4326},"x":LONG,"y":LAT}&distance=1&unit=9035&areatype=&areaid=&f=report'
 
 
-def _get_data_for_census_tract_fetch(property_view_ids, organization):
+def _get_data_for_census_tract_fetch(property_view_ids, organization, can_create_columns):
     """Performs basic validation of the properties for running EEEJ and returns any errors
     Fetches census tract information based on address if it doesn't exist already
 
     :param property_view_ids
     :param organization
+    :param can_create_columns - does the user have permission to create columns
     :returns: dictionary[id:str], dictionary of property_view_ids to error message
     """
     # invalid_location = []
     loc_data_by_property_view = {}
     errors_by_property_view_id = {}
 
-    # make sure the Census Tract column exists
-    column, created = Column.objects.get_or_create(
-        is_extra_data=True,
-        column_name=TRACT_FIELDNAME,
-        organization=organization,
-        table_name='PropertyState',
-    )
-    if created:
-        column.display_name = 'Census Tract'
-        column.column_description = '2010 Census Tract'
-        column.save()
+    # check that Census Tract column exists. If not, create if you can
+    try:
+        Column.objects.get(
+            column_name=TRACT_FIELDNAME,
+            organization=organization,
+            table_name='PropertyState',
+        )
+    except:
+        # does user have permission to create?
+        if can_create_columns:
+            column = Column.objects.create(
+                column_name=TRACT_FIELDNAME,
+                organization=organization,
+                table_name='PropertyState',
+                is_extra_data=True,
+            )
+            column.display_name = 'Census Tract'
+            column.column_description = '2010 Census Tract'
+            column.save()
 
     property_views = PropertyView.objects.filter(id__in=property_view_ids)
     for property_view in property_views:
@@ -326,9 +336,9 @@ class EEEJPipeline(AnalysisPipeline):
     def _prepare_analysis(self, property_view_ids, start_analysis=True):
         # current implementation will *always* start the analysis immediately
         analysis = Analysis.objects.get(id=self._analysis_id)
-
-        # TODO: check that we have the data we need to retrieve census tract for each property
-        loc_data_by_property_view, errors_by_property_view_id = _get_data_for_census_tract_fetch(property_view_ids, analysis.organization)
+        can_create = analysis.organization.is_owner(analysis.user.id)
+        # check that we have the data we need to retrieve census tract for each property
+        loc_data_by_property_view, errors_by_property_view_id = _get_data_for_census_tract_fetch(property_view_ids, analysis.organization, can_create)
 
         if not loc_data_by_property_view:
             AnalysisMessage.log_and_create(
@@ -393,76 +403,58 @@ def _run_analysis(self, loc_data_by_analysis_property_view, analysis_id):
     progress_data = pipeline.set_analysis_status_to_running()
     progress_data.step('Calculating EEEJ Indicators')
     analysis = Analysis.objects.get(id=analysis_id)
+    # if user is org owner, columns can be created, otherwise set the 'missing_columns' flag for later
+    missing_columns = False
+    can_create = analysis.organization.is_owner(analysis.user.id)
 
-    # make sure we have the extra data columns we need, don't set the
-    # displayname and description if the column already exists because
-    # the user might have changed them which would re-create new columns
-    # here.
-    column, created = Column.objects.get_or_create(
-        is_extra_data=True,
-        column_name='analysis_dac',
-        organization=analysis.organization,
-        table_name='PropertyState',
-    )
-    if created:
-        column.display_name = 'Disadvantaged Community'
-        column.column_description = 'Property located in a Disadvantaged Community as defined by CEJST'
-        column.save()
+    # make sure we have the extra data columns we need
+    column_meta = [
+        {   'column_name': 'analysis_dac',
+            'display_name': 'Disadvantaged Community',
+            'description': 'Property located in a Disadvantaged Community as defined by CEJST'
+        }, {
+            'column_name': 'analysis_energy_burden_low_income',
+            'display_name': 'Energy Burden and low Income?',
+            'description': 'Is this property located in an energy burdened census tract. Energy Burden defined by CEJST as greater than or equal to the 90th percentile for energy burden and is low income.'
+        }, {
+            'column_name': 'analysis_energy_burden_percentile',
+            'display_name': 'Energy Burden Percentile',
+            'description': 'Energy Burden Percentile as identified by CEJST'
+        }, {
+            'column_name': 'analysis_low_income',
+            'display_name': 'Low Income?',
+            'description': 'Is this property located in a census tract identified as Low Income by CEJST?'
+        }, {
+            'column_name': 'analysis_share_neighbors_disadvantaged',
+            'display_name': 'Share of Neighboring Tracts Identified as Disadvantaged',
+            'description': 'The percentage of neighboring census tracts that have been identified as disadvantaged by CEJST'
+        }, {
+            'column_name': 'analysis_number_affordable_housing',
+            'display_name': 'Number of Affordable Housing Locations in Tract',
+            'description': 'Number of affordable housing locations (both public housing developments and multi-family assisted housing) identified by HUD in census tract'
+        }
+    ]
 
-    column, created = Column.objects.get_or_create(
-        is_extra_data=True,
-        column_name='analysis_energy_burden_low_income',
-        organization=analysis.organization,
-        table_name='PropertyState',
-    )
-    if created:
-        column.display_name = 'Energy Burden and low Income?'
-        column.column_description = 'Is this property located in an energy burdened census tract. Energy Burden defined by CEJST as greater than or equal to the 90th percentile for energy burden and is low income.'
-        column.save()
-
-    column, created = Column.objects.get_or_create(
-        is_extra_data=True,
-        column_name='analysis_energy_burden_percentile',
-        organization=analysis.organization,
-        table_name='PropertyState',
-    )
-    if created:
-        column.display_name = 'Energy Burden Percentile'
-        column.column_description = 'Energy Burden Percentile as identified by CEJST'
-        column.save()
-
-    column, created = Column.objects.get_or_create(
-        is_extra_data=True,
-        column_name='analysis_low_income',
-        organization=analysis.organization,
-        table_name='PropertyState',
-    )
-    if created:
-        column.display_name = 'Low Income?'
-        column.column_description = 'Is this property located in a census tract identified as Low Income by CEJST?'
-        column.save()
-
-    column, created = Column.objects.get_or_create(
-        is_extra_data=True,
-        column_name='analysis_share_neighbors_disadvantaged',
-        organization=analysis.organization,
-        table_name='PropertyState',
-    )
-    if created:
-        column.display_name = 'Share of Neighboring Tracts Identified as Disadvantaged'
-        column.column_description = 'The percentage of neighboring census tracts that have been identified as disadvantaged by CEJST'
-        column.save()
-
-    column, created = Column.objects.get_or_create(
-        is_extra_data=True,
-        column_name='analysis_number_affordable_housing',
-        organization=analysis.organization,
-        table_name='PropertyState',
-    )
-    if created:
-        column.display_name = 'Number of Affordable Housing Locations in Tract'
-        column.column_description = 'Number of affordable housing locations (both public housing developments and multi-family assisted housing) identified by HUD in census tract'
-        column.save()
+    for col in column_meta:
+        try:
+            Column.objects.get(
+                column_name=col["column_name"],
+                organization=analysis.organization,
+                table_name='PropertyState',
+            )
+        except:
+            if can_create:
+                column = Column.objects.create(
+                    is_extra_data=True,
+                    column_name=col["column_name"],
+                    organization=analysis.organization,
+                    table_name='PropertyState',
+                )
+                column.display_name = col["display_name"]
+                column.column_description = col["description"]
+                column.save()
+            else:
+                missing_columns = True
 
     # fix the dict b/c celery messes with it when serializing
     analysis_property_view_ids = list(loc_data_by_analysis_property_view.keys())
@@ -505,17 +497,19 @@ def _run_analysis(self, loc_data_by_analysis_property_view, analysis_id):
 
         analysis_property_view.save()
 
-        # TODO: save each indicators back to property_view
+        # save each indicators back to property_view
+        # only if you can
         property_view = property_views_by_apv_id[analysis_property_view.id]
-        property_view.state.extra_data.update({
-            'analysis_census_tract': results[analysis_property_view.id]['census_tract'],
-            'analysis_dac': results[analysis_property_view.id]['dac'],
-            'analysis_energy_burden_low_income': results[analysis_property_view.id]['energy_burden_low_income'],
-            'analysis_energy_burden_percentile': results[analysis_property_view.id]['energy_burden_percentile'],
-            'analysis_low_income': results[analysis_property_view.id]['low_income'],
-            'analysis_share_neighbors_disadvantaged': results[analysis_property_view.id]['share_neighbors_disadvantaged'],
-            'analysis_number_affordable_housing': results[analysis_property_view.id]['number_affordable_housing'],
-        })
+        if not missing_columns:
+            property_view.state.extra_data.update({
+                'analysis_census_tract': results[analysis_property_view.id]['census_tract'],
+                'analysis_dac': results[analysis_property_view.id]['dac'],
+                'analysis_energy_burden_low_income': results[analysis_property_view.id]['energy_burden_low_income'],
+                'analysis_energy_burden_percentile': results[analysis_property_view.id]['energy_burden_percentile'],
+                'analysis_low_income': results[analysis_property_view.id]['low_income'],
+                'analysis_share_neighbors_disadvantaged': results[analysis_property_view.id]['share_neighbors_disadvantaged'],
+                'analysis_number_affordable_housing': results[analysis_property_view.id]['number_affordable_housing'],
+            })
 
         # store lat/lng (if blank) Census geocoder codes at the street address level (not Point level like mapquest)
         # store anyway but record as "Census Geocoder (L1AAA)" vs. mapquest "High (P1AAA)"

--- a/seed/analysis_pipelines/eeej.py
+++ b/seed/analysis_pipelines/eeej.py
@@ -337,7 +337,7 @@ class EEEJPipeline(AnalysisPipeline):
         analysis = Analysis.objects.get(id=self._analysis_id)
 
         # check that we have the data we need to retrieve census tract for each property
-        loc_data_by_property_view, errors_by_property_view_id = _get_data_for_census_tract_fetch(property_view_ids, analysis.organization, analysis.can_create)
+        loc_data_by_property_view, errors_by_property_view_id = _get_data_for_census_tract_fetch(property_view_ids, analysis.organization, analysis.can_create())
 
         if not loc_data_by_property_view:
             AnalysisMessage.log_and_create(
@@ -443,7 +443,7 @@ def _run_analysis(self, loc_data_by_analysis_property_view, analysis_id):
                 table_name='PropertyState',
             )
         except Exception:
-            if analysis.can_create:
+            if analysis.can_create():
                 column = Column.objects.create(
                     is_extra_data=True,
                     column_name=col["column_name"],

--- a/seed/analysis_pipelines/eeej.py
+++ b/seed/analysis_pipelines/eeej.py
@@ -18,7 +18,6 @@ from seed.analysis_pipelines.pipeline import (
     analysis_pipeline_task,
     task_create_analysis_property_views
 )
-
 from seed.models import (
     Analysis,
     AnalysisMessage,
@@ -72,7 +71,7 @@ def _get_data_for_census_tract_fetch(property_view_ids, organization, can_create
             organization=organization,
             table_name='PropertyState',
         )
-    except:
+    except Exception:
         # does user have permission to create?
         if can_create_columns:
             column = Column.objects.create(
@@ -409,7 +408,8 @@ def _run_analysis(self, loc_data_by_analysis_property_view, analysis_id):
 
     # make sure we have the extra data columns we need
     column_meta = [
-        {   'column_name': 'analysis_dac',
+        {
+            'column_name': 'analysis_dac',
             'display_name': 'Disadvantaged Community',
             'description': 'Property located in a Disadvantaged Community as defined by CEJST'
         }, {
@@ -442,7 +442,7 @@ def _run_analysis(self, loc_data_by_analysis_property_view, analysis_id):
                 organization=analysis.organization,
                 table_name='PropertyState',
             )
-        except:
+        except Exception:
             if analysis.can_create:
                 column = Column.objects.create(
                     is_extra_data=True,

--- a/seed/analysis_pipelines/eui.py
+++ b/seed/analysis_pipelines/eui.py
@@ -232,8 +232,14 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
     # the user might have changed them which would re-create new columns
     # here.
 
-    # if user is org owner, columns can be created, otherwise set the 'missing_columns' flag for later
-    can_create = analysis.organization.is_owner(analysis.user.id)
+    # if user is at root level and has role member or owner, columns can be created
+    # otherwise set the 'missing_columns' flag for later
+    can_create = False
+    if (
+        analysis.organization.is_user_ali_root(analysis.user.id)
+        and (analysis.organization.is_owner(analysis.user.id) or analysis.organization.has_role_member(analysis.user.id))
+       ):
+        can_create = True
     missing_columns = False
 
     column_meta = [

--- a/seed/analysis_pipelines/eui.py
+++ b/seed/analysis_pipelines/eui.py
@@ -256,7 +256,7 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
                 table_name='PropertyState',
             )
         except Exception:
-            if analysis.can_create:
+            if analysis.can_create():
                 column = Column.objects.create(
                     is_extra_data=True,
                     column_name=col["column_name"],

--- a/seed/analysis_pipelines/eui.py
+++ b/seed/analysis_pipelines/eui.py
@@ -234,12 +234,6 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
 
     # if user is at root level and has role member or owner, columns can be created
     # otherwise set the 'missing_columns' flag for later
-    can_create = False
-    if (
-        analysis.organization.is_user_ali_root(analysis.user.id)
-        and (analysis.organization.is_owner(analysis.user.id) or analysis.organization.has_role_member(analysis.user.id))
-       ):
-        can_create = True
     missing_columns = False
 
     column_meta = [
@@ -261,7 +255,7 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
                 table_name='PropertyState',
             )
         except:
-            if can_create:
+            if analysis.can_create:
                 column = Column.objects.create(
                     is_extra_data=True,
                     column_name=col["column_name"],

--- a/seed/analysis_pipelines/eui.py
+++ b/seed/analysis_pipelines/eui.py
@@ -237,7 +237,8 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
     missing_columns = False
 
     column_meta = [
-        {   'column_name': 'analysis_eui',
+        {
+            'column_name': 'analysis_eui',
             'display_name': 'Fractional EUI (kBtu/sqft)',
             'description': 'Fractional EUI (kBtu/sqft)'
         }, {
@@ -254,7 +255,7 @@ def _run_analysis(self, meter_readings_by_analysis_property_view, analysis_id):
                 organization=analysis.organization,
                 table_name='PropertyState',
             )
-        except:
+        except Exception:
             if analysis.can_create:
                 column = Column.objects.create(
                     is_extra_data=True,

--- a/seed/lib/superperms/orgs/models.py
+++ b/seed/lib/superperms/orgs/models.py
@@ -344,6 +344,30 @@ class Organization(models.Model):
             user=user, role_level=ROLE_OWNER, organization=self,
         ).exists()
 
+    def has_role_member(self, user):
+        """
+        Return True if the user has a relation to this org, with a role of
+        member.
+        """
+        return OrganizationUser.objects.filter(
+            user=user, role_level=ROLE_MEMBER, organization=self,
+        ).exists()
+
+    def is_user_ali_root(self, user):
+        """
+        Return True if the user's ali is at the root of the organization
+        """
+        is_root = False
+
+        ou = OrganizationUser.objects.filter(
+            user=user, organization=self,
+        )
+        if ou.count() > 0:
+            ou = ou.first()
+            if ou.access_level_instance == self.root:
+                is_root = True
+        return is_root
+
     def get_exportable_fields(self):
         """Default to parent definition of exportable fields."""
         if self.parent_org:

--- a/seed/models/analyses.py
+++ b/seed/models/analyses.py
@@ -196,3 +196,6 @@ class Analysis(models.Model):
         :returns: bool
         """
         return self.status in [self.FAILED, self.STOPPED, self.COMPLETED]
+
+    def can_create(self):
+        return self.organization.is_user_ali_root(self.user.id) and (self.organization.is_owner(self.user.id) or self.organization.has_role_member(self.user.id))

--- a/seed/static/seed/js/controllers/inventory_detail_analyses_modal_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_analyses_modal_controller.js
@@ -15,12 +15,14 @@ angular.module('BE.seed.controller.inventory_detail_analyses_modal', []).control
   'inventory_ids',
   'current_cycle',
   'cycles',
+  'user',
   // eslint-disable-next-line func-names
-  function ($scope, $log, $uibModalInstance, Notification, analyses_service, inventory_ids, current_cycle, cycles) {
+  function ($scope, $log, $uibModalInstance, Notification, analyses_service, inventory_ids, current_cycle, cycles, user) {
     $scope.inventory_count = inventory_ids.length;
     // used to disable buttons on submit
     $scope.waiting_for_server = false;
     $scope.cycles = cycles;
+    $scope.user = user;
 
     $scope.new_analysis = {
       name: null,
@@ -76,8 +78,12 @@ angular.module('BE.seed.controller.inventory_detail_analyses_modal', []).control
 
         case 'CO2':
           $scope.new_analysis.configuration = {
-            save_co2_results: true
+            save_co2_results: false
           };
+          // only root users can create columns
+          if (user.is_ali_root && ['member', 'owner'].includes(user.organization.user_role)) {
+            $scope.new_analysis.configuration.save_co2_results = true
+          }
           break;
 
         case 'BETTER':

--- a/seed/static/seed/js/controllers/inventory_detail_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_controller.js
@@ -551,7 +551,8 @@ angular.module('BE.seed.controller.inventory_detail', []).controller('inventory_
         resolve: {
           inventory_ids: () => [$scope.inventory.view_id],
           current_cycle: () => $scope.cycle,
-          cycles: () => cycle_service.get_cycles().then((result) => result.cycles)
+          cycles: () => cycle_service.get_cycles().then((result) => result.cycles),
+          user: () => $scope.menu.user
         }
       });
     };

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -1599,7 +1599,8 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
         resolve: {
           inventory_ids: () => ($scope.inventory_type === 'properties' ? selectedViewIds : []),
           cycles: () => cycles.cycles,
-          current_cycle: () => $scope.cycle.selected_cycle
+          current_cycle: () => $scope.cycle.selected_cycle,
+          user:  () => $scope.menu.user
         }
       });
       modalInstance.result.then(

--- a/seed/static/seed/partials/inventory_detail_analyses_modal.html
+++ b/seed/static/seed/partials/inventory_detail_analyses_modal.html
@@ -239,7 +239,7 @@
             </div>
           </div>
         </div>
-        <div class="form-group" ng-if="new_analysis.service == 'CO2' && user.is_ali_root && (user.organization.user_role == 'owner' || user.organization.user_role == 'member')">
+        <div class="form-group" ng-if="new_analysis.service == 'CO2'">
           <label class="control-label sectionLabel">CO2 Analysis Options</label>
           <div class="form-group" style="padding-top: 1em">
             <div class="form-row">

--- a/seed/static/seed/partials/inventory_detail_analyses_modal.html
+++ b/seed/static/seed/partials/inventory_detail_analyses_modal.html
@@ -239,7 +239,7 @@
             </div>
           </div>
         </div>
-        <div class="form-group" ng-if="new_analysis.service == 'CO2'">
+        <div class="form-group" ng-if="new_analysis.service == 'CO2' && user.is_ali_root && (user.organization.user_role == 'owner' || user.organization.user_role == 'member')">
           <label class="control-label sectionLabel">CO2 Analysis Options</label>
           <div class="form-group" style="padding-top: 1em">
             <div class="form-row">

--- a/seed/tests/test_analysis_pipelines.py
+++ b/seed/tests/test_analysis_pipelines.py
@@ -1153,7 +1153,7 @@ class TestEeejPipeline(TestCase):
 
     def test_get_data_for_census_tract_fetch(self):
         pvids = [self.property_view.id]
-        loc_data_by_property_view, errors_by_property_view_id = _get_data_for_census_tract_fetch(pvids, self.org)
+        loc_data_by_property_view, errors_by_property_view_id = _get_data_for_census_tract_fetch(pvids, self.org, True)
         self.assertEqual(errors_by_property_view_id, {})
         self.assertEqual(loc_data_by_property_view, {self.property_view.id: {'latitude': None, 'longitude': None, 'geocoding_confidence': None, 'tract': None, 'valid_coords': False, 'location': '730 Garcia Street, Boring, Oregon, 97080'}})
 

--- a/seed/tests/test_analysis_pipelines.py
+++ b/seed/tests/test_analysis_pipelines.py
@@ -1170,7 +1170,7 @@ class TestEeejPipeline(TestCase):
 
         apv_ids = [self.property_view_dac.id, self.property_view_not_dac.id]
         apvs = [self.property_view_dac, self.property_view_not_dac]
-        loc_data_by_property_view, errors_by_property_view_id = _get_data_for_census_tract_fetch(apv_ids, self.org)
+        loc_data_by_property_view, errors_by_property_view_id = _get_data_for_census_tract_fetch(apv_ids, self.org, True)
         results, errors_by_apv_id = _get_eeej_indicators(apvs, loc_data_by_property_view)
         self.assertEqual(len(results), 2)
         # DAC


### PR DESCRIPTION
#### What's this PR do?
Restrict creation of new extra data columns during an analysis run to root owner and members.
If the analysis is run by a leaf member, and the columns do not exist, they will not be created. If they exist, they will be populated with the analysis results.

#### How should this be manually tested?
Import data in a hierarchy-enabled org. 
Create a leaf node user
As leaf node user, create an analysis. Verify that no columns were created on the org.
As a root node user (owner or member role), create an analysis. Verify that columns were created and populated.

eligible analyses:  eui, co2, eeej, BETTER.

#### What are the relevant tickets?
#4220

#### Screenshots (if appropriate)
