### PR TITLE
Fix floating point rounding

### DIFF
--- a/seed/static/seed/js/controllers/inventory_detail_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_controller.js
@@ -819,11 +819,14 @@ angular.module('BE.seed.controller.inventory_detail', []).controller('inventory_
       $('.table-xscroll-fixed-header-container > .table-body-x-scroll').width(table_container.width() + table_container.scrollLeft());
     });
 
-    $scope.displayValue = (dataType, value) => {
-      if (dataType === 'datetime') {
+    $scope.displayValue = ({ column_name, data_type }, value) => {
+      if (data_type === 'datetime') {
         return $filter('date')(value, 'yyyy-MM-dd h:mm a');
       }
-      if (['area', 'eui', 'float', 'number'].includes(dataType)) {
+      if (['longitude', 'latitude'].includes(column_name)) {
+        return $filter('floatingPoint')(value);
+      }
+      if (['area', 'eui', 'float', 'number'].includes(data_type)) {
         return $filter('number')(value, $scope.organization.display_decimal_places);
       }
       return value;

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -801,10 +801,9 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
       // Modify misc
       if (col.data_type === 'datetime') {
         options.cellFilter = "date:'yyyy-MM-dd h:mm a'";
-      } else if (
-        ['area', 'eui', 'float', 'number'].includes(col.data_type) &&
-        !['longitude', 'latitude'].includes(col.column_name) // we need the whole number for these
-      ) {
+      } else if (['longitude', 'latitude'].includes(col.column_name)) {
+        options.cellFilter = 'floatingPoint';
+      } else if (['area', 'eui', 'float', 'number'].includes(col.data_type)) {
         options.cellFilter = `tolerantNumber: ${$scope.organization.display_decimal_places}`;
       } else if (col.is_derived_column) {
         options.cellFilter = `number: ${$scope.organization.display_decimal_places}`;

--- a/seed/static/seed/js/filters/floatingPoint.js
+++ b/seed/static/seed/js/filters/floatingPoint.js
@@ -1,0 +1,20 @@
+/**
+ * SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and other contributors.
+ * See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
+ *
+ * FloatingPoint
+ * Fix floating-point rounding errors
+ *
+ * @param {number} input - The input number
+ * @param {number} [precision=15] - An integer specifying the number of significant digits (optional)
+ *
+ * @example 0.09999999999999998 | floatingPoint // 0.1
+ */
+angular.module('floatingPoint', []).filter(
+  'floatingPoint',
+  () => (input, precision = 15) => {
+    if (_.isNil(input) || Number.isNaN(+input)) return input;
+
+    return +parseFloat((+input).toPrecision(precision));
+  }
+);

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -141,7 +141,7 @@ angular.module('BE.seed.controllers', [
   'BE.seed.controller.unmerge_modal',
   'BE.seed.controller.update_item_labels_modal'
 ]);
-angular.module('BE.seed.filters', ['district', 'fromNow', 'getAnalysisRunAuthor', 'htmlToPlainText', 'ignoremap', 'startFrom', 'stripImportPrefix', 'titleCase', 'tolerantNumber', 'typedNumber']);
+angular.module('BE.seed.filters', ['district', 'floatingPoint', 'fromNow', 'getAnalysisRunAuthor', 'htmlToPlainText', 'ignoremap', 'startFrom', 'stripImportPrefix', 'titleCase', 'tolerantNumber', 'typedNumber']);
 angular.module('BE.seed.directives', [
   'sdBasicPropertyInfoChart',
   'sdCheckCycleExists',

--- a/seed/static/seed/partials/inventory_detail.html
+++ b/seed/static/seed/partials/inventory_detail.html
@@ -218,21 +218,21 @@
               <!-- Show read-only current 'regular' field value -->
               <td ng-if="edit_form_showing===false && !col.is_extra_data && !col.derived_column && col.table_name.toLowerCase().includes('state')" ng-class="{highlight: col.changed}" class="ellipsis">
                 <span class="sd-data-content" uib-popover="{$:: item_state[col.column_description] $}" popover-trigger="'outsideClick'" popover-animation="false" popover-placement="top-left">
-                  <span>{$:: displayValue(col.data_type, item_state[col.column_name]) $}</span>
+                  <span>{$:: displayValue(col, item_state[col.column_name]) $}</span>
                 </span>
               </td>
 
               <!-- Show read-only current 'extra_data' field value -->
               <td ng-if="edit_form_showing===false && col.is_extra_data && col.table_name.toLowerCase().includes('state')" ng-class="{highlight: col.changed}" class="ellipsis">
                 <span class="sd-data-content" uib-popover="{$ item_state.extra_data[col.column_description] $}" popover-trigger="'outsideClick'" popover-animation="false" popover-placement="top-left">
-                  <span>{$:: displayValue(col.data_type, item_state.extra_data[col.column_name]) $}</span>
+                  <span>{$:: displayValue(col, item_state.extra_data[col.column_name]) $}</span>
                 </span>
               </td>
 
               <!-- Show read-only current 'property / taxlot' fields -->
               <td ng-if="edit_form_showing===false && !col.table_name.toLowerCase().includes('state') && !col.derived_column" ng-class="{highlight: col.changed}" class="ellipsis">
                 <span class="sd-data-content" uib-popover="{$ item_parent[col.column_description] $}" popover-trigger="'outsideClick'" popover-animation="false" popover-placement="top-left">
-                  <span>{$:: displayValue(col.data_type, item_parent[col.column_name]) $}</span>
+                  <span>{$:: displayValue(col, item_parent[col.column_name]) $}</span>
                 </span>
               </td>
 
@@ -268,7 +268,7 @@
                   popover-animation="false"
                   popover-placement="top-left"
                 >
-                  <span>{$:: displayValue(col.data_type, historical_item.state[col.column_name]) $}</span>
+                  <span>{$:: displayValue(col, historical_item.state[col.column_name]) $}</span>
                 </span>
                 <span
                   ng-if="::col.is_extra_data && col.table_name.toLowerCase().includes('state')"
@@ -278,7 +278,7 @@
                   popover-animation="false"
                   popover-placement="top-left"
                 >
-                  <span>{$:: displayValue(col.data_type, historical_item.state.extra_data[col.column_name]) $}</span>
+                  <span>{$:: displayValue(col, historical_item.state.extra_data[col.column_name]) $}</span>
                 </span>
               </td>
             </tr>

--- a/seed/templates/seed/_scripts.html
+++ b/seed/templates/seed/_scripts.html
@@ -9,6 +9,7 @@
   <script src="{{ STATIC_URL }}seed/js/decorators/ui-grid.js"></script>
 
   <script src="{{ STATIC_URL }}seed/js/filters/district.js"></script>
+  <script src="{{ STATIC_URL }}seed/js/filters/floatingPoint.js"></script>
   <script src="{{ STATIC_URL }}seed/js/filters/fromNow.js"></script>
   <script src="{{ STATIC_URL }}seed/js/filters/getAnalysisRunAuthor.js"></script>
   <script src="{{ STATIC_URL }}seed/js/filters/htmlToPlainText.js"></script>


### PR DESCRIPTION
#### Any background context you want to provide?
UBIDs like `86HJX66V+M5R-4-1-3-2` decode to latitude/longitude centroids with floating-point rounding errors:

> 41.96174999999997, -87.75712499999999

#### What's this PR do?
- Adds a new `floatingPoint` AngularJS filter that can automatically fix floating point rounding errors
- Applies the floatingPoint filter to latitude and longitude on the Inventory List/Detail pages
- Fixes latitude/longitude truncation on the Inventory Detail page

#### How should this be manually tested?
1. Upload the covered building list file, ensure that the geocoded lat/long values don't display floating point rounding errors

#### Screenshots (if appropriate)

Before and after:

![floating-point](https://github.com/SEED-platform/seed/assets/411466/99974d66-6204-424a-975e-0845c3704d75)
