### PR TITLE
Add button to match and merge cycle properties

### DIFF
--- a/seed/static/seed/partials/match_merge_modal.html
+++ b/seed/static/seed/partials/match_merge_modal.html
@@ -1,0 +1,36 @@
+<div class="modal-header">
+  <h3 class="modal-title" translate>Match and Merge Inventory</h3>
+</div>
+<div class="modal-body">
+  <div>
+    Select a cycle to re-trigger matching and merging with <strong>ubid threshold: {$ org.ubid_threshold $}</strong>. This process will match and merge all records within the selected cycle based on
+    the matching criteria. This process may take several minutes.
+  </div>
+  <ul style="margin-top: 20px">
+    <li>Property UBID Mathcing Criteria: <strong>{$ property_ubid_matching $}</strong></li>
+    <li>TaxLot UBID Matching Criteria: <strong>{$ taxlot_ubid_matching $}</strong></li>
+  </ul>
+
+  <div class="form-group cycle-select-container" ng-show="!uploader.in_progress">
+    <label for="cycle-select">Select Cycle</label>
+    <select
+      id="cycle-select"
+      class="form-control"
+      ng-model="selected_cycle"
+      ng-options="cycle.name for cycle in cycles"
+      ng-change="cycle_change()"
+      placeholder="{$:: 'Cycle Name' | translate $}"
+    ></select>
+  </div>
+  <div ng-show="uploader.in_progress" style="margin: 20px 0">Selected Cycle: <strong>{$ selected_cycle.name $}</strong></div>
+
+  <div class="progress_bar_container" ng-if="uploader.in_progress">
+    <div class="progress_bar_copy_top">Progress:</div>
+    <uib-progressbar class="progress-striped active" value="uploader.progress" type="success"></uib-progressbar>
+    <div class="progress_bar_copy_bottom">{$ uploader.progress | number:0 $}% {$:: 'Complete' | translate $} {$ uploader.status_message ? ': ' + uploader.status_message : '' $}</div>
+  </div>
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-primary" ng-click="close()" autofocus ng-disabled="uploader.in_progress" translate>Close</button>
+  <button type="button" class="btn btn-warning" ng-click="trigger_match_merge()" ng-disabled="uploader.in_progress" translate>Match and Merge</button>
+</div>


### PR DESCRIPTION
#### Any background context you want to provide?
With the introduction of UBID thresholds as an organization setting, there should be an option to trigger matching and merging following a UBID threshold change.

#### What's this PR do?
- adds button to trigger matching and merging using existing functionality from /data_importer/match.py
- adds modal to track progress
 
#### How should this be manually tested?
- make UBID threshold strict (1.0)
- upload a file that has properties with matching PM property IDs, and overlapping (not identical) UBIDs. 
- make UBID threshold loose (0.1)
- click Trigger Matching and Merging
- Properties with overlapping UBIDs should have been merged (assuming jaccard index was greater than UBID threshold)

#### What are the relevant tickets?
#4615

#### Screenshots (if appropriate)
![Screenshot 2024-05-06 at 9 39 08 AM](https://github.com/SEED-platform/seed/assets/58446472/216d07ae-e188-463a-a718-86f4b72bfd6c)
![Screenshot 2024-05-06 at 10 37 56 AM](https://github.com/SEED-platform/seed/assets/58446472/7ab61b16-a3a7-4b25-b44b-87188545290f)






