### PR TITLE
Fix property search endpoint in Swagger

### DIFF
--- a/seed/views/v3/properties.py
+++ b/seed/views/v3/properties.py
@@ -184,6 +184,11 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
     # For the Swagger page, GenericAPIView asserts a value exists for `queryset`
     queryset = PropertyView.objects.none()
 
+    @swagger_auto_schema(
+        manual_parameters=[
+            AutoSchemaHelper.query_org_id_field(required=True),
+        ]
+    )
     @has_perm_class('requires_viewer')
     @action(detail=False, filter_backends=[PropertyViewFilterBackend])
     def search(self, request):
@@ -200,9 +205,11 @@ class PropertyViewSet(generics.GenericAPIView, viewsets.ViewSet, OrgMixin, Profi
             property__access_level_instance__lft__gte=ali.lft,
             property__access_level_instance__rgt__lte=ali.rgt
         ).order_by('-state__id')
+
         # this is the entrypoint to the filtering backend
         # https://www.django-rest-framework.org/api-guide/filtering/#custom-generic-filtering
         qs = self.filter_queryset(qs)
+
         # converting QuerySet to list b/c serializer will only use column list profile this way
         return JsonResponse(
             PropertyViewAsStateSerializer(list(qs), context={'request': request}, many=True).data,


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### Any background context you want to provide?
The search endpoint in swagger was missing the org_id as a parameter, causing it not to return results.

#### What's this PR do?
* Add the schema helper to the endpoint

#### How should this be manually tested?
* in a property with data, go to swagger
* in search, enter data into one of the fields and the org_id
* results should return now

#### What are the relevant tickets?
n/a
#### Screenshots (if appropriate)
![image](https://github.com/SEED-platform/seed/assets/1907354/23ac0faf-17a9-4a08-9258-fe0b07401de0)

