### PR TITLE
Add various inventory group features

### DIFF
--- a/seed/models/tax_lot_properties.py
+++ b/seed/models/tax_lot_properties.py
@@ -299,8 +299,10 @@ class TaxLotProperty(models.Model):
             if this_cls == "Property":
                 obj_dict.update(ali_path_by_id[obj.property.access_level_instance_id])
                 obj_dict["meters_exist_indicator"] = obj_meter_counts.get(obj.property_id, 0) > 0
+                obj_dict["groups_indicator"] = obj.property.group_mappings.count() > 0
             else:
                 obj_dict.update(ali_path_by_id[obj.taxlot.access_level_instance_id])
+                obj_dict["groups_indicator"] = obj.taxlot.group_mappings.count() > 0
 
             # bring in GIS data
             obj_dict[lookups["bounding_box"]] = bounding_box_wkt(obj.state)

--- a/seed/static/seed/js/controllers/inventory_group_modal_controller.js
+++ b/seed/static/seed/js/controllers/inventory_group_modal_controller.js
@@ -45,6 +45,11 @@ angular.module('SEED.controller.inventory_group_modal', [])
         $scope.potential_level_instances = access_level_instances_by_depth[new_level_instance_depth];
       };
 
+      // prepopulate with first ali on lowest node
+      $scope.access_level.level_name_index = $scope.level_names.at(-1).index;
+      $scope.change_selected_level_index();
+      $scope.access_level.access_level_instance = $scope.potential_level_instances.at(0).id;
+
       $scope.edit_inventory_group = () => {
         if (!$scope.disabled()) {
           const id = $scope.data.id;

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -983,6 +983,27 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
           width: 30
         },
         {
+          name: 'groups_indicator',
+          displayName: '',
+          headerCellTemplate: '<span></span>',
+          cellTemplate:
+            '<div class="ui-grid-row-header-link">' +
+            '<div class="groups-indicator" title="Group Member">' +
+                '<i class="fa fa-circle-nodes text-info" ng-if="row.entity.groups_indicator" ></i>' +
+              '</div>' +
+            '</div>',
+          enableColumnMenu: false,
+          enableColumnMoving: false,
+          enableColumnResizing: false,
+          enableFiltering: false,
+          enableHiding: false,
+          enableSorting: false,
+          exporterSuppressExport: true,
+          pinnedLeft: true,
+          visible: true,
+          width: 30
+        },
+        {
           name: 'labels',
           displayName: '',
           headerCellTemplate: '<i ng-click="grid.appScope.toggle_labels()" class="ui-grid-cell-contents fas fa-chevron-circle-right" id="label-header-icon" style="margin:2px; float:right;"></i>',
@@ -1081,6 +1102,27 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
           width: 30
         },
         {
+          name: 'groups_indicator',
+          displayName: '',
+          headerCellTemplate: '<span></span>',
+          cellTemplate:
+            '<div class="ui-grid-row-header-link">' +
+            '<div class="groups-indicator" title="Group Member">' +
+            '<i class="fa fa-circle-nodes text-info" ng-if="row.entity.groups_indicator" ></i>' +
+            '</div>' +
+            '</div>',
+          enableColumnMenu: false,
+          enableColumnMoving: false,
+          enableColumnResizing: false,
+          enableFiltering: false,
+          enableHiding: false,
+          enableSorting: false,
+          exporterSuppressExport: true,
+          pinnedLeft: true,
+          visible: true,
+          width: 30
+        },
+        {
           name: 'labels',
           displayName: '',
           headerCellTemplate: '<i ng-click="grid.appScope.toggle_labels()" class="ui-grid-cell-contents fas fa-chevron-circle-right" id="label-header-icon" style="margin:2px; float:right;"></i>',
@@ -1124,7 +1166,7 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
       if (_.isUndefined(data)) data = $scope.data;
       const visibleColumns = [
         ..._.map($scope.columns, 'name'),
-        ...['$$treeLevel', 'notes_count', 'meters_exist_indicator', 'merged_indicator', 'id', 'property_state_id', 'property_view_id', 'taxlot_state_id', 'taxlot_view_id'],
+        ...['$$treeLevel', 'notes_count', 'meters_exist_indicator', 'grous_exist', 'merged_indicator', 'id', 'property_state_id', 'property_view_id', 'taxlot_state_id', 'taxlot_view_id'],
         ...$scope.organization.access_level_names
       ];
 
@@ -1768,7 +1810,7 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
       // Save all columns except first 3 and Access Level Instances
       let gridCols = _.filter(
         $scope.gridApi.grid.columns,
-        (col) => !_.includes(['treeBaseRowHeaderCol', 'selectionRowHeaderCol', 'notes_count', 'meters_exist_indicator', 'merged_indicator', 'id', 'labels'], col.name) &&
+        (col) => !_.includes(['treeBaseRowHeaderCol', 'selectionRowHeaderCol', 'notes_count', 'meters_exist_indicator', 'merged_indicator', 'groups_indicator', 'id', 'labels'], col.name) &&
           col.visible &&
           !col.colDef.is_derived_column &&
           col.colDef.group !== 'access_level_instance'
@@ -2081,6 +2123,12 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
             col = $scope.gridApi.grid.columns[staticColIndex];
             $scope.gridApi.grid.columns.splice(staticColIndex, 1);
             $scope.gridApi.grid.columns.splice(5, 0, col);
+          }
+          staticColIndex = _.findIndex($scope.gridApi.grid.columns, { name: 'groups_indicator' });
+          if (staticColIndex !== 6) {
+            col = $scope.gridApi.grid.columns[staticColIndex];
+            $scope.gridApi.grid.columns.splice(staticColIndex, 1);
+            $scope.gridApi.grid.columns.splice(6, 0, col);
           }
           saveSettings();
         });

--- a/seed/static/seed/js/seed.js
+++ b/seed/static/seed/js/seed.js
@@ -1921,7 +1921,7 @@
               'organization_service', 'user_service',
               (organization_service, user_service) => {
                 const organization_id = user_service.get_organization().id;
-                return organization_service.get_organization_access_level_tree(organization_id);
+                return organization_service.get_descendant_access_level_tree(organization_id);
               }
             ],
             inventory_groups: ['$stateParams', 'inventory_group_service', ($stateParams, inventory_group_service) => {
@@ -2858,7 +2858,7 @@
               'organization_service',
               (organization_payload, organization_service) => {
                 const organization_id = organization_payload.organization.id;
-                return organization_service.get_organization_access_level_tree(organization_id);
+                return organization_service.get_descendant_access_level_tree(organization_id);
               }
             ],
             auth_payload: [

--- a/seed/static/seed/js/services/organization_service.js
+++ b/seed/static/seed/js/services/organization_service.js
@@ -53,6 +53,8 @@ angular.module('SEED.service.organization', []).factory('organization_service', 
 
     organization_factory.get_organization_access_level_tree = (org_id) => $http.get(`/api/v3/organizations/${org_id}/access_levels/tree`).then((response) => response.data);
 
+    organization_factory.get_descendant_access_level_tree = (org_id) => $http.get(`/api/v3/organizations/${org_id}/access_levels/descendant_tree`).then((response) => response.data);
+
     organization_factory.update_organization_access_level_names = (org_id, new_access_level_names) => $http.post(
       `/api/v3/organizations/${org_id}/access_levels/access_level_names/`,
       { access_level_names: new_access_level_names }

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -3811,8 +3811,9 @@ $pairedCellWidth: 60px;
     width: 20px;
   }
 }
+
 .groups-indicator {
-  height:100%;
+  height: 100%;
   display: flex;
   align-items: center;
 

--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -3811,6 +3811,17 @@ $pairedCellWidth: 60px;
     width: 20px;
   }
 }
+.groups-indicator {
+  height:100%;
+  display: flex;
+  align-items: center;
+
+  i.fa {
+    width: 100%;
+    font-size: 17px;
+    text-align: center;
+  }
+}
 
 .merged-indicator {
   padding-top: 6px;

--- a/seed/tests/test_inventory_groups.py
+++ b/seed/tests/test_inventory_groups.py
@@ -172,7 +172,7 @@ class InventoryGroupViewTests(AccessLevelBaseTestCase):
         url = reverse_lazy("api:v3:properties-merge") + f"?organization_id={self.org.pk}"
         data = {"property_view_ids": [self.view1.pk, view.pk]}
         self.client.post(url, data=json.dumps(data), content_type="application/json")
-        
+
         new_property = Property.objects.last()
         assert new_property.group_mappings.count() == 1
 
@@ -184,13 +184,13 @@ class InventoryGroupViewTests(AccessLevelBaseTestCase):
         # test group history preserved if first view has groups, second has none
         data = {"property_view_ids": [self.view1.pk, view4.pk]}
         self.client.post(url, data=json.dumps(data), content_type="application/json")
-        
+
         new_property = Property.objects.last()
         assert new_property.group_mappings.count() == 1
 
         # test group history preserved if second has groups, first has none
         data = {"property_view_ids": [view5.pk, self.view1.pk]}
         self.client.post(url, data=json.dumps(data), content_type="application/json")
-        
+
         new_property = Property.objects.last()
         assert new_property.group_mappings.count() == 1

--- a/seed/tests/test_inventory_groups.py
+++ b/seed/tests/test_inventory_groups.py
@@ -62,7 +62,7 @@ class InventoryGroupViewTests(AccessLevelBaseTestCase):
             name="test2", organization=self.org, inventory_type=VIEW_LIST_TAXLOT, access_level_instance=self.org.root
         )
 
-        # setup: create 3 properties with 2 meters each. Each mmeter has 2 readings
+        # create 3 properties with 2 meters each. Each mmeter has 2 readings
         self.view1 = self.property_view_factory.get_property_view()
         self.view2 = self.property_view_factory.get_property_view()
         self.view3 = self.property_view_factory.get_property_view()
@@ -193,7 +193,7 @@ class InventoryGroupViewTests(AccessLevelBaseTestCase):
         self._put_group_mappings([self.property_group.id], [view4.id, view5.id], "property")
         assert self.property_group.group_mappings.count() == 4
 
-        # bulk delete those groups
+        # bulk delete views
         url = reverse_lazy("api:v3:properties-batch-delete") + f"?organization_id={self.org.pk}"
         params = json.dumps({"property_view_ids": [view4.id, view5.id]})
         self.client.delete(url, params, content_type="application/json")

--- a/seed/tests/test_organization_access_levels.py
+++ b/seed/tests/test_organization_access_levels.py
@@ -23,6 +23,7 @@ class TestOrganizationViews(AccessLevelBaseTestCase):
             "api:v3:organization-access_levels-tree",
             args=[self.org.id],
         )
+        url_descendant = reverse_lazy("api:v3:organization-access_levels-descendant-tree", args=[self.org.id])
         sibling = self.org.add_new_access_level_instance(self.org.root.id, "sibling")
         child_dict = {
             "id": self.child_level_instance.pk,
@@ -44,9 +45,15 @@ class TestOrganizationViews(AccessLevelBaseTestCase):
             "path": {"root": "root"},
         }
 
-        # get tree
+        # get tree & descendant tree
         self.login_as_root_member()
         raw_result = self.client.get(url)
+        result = json.loads(raw_result.content)
+        assert result == {
+            "access_level_names": ["root", "child"],
+            "access_level_tree": [{**root_dict, "children": [child_dict, sibling_dict]}],
+        }
+        raw_result = self.client.get(url_descendant)
         result = json.loads(raw_result.content)
         assert result == {
             "access_level_names": ["root", "child"],
@@ -59,6 +66,12 @@ class TestOrganizationViews(AccessLevelBaseTestCase):
         assert result == {
             "access_level_names": ["root", "child"],
             "access_level_tree": [{**root_dict, "children": [child_dict]}],
+        }
+        raw_result = self.client.get(url_descendant)
+        result = json.loads(raw_result.content)
+        assert result == {
+            "access_level_names": ["child"],
+            "access_level_tree": [child_dict],
         }
 
     def test_edit_access_level_names(self):

--- a/seed/utils/merge.py
+++ b/seed/utils/merge.py
@@ -14,6 +14,7 @@ from seed.models import (
     MERGE_STATE_UNKNOWN,
     Column,
     Element,
+    InventoryGroup,
     InventoryGroupMapping,
     Note,
     Property,
@@ -213,9 +214,9 @@ def _copy_propertyview_relationships(view_ids, new_view):
     new_view.labels.set(StatusLabel.objects.filter(pk__in=label_ids))
 
     # Associate groups
-    group_mappings = InventoryGroupMapping.objects.filter(property__views__in=view_ids)
-    for grouping in group_mappings:
-        InventoryGroupMapping(property=new_view.property, group=grouping.group).save()
+    groups = InventoryGroup.objects.filter(group_mappings__property__views__in=view_ids).distinct()
+    for group in groups:
+        InventoryGroupMapping(property=new_view.property, group=group).save()
     # Associate pairs while deleting old relationships
     paired_view_ids = list(
         TaxLotProperty.objects.filter(property_view_id__in=view_ids)


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
- Adds a function to limit available ALI selections to the current node and its descendants.
EX: say an org's access levels are
Level1 
Level2
Level3
A user who belongs to Level2 should be able to create a group for Level2 & Level3 but not for Level1

- Adds groups indicator
- Refactors group merge
- Adds logic for pruning orphaned inventory mappings & groups

#### How should this be manually tested?
Log in with a child user. Create a group from the group list page.

#### What are the relevant tickets?

#### Screenshots (if appropriate)
In this example, the user is a member of the SubSector level.
Existing:
![Screenshot 2024-10-07 at 3 34 33 PM](https://github.com/user-attachments/assets/bebec8c1-e4ec-4448-9950-023611bb68bd)

New:
![Screenshot 2024-10-07 at 3 34 01 PM](https://github.com/user-attachments/assets/0d1d2a10-da9b-46fa-9890-1023c2620c59)


Group Indicator (not clickable)
![Screenshot 2024-10-09 at 10 14 22 AM](https://github.com/user-attachments/assets/4c058de2-3f08-47bc-af56-654d3d0cf4b2)
