### PR TITLE
Lock Numpy

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -66,7 +66,7 @@ seed-salesforce==0.1.0
 # geospatial and pnnl/buildingid-py
 shapely==2.0.1
 usaddress==0.5.10
--e git+https://github.com/SEED-platform/buildingid.git@603300c8a7212b339b7e8cb7a4365be6726195aa#egg=pnnl-buildingid
+-e git+https://github.com/SEED-platform/buildingid.git@892958be07c55eebdbf582f5a81d4b1ce6d61412#egg=pnnl-buildingid
 
 oauthlib==2.0.3
 


### PR DESCRIPTION
#### Any background context you want to provide?
Numpy v2 was released yesterday, and pnnl-buildingid doesn't specify which version, so the CI (and updated local instances) are failing to work with the new major version

#### What's this PR do?
Locks [numpy to `v1.26.4`](https://github.com/SEED-platform/buildingid/commit/892958be07c55eebdbf582f5a81d4b1ce6d61412)

#### How should this be manually tested?
The CI should pass