### PR TITLE
Fix circular derived column error handling

### DIFF
--- a/seed/static/seed/js/controllers/derived_columns_editor_controller.js
+++ b/seed/static/seed/js/controllers/derived_columns_editor_controller.js
@@ -140,7 +140,7 @@ angular.module('BE.seed.controller.derived_columns_editor', []).controller('deri
     // a = b
     // b = a ----> b = b
     const check_for_circular_definition = (source_column) => {
-      if (!source_column.derived_column) {
+      if (!source_column.derived_column || !$scope.derived_column.id) {
         return false;
       }
       if (source_column.derived_column === $scope.derived_column.id) {


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
- fixes a bug causing the app to fail silently when a new derived column referenced an existing derived column.

#### How should this be manually tested?
- create a derived column, `dc1`
- create a second derived column, `dc2 = dc1`. Initially this failed silently, however this should be a valid action.
- edit `dc1` to `dc1 = dc2`. This should cause a circular warning to the user.

#### What are the relevant tickets?
#4429 

#### Screenshots (if appropriate)

https://github.com/SEED-platform/seed/assets/58446472/58a9bc52-5c28-4483-95e9-4bbca99eea56

