### PR TITLE
Remove jwt oauth

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -95,8 +95,6 @@ DJANGO_CORE_APPS = (
     "django_extensions",
     "django_filters",
     "rest_framework",
-    "oauth2_provider",
-    "oauth2_jwt_provider",
     "crispy_forms",  # needed to squash warnings around collectstatic with rest_framework
     "post_office",
     "django_celery_beat",
@@ -275,7 +273,6 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # Django Rest Framework
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "oauth2_provider.contrib.rest_framework.OAuth2Authentication",
         "rest_framework.authentication.SessionAuthentication",
         "seed.authentication.SEEDAuthentication",
     ),

--- a/config/settings/local_untracked.py.dist
+++ b/config/settings/local_untracked.py.dist
@@ -70,16 +70,6 @@ GOOGLE_RECAPTCHA_SECRET_KEY = os.environ.get("GOOGLE_RECAPTCHA_SECRET_KEY", "6Le
 #     send_default_pii=True
 # )
 
-# OAuth2 Configuration (Optional)
-# Token request Url is a common choice for audience
-# see https://tools.ietf.org/html/rfc7523#section-3 and
-# https://github.com/GreenBuildingRegistry/jwt-oauth2 for additional details
-# OAUTH2_JWT_PROVIDER = {
-#     'JWT_AUDIENCE': 'https://example.com/oauth/token/',
-#     'DEVELOPER_GROUP': 'developers',
-#     'TRUSTED_OAUTH_GROUP': 'trusted_developers',
-# }
-
 
 # ================================= Database settings ===============================
 DATABASES = {

--- a/config/urls.py
+++ b/config/urls.py
@@ -57,7 +57,6 @@ urlpatterns = [
     re_path(r"^api/swagger/$", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
     re_path(r"^api/version/$", version, name="version"),
     re_path(r"^api/", include((api, "seed"), namespace="api")),
-    re_path(r"^oauth/", include(("oauth2_jwt_provider.urls", "oauth2_jwt_provider"), namespace="oauth2_provider")),
     re_path(r"^account/login", CustomLoginView.as_view(), name="login"),
     re_path(r"^", include(tf_urls)),
     # test sentry error

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ django-pint==0.6
 djangorestframework==3.12.2
 # Django-post-office dependency needs to be installed via github b/c
 # with pypi version Celery fails to auto discover post_office tasks
--e git+https://github.com/ui/django-post_office.git@v3.6.0#egg=django-post_office
+django-post_office @ git+https://github.com/ui/django-post_office@v3.6.0
 drf-yasg==1.20.0  # TODO bump this to 1.21.7 to add `get_paginated_response_schema` bug fix (once pytz is bumped)
 django-filter==2.4.0
 drf-nested-routers==0.91
@@ -67,18 +67,7 @@ seed-salesforce==0.1.0
 # geospatial and pnnl/buildingid-py
 shapely==2.0.1
 usaddress==0.5.10
--e git+https://github.com/SEED-platform/buildingid.git@bdb0a6efc37754f1946095896fa507b5ce866d6a#egg=pnnl-buildingid
-
-oauthlib==2.0.3
-
-# Used by jwt-oauth2
-django-braces==1.14.0
-
-# Use forked jwt-oauth2 b/c the published version broke when updating to Django 3.x
-# See: https://docs.djangoproject.com/en/dev/releases/3.0/#removed-private-python-2-compatibility-apis
-# jwt-oauth2>=0.1.1
--e git+https://github.com/SEED-platform/jwt-oauth2.git@9726367db36b332c84fb1288a7df32196509c06d#egg=jwt-oauth2
-django-oauth-toolkit==1.2.0
+pnnl-buildingid @ git+https://github.com/SEED-platform/buildingid@bdb0a6e
 
 future==0.18.3
 

--- a/seed/landing/models.py
+++ b/seed/landing/models.py
@@ -82,25 +82,24 @@ class SEEDUser(AbstractBaseUser, PermissionsMixin):
         if not auth_header:
             return None
 
-        if not auth_header.startswith("Bearer") or not getattr(request, "user", None):
-            try:
-                if not auth_header.startswith("Basic"):
-                    raise exceptions.AuthenticationFailed("Only Basic HTTP_AUTHORIZATION is supported")
+        try:
+            if not auth_header.startswith("Basic"):
+                raise exceptions.AuthenticationFailed("Only Basic HTTP_AUTHORIZATION is supported")
 
-                auth_header = auth_header.split()[1]
-                auth_header = base64.urlsafe_b64decode(auth_header).decode("utf-8")
-                username, api_key = auth_header.split(":")
+            auth_header = auth_header.split()[1]
+            auth_header = base64.urlsafe_b64decode(auth_header).decode("utf-8")
+            username, api_key = auth_header.split(":")
 
-                valid_api_key = re.search("^[a-f0-9]{40}$", api_key)
-                if not valid_api_key:
-                    raise exceptions.AuthenticationFailed("Invalid API key")
-
-                user = SEEDUser.objects.get(api_key=api_key, username=username)
-                return user
-            except ValueError:
-                raise exceptions.AuthenticationFailed("Invalid HTTP_AUTHORIZATION Header")
-            except SEEDUser.DoesNotExist:
+            valid_api_key = re.search("^[a-f0-9]{40}$", api_key)
+            if not valid_api_key:
                 raise exceptions.AuthenticationFailed("Invalid API key")
+
+            user = SEEDUser.objects.get(api_key=api_key, username=username)
+            return user
+        except ValueError:
+            raise exceptions.AuthenticationFailed("Invalid HTTP_AUTHORIZATION Header")
+        except SEEDUser.DoesNotExist:
+            raise exceptions.AuthenticationFailed("Invalid API key")
 
     def get_absolute_url(self):
         return f"/users/{urlquote(self.username)}/"

--- a/seed/migrations/0227_remove_oauth.py
+++ b/seed/migrations/0227_remove_oauth.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+# remove the oauth2 tables from the database
+
+DROP_OAUTH_TABLES = """
+    DROP TABLE IF EXISTS oauth2_jwt_provider_publickey CASCADE;
+    DROP TABLE IF EXISTS oauth2_provider_accesstoken CASCADE;
+    DROP TABLE IF EXISTS oauth2_provider_application CASCADE;
+    DROP TABLE IF EXISTS oauth2_provider_grant CASCADE;
+    DROP TABLE IF EXISTS oauth2_provider_refreshtoken CASCADE;
+"""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("seed", "0226_rehash"),
+    ]
+
+    operations = [
+        migrations.RunSQL(DROP_OAUTH_TABLES),
+    ]

--- a/seed/utils/viewsets.py
+++ b/seed/utils/viewsets.py
@@ -13,7 +13,6 @@ parser_classes, authentication_classes, and pagination_classes attributes.
 
 from typing import Any
 
-from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.mixins import CreateModelMixin, DestroyModelMixin, ListModelMixin, RetrieveModelMixin, UpdateModelMixin
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
@@ -28,7 +27,6 @@ from seed.utils.api import OrgCreateUpdateMixin, OrgQuerySetMixin
 
 # Constants
 AUTHENTICATION_CLASSES = (
-    OAuth2Authentication,
     SessionAuthentication,
     SEEDAuthentication,
 )


### PR DESCRIPTION
#### Any background context you want to provide?
- We've been frequently seeing warnings related to our jwt oauth dependencies related to Django v4:

    `/usr/lib/python3.9/site-packages/oauth2_provider/signals.py:4: RemovedInDjango40Warning:The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.`

- The [jwt-oauth2](https://github.com/GreenBuildingRegistry/jwt-oauth2) library hasn't been updated in 6.5 years, and is incompatible with newer versions of the sub-dependencies that resolve this error.
- We've never used this dependency, but there's a chance that it's being used downstream by Earth Advantage. Once they upgrade to the latest version of SEED, if this is an issue for them we can discuss updating that dependency, or using a modern alternative that is actively maintained.

#### What's this PR do?
Removes the deprecated JWT OAuth2 authentication option that is constantly reporting warnings, and will not work with our near-term dependency upgrades.

#### How should this be manually tested?
1. Create a new, empty, virtual environment
2. Run `pip install -r requirements/base.txt`
3. Check that Django runs, and that API calls don't show constant Django v4 oauth warnings