### PR TITLE
Remove inventory list `Data` nav item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2385,7 +2385,7 @@ Accepted External Pull Requests: 11
 
 # SEED Version 2.0.0 (2016-06-11 to 2016-10-01)
 
-losed Issues: 21
+Closed Issues: 21
 - Fixed [#30]( https://github.com/SEED-platform/seed/issues/30 ), Multiple Data Files per Building Record
 - Fixed [#59]( https://github.com/SEED-platform/seed/issues/59 ), Column Reordering allowed in Matching Edit Columns view
 - Fixed [#66]( https://github.com/SEED-platform/seed/issues/66 ), Add Ability to handle multiple years of data

--- a/seed/static/seed/partials/inventory_nav.html
+++ b/seed/static/seed/partials/inventory_nav.html
@@ -4,5 +4,4 @@
 <a ng-if="inventory_type === 'properties'" id="inventory_groups" ui-sref="inventory_groups(::{inventory_type: inventory_type})" ui-sref-active="active" translate>Groups</a>
 <a id="inventory-cycles" ui-sref="inventory_cycles(::{inventory_type: inventory_type})" ui-sref-active="active" translate>Cross-Cycles</a>
 <a id="inventory-map" ui-sref="inventory_map(::{inventory_type: inventory_type})" ui-sref-active="active" translate>Map</a>
-<a id="inventory-data" ui-sref="custom_reports(::{inventory_type: inventory_type})" ui-sref-active="active" translate>Data</a>
 <a id="inventory-summary" ui-sref="inventory_summary(::{inventory_type: inventory_type})" ui-sref-active="active" translate>Summary</a>


### PR DESCRIPTION
#### Any background context you want to provide?
The `Data` nav item was ambiguous, and unnecessary, since it wasn't related to Inventory and would navigate away to the Insights page

#### What's this PR do?
- Removes the Inventory List `Data` nav item
- Small changelog cleanup

#### How should this be manually tested?
Check that `Data` no longer appears. Old nav:
![image](https://github.com/user-attachments/assets/e10ad433-d6ab-4ca5-935a-ebdb3f2b78e4)