### PR TITLE
Filter elements endpoint

### DIFF
--- a/seed/utils/api_schema.py
+++ b/seed/utils/api_schema.py
@@ -57,6 +57,10 @@ class AutoSchemaHelper(SwaggerAutoSchema):
         return openapi.Parameter(name, openapi.IN_QUERY, description=description, required=required, type=openapi.TYPE_BOOLEAN)
 
     @staticmethod
+    def query_enum_field(name, description, enum):
+        return openapi.Parameter(name, openapi.IN_QUERY, description=description, required=True, type=openapi.TYPE_STRING, enum=enum)
+
+    @staticmethod
     def form_string_field(name, required, description):
         return openapi.Parameter(name, openapi.IN_FORM, description=description, required=required, type=openapi.TYPE_STRING)
 


### PR DESCRIPTION
#### Any background context you want to provide?
We had endpoints to list all elements for an org (or a single element by id), but no method for filtering them

#### What's this PR do?
Adds a new `GET /v3/elements/filter/` endpoint that filters for all organization elements under a specific Uniformat code. This is useful for finding which properties have specific types of elements

#### How should this be manually tested?
Given a database with elements, test URL like:
`GET /api/v3/elements/filter/?page=1&per_page=10&organization_id=2&code=D2010`