### PR TITLE
Fix UBID matching behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,10 @@
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "lodash": "^4.17.21",
         "npm-run-all": "^4.1.5",
-        "prettier": "^3.2.5",
-        "puppeteer": "^22.11.2",
-        "sass": "^1.77.1",
-        "stylelint": "^16.5.0",
+        "prettier": "^3.3.2",
+        "puppeteer": "^22.12.1",
+        "sass": "^1.77.6",
+        "stylelint": "^16.6.1",
         "stylelint-config-standard-scss": "^13.1.0"
       },
       "engines": {
@@ -437,9 +437,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.5.tgz",
-      "integrity": "sha512-aoRR+fJkZT2l0aGOJhuA8frnCSoNX6W7U2mpNq63+BxBIj5BQFt8rHy627kijCmm63ijdSdwvGgpUsU6MBsZZA==",
+      "version": "20.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -948,9 +948,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.23.tgz",
-      "integrity": "sha512-1o/gLU9wDqbN5nL2MtfjykjOuighGXc3/hnWueO1haiEoFgX8h5vbvcA4tgdQfjw1mkZ1OEF4x/+HVeqEX6NoA==",
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.24.tgz",
+      "integrity": "sha512-5xQNN2SVBdZv4TxeMLaI+PelrnZsHDhn8h2JtyriLr+0qHcZS8BMuo93qN6J1VmtmrgYP+rmcLHcbpnA8QJh+w==",
       "dev": true,
       "dependencies": {
         "mitt": "3.0.1",
@@ -2343,9 +2343,9 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
       "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
@@ -3436,9 +3436,9 @@
       }
     },
     "node_modules/pac-proxy-agent": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
-      "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
       "dev": true,
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
@@ -3446,9 +3446,9 @@
         "debug": "^4.3.4",
         "get-uri": "^6.0.1",
         "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "pac-resolver": "^7.0.0",
-        "socks-proxy-agent": "^8.0.2"
+        "https-proxy-agent": "^7.0.5",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.4"
       },
       "engines": {
         "node": ">= 14"
@@ -3785,16 +3785,16 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.11.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.11.2.tgz",
-      "integrity": "sha512-8fjdQSgW0sq7471ftca24J7sXK+jXZ7OW7Gx+NEBFNyXrcTiBfukEI46gNq6hiMhbLEDT30NeylK/1ZoPdlKSA==",
+      "version": "22.12.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.12.1.tgz",
+      "integrity": "sha512-1GxY8dnEnHr1SLzdSDr0FCjM6JQfAh2E2I/EqzeF8a58DbGVk9oVjj4lFdqNoVbpgFSpAbz7VER9St7S1wDpNg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "2.2.3",
-        "cosmiconfig": "9.0.0",
+        "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1299070",
-        "puppeteer-core": "22.11.2"
+        "puppeteer-core": "22.12.1"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -3804,16 +3804,16 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.11.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.11.2.tgz",
-      "integrity": "sha512-vQo+YDuePyvj+92Z9cdtxi/HalKf+k/R4tE80nGtQqJRNqU81eHaHkbVfnLszdaLlvwFF5tipnnSCzqWlEddtw==",
+      "version": "22.12.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.12.1.tgz",
+      "integrity": "sha512-XmqeDPVdC5/3nGJys1jbgeoZ02wP0WV1GBlPtr/ULRbGXJFuqgXMcKQ3eeNtFpBzGRbpeoCGWHge1ZWKWl0Exw==",
       "dev": true,
       "dependencies": {
         "@puppeteer/browsers": "2.2.3",
-        "chromium-bidi": "0.5.23",
-        "debug": "4.3.5",
+        "chromium-bidi": "0.5.24",
+        "debug": "^4.3.5",
         "devtools-protocol": "0.0.1299070",
-        "ws": "8.17.1"
+        "ws": "^8.17.1"
       },
       "engines": {
         "node": ">=18"
@@ -4186,14 +4186,14 @@
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
-      "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
       "dev": true,
       "dependencies": {
         "agent-base": "^7.1.1",
         "debug": "^4.3.4",
-        "socks": "^2.7.1"
+        "socks": "^2.8.3"
       },
       "engines": {
         "node": ">= 14"

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
-    "prettier": "^3.2.5",
-    "puppeteer": "^22.11.2",
-    "sass": "^1.77.1",
-    "stylelint": "^16.5.0",
+    "prettier": "^3.3.2",
+    "puppeteer": "^22.12.1",
+    "sass": "^1.77.6",
+    "stylelint": "^16.6.1",
     "stylelint-config-standard-scss": "^13.1.0"
   },
   "scripts": {

--- a/seed/data_importer/match.py
+++ b/seed/data_importer/match.py
@@ -592,7 +592,7 @@ def states_to_views(unmatched_state_ids, org, access_level_instance, cycle, Stat
         matching_criteria = matching_filter_criteria(state, column_names)
 
         # compare UBIDs via jaccard index instead of a direct match
-        check_jaccard = "ubid" in matching_criteria and matching_criteria.get("ubid")
+        check_jaccard = bool(matching_criteria.get("ubid"))
         if check_jaccard:
             # Only pop the UBID value if it's populated
             # If it's `None` then we still want to match against existing records with empty UBIDs
@@ -706,7 +706,7 @@ def link_states(states, ViewClass, cycle, highest_ali, sub_progress_key):  # noq
     """
     Run each of the given -States through a linking round.
 
-    For details on the actual linking logic, please refer to the the
+    For details on the actual linking logic, please refer to the
     match_merge_link() method.
     """
 

--- a/seed/data_importer/models.py
+++ b/seed/data_importer/models.py
@@ -572,7 +572,7 @@ class ImportFile(NotDeletableModel, TimeStampedModel):
             raise ValueError("Must be one of our State objects [PropertyState, TaxLotState]!")
 
         return kls.objects.filter(
-            data_state__in=[DATA_STATE_MAPPING],
+            data_state=DATA_STATE_MAPPING,
             import_file=self.id,
         )
 

--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -1699,10 +1699,10 @@ def hash_state_object(obj, include_extra_data=True):
         return hash_obj
 
     def _get_field_from_obj(field_obj, field):
-        if not hasattr(field_obj, field):
-            return "FOO"  # Return a random value so we can distinguish between this and None.
-        else:
+        if hasattr(field_obj, field):
             return getattr(field_obj, field)
+        else:
+            return "FOO"  # Return a random value so we can distinguish between this and None.
 
     m = hashlib.md5()  # noqa: S324
     for f in Column.retrieve_db_field_name_for_hash_comparison():
@@ -1800,10 +1800,6 @@ def pair_new_states(merged_property_views, merged_taxlot_views, sub_progress_key
     sub_progress_data.delete()
     sub_progress_data.total = 12
     sub_progress_data.save()
-
-    # Not sure what the below cycle code does.
-    # Commented out during Python3 upgrade.
-    # cycle = chain(merged_property_views, merged_taxlot_views).next().cycle
 
     tax_cmp_fmt = [
         ("jurisdiction_tax_lot_id", "custom_id_1"),

--- a/seed/data_importer/tests/test_ah_import.py
+++ b/seed/data_importer/tests/test_ah_import.py
@@ -704,7 +704,7 @@ class TestAHImportMatchExistingDifferentCycle(TestAHImportFile):
 
     def test_has_ali_merges_and_links(self):
         # Set Up - create view for merge
-        self.property_view_factory.get_property_view(prprty=self.existing_property, cycle=self.cycle)
+        self.property_view_factory.get_property_view(prprty=self.existing_property, cycle=self.cycle, ubid=self.base_details["ubid"])
 
         # Set Up - update new state info
         self.base_details["raw_access_level_instance_id"] = self.me_ali.id
@@ -747,7 +747,7 @@ class TestAHImportMatchExistingDifferentCycle(TestAHImportFile):
 
     def test_no_ali_merges_and_links(self):
         # Set Up - create view for merge
-        self.property_view_factory.get_property_view(prprty=self.existing_property, cycle=self.cycle)
+        self.property_view_factory.get_property_view(prprty=self.existing_property, cycle=self.cycle, ubid=self.base_details["ubid"])
 
         # Set Up - update new state info
         self.base_details["raw_access_level_instance_error"] = "uh oh"

--- a/seed/utils/match.py
+++ b/seed/utils/match.py
@@ -47,7 +47,7 @@ def empty_criteria_filter(StateClass, column_names):  # noqa: N803
 
 def matching_filter_criteria(state, column_names):
     """
-    For a given -State, returns a dictionary of it's matching criteria values.
+    For a given -State, returns a dictionary of its matching criteria values.
 
     This dictionary is frequently unpacked for a QuerySet filter or exclude.
     """
@@ -63,7 +63,9 @@ def matching_criteria_column_names(organization_id, table_name):
     """
     return {
         "normalized_address" if c.column_name == "address_line_1" else c.column_name
-        for c in Column.objects.filter(organization_id=organization_id, is_matching_criteria=True, table_name=table_name)
+        for c in Column.objects.filter(organization_id=organization_id, is_matching_criteria=True, table_name=table_name).only(
+            "column_name"
+        )
     }
 
 
@@ -242,7 +244,7 @@ def _get_ali(view, matching_views, highest_ali, class_name, ViewClass):  # noqa:
     elif view_ali_id is None:
         ali_id = matching_ali_id
 
-    # if views ali is different, the views invalid
+    # if view's ali is different, the view is invalid
     elif view_ali_id != matching_ali_id:
         raise MultipleALIError
 
@@ -251,7 +253,7 @@ def _get_ali(view, matching_views, highest_ali, class_name, ViewClass):  # noqa:
 
     ali = AccessLevelInstance.objects.get(pk=ali_id)
 
-    # if we don't has access to matching_ali, raise an access error
+    # if we don't have access to matching_ali, raise an access error
     if highest_ali and not (ali == highest_ali or ali.is_descendant_of(highest_ali)):
         raise NoAccessError
 
@@ -284,7 +286,7 @@ def match_merge_link(state_id, state_class_name: Literal["PropertyState", "TaxLo
 
     # MERGE
     # TODO: _merge_matches_across_cycles wants _all_ the matching views. idk quite why. Why would
-    # the out of cycle views need to merge? Why would both the target state and view need to be
+    # the out-of-cycle views need to merge? Why would both the target state and view need to be
     # passed? We should take a look at this, But for now, I don't want to anger it.
     all_matching_views = (
         ViewClass.objects.filter(pk=view.id).prefetch_related("state") | matching_views_in_cycle | matching_views_out_of_cycle
@@ -312,7 +314,7 @@ def whole_org_match_merge_link(org_id, state_class_name, proposed_columns=[]):
             - Focus on -States associated with -Views in this Cycle.
             - Ignore -States where all matching criteria is None.
             - Group -State IDs by whether they match each other.
-            - Ignore each groups of size size 1 (not matched).
+            - Ignore each groups of size 1 (not matched).
             - For each remaining group, run merge logic so that there's only one
             Set left. Any labels, notes, pairings, and meters are transferred to
             and persisted in this Set.

--- a/seed/utils/ubid.py
+++ b/seed/utils/ubid.py
@@ -87,8 +87,8 @@ def get_jaccard_index(ubid1: str, ubid2: str) -> float:
     The Jaccard index is a value between zero and one, representing the area of the intersection divided by the area of the union.
     Not a Match (0.0) <-----> (1.0) Perfect Match
 
-    :param ubid1: A Property State Ubid
-    :param ubid2: A Property State Ubid
+    :param ubid1: A Property State UBID
+    :param ubid2: A Property State UBID
     :return: The Jaccard index
     """
     if (not ubid1 or not ubid2) or (ubid1 == ubid2):


### PR DESCRIPTION
#### Any background context you want to provide?
When `UBID` is part of the matching criteria along with other columns, importing records with empty UBIDs would incorrectly match against existing records with populated UBIDs.

#### What's this PR do?
- Treats UBID as a matching column as strictly as other matching columns
- Small cleanup

#### How should this be manually tested?
See the example in the related ticket

#### What are the relevant tickets?
#4713