### PR TITLE
Fix meter delete bug

### DIFF
--- a/seed/static/seed/js/controllers/inventory_detail_meters_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_meters_controller.js
@@ -144,6 +144,7 @@ angular.module('BE.seed.controller.inventory_detail_meters', []).controller('inv
         templateUrl: `${urls.static_url}seed/partials/meter_deletion_modal.html`,
         controller: 'meter_deletion_modal_controller',
         resolve: {
+          organization_id: () => $scope.organization.id,
           meter: () => meter,
           view_id: () => $scope.inventory.view_id,
           refresh_meters_and_readings: () => $scope.refresh_meters_and_readings
@@ -225,6 +226,7 @@ angular.module('BE.seed.controller.inventory_detail_meters', []).controller('inv
         [meters, property_meter_usage] = data;
 
         resetSelections();
+        $scope.meterGridApi.core.refresh()
         $scope.applyFilters();
         spinner_utility.hide();
       });

--- a/seed/static/seed/js/controllers/meter_deletion_modal_controller.js
+++ b/seed/static/seed/js/controllers/meter_deletion_modal_controller.js
@@ -8,16 +8,27 @@ angular.module('BE.seed.controller.meter_deletion_modal', []).controller('meter_
   '$uibModalInstance',
   'meter_service',
   'spinner_utility',
+  'organization_id',
   'meter',
   'view_id',
   'refresh_meters_and_readings',
   // eslint-disable-next-line func-names
-  function ($scope, $state, $uibModalInstance, meter_service, spinner_utility, meter, view_id, refresh_meters_and_readings) {
+  function (
+    $scope,
+    $state,
+    $uibModalInstance,
+    meter_service,
+    spinner_utility,
+    organization_id,
+    meter,
+    view_id,
+    refresh_meters_and_readings
+  ) {
     $scope.meter_name = meter.alias ?? 'meter';
 
     $scope.delete_meter = () => {
       spinner_utility.show();
-      meter_service.delete_meter(view_id, meter.id).then(() => {
+      meter_service.delete_meter(organization_id, view_id, meter.id).then(() => {
         refresh_meters_and_readings();
         spinner_utility.show();
         $uibModalInstance.dismiss('cancel');

--- a/seed/static/seed/js/services/meter_service.js
+++ b/seed/static/seed/js/services/meter_service.js
@@ -9,7 +9,12 @@ angular.module('BE.seed.service.meter', []).factory('meter_service', [
 
     meter_factory.get_meters = (property_view_id, organization_id) => $http.get(`/api/v3/properties/${property_view_id}/meters/`, { params: { organization_id } }).then((response) => response.data);
 
-    meter_factory.delete_meter = (property_view_id, meter_id) => $http.delete(`/api/v3/properties/${property_view_id}/meters/${meter_id}`).then((response) => response.data);
+    meter_factory.delete_meter = (organization_id, property_view_id, meter_id) => {
+      return $http
+        .delete(`/api/v3/properties/${property_view_id}/meters/${meter_id}/?organization_id=${organization_id}`)
+        .then((response) => response)
+        .catch((response) => response);
+    };
 
     meter_factory.property_meter_usage = (property_view_id, organization_id, interval, excluded_meter_ids) => {
       if (_.isUndefined(excluded_meter_ids)) excluded_meter_ids = [];


### PR DESCRIPTION
#### Any background context you want to provide?
On the Inventory Detail Meters page, a deleted meter was visible in the grid until the page was manually refreshed.

#### What's this PR do?
- refreshes the grid after the delete response is returned.
- adds organization to request url. Without it, I was constantly returning 403 - Organization does not exist.
- ups the create/update/delete permissions from `requires_viewer` to `requires_member.

#### How should this be manually tested?
Upload properties with meters.
From the meters page delete meters. 
The ui-grid should immediately reflect the changes

#### What are the relevant tickets?
#4507

#### Screenshots (if appropriate)

https://github.com/SEED-platform/seed/assets/58446472/1ade2b33-dd24-49a2-a27b-2af8e6ccfe4b

