### PR TITLE
Recheck for only numeric data in the rollup table

### DIFF
--- a/seed/views/v3/organizations.py
+++ b/seed/views/v3/organizations.py
@@ -1207,9 +1207,10 @@ class OrganizationViewSet(viewsets.ViewSet):
         data = [
             d[axis]
             for d in [apply_display_unit_preferences(organization, d) for d in filtered_properties.values(axis)]
-            if axis in d and d[axis] is not None
+            if axis in d and d[axis] is not None and isinstance(d[axis], (int, float))
         ]
 
+        logging.error(f"Data: {data}")
         if len(data) > 0:
             percentiles = np.percentile(data, [5, 25, 50, 75, 95])
             # order the cols: sum, min, 5%, 25%, mean, median (50%), 75, 95, max

--- a/seed/views/v3/organizations.py
+++ b/seed/views/v3/organizations.py
@@ -1210,7 +1210,6 @@ class OrganizationViewSet(viewsets.ViewSet):
             if axis in d and d[axis] is not None and isinstance(d[axis], (int, float))
         ]
 
-        logging.error(f"Data: {data}")
         if len(data) > 0:
             percentiles = np.percentile(data, [5, 25, 50, 75, 95])
             # order the cols: sum, min, 5%, 25%, mean, median (50%), 75, 95, max


### PR DESCRIPTION
#### What's this PR do?

Handles non-numeric x-axis selections properly - assuming properly means those axis should have all zero values in the rollup table.

#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
