### PR TITLE
Clear invalid label tags

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -480,20 +480,19 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
     const localStorageKey = `grid.${$scope.inventory_type}`;
     const localStorageLabelKey = `grid.${$scope.inventory_type}.labels`;
 
-    // clear the selected_labels and re-render the component as invalid text is not attatched to the model.
-    const reset_tags_input = (key, selected_labels) => {
-      selected_labels.splice(0);
-      $scope.show_tags_input[key] = false;
-      setTimeout(() => {
-        // immediately re-render
-        $scope.$apply(() => $scope.show_tags_input[key] = true);
-      }, 0);
-    }
-
+    // clear the selected_labels and re-render the <tags-input> component as invalid text is not attatched to the model.
     $scope.clear_labels = function (action) {
-      if (action === 'and') reset_tags_input('and', $scope.selected_and_labels);
-      if (action === 'or') reset_tags_input('or', $scope.selected_or_labels);
-      if (action === 'exclude') reset_tags_input('exclude', $scope.selected_exclude_labels);
+      selected_labels = {
+        'and': $scope.selected_and_labels,
+        'or': $scope.selected_or_labels,
+        'exclude': $scope.selected_exclude_labels
+      };
+      selected_labels[action].splice(0);
+      $scope.show_tags_input[action] = false;
+      // immediately re-render
+      setTimeout(() => {
+        $scope.$apply(() => $scope.show_tags_input[action] = true);
+      }, 0);
       $scope.filterUsingLabels();
     };
 

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -471,7 +471,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
       return Math.min(maxWidth, $scope.max_label_width);
     };
 
-    $scope.show_tags_input = { or: true, and: true, exclude: true };
+    $scope.show_tags_input = { and: true, or: true, exclude: true };
     // Reduce labels to only records found in the current cycle
     $scope.selected_and_labels = [];
     $scope.selected_or_labels = [];
@@ -480,7 +480,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
     const localStorageKey = `grid.${$scope.inventory_type}`;
     const localStorageLabelKey = `grid.${$scope.inventory_type}.labels`;
 
-    // clear the selected_labels and re-render the <tags-input> component as invalid text is not attatched to the model.
+    // reset the selected_labels to [] and re-render the <tags-input> component as invalid text is not attatched to the model.
     $scope.clear_labels = function (action) {
       selected_labels = {
         'and': $scope.selected_and_labels,

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -470,6 +470,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
       return maxWidth > $scope.max_label_width ? $scope.max_label_width : maxWidth + 2;
     };
 
+    $scope.show_tags_input = { or: true, and: true, exclude: true };
     // Reduce labels to only records found in the current cycle
     $scope.selected_and_labels = [];
     $scope.selected_or_labels = [];
@@ -478,10 +479,20 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
     const localStorageKey = `grid.${$scope.inventory_type}`;
     const localStorageLabelKey = `grid.${$scope.inventory_type}.labels`;
 
+    // clear the selected_labels and re-render the component as invalid text is not attatched to the model.
+    const reset_tags_input = (key, selected_labels) => {
+      selected_labels.splice(0);
+      $scope.show_tags_input[key] = false;
+      setTimeout(() => {
+        // immediately re-render
+        $scope.$apply(() => $scope.show_tags_input[key] = true);
+      }, 0);
+    }
+
     $scope.clear_labels = function (action) {
-      if (action === 'and') $scope.selected_and_labels = [];
-      if (action === 'or') $scope.selected_or_labels = [];
-      if (action === 'exclude') $scope.selected_exclude_labels = [];
+      if (action === 'and') reset_tags_input('and', $scope.selected_and_labels);
+      if (action === 'or') reset_tags_input('or', $scope.selected_or_labels);
+      if (action === 'exclude') reset_tags_input('exclude', $scope.selected_exclude_labels);
       $scope.filterUsingLabels();
     };
 

--- a/seed/static/seed/partials/inventory_list.html
+++ b/seed/static/seed/partials/inventory_list.html
@@ -99,7 +99,7 @@
     <div class="row">
       <label for="and-tags-input">{$:: 'Must Include' | translate $}:</label>
       <div class="input-group input-group-sm grow">
-        <tags-input id="and-tags-input" class="remove-editing ti-input-sm tags-input-style grow" ng-model="selected_and_labels" on-tag-added="filterUsingLabels()" on-tag-removed="filterUsingLabels()" min-length="1" placeholder="{$:: 'Add a label' | translate $}" replace-spaces-with-dashes="false" add-from-autocomplete-only="true" ng-disabled="!labels.length">
+        <tags-input id="and-tags-input" class="remove-editing ti-input-sm tags-input-style grow" ng-if="show_tags_input.and" ng-model="selected_and_labels" on-tag-added="filterUsingLabels()" on-tag-removed="filterUsingLabels()" min-length="1" placeholder="{$:: 'Add a label' | translate $}" replace-spaces-with-dashes="false" add-from-autocomplete-only="true" ng-disabled="!labels.length">
           <auto-complete source="loadLabelsForFilter($query)" max-results-to-show="255" min-length="0" load-on-empty="true" load-on-focus="true" ng-disabled="!labels.length"></auto-complete>
         </tags-input>
         <span ng-click="clear_labels('and')" class="btn btn-default btn-sm input-group-addon" ng-disabled="!selected_and_labels.length"><i class="fa fa-lg fa-trash"></i></span>
@@ -108,7 +108,7 @@
     <div class="row">
       <label for="or-tags-input">{$:: 'Include Any' | translate $}:</label>
       <div class="input-group input-group-sm grow">
-        <tags-input id="or-tags-input" class="remove-editing ti-input-sm tags-input-style grow" ng-model="selected_or_labels" on-tag-added="filterUsingLabels()" on-tag-removed="filterUsingLabels()" min-length="1" placeholder="{$:: 'Add a label' | translate $}" replace-spaces-with-dashes="false" add-from-autocomplete-only="true" ng-disabled="!labels.length">
+        <tags-input id="or-tags-input" class="remove-editing ti-input-sm tags-input-style grow" ng-if="show_tags_input.or" ng-model="selected_or_labels" on-tag-added="filterUsingLabels()" on-tag-removed="filterUsingLabels()" min-length="1" placeholder="{$:: 'Add a label' | translate $}" replace-spaces-with-dashes="false" add-from-autocomplete-only="true" ng-disabled="!labels.length">
           <auto-complete source="loadLabelsForFilter($query)" max-results-to-show="255" min-length="0" load-on-empty="true" load-on-focus="true" ng-disabled="!labels.length"></auto-complete>
         </tags-input>
         <span ng-click="clear_labels('or')" class="btn btn-default btn-sm input-group-addon" ng-disabled="!selected_or_labels.length"><i class="fa fa-lg fa-trash"></i></span>
@@ -117,7 +117,7 @@
     <div class="row">
       <label for="exclude-tags-input">{$:: 'Exclude' | translate $}:</label>
       <div class="input-group input-group-sm grow">
-        <tags-input id="exclude-tags-input" class="remove-editing ti-input-sm tags-input-style grow" ng-model="selected_exclude_labels" on-tag-added="filterUsingLabels()" on-tag-removed="filterUsingLabels()" min-length="1" placeholder="{$:: 'Add a label' | translate $}" replace-spaces-with-dashes="false" add-from-autocomplete-only="true" ng-disabled="!labels.length">
+        <tags-input id="exclude-tags-input" class="remove-editing ti-input-sm tags-input-style grow" ng-if="show_tags_input.exclude" ng-model="selected_exclude_labels" on-tag-added="filterUsingLabels()" on-tag-removed="filterUsingLabels()" min-length="1" placeholder="{$:: 'Add a label' | translate $}" replace-spaces-with-dashes="false" add-from-autocomplete-only="true" ng-disabled="!labels.length">
           <auto-complete source="loadLabelsForFilter($query)" max-results-to-show="255" min-length="0" load-on-empty="true" load-on-focus="true" ng-disabled="!labels.length"></auto-complete>
         </tags-input>
         <span ng-click="clear_labels('exclude')" class="btn btn-default btn-sm input-group-addon" ng-disabled="!selected_exclude_labels.length"><i class="fa fa-lg fa-trash"></i></span>


### PR DESCRIPTION
#### Any background context you want to provide?
The label filters (and, or, exclude) are based attached to the model via a `<tags-input>` and `<auto-complete>` elements. If a valid label is selected, its value is attached to the `<tags-input>`'s ng-model. If invalid text is entered, it is not attached to the ng-model and not available to reset in $scope. This makes clearing the text difficult.

#### What's this PR do?
After resetting the ng-model's labels, the trashcan icon will also re-render the `<tags-input>` element, clearing any remaining text. 

It's a little hacky, but it's cleaner than trying to locate the correct HTML element within <tags-input>, clear its contents, and convince the element that it is now in a 'valid' state.

#### How should this be manually tested?
Add a few labels. Filter on those labels. Add some random text to the filter fields. Hit the trash icon.

#### What are the relevant tickets?
#4305 

#### Screenshots (if appropriate)

https://github.com/SEED-platform/seed/assets/58446472/5b71532b-5f35-4ce6-adc6-066d1fbcbaba

