### PR TITLE
Limit member visibility to users within access level instance

### DIFF
--- a/seed/static/seed/partials/members.html
+++ b/seed/static/seed/partials/members.html
@@ -72,7 +72,7 @@
                 <select
                   ng-if="user_id_being_edited == u.user_id"
                   class="form-control"
-                  ng-model="user_edits['access_level']"
+                  ng-model="user_edits.access_level"
                   ng-options="potential_level_name for potential_level_name in access_level_names"
                   ng-change="change_access_level_instance_options()">
                 </select>
@@ -82,7 +82,7 @@
                 <select
                   ng-if="user_id_being_edited == u.user_id"
                   class="form-control"
-                  ng-model="user_edits['access_level_instance']"
+                  ng-model="user_edits.access_level_instance"
                   ng-options="potential_access_level_instance as potential_access_level_instance.name for potential_access_level_instance in access_level_instances track by potential_access_level_instance.id">
                 </select>
               <td>
@@ -90,7 +90,14 @@
                 <div class="row" ng-if="user_id_being_edited == u.user_id">
                   <div class="form-group">
                     <div class="col-sm-12" ng-switch="can_edit(u)">
-                      <select ng-switch-when="owner|member" ng-switch-when-separator="|" class="form-control input-sm hide_transition" ng-model="u.role" ng-options="role for role in ::get_roles(u)" ng-change="update_role(u)"></select>
+                      <select
+                        ng-switch-when="owner|member"
+                        ng-switch-when-separator="|"
+                        class="form-control input-sm hide_transition"
+                        ng-model="user_edits.role"
+                        ng-options="role for role in ::get_roles(u)"
+                        ng-change="update_role(u)">
+                      </select>
                       <span ng-switch-default style="padding-left: 15px">{$:: u.role | translate $}</span>
                     </div>
                   </div>

--- a/seed/tests/test_organization_users.py
+++ b/seed/tests/test_organization_users.py
@@ -7,9 +7,9 @@ See also https://github.com/seed-platform/seed/main/LICENSE.md
 from django.urls import reverse_lazy
 
 from seed.landing.models import SEEDUser as User
-from seed.tests.util import AccessLevelBaseTestCase
-from seed.utils.organizations import create_organization
 from seed.lib.superperms.orgs.models import OrganizationUser
+from seed.tests.util import AccessLevelBaseTestCase
+
 
 class TestOrganizationPermissions(AccessLevelBaseTestCase):
     def setUp(self):
@@ -21,12 +21,11 @@ class TestOrganizationPermissions(AccessLevelBaseTestCase):
         self.child_user1 = User.objects.get(username='child_member@demo.com')
         self.child_user2 = User.objects.create(username='child_member2@demo.com')
         OrganizationUser.objects.create(
-            user=self.child_user2, 
-            organization=self.org, 
+            user=self.child_user2,
+            organization=self.org,
             access_level_instance_id=self.child_ali.id,
             role_level=0,
         )
-
 
     def test_org_user_permissions(self):
         user_count = User.objects.count()
@@ -41,6 +40,5 @@ class TestOrganizationPermissions(AccessLevelBaseTestCase):
         response = self.client.get(url, content_type='application/json')
         assert response.status_code == 200
         users = response.json()['users']
-        assert len(users) < user_count 
+        assert len(users) < user_count
         assert len(users) == 2
-        

--- a/seed/tests/test_organization_users.py
+++ b/seed/tests/test_organization_users.py
@@ -1,0 +1,46 @@
+# !/usr/bin/env python
+# encoding: utf-8
+"""
+SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and other contributors.
+See also https://github.com/seed-platform/seed/main/LICENSE.md
+"""
+from django.urls import reverse_lazy
+
+from seed.landing.models import SEEDUser as User
+from seed.tests.util import AccessLevelBaseTestCase
+from seed.utils.organizations import create_organization
+from seed.lib.superperms.orgs.models import OrganizationUser
+
+class TestOrganizationPermissions(AccessLevelBaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.root_ali = self.org.root
+        self.child_ali = self.org.root.get_children().first()
+
+        self.root_user = User.objects.get(username='test_user@demo.com')
+        self.child_user1 = User.objects.get(username='child_member@demo.com')
+        self.child_user2 = User.objects.create(username='child_member2@demo.com')
+        OrganizationUser.objects.create(
+            user=self.child_user2, 
+            organization=self.org, 
+            access_level_instance_id=self.child_ali.id,
+            role_level=0,
+        )
+
+
+    def test_org_user_permissions(self):
+        user_count = User.objects.count()
+        self.login_as_root_member()
+        url = reverse_lazy('api:v3:organization-users-list', args=[self.org.id]) + f'?organization_id={self.org.id}'
+        response = self.client.get(url, content_type='application/json')
+        assert response.status_code == 200
+        users = response.json()['users']
+        assert len(users) == user_count
+
+        self.login_as_child_member()
+        response = self.client.get(url, content_type='application/json')
+        assert response.status_code == 200
+        users = response.json()['users']
+        assert len(users) < user_count 
+        assert len(users) == 2
+        

--- a/seed/views/v3/organization_users.py
+++ b/seed/views/v3/organization_users.py
@@ -45,7 +45,11 @@ class OrganizationUserViewSet(viewsets.ViewSet):
         is_member = org_user.role_level >= ROLE_MEMBER
 
         users = []
-        for u in org.organizationuser_set.all():
+        org_users = org.organizationuser_set.filter(
+            access_level_instance__rgt__lte=org_user.access_level_instance.rgt,
+            access_level_instance__lft__gte=org_user.access_level_instance.lft,
+        )
+        for u in org_users:
             user = u.user
             user_info = {
                 'email': user.email,


### PR DESCRIPTION
#### Any background context you want to provide?
ICF requested that the members page should only show users that are at their own level or below.
i.e. starbucks partners should only be able to see starbucks partners, not admin users, and not other partner users
#### What's this PR do?
Uses ALIs to filter out users with higher permissions

#### How should this be manually tested?
create a few members at different access levels. 
Log in and navigate to 'members' page. Only users in your ali or below are visible.

#### What are the relevant tickets?
#4569
#### Screenshots (if appropriate)
Admin
![Screenshot 2024-03-18 at 3 02 46 PM](https://github.com/SEED-platform/seed/assets/58446472/86f397b8-5919-4843-9e37-9ab85f42db3c)
Sector Level
![Screenshot 2024-03-18 at 3 00 48 PM](https://github.com/SEED-platform/seed/assets/58446472/2c145b32-1883-491d-aa03-0d87bd913dda)
Partner Level
![Screenshot 2024-03-18 at 3 02 03 PM](https://github.com/SEED-platform/seed/assets/58446472/c1b442bf-5c5a-4fb6-9d5d-a0bbdc09daa4)
