### PR TITLE
Fix merge modal for all cycles

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -648,7 +648,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
             const data = new Array(selectedViewIds.length);
 
             if ($scope.inventory_type === 'properties') {
-              return inventory_service.get_properties(1, undefined, undefined, -1, selectedViewIds).then((inventory_data) => {
+              return inventory_service.get_properties(1, undefined, $scope.cycle.selected_cycle, -1, selectedViewIds).then((inventory_data) => {
                 _.forEach(selectedViewIds, (id, index) => {
                   const match = _.find(inventory_data.results, [viewIdProp, id]);
                   if (match) {
@@ -659,7 +659,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
               });
             }
             if ($scope.inventory_type === 'taxlots') {
-              return inventory_service.get_taxlots(1, undefined, undefined, -1, selectedViewIds).then((inventory_data) => {
+              return inventory_service.get_taxlots(1, undefined, $scope.cycle.selected_cycle, -1, selectedViewIds).then((inventory_data) => {
                 _.forEach(selectedViewIds, (id, index) => {
                   const match = _.find(inventory_data.results, [viewIdProp, id]);
                   if (match) {

--- a/seed/static/seed/js/controllers/inventory_map_controller.js
+++ b/seed/static/seed/js/controllers/inventory_map_controller.js
@@ -45,7 +45,7 @@ angular.module('BE.seed.controller.inventory_map', []).controller('inventory_map
 
     const chunk = 250;
     const fetchRecords = async (fn) => {
-      const pagination = await fn(1, chunk, undefined, undefined).then((data) => data.pagination);
+      const pagination = await fn(1, chunk, $scope.cycle.selected_cycle, undefined).then((data) => data.pagination);
 
       $scope.progress = { current: 0, total: pagination.total, percent: 0 };
 

--- a/seed/static/seed/js/services/inventory_service.js
+++ b/seed/static/seed/js/services/inventory_service.js
@@ -90,6 +90,8 @@ angular.module('BE.seed.service.inventory', []).factory('inventory_service', [
         if (save_last_cycle === true) {
           inventory_service.save_last_cycle(cycle.id);
         }
+      } else {
+        params.cycle = inventory_service.get_last_cycle();
       }
 
       const data = {


### PR DESCRIPTION
#### Any background context you want to provide?
When requesting filtered properties with the `/api/v3/properties/filter/` endpoint, if you leave out the `cycle` param the backend defaults to the first alphabetical cycle

#### What's this PR do?
- Makes the cycle id explicit, so that when you're on the Inventory List page, select records, and open the merge modal, it will now work for all cycles and not just the first alphabetical cycle
- Fixes the cycle toggle on the map page, it was also affected by this issue
- Adds a fallback on the front-end, such that if a cycle isn't passed when filtering properties it will use the most-recently selected cycle

#### How should this be manually tested?
1. In an org with multiple cycles, go to the Inventory List page and select any cycle that is not alphabetically sorted first
2. Select a few records, and then open the Merge modal
3. Ensure that the data appears as expected

1. Go to the Inventory Map page
2. Toggle between different cycles, ensure that different (and correct) data appears for each cycle