### PR TITLE
ensure is_ali_root is populated on redirects

### DIFF
--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -90,6 +90,9 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
     };
     $scope.organization = organization_payload.organization;
 
+    // $scope.menu.user.is_ali_root not always populated (on redirects); force it
+    $scope.menu.user.is_ali_root = window.BE.is_ali_root
+
     // set up i18n
     //
     // let angular-translate be in charge ... need

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -91,7 +91,7 @@ angular.module('BE.seed.controller.inventory_list', []).controller('inventory_li
     $scope.organization = organization_payload.organization;
 
     // $scope.menu.user.is_ali_root not always populated (on redirects); force it
-    $scope.menu.user.is_ali_root = window.BE.is_ali_root
+    $scope.menu.user.is_ali_root = window.BE.is_ali_root;
 
     // set up i18n
     //


### PR DESCRIPTION
Sometimes some of the items are not shown in the Actions dropdown on the inventory list (the one I notice is "Only Show Populated Columns").  Refreshing the page fixes the issue, but this is annoying.
I tracked the issue down to menu.user.is_ali_root not always being populated on some redirect issues.

To test:
- go to inventory list page
-  ensure you see 'only show populated columns' from actions dropdown
- switch the org to a different org in the top right of the page. the page will refresh
- open up the actions dropdown and ensure AGAIN that 'only show populated columns' is still there
