### PR TITLE
Fix several AH meter issues

### DIFF
--- a/seed/tests/test_meter_views.py
+++ b/seed/tests/test_meter_views.py
@@ -7,12 +7,14 @@ See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 import ast
 import copy
 import json
+from datetime import datetime
 
 from django.urls import reverse
+from django.utils import timezone as tz
 
 from seed.data_importer.utils import kbtu_thermal_conversion_factors as conversion_factors
 from seed.landing.models import SEEDUser as User
-from seed.models import Meter, Property
+from seed.models import Meter, MeterReading, Property
 from seed.models.scenarios import Scenario
 from seed.test_helpers.fake import FakePropertyViewFactory
 from seed.tests.util import AccessLevelBaseTestCase, DeleteModelsTestCase
@@ -64,7 +66,7 @@ class TestMeterCRUD(DeleteModelsTestCase):
 
     def test_create_meter(self):
         property_view = self.property_view_factory.get_property_view()
-        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + "?organization_id=" + str(self.org.id)
+        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + f"?organization_id={self.org.id}"
 
         payload = {
             "type": "Electric - Grid",
@@ -101,7 +103,7 @@ class TestMeterCRUD(DeleteModelsTestCase):
 
     def test_create_meter_with_scenario(self):
         property_view = self.property_view_factory.get_property_view()
-        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + "?organization_id=" + str(self.org.id)
+        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + f"?organization_id={self.org.id}"
 
         # create a scenario and test again
         scenario = Scenario.objects.create(
@@ -136,7 +138,7 @@ class TestMeterCRUD(DeleteModelsTestCase):
         )
 
         property_view = self.property_view_factory.get_property_view()
-        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + "?organization_id=" + str(self.org.id)
+        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + f"?organization_id={self.org.id}"
 
         payload = {
             "type": "Electric - Grid",
@@ -152,7 +154,7 @@ class TestMeterCRUD(DeleteModelsTestCase):
     def test_delete_meter(self):
         # create meter
         property_view = self.property_view_factory.get_property_view()
-        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + "?organization_id=" + str(self.org.id)
+        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + f"?organization_id={self.org.id}"
         payload = {
             "type": "Natural Gas",
             "source": "Portfolio Manager",
@@ -171,8 +173,7 @@ class TestMeterCRUD(DeleteModelsTestCase):
         meter_id = response.data[0]["id"]
         meter_url = (
             reverse("api:v3:property-meters-detail", kwargs={"property_pk": property_view.id, "pk": meter_id})
-            + "?organization_id="
-            + str(self.org.id)
+            + f"?organization_id={self.org.id}"
         )
         response = self.client.delete(meter_url, content_type="application/json")
         self.assertEqual(response.status_code, 204)
@@ -184,7 +185,7 @@ class TestMeterCRUD(DeleteModelsTestCase):
     def test_update_meter(self):
         # create meter
         property_view = self.property_view_factory.get_property_view()
-        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + "?organization_id=" + str(self.org.id)
+        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + f"?organization_id={self.org.id}"
         payload = {
             "type": "Natural Gas",
             "source": "Portfolio Manager",
@@ -200,8 +201,7 @@ class TestMeterCRUD(DeleteModelsTestCase):
         meter_id = response.data["id"]
         meter_url = (
             reverse("api:v3:property-meters-detail", kwargs={"property_pk": property_view.id, "pk": meter_id})
-            + "?organization_id="
-            + str(self.org.id)
+            + f"?organization_id={self.org.id}"
         )
         response = self.client.put(meter_url, data=json.dumps(new_payload), content_type="application/json")
         self.assertEqual(response.status_code, 200)
@@ -215,12 +215,19 @@ class TestMetersPermissions(AccessLevelBaseTestCase, DeleteModelsTestCase):
         self.property = self.property_factory.get_property()
         self.property_view = self.property_view_factory.get_property_view(self.property)
         self.meter = Meter.objects.create(property=self.property)
+        self.meter_reading = MeterReading.objects.create(
+            meter=self.meter,
+            start_time=datetime(2024, 1, 1, 0, 0, tzinfo=tz.utc),
+            end_time=datetime(2024, 1, 2, 0, 0, tzinfo=tz.utc),
+            reading=12345,
+            source_unit="kWh",
+            conversion_factor=1,
+        )
 
     def test_get_meters_detail_permissions(self):
         meter_url = (
             reverse("api:v3:property-meters-detail", kwargs={"property_pk": self.property_view.id, "pk": self.meter.id})
-            + "?organization_id="
-            + str(self.org.id)
+            + f"?organization_id={self.org.id}"
         )
 
         # root users can see meters in root
@@ -235,7 +242,7 @@ class TestMetersPermissions(AccessLevelBaseTestCase, DeleteModelsTestCase):
 
     def test_get_meters_list_permissions(self):
         meter_url = (
-            reverse("api:v3:property-meters-list", kwargs={"property_pk": self.property_view.id}) + "?organization_id=" + str(self.org.id)
+            reverse("api:v3:property-meters-list", kwargs={"property_pk": self.property_view.id}) + f"?organization_id={self.org.id}"
         )
 
         # root users can see meters in root
@@ -251,8 +258,7 @@ class TestMetersPermissions(AccessLevelBaseTestCase, DeleteModelsTestCase):
     def test_get_meters_delete_permissions(self):
         meter_url = (
             reverse("api:v3:property-meters-detail", kwargs={"property_pk": self.property_view.id, "pk": self.meter.id})
-            + "?organization_id="
-            + str(self.org.id)
+            + f"?organization_id={self.org.id}"
         )
 
         # child user cannot delete meters in root
@@ -266,7 +272,7 @@ class TestMetersPermissions(AccessLevelBaseTestCase, DeleteModelsTestCase):
         assert response.status_code == 204
 
     def test_create_meter_permissions(self):
-        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": self.property_view.id}) + "?organization_id=" + str(self.org.id)
+        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": self.property_view.id}) + f"?organization_id={self.org.id}"
         payload = {"type": "Electric", "source": "Manual Entry", "source_id": "1234567890"}
 
         # root users can create meters in root
@@ -282,8 +288,7 @@ class TestMetersPermissions(AccessLevelBaseTestCase, DeleteModelsTestCase):
     def test_update_meter_permissions(self):
         url = (
             reverse("api:v3:property-meters-detail", kwargs={"property_pk": self.property_view.id, "pk": self.meter.id})
-            + "?organization_id="
-            + str(self.org.id)
+            + f"?organization_id={self.org.id}"
         )
         payload = {"type": "Electric", "source": "Manual Entry", "source_id": "boo"}
 
@@ -296,6 +301,133 @@ class TestMetersPermissions(AccessLevelBaseTestCase, DeleteModelsTestCase):
         self.login_as_child_member()
         response = self.client.put(url, data=json.dumps(payload), content_type="application/json")
         assert response.status_code == 404
+
+    def test_get_meter_reading_list_permissions(self):
+        meter_reading_url = (
+            reverse(
+                "api:v3:property-meter-readings-list",
+                kwargs={
+                    "property_pk": self.property_view.id,
+                    "meter_pk": self.meter.id,
+                },
+            )
+            + f"?organization_id={self.org.id}"
+        )
+
+        # root users can see meters in root
+        self.login_as_root_member()
+        response = self.client.get(meter_reading_url)
+        assert response.status_code == 200
+
+        # child user cannot
+        self.login_as_child_member()
+        response = self.client.get(meter_reading_url)
+        assert response.status_code == 404
+
+    def test_create_meter_reading_list_permissions(self):
+        meter_reading_url = (
+            reverse(
+                "api:v3:property-meter-readings-list",
+                kwargs={
+                    "property_pk": self.property_view.id,
+                    "meter_pk": self.meter.id,
+                },
+            )
+            + f"?organization_id={self.org.id}"
+        )
+        payload = {
+            "start_time": "2024-01-01T00:00:00",
+            "end_time": "2024-01-02T00:00:00",
+            "reading": 12345,
+            "source_unit": "kWh",
+            "conversion_factor": 1,
+        }
+
+        # root users can create meter readings in root
+        self.login_as_root_member()
+        response = self.client.post(meter_reading_url, data=json.dumps(payload), content_type="application/json")
+        assert response.status_code == 201
+
+        # child user cannot
+        self.login_as_child_member()
+        response = self.client.post(meter_reading_url, data=json.dumps(payload), content_type="application/json")
+        assert response.status_code == 404
+
+    def test_get_meter_reading_detail_permissions(self):
+        meter_reading_url = (
+            reverse(
+                "api:v3:property-meter-readings-detail",
+                kwargs={
+                    "property_pk": self.property_view.id,
+                    "meter_pk": self.meter.id,
+                    "pk": "2024-01-01T00:00:00Z",
+                },
+            )
+            + f"?organization_id={self.org.id}"
+        )
+
+        # root users can see meter readings in root
+        self.login_as_root_member()
+        response = self.client.get(meter_reading_url)
+        assert response.status_code == 200
+
+        # child user cannot
+        self.login_as_child_member()
+        response = self.client.get(meter_reading_url)
+        assert response.status_code == 404
+
+    def test_update_meter_reading_detail_permissions(self):
+        meter_reading_url = (
+            reverse(
+                "api:v3:property-meter-readings-detail",
+                kwargs={
+                    "property_pk": self.property_view.id,
+                    "meter_pk": self.meter.id,
+                    "pk": "2024-01-01T00:00:00Z",
+                },
+            )
+            + f"?organization_id={self.org.id}"
+        )
+        payload = {
+            "start_time": "2024-01-01T00:00:00",
+            "end_time": "2024-01-02T00:00:00",
+            "reading": 1337,
+            "source_unit": "kWh",
+            "conversion_factor": 1,
+        }
+
+        # root users can update meter readings in root
+        self.login_as_root_member()
+        response = self.client.put(meter_reading_url, data=json.dumps(payload), content_type="application/json")
+        assert response.status_code == 200
+
+        # child user cannot
+        self.login_as_child_member()
+        response = self.client.put(meter_reading_url, data=json.dumps(payload), content_type="application/json")
+        assert response.status_code == 404
+
+    def test_delete_meter_reading_detail_permissions(self):
+        meter_reading_url = (
+            reverse(
+                "api:v3:property-meter-readings-detail",
+                kwargs={
+                    "property_pk": self.property_view.id,
+                    "meter_pk": self.meter.id,
+                    "pk": "2024-01-01T00:00:00Z",
+                },
+            )
+            + f"?organization_id={self.org.id}"
+        )
+
+        # child user cannot delete meter readings in root
+        self.login_as_child_member()
+        response = self.client.delete(meter_reading_url)
+        assert response.status_code == 404
+
+        # root users can
+        self.login_as_root_member()
+        response = self.client.delete(meter_reading_url)
+        assert response.status_code == 204
 
 
 class TestMeterReadingCRUD(DeleteModelsTestCase):
@@ -315,7 +447,7 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
 
     def test_create_meter_readings(self):
         property_view = self.property_view_factory.get_property_view()
-        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + "?organization_id=" + str(self.org.id)
+        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + f"?organization_id={self.org.id}"
 
         payload = {
             "type": "Electric",
@@ -329,8 +461,7 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         # create meter readings
         url = (
             reverse("api:v3:property-meter-readings-list", kwargs={"property_pk": property_view.id, "meter_pk": meter_pk})
-            + "?organization_id="
-            + str(self.org.id)
+            + f"?organization_id={self.org.id}"
         )
 
         # write a few values to the database
@@ -361,7 +492,7 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         """Test edge case to make sure that data for two different meters don't overwrite each other"""
         property_view = self.property_view_factory.get_property_view()
         url_meters = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id})
-        url_meters += "?organization_id=" + str(self.org.id)
+        url_meters += f"?organization_id={self.org.id}"
 
         payload = {
             "type": "Electric",
@@ -418,7 +549,7 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         """Test edge case to make sure that data for two different meters don't overwrite each other"""
         property_view = self.property_view_factory.get_property_view()
         url_meters = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id})
-        url_meters += "?organization_id=" + str(self.org.id)
+        url_meters += f"?organization_id={self.org.id}"
 
         payload = {
             "type": "Electric",
@@ -482,7 +613,7 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
 
     def test_error_with_time_aware(self):
         property_view = self.property_view_factory.get_property_view()
-        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + "?organization_id=" + str(self.org.id)
+        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + f"?organization_id={self.org.id}"
 
         payload = {
             "type": "Electric",
@@ -496,8 +627,7 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         # create meter readings
         url = (
             reverse("api:v3:property-meter-readings-list", kwargs={"property_pk": property_view.id, "meter_pk": meter_pk})
-            + "?organization_id="
-            + str(self.org.id)
+            + f"?organization_id={self.org.id}"
         )
 
         # write a few values to the database
@@ -532,7 +662,7 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
     def test_bulk_import(self):
         # create property
         property_view = self.property_view_factory.get_property_view()
-        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + "?organization_id=" + str(self.org.id)
+        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + f"?organization_id={self.org.id}"
 
         payload = {
             "type": "Electric",
@@ -545,8 +675,7 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
 
         url = (
             reverse("api:v3:property-meter-readings-list", kwargs={"property_pk": property_view.id, "meter_pk": meter_pk})
-            + "?organization_id="
-            + str(self.org.id)
+            + f"?organization_id={self.org.id}"
         )
 
         # prepare the data in bulk format
@@ -582,7 +711,7 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
 
         property_view = self.property_view_factory.get_property_view()
         url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id})
-        url += "?organization_id=" + str(self.org.id)
+        url += f"?organization_id={self.org.id}"
 
         payload = {
             "type": "Electric",
@@ -594,7 +723,7 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         meter_pk = response.json()["id"]
 
         url = reverse("api:v3:property-meter-readings-list", kwargs={"property_pk": property_view.id, "meter_pk": meter_pk})
-        url += "?organization_id=" + str(self.org.id)
+        url += f"?organization_id={self.org.id}"
 
         # prepare the data in bulk format
         reading1 = {
@@ -623,9 +752,9 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         )
 
     def test_delete_meter_readings(self):
-        # would be nice nice to make a factory out of the meter / meter reading requests
+        # would be nice to make a factory out of the meter / meter reading requests
         property_view = self.property_view_factory.get_property_view()
-        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + "?organization_id=" + str(self.org.id)
+        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": property_view.id}) + f"?organization_id={self.org.id}"
 
         payload = {
             "type": "Natural Gas",
@@ -639,8 +768,7 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         # create meter reading  property-meter-readings-list
         url = (
             reverse("api:v3:property-meter-readings-list", kwargs={"property_pk": property_view.id, "meter_pk": meter_pk})
-            + "?organization_id="
-            + str(self.org.id)
+            + f"?organization_id={self.org.id}"
         )
 
         payload = {
@@ -697,8 +825,7 @@ class TestMeterReadingPermission(AccessLevelBaseTestCase):
     def test_meter_readings_get(self):
         url = (
             reverse("api:v3:property-meters-detail", kwargs={"property_pk": self.view.id, "pk": self.meter.id})
-            + "?organization_id="
-            + str(self.org.id)
+            + f"?organization_id={self.org.id}"
         )
 
         # root member can
@@ -714,8 +841,7 @@ class TestMeterReadingPermission(AccessLevelBaseTestCase):
     def test_meter_readings_update(self):
         url = (
             reverse("api:v3:property-meters-detail", kwargs={"property_pk": self.view.id, "pk": self.meter.id})
-            + "?organization_id="
-            + str(self.org.id)
+            + f"?organization_id={self.org.id}"
         )
         param = json.dumps({"type": "Electric", "source": "Manual Entry", "source_id": "boo"})
 
@@ -730,7 +856,7 @@ class TestMeterReadingPermission(AccessLevelBaseTestCase):
         assert resp.status_code == 404
 
     def test_meter_readings_create(self):
-        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": self.view.id}) + "?organization_id=" + str(self.org.id)
+        url = reverse("api:v3:property-meters-list", kwargs={"property_pk": self.view.id}) + f"?organization_id={self.org.id}"
         param = json.dumps({"type": "Electric", "source": "Manual Entry", "source_id": "boo"})
 
         # root member can
@@ -746,8 +872,7 @@ class TestMeterReadingPermission(AccessLevelBaseTestCase):
     def test_meter_readings_delete(self):
         url = (
             reverse("api:v3:property-meters-detail", kwargs={"property_pk": self.view.id, "pk": self.meter.id})
-            + "?organization_id="
-            + str(self.org.id)
+            + f"?organization_id={self.org.id}"
         )
 
         # child member cannot

--- a/seed/tests/test_meter_views.py
+++ b/seed/tests/test_meter_views.py
@@ -511,8 +511,14 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         meter_pk_2 = response.json()["id"]
 
         # create meter readings
-        url_1 = reverse("api:v3:property-meter-readings-list", kwargs={"property_pk": property_view.id, "meter_pk": meter_pk_1})
-        url_2 = reverse("api:v3:property-meter-readings-list", kwargs={"property_pk": property_view.id, "meter_pk": meter_pk_2})
+        url_1 = (
+            reverse("api:v3:property-meter-readings-list", kwargs={"property_pk": property_view.id, "meter_pk": meter_pk_1})
+            + f"?organization_id={self.org.id}"
+        )
+        url_2 = (
+            reverse("api:v3:property-meter-readings-list", kwargs={"property_pk": property_view.id, "meter_pk": meter_pk_2})
+            + f"?organization_id={self.org.id}"
+        )
 
         readings_1 = {
             "start_time": "2022-01-05 05:00:00",
@@ -568,8 +574,14 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         meter_pk_2 = response.json()["id"]
 
         # create meter readings
-        url_1 = reverse("api:v3:property-meter-readings-list", kwargs={"property_pk": property_view.id, "meter_pk": meter_pk_1})
-        url_2 = reverse("api:v3:property-meter-readings-list", kwargs={"property_pk": property_view.id, "meter_pk": meter_pk_2})
+        url_1 = (
+            reverse("api:v3:property-meter-readings-list", kwargs={"property_pk": property_view.id, "meter_pk": meter_pk_1})
+            + f"?organization_id={self.org.id}"
+        )
+        url_2 = (
+            reverse("api:v3:property-meter-readings-list", kwargs={"property_pk": property_view.id, "meter_pk": meter_pk_2})
+            + f"?organization_id={self.org.id}"
+        )
 
         # write a few values to the database
         for values in [
@@ -785,9 +797,12 @@ class TestMeterReadingCRUD(DeleteModelsTestCase):
         self.assertEqual(response.json()["reading"], 10)
 
         # now delete the item and verify that there are no more readings in the database
-        detail_url = reverse(
-            "api:v3:property-meter-readings-detail",
-            kwargs={"property_pk": property_view.id, "meter_pk": meter_pk, "pk": "2022-01-05 05:00:00"},
+        detail_url = (
+            reverse(
+                "api:v3:property-meter-readings-detail",
+                kwargs={"property_pk": property_view.id, "meter_pk": meter_pk, "pk": "2022-01-05T13:00:00Z"},
+            )
+            + f"?organization_id={self.org.id}"
         )
         response = self.client.get(detail_url, content_type="application/json")
         self.assertEqual(response.status_code, 200)

--- a/seed/utils/api_schema.py
+++ b/seed/utils/api_schema.py
@@ -17,6 +17,7 @@ class AutoSchemaHelper(SwaggerAutoSchema):
         "integer": openapi.TYPE_INTEGER,
         "object": openapi.TYPE_OBJECT,
         "number": openapi.TYPE_NUMBER,
+        "datetime": openapi.TYPE_STRING,
     }
 
     @classmethod
@@ -101,6 +102,8 @@ class AutoSchemaHelper(SwaggerAutoSchema):
 
         if isinstance(obj, str):
             openapi_type = cls._openapi_type(obj)
+            if obj == "datetime":
+                return openapi.Schema(type=openapi_type, format=openapi.FORMAT_DATETIME, **kwargs)
             return openapi.Schema(type=openapi_type, **kwargs)
 
         if isinstance(obj, list):

--- a/seed/utils/viewsets.py
+++ b/seed/utils/viewsets.py
@@ -92,7 +92,7 @@ class SEEDOrgReadOnlyModelViewSet(
 
 
 class SEEDOrgCreateUpdateModelViewSet(OrgCreateUpdateMixin, SEEDOrgModelViewSet):
-    """Extends SEEDModelViewset to add perform_create method to attach org.
+    """Extends SEEDOrgModelViewSet to add perform_create method to attach org.
 
     Provides the perform_create and update_create methods to save the
     Organization foreignkey relationship for models that have linked via an
@@ -100,7 +100,7 @@ class SEEDOrgCreateUpdateModelViewSet(OrgCreateUpdateMixin, SEEDOrgModelViewSet)
 
     This viewset is not suitable for models using 'super_organization' or
     having additional foreign key relationships, such as user. Any such models
-    should instead extend SEEDOrgModelViewset and create perform_create
+    should instead extend SEEDOrgModelViewSet and create perform_create
     and/or perform_update overrides appropriate to the model's needs.
     """
 

--- a/seed/views/v3/building_files.py
+++ b/seed/views/v3/building_files.py
@@ -41,7 +41,7 @@ class BuildingFileViewSet(SEEDOrgReadOnlyModelViewSet):
             )
 
         else:
-            return BuildingFile.objects.filter(pk=-1)
+            return BuildingFile.objects.none()
 
     def get_serializer_class(self):
         if self.action == "create":

--- a/seed/views/v3/gbr_properties.py
+++ b/seed/views/v3/gbr_properties.py
@@ -65,7 +65,7 @@ class GBRPropertyViewSet(SEEDOrgCreateUpdateModelViewSet):
             )
 
         else:
-            return PropertyModel.objects.filter(pk=-1)
+            return PropertyModel.objects.none()
 
     def create(self, request, *args, **kwargs):
         org_id = self.get_organization(self.request)

--- a/seed/views/v3/meter_readings.py
+++ b/seed/views/v3/meter_readings.py
@@ -8,6 +8,7 @@ from django.utils.decorators import method_decorator
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.parsers import FormParser, JSONParser
+from rest_framework.renderers import JSONRenderer
 
 from seed.lib.superperms.orgs.decorators import has_hierarchy_access, has_perm_class
 from seed.models import MeterReading, PropertyView
@@ -121,6 +122,7 @@ class MeterReadingViewSet(SEEDOrgNoPatchOrOrgCreateModelViewSet):
     """API endpoint for managing meters."""
 
     serializer_class = MeterReadingSerializer
+    renderer_classes = (JSONRenderer,)
     pagination_class = None
     model = MeterReading
     parser_classes = (JSONParser, FormParser)

--- a/seed/views/v3/meters.py
+++ b/seed/views/v3/meters.py
@@ -12,13 +12,25 @@ from rest_framework.renderers import JSONRenderer
 from seed.lib.superperms.orgs.decorators import has_hierarchy_access, has_perm_class
 from seed.models import Meter, PropertyView
 from seed.serializers.meters import MeterSerializer
-from seed.utils.api_schema import AutoSchemaHelper
+from seed.utils.api_schema import AutoSchemaHelper, swagger_auto_schema_org_query_param
 from seed.utils.viewsets import SEEDOrgNoPatchOrOrgCreateModelViewSet
 
 
-@method_decorator(name="list", decorator=[has_perm_class("requires_viewer"), has_hierarchy_access(property_view_id_kwarg="property_pk")])
 @method_decorator(
-    name="retrieve", decorator=[has_perm_class("requires_viewer"), has_hierarchy_access(property_view_id_kwarg="property_pk")]
+    name="list",
+    decorator=[
+        swagger_auto_schema_org_query_param,
+        has_perm_class("requires_viewer"),
+        has_hierarchy_access(property_view_id_kwarg="property_pk"),
+    ],
+)
+@method_decorator(
+    name="retrieve",
+    decorator=[
+        swagger_auto_schema_org_query_param,
+        has_perm_class("requires_viewer"),
+        has_hierarchy_access(property_view_id_kwarg="property_pk"),
+    ],
 )
 @method_decorator(
     name="create",
@@ -27,6 +39,7 @@ from seed.utils.viewsets import SEEDOrgNoPatchOrOrgCreateModelViewSet
         has_hierarchy_access(property_view_id_kwarg="property_pk"),
         swagger_auto_schema(
             manual_parameters=[
+                AutoSchemaHelper.query_org_id_field(),
                 AutoSchemaHelper.base_field(
                     name="property_pk",
                     location_attr="IN_PATH",
@@ -50,8 +63,22 @@ from seed.utils.viewsets import SEEDOrgNoPatchOrOrgCreateModelViewSet
         ),
     ],
 )
-@method_decorator(name="destroy", decorator=[has_perm_class("requires_member"), has_hierarchy_access(property_view_id_kwarg="property_pk")])
-@method_decorator(name="update", decorator=[has_perm_class("requires_member"), has_hierarchy_access(property_view_id_kwarg="property_pk")])
+@method_decorator(
+    name="update",
+    decorator=[
+        swagger_auto_schema_org_query_param,
+        has_perm_class("requires_member"),
+        has_hierarchy_access(property_view_id_kwarg="property_pk"),
+    ],
+)
+@method_decorator(
+    name="destroy",
+    decorator=[
+        swagger_auto_schema_org_query_param,
+        has_perm_class("requires_member"),
+        has_hierarchy_access(property_view_id_kwarg="property_pk"),
+    ],
+)
 class MeterViewSet(SEEDOrgNoPatchOrOrgCreateModelViewSet):
     """API endpoint for managing meters."""
 
@@ -74,7 +101,7 @@ class MeterViewSet(SEEDOrgNoPatchOrOrgCreateModelViewSet):
             return Meter.objects.none()
 
         property_view = PropertyView.objects.get(pk=property_view_pk)
-        self.property_pk = property_view.property.pk
+        self.property_pk = property_view.property_id
         return Meter.objects.filter(property__organization_id=org_id, property_id=self.property_pk)
 
     def perform_create(self, serializer):

--- a/seed/views/v3/property_views.py
+++ b/seed/views/v3/property_views.py
@@ -13,15 +13,31 @@ from seed.filtersets import PropertyViewFilterSet
 from seed.lib.superperms.orgs.decorators import has_hierarchy_access, has_perm_class
 from seed.models import AccessLevelInstance, Organization, PropertyView
 from seed.serializers.properties import BriefPropertyViewSerializer
-from seed.utils.api import api_endpoint_class
+from seed.utils.api_schema import swagger_auto_schema_org_query_param
 from seed.utils.viewsets import SEEDOrgModelViewSet
 
 
-@method_decorator(name="list", decorator=[has_perm_class("requires_viewer")])
-@method_decorator(name="retrieve", decorator=[has_perm_class("requires_viewer"), has_hierarchy_access(property_view_id_kwarg="pk")])
-@method_decorator(name="destroy", decorator=[has_perm_class("requires_viewer"), has_hierarchy_access(property_view_id_kwarg="pk")])
-@method_decorator(name="update", decorator=[has_perm_class("requires_viewer"), has_hierarchy_access(property_view_id_kwarg="pk")])
-@method_decorator(name="create", decorator=[has_perm_class("requires_viewer"), has_hierarchy_access(body_property_id="property_id")])
+@method_decorator(name="list", decorator=[swagger_auto_schema_org_query_param, has_perm_class("requires_viewer")])
+@method_decorator(
+    name="retrieve",
+    decorator=[swagger_auto_schema_org_query_param, has_perm_class("requires_viewer"), has_hierarchy_access(property_view_id_kwarg="pk")],
+)
+@method_decorator(
+    name="destroy",
+    decorator=[swagger_auto_schema_org_query_param, has_perm_class("requires_member"), has_hierarchy_access(property_view_id_kwarg="pk")],
+)
+@method_decorator(
+    name="update",
+    decorator=[swagger_auto_schema_org_query_param, has_perm_class("requires_member"), has_hierarchy_access(property_view_id_kwarg="pk")],
+)
+@method_decorator(
+    name="create",
+    decorator=[
+        swagger_auto_schema_org_query_param,
+        has_perm_class("requires_member"),
+        has_hierarchy_access(body_property_id="property_id"),
+    ],
+)
 class PropertyViewViewSet(SEEDOrgModelViewSet):
     """PropertyViews API Endpoint
 
@@ -69,7 +85,7 @@ class PropertyViewViewSet(SEEDOrgModelViewSet):
             )
 
         else:
-            return PropertyView.objects.filter(pk=-1)
+            return PropertyView.objects.none()
 
     serializer_class = BriefPropertyViewSerializer
     pagination_class = None
@@ -79,10 +95,7 @@ class PropertyViewViewSet(SEEDOrgModelViewSet):
     data_name = "property_views"
     queryset = PropertyView.objects.all()
 
-    # Overwrite method to make it work
-    @api_endpoint_class
-    @has_perm_class("requires_viewer")
-    def create(self, request, organization_pk=None):
+    def create(self, request, *args, **kwargs):
         org_id = int(self.get_organization(request))
         try:
             Organization.objects.get(pk=org_id)


### PR DESCRIPTION
#### What's this PR do?
- Adds missing AH restrictions to all meter reading endpoints
- Adds AH tests for all meter reading endpoints
- Removes meter reading `PATCH` endpoint for consistency
- Fixes all writable PropertyView endpoints to restrict actions to members or higher, and include `organization_id`
- Fixes all meters Swagger endpoints to include `organization_id`
- Query reduction in `MeterReadingViewSet`
- Adds a `datetime` Swagger schema helper

#### How should this be manually tested?
Tests should pass