### PR TITLE
Fix ubid bugs

### DIFF
--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -843,20 +843,19 @@ def check_jaccard_match(ubid, state_ubid, ubid_threshold, matching_criteria):
     """
     Use jaccard index between an incoming ubid and an existing state_ubid to determine if states are 'matching'
 
-    :param ubid: sring, incoming ubid
+    :param ubid: string, incoming ubid
     :param state_ubid: string, existing state's ubid
     :param ubid_threshold: float, organization's ubid_threshold
     :param matching_criteria: dict, organization's matching criteria with ubid removed
     """
-    # If state_ubis is None and ubid is the only matching_criteria, no match
+    # If state_ubid is None and ubid is the only matching_criteria, no match
     if not state_ubid and not matching_criteria:
         return False
 
     # If state_ubid is None and matching_criteria exists, get_jaccard_index will default to 1.0
-    # allowing the remaining matching criteria to determine if it's a  match
+    # allowing the remaining matching criteria to determine if it's a match
     jaccard_index = get_jaccard_index(ubid, state_ubid)
 
-    # If threshold is 0 then it will match any UBID with overlap
     if ubid_threshold == 0:
         return jaccard_index > ubid_threshold
     else:

--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -618,7 +618,7 @@ def states_to_views(unmatched_state_ids, org, access_level_instance, cycle, Stat
             existing_state_matches = [
                 state
                 for state in existing_state_matches
-                if check_jaccard_match(ubid, state.ubid, org.ubid_threshold)
+                if check_jaccard_match(ubid, state.ubid, org.ubid_threshold, matching_criteria)
             ]
 
         count = len(existing_state_matches)
@@ -839,7 +839,21 @@ def save_state_match(state1, state2, priorities):
     return merged_state
 
 
-def check_jaccard_match(ubid, state_ubid, ubid_threshold):
+def check_jaccard_match(ubid, state_ubid, ubid_threshold, matching_criteria):
+    """
+    Use jaccard index between an incoming ubid and an existing state_ubid to determine if states are 'matching'
+
+    :param ubid: sring, incoming ubid
+    :param state_ubid: string, existing state's ubid
+    :param ubid_threshold: float, organization's ubid_threshold
+    :param matching_criteria: dict, organization's matching criteria with ubid removed
+    """
+    # If state_ubis is None and ubid is the only matching_criteria, no match
+    if not state_ubid and not matching_criteria:
+        return False
+
+    # If state_ubid is None and matching_criteria exists, get_jaccard_index will default to 1.0
+    # allowing the remaining matching criteria to determine if it's a  match
     jaccard_index = get_jaccard_index(ubid, state_ubid)
 
     # If threshold is 0 then it will match any UBID with overlap

--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -651,7 +651,9 @@ def states_to_views(unmatched_state_ids, org, access_level_instance, cycle, Stat
             batch_size = math.ceil(len(merge_state_pairs) / 100)
             for idx, state_pair in enumerate(merge_state_pairs):
                 existing_state, newer_state = state_pair
-                existing_view = ViewClass.objects.get(state_id=existing_state.id)
+                existing_view = ViewClass.objects.filter(state_id=existing_state.id).first()
+                if not existing_view:
+                    continue
                 existing_obj = getattr(existing_view, "property" if table_name == 'PropertyState' else "taxlot")
 
                 # ensure that new ali and existing ali match and that we have access to existing ali.

--- a/seed/utils/merge.py
+++ b/seed/utils/merge.py
@@ -65,7 +65,10 @@ def merge_properties(state_ids, org_id, log_name, ignore_merge_protection=False)
             raise MultipleALIError
 
         # Create new inventory record and associate it to a new view
-        new_property = Property(organization_id=org_id)
+        new_property = Property(
+            organization_id=org_id,
+            access_level_instance_id=alis.first()
+        )
         new_property.save()
 
         cycle_id = views.first().cycle_id

--- a/seed/utils/ubid.py
+++ b/seed/utils/ubid.py
@@ -105,7 +105,7 @@ def get_jaccard_index(ubid1, ubid2):
             result = cursor.fetchone()[0]
     except Exception as e:
         logging.error(e)
-        result = 0
+        return 0.0
 
     return result
 

--- a/seed/utils/ubid.py
+++ b/seed/utils/ubid.py
@@ -99,10 +99,14 @@ def get_jaccard_index(ubid1, ubid2):
                 UBID_CodeArea_Jaccard(left_code_area, right_code_area)
             FROM
                 decoded """
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(sql, [ubid1, ubid2])
+            result = cursor.fetchone()[0]
+    except Exception as e:
+        logging.error(e)
+        result = 0
 
-    with connection.cursor() as cursor:
-        cursor.execute(sql, [ubid1, ubid2])
-        result = cursor.fetchone()[0]
     return result
 
 


### PR DESCRIPTION
#### Any background context you want to provide?
This is in response to some bugs Robin encountered while testing the UBID work

#### What's this PR do?
- Fixes a bug that caused the import process to hang if ubid was the only matching criteria 
- Fixes a bug that did not preserve access level instances on merges

#### How should this be manually tested?
The following test files include the NREL FTLB, the NREL Cafe, and an invalid property without a ubid. Each file increases the ubid footprint.

1. set matching criteria to only ubid
2. upload a file with ubids [3props_ubids_0.xlsx](https://github.com/SEED-platform/seed/files/14910546/3props_ubids_0.xlsx)
3. in org settings change the ubid threshold to 0.1 to allow matching 
4. upload a file with slightly different ubids [3props_ubids_1.xlsx](https://github.com/SEED-platform/seed/files/14910547/3props_ubids_1.xlsx)
5. properties should have been merged and preferred ubid set to the incoming ubid (see inventory detail ubid)
6. change the org setting ubid threshold to something more strict, like 0.9 
7. upload a file with slightly different ubids [3props_ubids_4.xlsx](https://github.com/SEED-platform/seed/files/14910548/3props_ubids_4.xlsx)
8. new views have been created as incoming properties did not meet matching criteria 
9. change the org setting ubid_threshold back to 0.1 
10. upload a file with slightly different ubids [3props_ubids_5.xlsx](https://github.com/SEED-platform/seed/files/14910549/3props_ubids_5.xlsx)
11. all properties with overlapping ubids should have been merged and ubid history preserved 
12. unmerge a merged property, check ubid history for each property


#### What are the relevant tickets?

#### Screenshots (if appropriate)
