### PR TITLE
Reduce dockerfile-dev build time in half with `uv` and `pnpm`

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,6 +1,8 @@
 FROM node:20-alpine3.16 AS node
+# Use a multi-stage build to first get uv
+FROM ghcr.io/astral-sh/uv:0.2.12 as uv
 
-FROM alpine:3.14
+FROM alpine:3.16
 
 COPY --from=node /usr/lib /usr/lib
 COPY --from=node /usr/local/lib /usr/local/lib
@@ -41,10 +43,23 @@ RUN apk add --no-cache \
 
 ### Install python requirements
 WORKDIR /seed
+# Create a virtual environment with uv inside the container
+RUN --mount=from=uv,source=/uv,target=./uv \
+    ./uv venv /opt/venv
+# We need to set this environment variable so that uv knows where
+# the virtual environment is to install packages
+ENV VIRTUAL_ENV=/opt/venv
+# Make sure that the virtual environment is in the PATH so
+# we can use the binaries of packages that we install such as pip
+# without needing to activate the virtual environment explicitly
+ENV PATH="/opt/venv/bin:$PATH"
 COPY ./requirements.txt /seed/requirements.txt
 COPY ./requirements/*.txt /seed/requirements/
 RUN pip uninstall -y enum34
-RUN pip install -r requirements/local.txt
+# Install the packages with uv using --mount=type=cache to cache the downloaded packages
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=from=uv,source=/uv,target=./uv \
+    ./uv pip install  -r requirements/local.txt
 # for remote debugging
 RUN pip install remote-pdb
 # for live reloading celery
@@ -57,7 +72,8 @@ COPY ./package.json /seed/package.json
 COPY ./vendors/package.json /seed/vendors/package.json
 COPY ./README.md /seed/README.md
 # unsafe-perm allows the package.json postinstall script to run with the elevated permissions
-RUN npm install --unsafe-perm
+RUN npm install -g pnpm
+RUN pnpm install --unsafe-perm
 
 ### Copy over the remaining part of the SEED application and some helpers
 WORKDIR /seed

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,7 +48,7 @@ street-address==0.4.0
 xlrd==1.2.0
 xlsxwriter==1.2.7
 xmltodict==0.12.0
-requests==2.32.0
+requests==2.32.3
 probablepeople==0.5.4
 xmlschema==1.1.1
 lark==0.11.3


### PR DESCRIPTION
#### Any background context you want to provide?
I started using `uv` locally to replace `pip` and noticed that it reduces the time to install packages by about half. Additionally, I noticed that when the dockerfile is built, that the `pip install -r requirements/local.txt` step was taking most of the time.

#### What's this PR do?
I looked up how to switch to `uv` from `pip` and implemented those changes. I also looked up if there was an equivalent speed up that can happen for replacing `npm install` and tried using `pnpm`. These changes are only included in the dockerfile-dev file since likely needs to be rebuilt the most often compared to dockerfile which is used for deploying seed.

#### How should this be manually tested?
Switch to the branch and use the following command: `docker-compose stop && docker-compose rm -f && docker-compose -f docker-compose.yml -f docker-compose.dev.yml build` and see how long the build process takes. For me it was about 150 seconds compared to about 300 seconds on the develop branch.

#### What are the relevant tickets?

#### Screenshots (if appropriate)
