### PR TITLE
Handle null values in related columns

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -1101,7 +1101,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
         for (let j = 0; j < related.length; ++j) {
           // eslint-disable-next-line no-loop-func
           const updated = Object.entries(related[j]).reduce((result, [key, value]) => {
-            if (columnNamesToAggregate.includes(key)) aggregations[key] = (aggregations[key] ?? []).concat(value.split('; '));
+            if (columnNamesToAggregate.includes(key)) aggregations[key] = (aggregations[key] ?? []).concat(String(value ?? '').split('; '));
             result[key] = value;
             return result;
           }, {});


### PR DESCRIPTION
#### What's this PR do?
Related values could be null, when we were expecting strings. This change fixes that issue

#### How should this be manually tested?
1. Create a new database
2. Import `covered-buildings-sample.csv` with taxlot and property mappings
3. Check that the inventory list loads

#### What are the relevant tickets?
#4624 
