### PR TITLE
Geocode UBIDs using centroid

### DIFF
--- a/seed/tests/test_utils_ubid.py
+++ b/seed/tests/test_utils_ubid.py
@@ -107,7 +107,7 @@ class UbidUtilMethods(TestCase):
             self.assertAlmostEqual(coord[0], known_property_centroid[index][0])
             self.assertAlmostEqual(coord[1], known_property_centroid[index][1])
 
-        self.assertAlmostEqual(refreshed_property.latitude, 41.7451)
+        self.assertAlmostEqual(refreshed_property.latitude, 41.7451125)
         self.assertAlmostEqual(refreshed_property.longitude, -87.560328125)
 
     def test_decode_taxlot_ubids_is_successful_when_valid_taxlot_UBID_provided(self):
@@ -148,7 +148,7 @@ class UbidUtilMethods(TestCase):
             self.assertAlmostEqual(coord[0], known_taxlot_centroid[index][0])
             self.assertAlmostEqual(coord[1], known_taxlot_centroid[index][1])
 
-        self.assertAlmostEqual(refreshed_taxlot.latitude, 41.7451)
+        self.assertAlmostEqual(refreshed_taxlot.latitude, 41.7451125)
         self.assertAlmostEqual(refreshed_taxlot.longitude, -87.560328125)
 
     def test_decode_ubids_does_nothing_if_no_UBID_provided(self):

--- a/seed/utils/ubid.py
+++ b/seed/utils/ubid.py
@@ -68,7 +68,9 @@ def decode_unique_ids(qs):
         )
         state.centroid = centroid_polygon
 
-        state.latitude, state.longitude = bounding_box_obj.latlng()
+        # Round to avoid floating point errors
+        state.latitude = round(bounding_box_obj.centroid.latitudeCenter, 12)
+        state.longitude = round(bounding_box_obj.centroid.longitudeCenter, 12)
 
         state.save()
 


### PR DESCRIPTION
#### Any background context you want to provide?
Prior to this change, when importing a file with a UBID we were setting the PropertyState's latitude and longitude to the center of the UBID _**bounding box**_, which isn't necessarily representative of the footprint.

#### What's this PR do?
- Sets the PropertyState's latitude and longitude to the center of the UBID _**centroid**_.
- This PR also fixes floating-point rounding errors for lat/long values when geocoding from a UBID by rounding to 12 decimal places. There's no risk of loss of precision, because at its highest precision the area encompassed by the coordinate would be _12,392 square nanometers_ at the equator.

#### How should this be manually tested?
1. Upload a file with a UBID like `85FPPRRC+XH9-7-8-3-6`
2. Confirm that the lat/long is `39.7424125, -105.178515625`, NOT `39.7424625, -105.178484375`

#### Screenshots (if appropriate)
The red dot represents the lat/long SEED was setting, the center the centroid (blue pin) is what is now used:
![image](https://github.com/SEED-platform/seed/assets/411466/88f1374c-e1cf-4b95-9d49-a542bc865c89)
