### PR TITLE
Set default portfolio summary cell type

### DIFF
--- a/seed/static/seed/js/controllers/portfolio_summary_controller.js
+++ b/seed/static/seed/js/controllers/portfolio_summary_controller.js
@@ -509,6 +509,7 @@ angular.module('BE.seed.controller.portfolio_summary', [])
         const default_baseline = { headerCellClass: 'portfolio-summary-baseline-header', cellClass: 'portfolio-summary-baseline-cell' };
         const default_current = { headerCellClass: 'portfolio-summary-current-header', cellClass: 'portfolio-summary-current-cell' };
         const default_styles = { headerCellFilter: 'translate', minWidth: 75, width: 150 };
+        const default_no_edit = { enableCellEdit: false }
 
         const baseline_cols = [
           { field: 'baseline_cycle', displayName: 'Cycle' },
@@ -631,7 +632,9 @@ angular.module('BE.seed.controller.portfolio_summary', [])
 
         apply_defaults(baseline_cols, default_baseline);
         apply_defaults(current_cols, default_current);
-        cols = [...cols, ...baseline_cols, ...current_cols, ...summary_cols, ...goal_note_cols];
+        cols = [...cols, ...baseline_cols, ...current_cols, ...summary_cols];
+        apply_defaults(cols, default_no_edit)
+        cols = [...cols, ...goal_note_cols]
 
         // Apply filters
         // from inventory_list_controller

--- a/seed/static/seed/js/controllers/portfolio_summary_controller.js
+++ b/seed/static/seed/js/controllers/portfolio_summary_controller.js
@@ -509,7 +509,7 @@ angular.module('BE.seed.controller.portfolio_summary', [])
         const default_baseline = { headerCellClass: 'portfolio-summary-baseline-header', cellClass: 'portfolio-summary-baseline-cell' };
         const default_current = { headerCellClass: 'portfolio-summary-current-header', cellClass: 'portfolio-summary-current-cell' };
         const default_styles = { headerCellFilter: 'translate', minWidth: 75, width: 150 };
-        const default_no_edit = { enableCellEdit: false }
+        const default_no_edit = { enableCellEdit: false };
 
         const baseline_cols = [
           { field: 'baseline_cycle', displayName: 'Cycle' },
@@ -633,8 +633,8 @@ angular.module('BE.seed.controller.portfolio_summary', [])
         apply_defaults(baseline_cols, default_baseline);
         apply_defaults(current_cols, default_current);
         cols = [...cols, ...baseline_cols, ...current_cols, ...summary_cols];
-        apply_defaults(cols, default_no_edit)
-        cols = [...cols, ...goal_note_cols]
+        apply_defaults(cols, default_no_edit);
+        cols = [...cols, ...goal_note_cols];
 
         // Apply filters
         // from inventory_list_controller


### PR DESCRIPTION
#### Any background context you want to provide?
All cells appeared editable. It's only a UI issue as there was no backend logic to make changes permanent

#### What's this PR do?
Sets the default cell style to non-editable

#### How should this be manually tested?
- go to portfolio summary
- double-click a non-goal_note cell in the bottom table
- cell should not appear editable
- goal notes should still be editable

#### What are the relevant tickets?

#### Screenshots (if appropriate)
![Screenshot 2024-05-28 at 9 03 06 AM](https://github.com/SEED-platform/seed/assets/58446472/adfa0dea-e559-482d-8a69-2114dc3fd91b)
