### PR TITLE
Redirect on org change if necessary

### DIFF
--- a/seed/static/seed/js/controllers/menu_controller.js
+++ b/seed/static/seed/js/controllers/menu_controller.js
@@ -21,8 +21,6 @@ angular.module('BE.seed.controller.menu', []).controller('menu_controller', [
   '$stateParams',
   // eslint-disable-next-line func-names
   function ($rootScope, $scope, $location, $window, $uibModal, $log, urls, auth_service, organization_service, user_service, dataset_service, modified_service, inventory_service, $timeout, $state, $stateParams) {
-    console.log('$stateParams', $stateParams)
-    $scope.stateParams = $stateParams
     // initial state of css classes for menu and sidebar
     $scope.expanded_controller = false;
     $scope.collapsed_controller = false;

--- a/seed/static/seed/js/controllers/menu_controller.js
+++ b/seed/static/seed/js/controllers/menu_controller.js
@@ -18,8 +18,11 @@ angular.module('BE.seed.controller.menu', []).controller('menu_controller', [
   'inventory_service',
   '$timeout',
   '$state',
+  '$stateParams',
   // eslint-disable-next-line func-names
-  function ($rootScope, $scope, $location, $window, $uibModal, $log, urls, auth_service, organization_service, user_service, dataset_service, modified_service, inventory_service, $timeout, $state) {
+  function ($rootScope, $scope, $location, $window, $uibModal, $log, urls, auth_service, organization_service, user_service, dataset_service, modified_service, inventory_service, $timeout, $state, $stateParams) {
+    console.log('$stateParams', $stateParams)
+    $scope.stateParams = $stateParams
     // initial state of css classes for menu and sidebar
     $scope.expanded_controller = false;
     $scope.collapsed_controller = false;
@@ -167,6 +170,9 @@ angular.module('BE.seed.controller.menu', []).controller('menu_controller', [
       $scope.mouseout_org();
       await user_service.set_organization(org);
       $scope.menu.user.organization = org;
+      if ($stateParams.organization_id && $stateParams.organization_id != org.id) {
+        $stateParams.organization_id = org.id
+      }
       $state.reload();
       init();
     };


### PR DESCRIPTION
#### Any background context you want to provide?
When changing the organization from the menu, the page did not redirect to that org's data if the url contained an `organization_id` argument.

#### What's this PR do?
checks for the presence of the `organization_id` arg and updates it if necessary

#### How should this be manually tested?
With multiple orgs navigate to any of the organization settings pages. Change the org from the dropdown. The page data should reflect the newly selected org.

#### What are the relevant tickets?
#4575

#### Screenshots (if appropriate)
![Screenshot 2024-03-19 at 1 17 45 PM](https://github.com/SEED-platform/seed/assets/58446472/a399ce09-caab-491d-bf32-e251a3c2b2f7)
