### PR TITLE
Ensure year_built labels do not have commas, adjust width of scatterchart

### DIFF
--- a/seed/static/seed/js/controllers/inventory_reports_controller.js
+++ b/seed/static/seed/js/controllers/inventory_reports_controller.js
@@ -476,11 +476,29 @@ angular.module('SEED.controller.inventory_reports', []).controller('inventory_re
 
             if ($scope.chartData.chartData.every((d) => typeof d.x === 'number')) {
               $scope.scatterChart.options.scales.x.type = 'linear';
+
+              // Set the min / max for the axis to be the min/max values -/+ 0.5 percent
+              $scope.scatterChart.options.scales.x.min = Math.min(...$scope.chartData.chartData.map(d => d.x));
+              $scope.scatterChart.options.scales.x.min = $scope.scatterChart.options.scales.x.min - Math.round(Math.abs($scope.scatterChart.options.scales.x.min * 0.005));
+
+              $scope.scatterChart.options.scales.x.max = Math.max(...$scope.chartData.chartData.map(d => d.x));
+              $scope.scatterChart.options.scales.x.max = $scope.scatterChart.options.scales.x.max + Math.round(Math.abs($scope.scatterChart.options.scales.x.max * 0.005));
+
+              if ($scope.xAxisSelectedItem.varName === 'year_built') {
+                $scope.scatterChart.options.scales.x.ticks.callback = (value, index, ticks) => {
+                  return String(value);
+                }
+              }
             } else {
               $scope.scatterChart.options.scales.x = {
                 type: 'category',
                 labels: Array.from([...new Set($scope.chartData.chartData.map((d) => d.x))]).sort()
               };
+            }
+            if ($scope.yAxisSelectedItem.varName === 'year_built') {
+              $scope.scatterChart.options.scales.y.ticks.callback = (value, index, ticks) => {
+                return String(value);
+              }
             }
             $scope.scatterChart.data.datasets[0].data = $scope.chartData.chartData;
             // add the colors to the datapoints, need to create a hash map first

--- a/seed/static/seed/js/controllers/inventory_reports_controller.js
+++ b/seed/static/seed/js/controllers/inventory_reports_controller.js
@@ -478,16 +478,14 @@ angular.module('SEED.controller.inventory_reports', []).controller('inventory_re
               $scope.scatterChart.options.scales.x.type = 'linear';
 
               // Set the min / max for the axis to be the min/max values -/+ 0.5 percent
-              $scope.scatterChart.options.scales.x.min = Math.min(...$scope.chartData.chartData.map(d => d.x));
-              $scope.scatterChart.options.scales.x.min = $scope.scatterChart.options.scales.x.min - Math.round(Math.abs($scope.scatterChart.options.scales.x.min * 0.005));
+              $scope.scatterChart.options.scales.x.min = Math.min(...$scope.chartData.chartData.map((d) => d.x));
+              $scope.scatterChart.options.scales.x.min -= Math.round(Math.abs($scope.scatterChart.options.scales.x.min * 0.005));
 
-              $scope.scatterChart.options.scales.x.max = Math.max(...$scope.chartData.chartData.map(d => d.x));
-              $scope.scatterChart.options.scales.x.max = $scope.scatterChart.options.scales.x.max + Math.round(Math.abs($scope.scatterChart.options.scales.x.max * 0.005));
+              $scope.scatterChart.options.scales.x.max = Math.max(...$scope.chartData.chartData.map((d) => d.x));
+              $scope.scatterChart.options.scales.x.max += Math.round(Math.abs($scope.scatterChart.options.scales.x.max * 0.005));
 
               if ($scope.xAxisSelectedItem.varName === 'year_built') {
-                $scope.scatterChart.options.scales.x.ticks.callback = (value, index, ticks) => {
-                  return String(value);
-                }
+                $scope.scatterChart.options.scales.x.ticks.callback = (value) => String(value);
               }
             } else {
               $scope.scatterChart.options.scales.x = {
@@ -496,9 +494,7 @@ angular.module('SEED.controller.inventory_reports', []).controller('inventory_re
               };
             }
             if ($scope.yAxisSelectedItem.varName === 'year_built') {
-              $scope.scatterChart.options.scales.y.ticks.callback = (value, index, ticks) => {
-                return String(value);
-              }
+              $scope.scatterChart.options.scales.y.ticks.callback = (value) => String(value);
             }
             $scope.scatterChart.data.datasets[0].data = $scope.chartData.chartData;
             // add the colors to the datapoints, need to create a hash map first


### PR DESCRIPTION
#### What's this PR do?

Fixes the range for numeric x-axis values to be the actual range of data +/- a half percent cushion

Fixes year_built labels to be strings, so the system will not add commas after the thousands digit.

#### How should this be manually tested?

Run a chart where the x-axis is year built, note the range and labels.

#### What are the relevant tickets?
#4858

#### Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/43bd56c1-e2c0-4911-aa54-46c61c18df13)
