### PR TITLE
Allow jurisdiction_tax_lot_id display name change

### DIFF
--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -303,21 +303,19 @@ def map_row_chunk(ids, file_pk, source_type, prog_key, **kwargs):
     # figure out which import field is defined as the unique field that may have a delimiter of
     # individual values (e.g., tax lot ids). The definition of the delimited field is currently
     # hard coded
-    try:
-        delimited_fields = {}
-        if 'TaxLotState' in table_mappings:
-            tmp = list(table_mappings['TaxLotState'].keys())[
-                list(table_mappings['TaxLotState'].values()).index(ColumnMapping.DELIMITED_FIELD)
-            ]
+    delimited_fields = {}
+    if 'TaxLotState' in table_mappings:
+        jurisdiction_tax_lot_id_table_mapping = next(iter(
+            k for k, v in table_mappings["TaxLotState"].items()
+            if v[1] == "jurisdiction_tax_lot_id"
+        ), None)
+
+        if jurisdiction_tax_lot_id_table_mapping:
             delimited_fields['jurisdiction_tax_lot_id'] = {
-                'from_field': tmp,
+                'from_field': jurisdiction_tax_lot_id_table_mapping,
                 'to_table': 'TaxLotState',
                 'to_field_name': 'jurisdiction_tax_lot_id',
             }
-
-    except ValueError:
-        delimited_fields = {}
-        # field does not exist in mapping list, so ignoring
 
     # _log.debug("my table mappings are {}".format(table_mappings))
     # _log.debug("delimited_field that will be expanded and normalized: {}".format(delimited_fields))

--- a/seed/models/column_mappings.py
+++ b/seed/models/column_mappings.py
@@ -117,9 +117,6 @@ class ColumnMapping(models.Model):
     column_raw = models.ManyToManyField('Column', related_name='raw_mappings', blank=True, )
     column_mapped = models.ManyToManyField('Column', related_name='mapped_mappings', blank=True, )
 
-    # This field is the database column which allows checks for delimited values (e.g., a;b;c;d)
-    DELIMITED_FIELD = ('TaxLotState', 'jurisdiction_tax_lot_id', 'Jurisdiction Tax Lot ID', False)
-
     def is_direct(self):
         """
         Returns True if the ColumnMapping is a direct mapping from imported


### PR DESCRIPTION
https://github.com/SEED-platform/seed/issues/4164
I have a version that factors out the section that is asking to be factored out, but `delimited_fields` is called again outside that, when "expanding the row"
