### PR TITLE
Speed up UBID merging

### DIFF
--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -3,7 +3,7 @@
 SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and other contributors.
 See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 """
-
+import logging
 import datetime as dt
 import math
 
@@ -554,8 +554,8 @@ def states_to_views(unmatched_state_ids, org, access_level_instance, cycle, Stat
         ViewClass = TaxLotView
 
     # Identify existing used -States
-    existing_cycle_views = ViewClass.objects.filter(cycle_id=cycle)
-    existing_states = StateClass.objects.filter(pk__in=Subquery(existing_cycle_views.values("state_id")))
+    existing_cycle_state_ids = ViewClass.objects.filter(cycle_id=cycle).values_list("state_id", flat=True)
+    existing_states = StateClass.objects.filter(pk__in=existing_cycle_state_ids)
 
     if merge_duplicates:
         duplicate_states = StateClass.objects.none()
@@ -596,8 +596,8 @@ def states_to_views(unmatched_state_ids, org, access_level_instance, cycle, Stat
             check_jaccard = bool(matching_criteria.get("ubid"))
             ubid = matching_criteria.pop("ubid")
 
-        existing_state_matches = StateClass.objects.filter(
-            pk__in=Subquery(existing_cycle_views.values("state_id")),
+        existing_state_matches = existing_states.filter(
+            pk__in=existing_cycle_state_ids,
             **matching_criteria,
         )
 

--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -603,7 +603,6 @@ def states_to_views(unmatched_state_ids, org, access_level_instance, cycle, Stat
             )
 
         else:
-            # existing_state_matches = StateClass.objects.filter(
             existing_state_matches = existing_states.filter(
                 pk__in=existing_cycle_state_ids,
                 **matching_criteria,

--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -595,18 +595,11 @@ def states_to_views(unmatched_state_ids, org, access_level_instance, cycle, Stat
         if "ubid" in matching_criteria:
             check_jaccard = bool(matching_criteria.get("ubid"))
             ubid = matching_criteria.pop("ubid")
-            region = ubid.split("+")[0]
-            existing_state_matches = existing_states.filter(
-                pk__in=existing_cycle_state_ids,
-                **matching_criteria,
-                ubid__startswith=region,  # only helpful if ubid is the only matching criteria present
-            )
 
-        else:
-            existing_state_matches = existing_states.filter(
-                pk__in=existing_cycle_state_ids,
-                **matching_criteria,
-            )
+        existing_state_matches = existing_states.filter(
+            pk__in=existing_cycle_state_ids,
+            **matching_criteria,
+        )
 
         if check_jaccard:
             existing_state_matches = [

--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -3,7 +3,7 @@
 SEED Platform (TM), Copyright (c) Alliance for Sustainable Energy, LLC, and other contributors.
 See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 """
-import logging
+
 import datetime as dt
 import math
 

--- a/seed/utils/ubid.py
+++ b/seed/utils/ubid.py
@@ -135,7 +135,7 @@ def merge_ubid_models(old_state_ids, new_state_id, StateClass):  # noqa: N803
     """
     from seed.models import UbidModel
 
-    old_states = StateClass.objects.filter(id__in=old_state_ids).order_by("-id").prefetch_related("ubidmodel_set")
+    old_states = StateClass.objects.filter(id__in=old_state_ids).order_by("-id")
     new_state = StateClass.objects.get(id=new_state_id)
     new_ubids_set = set(new_state.ubidmodel_set.values_list("ubid", flat=True))
 
@@ -149,11 +149,12 @@ def merge_ubid_models(old_state_ids, new_state_id, StateClass):  # noqa: N803
     old_ubids_to_promote = old_ubids_set - new_ubids_set
     if not old_ubids_to_promote:
         return
-    
-    preferred_ubid = find_preferred(old_states, new_state)
-    promote_ubids = [UbidModel(**{"ubid": ubid.ubid, state_field: new_state, "preferred": ubid.ubid == preferred_ubid}) for ubid in old_ubids_to_promote]
-    new_state.ubidmodel_set.bulk_create(promote_ubids)
 
+    preferred_ubid = find_preferred(old_states, new_state)
+    promote_ubids = [
+        UbidModel(**{"ubid": ubid.ubid, state_field: new_state, "preferred": ubid.ubid == preferred_ubid}) for ubid in old_ubids_to_promote
+    ]
+    new_state.ubidmodel_set.bulk_create(promote_ubids)
 
     if preferred_ubid:
         state_qs = StateClass.objects.filter(id=new_state.id)


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
- Refactors a query within states_to_views to query against all states within the cycle, while the original queried against all property states regardless of cycle. Depending on the size of the db this could be a very large number of states that \
- Improves ubid merging

Time savings for 2 files with 500 matching records: 
develop: 90s 
this branch: 45s

#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
