### PR TITLE
Inventory groups descendant tree

### DIFF
--- a/seed/static/seed/js/controllers/inventory_group_modal_controller.js
+++ b/seed/static/seed/js/controllers/inventory_group_modal_controller.js
@@ -45,6 +45,11 @@ angular.module('SEED.controller.inventory_group_modal', [])
         $scope.potential_level_instances = access_level_instances_by_depth[new_level_instance_depth];
       };
 
+      // prepopulate with first ali on lowest node
+      $scope.access_level.level_name_index = $scope.level_names.at(-1).index;
+      $scope.change_selected_level_index();
+      $scope.access_level.access_level_instance = $scope.potential_level_instances.at(0).id;
+
       $scope.edit_inventory_group = () => {
         if (!$scope.disabled()) {
           const id = $scope.data.id;

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -1921,7 +1921,7 @@
               'organization_service', 'user_service',
               (organization_service, user_service) => {
                 const organization_id = user_service.get_organization().id;
-                return organization_service.get_organization_access_level_tree(organization_id);
+                return organization_service.get_descendant_access_level_tree(organization_id);
               }
             ],
             inventory_groups: ['$stateParams', 'inventory_group_service', ($stateParams, inventory_group_service) => {
@@ -2858,7 +2858,7 @@
               'organization_service',
               (organization_payload, organization_service) => {
                 const organization_id = organization_payload.organization.id;
-                return organization_service.get_organization_access_level_tree(organization_id);
+                return organization_service.get_descendant_access_level_tree(organization_id);
               }
             ],
             auth_payload: [

--- a/seed/static/seed/js/services/organization_service.js
+++ b/seed/static/seed/js/services/organization_service.js
@@ -53,6 +53,8 @@ angular.module('SEED.service.organization', []).factory('organization_service', 
 
     organization_factory.get_organization_access_level_tree = (org_id) => $http.get(`/api/v3/organizations/${org_id}/access_levels/tree`).then((response) => response.data);
 
+    organization_factory.get_descendant_access_level_tree = (org_id) => $http.get(`/api/v3/organizations/${org_id}/access_levels/descendant_tree`).then((response) => response.data);
+
     organization_factory.update_organization_access_level_names = (org_id, new_access_level_names) => $http.post(
       `/api/v3/organizations/${org_id}/access_levels/access_level_names/`,
       { access_level_names: new_access_level_names }

--- a/seed/tests/test_organization_access_levels.py
+++ b/seed/tests/test_organization_access_levels.py
@@ -23,6 +23,7 @@ class TestOrganizationViews(AccessLevelBaseTestCase):
             "api:v3:organization-access_levels-tree",
             args=[self.org.id],
         )
+        url_descendant = reverse_lazy("api:v3:organization-access_levels-descendant-tree", args=[self.org.id])
         sibling = self.org.add_new_access_level_instance(self.org.root.id, "sibling")
         child_dict = {
             "id": self.child_level_instance.pk,
@@ -44,9 +45,15 @@ class TestOrganizationViews(AccessLevelBaseTestCase):
             "path": {"root": "root"},
         }
 
-        # get tree
+        # get tree & descendant tree
         self.login_as_root_member()
         raw_result = self.client.get(url)
+        result = json.loads(raw_result.content)
+        assert result == {
+            "access_level_names": ["root", "child"],
+            "access_level_tree": [{**root_dict, "children": [child_dict, sibling_dict]}],
+        }
+        raw_result = self.client.get(url_descendant)
         result = json.loads(raw_result.content)
         assert result == {
             "access_level_names": ["root", "child"],
@@ -59,6 +66,12 @@ class TestOrganizationViews(AccessLevelBaseTestCase):
         assert result == {
             "access_level_names": ["root", "child"],
             "access_level_tree": [{**root_dict, "children": [child_dict]}],
+        }
+        raw_result = self.client.get(url_descendant)
+        result = json.loads(raw_result.content)
+        assert result == {
+            "access_level_names": ["child"],
+            "access_level_tree": [child_dict],
         }
 
     def test_edit_access_level_names(self):


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
Limits available ALI selections to the current node and its descendants.
EX: say an orgs access levels are
Level1 
Level2
Level3
A user who belongs to Level2 should be able to create a group for Level2 & Level3 but not for Level1

#### How should this be manually tested?
Log in with a child user. Create a group from the group list page.

#### What are the relevant tickets?

#### Screenshots (if appropriate)
In this example, the user is a member of the SubSector level.
Existing:
![Screenshot 2024-10-07 at 3 34 33 PM](https://github.com/user-attachments/assets/bebec8c1-e4ec-4448-9950-023611bb68bd)

New:
![Screenshot 2024-10-07 at 3 34 01 PM](https://github.com/user-attachments/assets/0d1d2a10-da9b-46fa-9890-1023c2620c59)
