### PR TITLE
Add parallelization to import tasks

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,8 +21,10 @@ django-extensions==3.1.3
 django-model-utils==4.3.1
 
 # Time zones support - Do not update these without doing significant testing!
-pytz==2018.7
-python-dateutil==2.7.3
+# pytz==2018.7
+# python-dateutil==2.7.3
+pytz==2024.1
+python-dateutil==2.9.0.post0
 
 # Metric/imperial units support
 django-pint==0.6
@@ -66,7 +68,9 @@ seed-salesforce==0.1.0
 # geospatial and pnnl/buildingid-py
 shapely==2.0.1
 usaddress==0.5.10
--e git+https://github.com/SEED-platform/buildingid.git@603300c8a7212b339b7e8cb7a4365be6726195aa#egg=pnnl-buildingid
+# -e git+https://github.com/SEED-platform/buildingid.git@603300c8a7212b339b7e8cb7a4365be6726195aa#egg=pnnl-buildingid
+-e git+https://github.com/SEED-platform/buildingid.git@8d59ec016921d47e998a78339a8195913ee36bee#egg=pnnl-buildingid
+
 
 oauthlib==2.0.3
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,10 +21,8 @@ django-extensions==3.1.3
 django-model-utils==4.3.1
 
 # Time zones support - Do not update these without doing significant testing!
-# pytz==2018.7
-# python-dateutil==2.7.3
-pytz==2024.1
-python-dateutil==2.9.0.post0
+pytz==2018.7
+python-dateutil==2.7.3
 
 # Metric/imperial units support
 django-pint==0.6
@@ -68,8 +66,7 @@ seed-salesforce==0.1.0
 # geospatial and pnnl/buildingid-py
 shapely==2.0.1
 usaddress==0.5.10
-# -e git+https://github.com/SEED-platform/buildingid.git@603300c8a7212b339b7e8cb7a4365be6726195aa#egg=pnnl-buildingid
--e git+https://github.com/SEED-platform/buildingid.git@8d59ec016921d47e998a78339a8195913ee36bee#egg=pnnl-buildingid
+-e git+https://github.com/SEED-platform/buildingid.git@603300c8a7212b339b7e8cb7a4365be6726195aa#egg=pnnl-buildingid
 
 
 oauthlib==2.0.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,8 +21,10 @@ django-extensions==3.1.3
 django-model-utils==4.3.1
 
 # Time zones support - Do not update these without doing significant testing!
-pytz==2018.7
-python-dateutil==2.7.3
+# pytz==2018.7
+# python-dateutil==2.7.3
+pytz==2024.1
+python-dateutil==2.9.0.post0
 
 # Metric/imperial units support
 django-pint==0.6
@@ -66,8 +68,8 @@ seed-salesforce==0.1.0
 # geospatial and pnnl/buildingid-py
 shapely==2.0.1
 usaddress==0.5.10
--e git+https://github.com/SEED-platform/buildingid.git@603300c8a7212b339b7e8cb7a4365be6726195aa#egg=pnnl-buildingid
-
+-e git+https://github.com/SEED-platform/buildingid.git@8d59ec016921d47e998a78339a8195913ee36bee#egg=pnnl-buildingid
+# -e git+https://github.com/SEED-platform/buildingid.git@603300c8a7212b339b7e8cb7a4365be6726195aa#egg=pnnl-buildingid
 
 oauthlib==2.0.3
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,10 +21,8 @@ django-extensions==3.1.3
 django-model-utils==4.3.1
 
 # Time zones support - Do not update these without doing significant testing!
-# pytz==2018.7
-# python-dateutil==2.7.3
-pytz==2024.1
-python-dateutil==2.9.0.post0
+pytz==2018.7
+python-dateutil==2.7.3
 
 # Metric/imperial units support
 django-pint==0.6
@@ -68,8 +66,7 @@ seed-salesforce==0.1.0
 # geospatial and pnnl/buildingid-py
 shapely==2.0.1
 usaddress==0.5.10
--e git+https://github.com/SEED-platform/buildingid.git@8d59ec016921d47e998a78339a8195913ee36bee#egg=pnnl-buildingid
-# -e git+https://github.com/SEED-platform/buildingid.git@603300c8a7212b339b7e8cb7a4365be6726195aa#egg=pnnl-buildingid
+-e git+https://github.com/SEED-platform/buildingid.git@603300c8a7212b339b7e8cb7a4365be6726195aa#egg=pnnl-buildingid
 
 oauthlib==2.0.3
 

--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -61,6 +61,7 @@ def log_debug(message):
 def match_and_link_incoming_properties_and_taxlots(file_pk, progress_key, sub_progress_key, property_state_ids_by_cycle=None):
     """
     Utilizes the helper function match_and_link_incoming_properties_and_taxlots_by_cycle
+    Uses parallel celery tasks to run `match_and_link_incoming_properties_and_taxlots_by_cycle`
 
     :param file_pk: ImportFile Primary Key
     :param property_state_ids_by_cycle: A dictionary that with cycle ids as the keys
@@ -120,8 +121,8 @@ def aggregate_results(result_list, import_file_id, progress_key):
     import_file = ImportFile.objects.get(pk=import_file_id)
     import_file.matching_done = True
     import_file.mapping_completion = 100
-    import_file.matching_results_data = result
-    result["import_file_records"] = import_file.num_rows
+    import_file.matching_results_data = results
+    results["import_file_records"] = import_file.num_rows
     import_file.save()
 
     return progress_data.finish_with_success()
@@ -152,7 +153,6 @@ def match_and_link_incoming_properties_and_taxlots_by_cycle(
     :param cycle: cycle object
     :return results: dict
     """
-
     from seed.data_importer.tasks import pair_new_states
 
     import_file = ImportFile.objects.get(pk=file_pk)

--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -3,11 +3,11 @@
 SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and other contributors.
 See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 """
-
 import datetime as dt
+import logging
 import math
 
-from celery import shared_task
+from celery import shared_task, chain, chord
 from celery.utils.log import get_task_logger
 from django.contrib.postgres.aggregates.general import ArrayAgg
 from django.db import IntegrityError, transaction
@@ -36,6 +36,7 @@ from seed.models import (
 )
 from seed.models.auditlog import AUDIT_IMPORT
 from seed.utils.match import (
+    chunk_inventory_pairs,
     MultipleALIError,
     NoAccessError,
     NoViewsError,
@@ -74,39 +75,120 @@ def match_and_link_incoming_properties_and_taxlots(file_pk, progress_key, sub_pr
         # Get lists and counts of all the properties and tax lots based on the import file.
         incoming_properties = import_file.find_unmatched_property_states()
         incoming_tax_lots = import_file.find_unmatched_tax_lot_states()
+        property_ids = incoming_properties.values_list("id", flat=True)
+        tax_lot_ids = incoming_tax_lots.values_list("id", flat=True)
+
         cycle = import_file.cycle
+        inventory_chunk_pairs = chunk_inventory_pairs(property_ids, tax_lot_ids)
 
-        results = match_and_link_incoming_properties_and_taxlots_by_cycle(
-            file_pk, progress_key, sub_progress_key, incoming_properties, incoming_tax_lots, cycle
-        )
 
-    else:
-        results_list = []
-        for cycle_id, property_state_ids in property_state_ids_by_cycle.items():
-            # Get lists and counts of all the properties and tax lots based on the import file.
-            incoming_properties = PropertyState.objects.filter(pk__in=property_state_ids, organization=org)
-            incoming_tax_lots = import_file.find_unmatched_tax_lot_states()
+        tasks = [
+            match_and_link_incoming_properties_and_taxlots_by_cycle.s(file_pk, progress_key, sub_progress_key, p_chunk, t_chunk, cycle.id)
+            for p_chunk, t_chunk in inventory_chunk_pairs
+        ]
+        
+        results = chord(tasks)(aggregate_results.s(file_pk, progress_key))
 
-            cycle = Cycle.objects.get(id=cycle_id)
-            results_list.append(
-                match_and_link_incoming_properties_and_taxlots_by_cycle(
-                    file_pk, progress_key, sub_progress_key, incoming_properties, incoming_tax_lots, cycle
-                )
-            )
+    return results.id
 
-        # combine array of dictionaries in results_list into results
-        results = {}
-        for dict in results_list:
-            for key, value in dict.items():
-                results[key] = results.get(key, 0) + value
+@shared_task
+def aggregate_results(result_list, import_file_id, progress_key):
+    results = {}
+    for result in result_list:
+        for key, value in result.items():
+            results[key] = results.get(key, 0) + value
 
-    results["import_file_records"] = import_file.num_rows
+    # progress_data = ProgressData.from_key(progress_key)
+
+    # import_file = ImportFile.objects.get(pk=import_file_id)
+    # import_file.matching_done = True
+    # import_file.mapping_completion = 100
+    # import_file.matching_results_data = result
+    # result["import_file_records"] = import_file.num_rows
+    # import_file.save()
+    # logging.error(">>> Aggregate results")
+
+    # return progress_data.finish_with_success()
+
 
     return results
 
+    # THIS GOES IN match_and_link_incoming_properties_and_taxlots
+    # else:
+    #     results_list = []
+    #     for cycle_id, property_state_ids in property_state_ids_by_cycle.items():
+    #         # Get lists and counts of all the properties and tax lots based on the import file.
+    #         incoming_properties = PropertyState.objects.filter(pk__in=property_state_ids, organization=org)
+    #         incoming_tax_lots = import_file.find_unmatched_tax_lot_states()
 
+    #         cycle = Cycle.objects.get(id=cycle_id)
+    #         results_list.append(
+    #             match_and_link_incoming_properties_and_taxlots_by_cycle(
+    #                 file_pk, progress_key, sub_progress_key, incoming_properties, incoming_tax_lots, cycle
+    #             )
+    #         )
+
+    #     # combine array of dictionaries in results_list into results
+    #     results = {}
+    #     for dict in results_list:
+    #         for key, value in dict.items():
+    #             results[key] = results.get(key, 0) + value
+    #
+    # results["import_file_records"] = import_file.num_rows
+
+
+# @shared_task
+# @lock_and_track
+# def match_and_link_incoming_properties_and_taxlots(file_pk, progress_key, sub_progress_key, property_state_ids_by_cycle=None):
+#     """
+#     Utilizes the helper function match_and_link_incoming_properties_and_taxlots_by_cycle
+
+#     :param file_pk: ImportFile Primary Key
+#     :param property_state_ids_by_cycle: A dictionary that with cycle ids as the keys
+#     and an array of associated property states as the values
+#     :return results: dict
+#     """
+
+#     import_file = ImportFile.objects.get(pk=file_pk)
+#     org = import_file.import_record.super_organization
+
+#     if property_state_ids_by_cycle is None:
+#         # Get lists and counts of all the properties and tax lots based on the import file.
+#         incoming_properties = import_file.find_unmatched_property_states()
+#         incoming_tax_lots = import_file.find_unmatched_tax_lot_states()
+#         cycle = import_file.cycle
+
+#         results = match_and_link_incoming_properties_and_taxlots_by_cycle(
+#             file_pk, progress_key, sub_progress_key, incoming_properties, incoming_tax_lots, cycle
+#         )
+
+#     else:
+#         results_list = []
+#         for cycle_id, property_state_ids in property_state_ids_by_cycle.items():
+#             # Get lists and counts of all the properties and tax lots based on the import file.
+#             incoming_properties = PropertyState.objects.filter(pk__in=property_state_ids, organization=org)
+#             incoming_tax_lots = import_file.find_unmatched_tax_lot_states()
+
+#             cycle = Cycle.objects.get(id=cycle_id)
+#             results_list.append(
+#                 match_and_link_incoming_properties_and_taxlots_by_cycle(
+#                     file_pk, progress_key, sub_progress_key, incoming_properties, incoming_tax_lots, cycle
+#                 )
+#             )
+
+#         # combine array of dictionaries in results_list into results
+#         results = {}
+#         for dict in results_list:
+#             for key, value in dict.items():
+#                 results[key] = results.get(key, 0) + value
+
+#     results["import_file_records"] = import_file.num_rows
+
+#     return results
+
+@shared_task
 def match_and_link_incoming_properties_and_taxlots_by_cycle(
-    file_pk, progress_key, sub_progress_key, incoming_properties, incoming_tax_lots, cycle
+    file_pk, progress_key, sub_progress_key, incoming_properties_ids, incoming_tax_lots_ids, cycle_id
 ):
     """
     Match incoming the properties and taxlots. Then, search for links for them.
@@ -129,6 +211,8 @@ def match_and_link_incoming_properties_and_taxlots_by_cycle(
     :param cycle: cycle object
     :return results: dict
     """
+    
+    logging.error('>>> match_and_link_incoming_properties_and_taxlots_by_cycle')
     from seed.data_importer.tasks import pair_new_states
 
     import_file = ImportFile.objects.get(pk=file_pk)
@@ -137,6 +221,9 @@ def match_and_link_incoming_properties_and_taxlots_by_cycle(
 
     # Don't query the org table here, just get the organization from the import_record
     org = import_file.import_record.super_organization
+    cycle = Cycle.objects.get(id=cycle_id)
+    incoming_properties = PropertyState.objects.filter(id__in=incoming_properties_ids)
+    incoming_tax_lots = PropertyState.objects.filter(id__in=incoming_tax_lots_ids)
 
     # Set the progress to started - 33%
     progress_data.step("Matching data")

--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -166,9 +166,6 @@ def match_and_link_incoming_properties_and_taxlots_by_cycle(
     incoming_properties = PropertyState.objects.filter(id__in=incoming_properties_ids)
     incoming_tax_lots = PropertyState.objects.filter(id__in=incoming_tax_lots_ids)
 
-    # Set the progress to started - 33%
-    # progress_data.step("Matching data")
-
     # Set defaults
     # property - within file
     property_initial_incoming_count = 0
@@ -340,7 +337,6 @@ def match_and_link_incoming_properties_and_taxlots_by_cycle(
         errored_linked_taxlot_views.delete()
 
     log_debug("Start pair_new_states")
-    # progress_data.step("Pairing data")
     pair_new_states(
         linked_property_views + new_property_views + merged_property_views,
         linked_taxlot_views + new_taxlot_views + merged_taxlot_views,

--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -164,7 +164,7 @@ def match_and_link_incoming_properties_and_taxlots_by_cycle(
     org = import_file.import_record.super_organization
     cycle = Cycle.objects.get(id=cycle_id)
     incoming_properties = PropertyState.objects.filter(id__in=incoming_properties_ids)
-    incoming_tax_lots = PropertyState.objects.filter(id__in=incoming_tax_lots_ids)
+    incoming_tax_lots = TaxLotState.objects.filter(id__in=incoming_tax_lots_ids)
 
     # Set defaults
     # property - within file

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1613,6 +1613,7 @@ def geocode_and_match_buildings_task(file_pk):
         1  # geocoding
         + len(map_additional_models_group)  # map additional models tasks
         + celery_worker_count  # match and link
+        + 1
     )
     progress_data.save()
 

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1624,7 +1624,7 @@ def geocode_and_match_buildings_task(file_pk):
         _geocode_properties_or_tax_lots.si(file_pk, progress_data.key),
         map_additional_models_group,
         match_and_link_incoming_properties_and_taxlots.si(file_pk, progress_data.key, sub_progress_data.key, property_state_ids_by_cycle),
-        finish_matching.s(file_pk, progress_data.key),
+        # finish_matching.s(file_pk, progress_data.key),
     )()
 
     sub_progress_data.total = 100
@@ -1668,17 +1668,25 @@ def _geocode_properties_or_tax_lots(file_pk, progress_key, sub_progress_key=None
         sub_progress_data.finish_with_success()
 
 
-@shared_task(ignore_result=True)
-def finish_matching(result, import_file_id, progress_key):
-    progress_data = ProgressData.from_key(progress_key)
+# @shared_task(ignore_result=True)
+# def finish_matching(result, import_file_id, progress_key):
+#     from celery.result import AsyncResult
+#     async_result = AsyncResult(result)
+#     if async_result.ready():
+#         import remote_pdb; remote_pdb.set_trace()
+#         result = async_result.result 
+        
+#     else:
+#         logging.error(">>> task still running")
+#     progress_data = ProgressData.from_key(progress_key)
 
-    import_file = ImportFile.objects.get(pk=import_file_id)
-    import_file.matching_done = True
-    import_file.mapping_completion = 100
-    import_file.matching_results_data = result
-    import_file.save()
+#     import_file = ImportFile.objects.get(pk=import_file_id)
+#     import_file.matching_done = True
+#     import_file.mapping_completion = 100
+#     import_file.matching_results_data = result
+#     import_file.save()
 
-    return progress_data.finish_with_success()
+#     return progress_data.finish_with_success()
 
 
 def hash_state_object(obj, include_extra_data=True):

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -4,7 +4,6 @@ SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and othe
 See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 """
 
-import celery
 import collections
 import copy
 import hashlib
@@ -86,6 +85,7 @@ from seed.models import (
 from seed.models.auditlog import AUDIT_IMPORT
 from seed.models.data_quality import DataQualityCheck, Rule
 from seed.utils.buildings import get_source_type
+from seed.utils.celery import get_celery_worker_count
 from seed.utils.geocode import MapQuestAPIKeyError, create_geocoded_additional_columns, geocode_buildings
 from seed.utils.match import update_sub_progress_total
 from seed.utils.ubid import decode_unique_ids
@@ -1631,22 +1631,6 @@ def geocode_and_match_buildings_task(file_pk):
     sub_progress_data.save()
 
     return {"progress_data": progress_data.result(), "sub_progress_data": sub_progress_data.result()}
-
-def get_celery_worker_count():
-    app = celery.Celery("seed")
-    app.config_from_object("django.conf:settings", namespace="CELERY")
-    inspector = app.control.inspect()
-    stats = inspector.stats()
-    if not stats:
-        return 1
-
-    total_workers = 0
-    for worker, info in stats.items():
-        total_workers += info["pool"]["max-concurrency"]
-
-    return total_workers
-
-
 
 
 @shared_task

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1608,11 +1608,10 @@ def geocode_and_match_buildings_task(file_pk):
         id_chunks = [[obj.id for obj in chunk] for chunk in batch(property_states, 100)]
         map_additional_models_group = group(_map_additional_models.si(id_chunk, file_pk, progress_data.key) for id_chunk in id_chunks)
 
-    celery_worker_count = get_celery_worker_count()
     progress_data.total = (
         1  # geocoding
         + len(map_additional_models_group)  # map additional models tasks
-        + celery_worker_count  # match and link
+        + get_celery_worker_count()  # match and link
     )
     progress_data.save()
 

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1608,10 +1608,11 @@ def geocode_and_match_buildings_task(file_pk):
         id_chunks = [[obj.id for obj in chunk] for chunk in batch(property_states, 100)]
         map_additional_models_group = group(_map_additional_models.si(id_chunk, file_pk, progress_data.key) for id_chunk in id_chunks)
 
+    celery_worker_count = get_celery_worker_count()
     progress_data.total = (
         1  # geocoding
         + len(map_additional_models_group)  # map additional models tasks
-        + get_celery_worker_count()  # match and link
+        + celery_worker_count  # match and link
     )
     progress_data.save()
 

--- a/seed/data_importer/tests/test_ah_import.py
+++ b/seed/data_importer/tests/test_ah_import.py
@@ -66,6 +66,10 @@ class TestAHImportFile(DataMappingBaseTestCase):
             "tax_lot_new_errored": 0,
         }
 
+    def get_results(self):
+        self.import_file.refresh_from_db()
+        return self.import_file.matching_results_data
+
 
 class TestAHImport(TestAHImportFile):
     def test_hierarchy_set(self):
@@ -74,7 +78,8 @@ class TestAHImport(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -92,7 +97,8 @@ class TestAHImport(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -123,7 +129,8 @@ class TestAHImportDuplicateIncoming(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 2
@@ -146,7 +153,8 @@ class TestAHImportDuplicateIncoming(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 2
@@ -167,7 +175,8 @@ class TestAHImportDuplicateIncoming(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 2
@@ -189,7 +198,8 @@ class TestAHImportDuplicateIncoming(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 2
@@ -213,7 +223,8 @@ class TestAHImportDuplicateIncoming(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 2
@@ -235,7 +246,8 @@ class TestAHImportDuplicateIncoming(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 2
@@ -266,7 +278,8 @@ class TestAHImportMatchIncoming(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 2
@@ -290,7 +303,8 @@ class TestAHImportMatchIncoming(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 2
@@ -312,7 +326,8 @@ class TestAHImportMatchIncoming(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 2
@@ -335,7 +350,8 @@ class TestAHImportMatchIncoming(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 2
@@ -360,7 +376,8 @@ class TestAHImportMatchIncoming(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 2
@@ -383,7 +400,8 @@ class TestAHImportMatchIncoming(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 2
@@ -415,7 +433,8 @@ class TestAHImportDuplicateExisting(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -435,7 +454,8 @@ class TestAHImportDuplicateExisting(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -458,7 +478,8 @@ class TestAHImportDuplicateExisting(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -483,7 +504,8 @@ class TestAHImportDuplicateExisting(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -508,7 +530,8 @@ class TestAHImportDuplicateExisting(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -549,7 +572,8 @@ class TestAHImportMatchExisting(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -577,7 +601,8 @@ class TestAHImportMatchExisting(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -608,7 +633,8 @@ class TestAHImportMatchExisting(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -634,7 +660,8 @@ class TestAHImportMatchExisting(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -665,7 +692,8 @@ class TestAHImportMatchExisting(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -712,7 +740,8 @@ class TestAHImportMatchExistingDifferentCycle(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -755,7 +784,8 @@ class TestAHImportMatchExistingDifferentCycle(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -796,7 +826,8 @@ class TestAHImportMatchExistingDifferentCycle(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -836,7 +867,8 @@ class TestAHImportMatchExistingDifferentCycle(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -866,7 +898,8 @@ class TestAHImportMatchExistingDifferentCycle(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1
@@ -909,7 +942,8 @@ class TestAHImportMatchExistingDifferentCycle(TestAHImportFile):
         self.property_state_factory.get_property_state(**self.base_details)
 
         # Action
-        results = match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        match_and_link_incoming_properties_and_taxlots(*self.action_args)
+        results = self.get_results()
 
         # Assert - results
         self.blank_result["property_initial_incoming"] = 1

--- a/seed/data_importer/tests/test_match_incoming.py
+++ b/seed/data_importer/tests/test_match_incoming.py
@@ -839,7 +839,6 @@ class TestMatchingImportIntegration(DataMappingBaseTestCase):
 
         rimport_file_2 = ImportFile.objects.get(pk=self.import_file_2.id)
         results = rimport_file_2.matching_results_data
-        del results["progress_key"]
 
         expected = {
             "import_file_records": None,  # This is calculated in a separate process
@@ -986,7 +985,6 @@ class TestMatchingImportIntegration(DataMappingBaseTestCase):
 
         rimport_file_2 = ImportFile.objects.get(pk=self.import_file_2.id)
         results = rimport_file_2.matching_results_data
-        del results["progress_key"]
 
         expected = {
             "import_file_records": None,  # This is calculated in a separate process

--- a/seed/lib/progress_data/progress_data.py
+++ b/seed/lib/progress_data/progress_data.py
@@ -99,7 +99,6 @@ class ProgressData:
     @classmethod
     def from_key(cls, key):
         data = get_cache(key)
-        # logging.error('>>> data progress_key %s', data)
         if "func_name" in data and "unique_id" in data:
             return cls(func_name=data["func_name"], unique_id=data["unique_id"], init_data=data)
         elif data.get("status") == "parsing":

--- a/seed/lib/progress_data/progress_data.py
+++ b/seed/lib/progress_data/progress_data.py
@@ -99,8 +99,11 @@ class ProgressData:
     @classmethod
     def from_key(cls, key):
         data = get_cache(key)
+        # logging.error('>>> data progress_key %s', data)
         if "func_name" in data and "unique_id" in data:
             return cls(func_name=data["func_name"], unique_id=data["unique_id"], init_data=data)
+        elif data.get("status") == "parsing":
+            return cls(func_name=data["status"], unique_id=data["status"])
         else:
             raise Exception(f"Could not find key {key} in cache")
 

--- a/seed/utils/celery.py
+++ b/seed/utils/celery.py
@@ -1,0 +1,20 @@
+"""
+SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and other contributors.
+See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
+"""
+
+import celery 
+
+def get_celery_worker_count():
+    app = celery.Celery("seed")
+    app.config_from_object("django.conf:settings", namespace="CELERY")
+    inspector = app.control.inspect()
+    stats = inspector.stats()
+    if not stats:
+        return 1
+
+    total_workers = 0
+    for worker, info in stats.items():
+        total_workers += info["pool"]["max-concurrency"]
+
+    return total_workers

--- a/seed/utils/celery.py
+++ b/seed/utils/celery.py
@@ -2,7 +2,9 @@
 SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and other contributors.
 See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 """
+
 import logging
+
 import celery
 
 
@@ -11,7 +13,7 @@ def get_celery_worker_count():
         app = celery.Celery("seed")
         app.config_from_object("django.conf:settings", namespace="CELERY")
         inspector = app.control.inspect()
-        stats = inspector.stats()        
+        stats = inspector.stats()
         if not stats:
             return 1
         total_workers = sum(info["pool"]["max-concurrency"] for worker, info in stats.items())

--- a/seed/utils/celery.py
+++ b/seed/utils/celery.py
@@ -9,16 +9,15 @@ import celery
 
 
 def get_celery_worker_count():
+    total_workers = 1
     try:
         app = celery.Celery("seed")
         app.config_from_object("django.conf:settings", namespace="CELERY")
         inspector = app.control.inspect()
         stats = inspector.stats()
-        if not stats:
-            return 1
-        total_workers = sum(info["pool"]["max-concurrency"] for worker, info in stats.items())
+        if stats:
+            total_workers = sum(info["pool"]["max-concurrency"] for worker, info in stats.items()) or 1
     except Exception as e:
         logging.warning(f"An error occured while fetching celery stats: {e}")
-        return 1
 
     return total_workers

--- a/seed/utils/celery.py
+++ b/seed/utils/celery.py
@@ -2,20 +2,21 @@
 SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and other contributors.
 See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 """
-
+import logging
 import celery
 
 
 def get_celery_worker_count():
-    app = celery.Celery("seed")
-    app.config_from_object("django.conf:settings", namespace="CELERY")
-    inspector = app.control.inspect()
-    stats = inspector.stats()
-    if not stats:
+    try:
+        app = celery.Celery("seed")
+        app.config_from_object("django.conf:settings", namespace="CELERY")
+        inspector = app.control.inspect()
+        stats = inspector.stats()        
+        if not stats:
+            return 1
+        total_workers = sum(info["pool"]["max-concurrency"] for worker, info in stats.items())
+    except Exception as e:
+        logging.warning(f"An error occured while fetching celery stats: {e}")
         return 1
-
-    total_workers = 0
-    for worker, info in stats.items():
-        total_workers += info["pool"]["max-concurrency"]
 
     return total_workers

--- a/seed/utils/celery.py
+++ b/seed/utils/celery.py
@@ -3,7 +3,8 @@ SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and othe
 See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 """
 
-import celery 
+import celery
+
 
 def get_celery_worker_count():
     app = celery.Celery("seed")

--- a/seed/utils/match.py
+++ b/seed/utils/match.py
@@ -4,6 +4,7 @@ SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and othe
 See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 """
 
+import math
 from typing import Literal
 
 from celery import shared_task
@@ -488,7 +489,8 @@ def chunk_inventory_pairs(properties, taxlots):
     Returns a list of chunk pairs
     return [[p_chunk0, t_chunk0], [p_chunk1, t_chunk1], ...]
     """
-    chunk_size = 5
+    chunk_size = math.ceil(max(len(properties), len(taxlots)) / 5)
+                           
     p_chunks = [properties[i:i + chunk_size] for i in range(0, len(properties), chunk_size)]
     t_chunks = [taxlots[i:i + chunk_size] for i in range(0, len(taxlots), chunk_size)]
     return zip_longest(p_chunks, t_chunks, fillvalue=[])

--- a/seed/utils/match.py
+++ b/seed/utils/match.py
@@ -5,6 +5,7 @@ See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 """
 
 import math
+from itertools import zip_longest
 from typing import Literal
 
 from celery import shared_task
@@ -12,7 +13,6 @@ from django.contrib.postgres.aggregates.general import ArrayAgg
 from django.db import transaction
 from django.db.models import Subquery
 from django.db.models.aggregates import Count
-from itertools import zip_longest
 
 from seed.lib.progress_data.progress_data import ProgressData
 from seed.lib.superperms.orgs.models import AccessLevelInstance
@@ -484,13 +484,14 @@ def update_sub_progress_total(total, sub_progress_key=None, finish=False):
         sub_progress_data.save()
         return sub_progress_data
 
+
 def chunk_inventory_pairs(properties, taxlots):
     """
     Returns a list of chunk pairs
     return [[p_chunk0, t_chunk0], [p_chunk1, t_chunk1], ...]
     """
     chunk_size = math.ceil(max(len(properties), len(taxlots)) / 5)
-                           
-    p_chunks = [properties[i:i + chunk_size] for i in range(0, len(properties), chunk_size)]
-    t_chunks = [taxlots[i:i + chunk_size] for i in range(0, len(taxlots), chunk_size)]
+
+    p_chunks = [properties[i : i + chunk_size] for i in range(0, len(properties), chunk_size)]
+    t_chunks = [taxlots[i : i + chunk_size] for i in range(0, len(taxlots), chunk_size)]
     return zip_longest(p_chunks, t_chunks, fillvalue=[])

--- a/seed/utils/match.py
+++ b/seed/utils/match.py
@@ -11,6 +11,7 @@ from django.contrib.postgres.aggregates.general import ArrayAgg
 from django.db import transaction
 from django.db.models import Subquery
 from django.db.models.aggregates import Count
+from itertools import zip_longest
 
 from seed.lib.progress_data.progress_data import ProgressData
 from seed.lib.superperms.orgs.models import AccessLevelInstance
@@ -481,3 +482,13 @@ def update_sub_progress_total(total, sub_progress_key=None, finish=False):
         sub_progress_data.total = total
         sub_progress_data.save()
         return sub_progress_data
+
+def chunk_inventory_pairs(properties, taxlots):
+    """
+    Returns a list of chunk pairs
+    return [[p_chunk0, t_chunk0], [p_chunk1, t_chunk1], ...]
+    """
+    chunk_size = 5
+    p_chunks = [properties[i:i + chunk_size] for i in range(0, len(properties), chunk_size)]
+    t_chunks = [taxlots[i:i + chunk_size] for i in range(0, len(taxlots), chunk_size)]
+    return zip_longest(p_chunks, t_chunks, fillvalue=[])

--- a/seed/utils/match.py
+++ b/seed/utils/match.py
@@ -490,7 +490,7 @@ def chunk_inventory_pairs(properties, taxlots):
     Returns a list of chunk pairs
     return [[p_chunk0, t_chunk0], [p_chunk1, t_chunk1], ...]
     """
-    chunk_size = math.ceil(max(len(properties), len(taxlots)) / 5)
+    chunk_size = math.ceil(max(len(properties), len(taxlots)) / 5) or 1
 
     p_chunks = [properties[i : i + chunk_size] for i in range(0, len(properties), chunk_size)]
     t_chunks = [taxlots[i : i + chunk_size] for i in range(0, len(taxlots), chunk_size)]

--- a/seed/utils/match.py
+++ b/seed/utils/match.py
@@ -17,6 +17,7 @@ from django.db.models.aggregates import Count
 from seed.lib.progress_data.progress_data import ProgressData
 from seed.lib.superperms.orgs.models import AccessLevelInstance
 from seed.models import Column, Cycle, Property, PropertyState, PropertyView, TaxLot, TaxLotState, TaxLotView
+from seed.utils.celery import get_celery_worker_count
 from seed.utils.merge import merge_states_with_views
 from seed.utils.properties import properties_across_cycles
 from seed.utils.taxlots import taxlots_across_cycles
@@ -490,7 +491,8 @@ def chunk_inventory_pairs(properties, taxlots):
     Returns a list of chunk pairs
     return [[p_chunk0, t_chunk0], [p_chunk1, t_chunk1], ...]
     """
-    chunk_size = math.ceil(max(len(properties), len(taxlots)) / 5) or 1
+    celery_worker_count = get_celery_worker_count()
+    chunk_size = math.ceil(max(len(properties), len(taxlots)) / celery_worker_count) or 1
 
     p_chunks = [properties[i : i + chunk_size] for i in range(0, len(properties), chunk_size)]
     t_chunks = [taxlots[i : i + chunk_size] for i in range(0, len(taxlots), chunk_size)]


### PR DESCRIPTION
#### Any background context you want to provide?
To import a file of 500 records with matching fields, but different "notes" took 90 seconds. After improvements, importing took 16 seconds.

#### What's this PR do?
- Moves a db query outside of a loop - saved 25 seconds 
- Chunks incoming data and runs task `match_and_link_incoming_properties_and_taxlots_by_cycle` in parallel chunks, using the number of celery workers to determine the number of parallel tasks. Results are aggregated at the conclusion of all tasks. With 5 tasks, all tasks complete within 16 seconds.

#### How should this be manually tested?
upload files, monitor flower

#### What are the relevant tickets?

#### Screenshots (if appropriate)
![Screenshot 2024-06-12 at 10 52 38 AM](https://github.com/SEED-platform/seed/assets/58446472/8fea7656-2ad2-46ca-969a-c277f28edca8)

