### PR TITLE
Fix `hiredis` not found error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Improvements to UBID handling during upload by @perryr16 in https://github.com/SEED-platform/seed/pull/4780
 * Add property measure class method defaults by @perryr16 in https://github.com/SEED-platform/seed/pull/4778
 * Delete events when related cycle is deleted. by @perryr16 in https://github.com/SEED-platform/seed/pull/4779
+* Fix `hiredis` not found error by @axelstudios in https://github.com/SEED-platform/seed/pull/4821
 
 
 **Full Changelog**: https://github.com/SEED-platform/seed/compare/v3.1.0...v3.2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ psycopg2-binary==2.9.9
 celery==5.2.2
 django-celery-beat==2.2.1
 django-redis==5.2.0  # Version is tied to compatibility with boto3
-hiredis==2.3.2
+hiredis==3.0.0
 
 brotli==1.1.0
 django-compressor==4.4


### PR DESCRIPTION
#### Any background context you want to provide?
Any new docker builds (or virtual environments) created within the last 5 hours have failed to start celery due to the error `name 'hiredis' is not defined`.

This is because `redis` v5.0.8 had the dependency `hiredis>=1.0.0`, but v5.1.0 included the breaking change `hiredis>=3.0.0`. `redis` is a sub-dependency of our dependency `django-redis`, which has a _very_ liberal requirement of `redis>=4.0.2`.

#### What's this PR do?
Updates `hiredis` to v3.0.0 to match the [requirement from the sub-dependency `redis`](https://github.com/redis/redis-py/blob/v5.1.0/setup.py#L59) to resolve celery launch errors

#### How should this be manually tested?
1. Create a new virtual environment
2. Run `pip install -r requirements/base.txt`
3. Ensure Django and celery both start successfully