### PR TITLE
Fix portfolio summary layout

### DIFF
--- a/seed/static/seed/partials/portfolio_summary.html
+++ b/seed/static/seed/partials/portfolio_summary.html
@@ -1,123 +1,89 @@
 <div class="page_header_container" ng-cloak>
-    <div class="page_header">
-        <div class="left page_action_container"></div>
-        <div class="page_title">
-            <h1 translate>Portfolio Summary</h1>
-        </div>
-        <div class="right page_action_container"></div>
+  <div class="page_header">
+    <div class="left page_action_container"></div>
+    <div class="page_title">
+      <h1 translate>Portfolio Summary</h1>
     </div>
+    <div class="right page_action_container"></div>
+  </div>
 </div>
 
 <div class="section_nav_container">
-    <div class="section_nav" ng-include="::urls.static_url + 'seed/partials/insights_nav.html'"></div>
+  <div class="section_nav" ng-include="::urls.static_url + 'seed/partials/insights_nav.html'"></div>
 </div>
 <div class="portfolio-summary-wrapper">
-    <div class="goals-header-text" >
-        {$:: 'The portfolio summary page compares 2 cycles to calculate progress toward an Energy Use Intensity reduction goal.' | translate $}
-        <span ng-if="write_permission">{$:: 'Cycle selection and goal details can be customized by clicking the Configure Goals button below.' | translate $}</span>
+  <div class="goals-header-text">
+    {$:: 'The portfolio summary page compares 2 cycles to calculate progress toward an Energy Use Intensity reduction goal.' | translate $}
+    <span ng-if="write_permission">{$:: 'Cycle selection and goal details can be customized by clicking the Configure Goals button below.' | translate $}</span>
+  </div>
+  <div class="goal-actions-wrapper">
+    <div class="goal-select-wrapper">
+      <label class="goal-select-label" for="goal-select" ng-show="goal" translate>GOAL</label>
+      <div class="goal-selection" ng-show="goal">
+        <select name="goal-select" id="goal-select" ng-options="goal as goal.name for goal in goals" ng-model="goal"></select>
+      </div>
+      <button class="btn btn-primary portfolio-summary-btn" type="submit" ng-click="open_goal_editor_modal()" ng-if="write_permission">{$:: 'Configure Goals' | translate $}</button>
     </div>
-    <div class="goal-actions-wrapper">
-        <div class="goal-select-wrapper">
-            <label class="goal-select-label" for="goal-select" ng-show="goal" translate>
-                GOAL
-            </label>
-            <div class="goal-selection" ng-show="goal">
-                <select name="goal-select" id="goal-select"
-                    ng-options="goal as goal.name for goal in goals" ng-model="goal">
-                </select>
-            </div>
-            <button class="btn btn-primary portfolio-summary-btn" type="submit" ng-click="open_goal_editor_modal()" ng-if="write_permission">
-                {$:: 'Configure Goals' | translate $}
-            </button>
-        </div>
+  </div>
+  <!-- GOAL DETAILS -->
+  <div class="goal-details-container" ng-if="valid">
+    <div class="goal-details-column" style="margin-left: 10px">
+      <div ng-repeat="detail in goal_details.slice(0, 3)" class="goal-detail">
+        <div class="goal-detail-key" style="width: 100px">{$ detail[0] $}:</div>
+        <div class="goal-detail-value" uib-tooltip="{$ (detail[1].length > 25) ? detail[1] : '' $}">{$ detail[1] $}</div>
+      </div>
     </div>
-    <!-- GOAL DETAILS -->
-    <div class="goal-details-container" ng-if="valid">
-        <div class="goal-details-column" style="margin-left: 10px;">
-            <div ng-repeat="detail in goal_details.slice(0, 3)" class="goal-detail">
-                <div class="goal-detail-key" style="width: 100px">
-                    {$ detail[0] $}:
-                </div>
-                <div class="goal-detail-value" uib-tooltip="{$ (detail[1].length > 25) ? detail[1] : '' $}">
-                    {$ detail[1] $}
-                </div>
-            </div>
-        </div>
-        <div class="goal-details-column">
-            <div ng-repeat="detail in goal_details.slice(3)" class="goal-detail">
-                <div class="goal-detail-key">
-                    {$ detail[0] $}:
-                </div>
-                <div class="goal-detail-value" uib-tooltip="{$ (detail[1].length > 25) ? detail[1] : '' $}">
-                    {$ detail[1] $}
-                </div>
-            </div>
-
-        </div>
-
+    <div class="goal-details-column">
+      <div ng-repeat="detail in goal_details.slice(3)" class="goal-detail">
+        <div class="goal-detail-key">{$ detail[0] $}:</div>
+        <div class="goal-detail-value" uib-tooltip="{$ (detail[1].length > 25) ? detail[1] : '' $}">{$ detail[1] $}</div>
+      </div>
     </div>
-    <div id="portfolio-summary-selection-wrapper" class="row">
-
-        <!-- Summary Table-->
-        <div id="portfolio-summary" class="col-sm-10x" ng-if="summary_loading || summary_valid">
-            <h3 style="margin-top:0;" translate>
-                Portfolio Summary
-            </h3>
-            <div ng-if="summary_valid" ui-grid="summaryGridOptions" ui-grid-resize-columns ui-grid-group-columns style="height:60px"></div>
-            <div class="portfolio-summary-loading" ng-if="summary_loading">
-                <h4>{$:: 'Loading Summary Data...' | translate $}</h4>
-                <uib-progress class="progress-striped active">
-                    <uib-bar value="100" type="info"></uib-bar>
-                </uib-progress>
-            </div>
-        </div>
-
-    </div>
-    <!-- Data Table container -->
-    <!-- Pagination -->
-    <div class="portfolio-summary-item-count" ng-if="data_valid">
-        <div class="form-group" ng-if="data_valid">
-            <button class="btn btn-primary portfolio-summary-btn" ng-click="toggle_access_level_instances()">
-                {$ show_access_level_instances ? 'Hide' : 'Show' $} Access Levels
-            </button>
-        </div>
-        <div>
-            {$ inventory_pagination.start $}-{$ inventory_pagination.end $}<span ng-if="inventory_pagination.num_pages > 1"> of
-                {$ inventory_pagination.total $}</span>
-            <i ng-if="selectedCount > 0">
-                <span>({$ selected_display $}</span><span ng-if="selectedCount < inventory_pagination.total"> - <a
-                    ng-click="select_all()" translate>Select All</a></span><span
-                    ng-if="selectedCount === inventory_pagination.total"> - <a ng-click="select_none()" translate>Select
-                        None</a></span><span>)</span>
-                    </i>
-                    <button ng-click="page_change(inventory_pagination.page - 1)" ng-disabled="!inventory_pagination.has_previous"
-                    class="btn btn-default btn-sm">
-                    <i class="fa-solid fa-chevron-left"></i>
-                </button>
-                <button ng-click="page_change(inventory_pagination.page + 1)" ng-disabled="!inventory_pagination.has_next"
-                    class="btn btn-default btn-sm">
-                <i class="fa-solid fa-chevron-right"></i>
-            </button>
-        </div>
-    </div>
-    <!-- Data Table -->
-    <div id="portfolio-summary-grid" ng-if="data_valid" style="overflow-x: scroll;">
-        <div class="portfolioSummary-gridOptions-wrapper" ng-style="{'heightx': gridHeight}">
-            <div
-                ui-grid="gridOptions"
-                ui-grid-save-state
-                ui-grid-resize-columns
-                ui-grid-group-columns
-                ui-grid-exporter
-                ui-grid-edit
-            ></div>
-        </div>
-
-    </div>
-    <div class="portfolio-summary-loading" ng-if="data_loading" style="margin:100px 20px;">
-        <h4>Loading Data...</h4>
-        <uib-progress class="progress-striped active" >
-            <uib-bar value="100" type="info"></uib-bar>
+  </div>
+  <div id="portfolio-summary-selection-wrapper">
+    <!-- Summary Table-->
+    <div id="portfolio-summary" ng-if="summary_loading || summary_valid">
+      <h3 translate>Portfolio Summary</h3>
+      <div ng-if="summary_valid" ui-grid="summaryGridOptions" ui-grid-resize-columns></div>
+      <div class="portfolio-summary-loading" ng-if="summary_loading">
+        <h4>{$:: 'Loading Summary Data...' | translate $}</h4>
+        <uib-progress class="progress-striped active">
+          <uib-bar value="100" type="info"></uib-bar>
         </uib-progress>
+      </div>
     </div>
+  </div>
+  <!-- Data Table container -->
+  <!-- Pagination -->
+  <div class="portfolio-summary-item-count" ng-if="data_valid">
+    <div ng-if="data_valid">
+      <button class="btn btn-primary portfolio-summary-btn" ng-click="toggle_access_level_instances()">{$ show_access_level_instances ? 'Hide' : 'Show' $} Access Levels</button>
+    </div>
+    <div>
+      {$ inventory_pagination.start $}-{$ inventory_pagination.end $}<span ng-if="inventory_pagination.num_pages > 1"> of {$ inventory_pagination.total $}</span>
+      <i ng-if="selectedCount > 0">
+        <span>({$ selected_display $}</span><span ng-if="selectedCount < inventory_pagination.total"> - <a ng-click="select_all()" translate>Select All</a></span
+        ><span ng-if="selectedCount === inventory_pagination.total"> - <a ng-click="select_none()" translate>Select None</a></span
+        ><span>)</span>
+      </i>
+      <button ng-click="page_change(inventory_pagination.page - 1)" ng-disabled="!inventory_pagination.has_previous" class="btn btn-default btn-sm">
+        <i class="fa-solid fa-chevron-left"></i>
+      </button>
+      <button ng-click="page_change(inventory_pagination.page + 1)" ng-disabled="!inventory_pagination.has_next" class="btn btn-default btn-sm">
+        <i class="fa-solid fa-chevron-right"></i>
+      </button>
+    </div>
+  </div>
+  <!-- Data Table -->
+  <div id="portfolio-summary-grid" ng-if="data_valid">
+    <div id="portfolioSummary-gridOptions-wrapper">
+      <div ui-grid="gridOptions" ui-grid-save-state ui-grid-resize-columns ui-grid-exporter ui-grid-edit style="display: flex; width: 100%"></div>
+    </div>
+  </div>
+  <div class="portfolio-summary-loading" ng-if="data_loading && !data_valid" style="margin: 100px 20px">
+    <h4>Loading Data...</h4>
+    <uib-progress class="progress-striped active">
+      <uib-bar value="100" type="info"></uib-bar>
+    </uib-progress>
+  </div>
 </div>

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -5111,11 +5111,12 @@ ul.r-list {
 
 .portfolio-summary-wrapper {
   display: flex;
+  flex: 1;
   flex-direction: column;
 
   .goals-header-text {
-    padding: 10px;
-    padding-bottom: 0;
+    min-height: 30px;
+    padding: 10px 10px 0;
   }
 
   .goal-actions-wrapper {
@@ -5153,7 +5154,7 @@ ul.r-list {
   }
 
   #portfolio-summary-selection-wrapper {
-    margin: 10px 7px;
+    padding: 20px 24px 0;
     display: flex;
 
     #portfolio-summary-selections {
@@ -5193,8 +5194,12 @@ ul.r-list {
     #portfolio-summary {
       width: 100%;
       padding-bottom: 30px;
-      margin: 0 16px 10px;
       border-bottom: 1px solid rgb(199, 199, 199);
+
+      h3 {
+        margin: 0;
+        padding-bottom: 10px;
+      }
     }
   }
 
@@ -5204,7 +5209,9 @@ ul.r-list {
   }
 
   #portfolio-summary-grid {
-    margin: 0 24px;
+    display: flex;
+    flex: 1;
+    padding: 0 24px;
   }
 
   #portfolio-summary-grid,
@@ -5241,12 +5248,10 @@ ul.r-list {
       background: #ca8f8f;
     }
 
-    .portfolioSummary-gridOptions-wrapper {
-      height: calc(100vh - 490px);
-
-      .ui-grid {
-        height: 100%;
-      }
+    #portfolioSummary-gridOptions-wrapper {
+      display: flex;
+      overflow-x: hidden;
+      width: 100%;
     }
   }
 
@@ -5261,9 +5266,10 @@ ul.r-list {
   }
 
   .portfolio-summary-item-count {
+    height: 64px;
     margin: 0 24px;
-    margin-top: 2px;
 
+    align-items: center;
     justify-content: space-between;
     display: flex;
   }
@@ -5275,7 +5281,7 @@ ul.r-list {
     border-radius: 5px;
     background: rgb(241, 241, 241);
     width: fit-content;
-    margin: 0 0 16px 25px;
+    margin: 0 24px;
 
     .goal-details-column {
       .goal-detail {
@@ -5431,11 +5437,13 @@ tags-input .tags .tag-item {
 .cell-edit {
   cursor: copy;
 }
+
 .cell-dropdown-indicator {
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-right: 3px;
+
   i {
     color: gray;
   }
@@ -5445,14 +5453,17 @@ tags-input .tags .tag-item {
   padding: 10px;
   color: #c24e00;
 }
+
 .confirm-label {
   padding-left: 5px;
   text-align: left;
 }
+
 .cell-pass {
   background-color: #d0e6d4;
   border-top: 1px solid #d4d4d4;
 }
+
 .cell-fail {
   background-color: #fefbd1;
   border-top: 1px solid #d4d4d4;


### PR DESCRIPTION
#### Any background context you want to provide?
The Portfolio Summary page had a number of layout issues, especially on Windows with 3x nested scrollbars:
![image](https://github.com/SEED-platform/seed/assets/411466/c65b81cb-e479-4a02-a5f1-3a99dcdf182a)

#### What's this PR do?
- Fixes several layout issues with the Portfolio Summary page, and removes all unnecessary scrollbars
- Adds responsive layout handling
- Adds minimum column width to the summary grid

#### How should this be manually tested?
1. Go to the Portfolio Summary page, and create a goal if necessary
2. Test that the page appears as expected, on reload, and as the browser window is resized

#### Screenshots (if appropriate)
![image](https://github.com/SEED-platform/seed/assets/411466/969adbf2-1263-4c90-a4bb-c1218c5dc873)