### PR TITLE
Fix rehash migrations prior to `is_excluded_from_hash`

### DIFF
--- a/seed/data_importer/tasks.py
+++ b/seed/data_importer/tasks.py
@@ -18,7 +18,7 @@ from collections import defaultdict, namedtuple
 from datetime import date, datetime
 from itertools import chain
 from math import ceil
-from typing import Union
+from typing import Optional, Union
 
 from _csv import Error
 from celery import chain as celery_chain
@@ -1720,9 +1720,9 @@ def add_dictionary_repr_to_hash(hash_obj, dict_obj: dict):
     return hash_obj
 
 
-def hash_state_object(obj: Union[PropertyState, TaxLotState], include_extra_data=True):
+def hash_state_object(obj: Union[PropertyState, TaxLotState], include_extra_data=True, prefetched_columns: Optional[list[str]] = None):
     m = hashlib.md5()  # noqa: S324
-    for field in Column.retrieve_db_field_name_for_hash_comparison(type(obj), obj.organization_id):
+    for field in prefetched_columns or Column.retrieve_db_field_name_for_hash_comparison(type(obj), obj.organization_id):
         # Default to a random value so we can distinguish between this and None.
         obj_val = getattr(obj, field, "FOO")
         m.update(field.encode("utf-8"))

--- a/seed/utils/migrations.py
+++ b/seed/utils/migrations.py
@@ -6,8 +6,10 @@ See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 from datetime import datetime
 
 from django.db import connection, transaction
+from django.db.migrations.recorder import MigrationRecorder
 
 from seed.data_importer.tasks import hash_state_object
+from seed.models import Column
 
 
 class ProgressLogger:
@@ -40,12 +42,29 @@ def rehash(apps, properties=True, taxlots=True):
         for table in model:
             count = model[table].objects.count()
             if count > 0:
-                print(f"Re-hashing {table} ({count:,} states)")
+                print(f"\nRe-hashing {table} ({count:,} states)")
                 cursor.execute(f"PREPARE update_hash (integer, text) AS UPDATE {table} SET hash_object = $2 WHERE id = $1;")  # noqa: S608
                 progress = ProgressLogger(count)
+
+                # Check if SEED migration 0225 has run yet
+                excluded_migration_complete = MigrationRecorder.Migration.objects.filter(
+                    app="seed", name="0225_column_is_excluded_from_hash"
+                ).exists()
+
+                # Pre-fetch the column names for every org with states
+                org_ids: list[int] = list(model[table].objects.values_list("organization_id", flat=True).distinct())
+                prefetched_columns: dict[int, list[str]] = {}
+                for org_id in org_ids:
+                    if excluded_migration_complete:
+                        prefetched_columns[org_id] = Column.retrieve_db_field_name_for_hash_comparison(model[table], org_id)
+                    else:
+                        # Use the old rehash methodology for databases that need to run rehash migrations prior to the
+                        # `is_excluded_from_hash` column being added in `0225_column_is_excluded_from_hash.py`
+                        prefetched_columns[org_id] = sorted({c["column_name"] for c in Column.retrieve_db_fields_from_db_tables()})
+
                 for idx, state in enumerate(model[table].objects.iterator(chunk_size=1000)):
                     old_hash = state.hash_object
-                    new_hash = hash_state_object(state)
+                    new_hash = hash_state_object(state, prefetched_columns=prefetched_columns.get(state.organization_id))
 
                     update = new_hash != old_hash
                     if update:


### PR DESCRIPTION
#### Any background context you want to provide?
If you had a database that was on a migration earlier than [migration 0223](https://github.com/SEED-platform/seed/blob/develop/seed/migrations/0223_water_use_columns.py) and attempted to migrate using the latest codebase, then 0223 would fail because #4769 changed the rehash function to expect a new column to exist.

#### What's this PR do?
- Changes the rehash function to check if [migration 0225](https://github.com/SEED-platform/seed/blob/develop/seed/migrations/0225_column_is_excluded_from_hash.py) has run yet, and if not it uses the older rehash logic
- Adds a performance improvement so that an organization's columns are fetched only once instead of for every Property/TaxLot State (19% faster than the improvements added in #4754)

#### How should this be manually tested?
1. Checkout SEED v3.0 and create a new database
2. Import some data
3. Checkout the develop branch
4. Run migrations - there should be 2 rehash migrations (the first uses the old logic, and the second uses the new logic)