### PR TITLE
Show default display name on analyses

### DIFF
--- a/seed/models/properties.py
+++ b/seed/models/properties.py
@@ -847,6 +847,13 @@ class PropertyState(models.Model):
 
         return merged_state
 
+    def default_display_value(self):
+        try:
+            field = self.organization.property_display_field
+            return self.extra_data.get(field) or getattr(self, field)
+        except AttributeError:
+            return None
+
 
 @receiver(pre_delete, sender=PropertyState)
 def pre_delete_state(sender, **kwargs):

--- a/seed/serializers/analysis_property_views.py
+++ b/seed/serializers/analysis_property_views.py
@@ -16,3 +16,9 @@ class AnalysisPropertyViewSerializer(serializers.ModelSerializer):
     class Meta:
         model = AnalysisPropertyView
         fields = "__all__"
+
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        state = instance.property_state
+        ret["display_name"] = state.default_display_value() if state else None
+        return ret

--- a/seed/static/seed/js/controllers/analysis_controller.js
+++ b/seed/static/seed/js/controllers/analysis_controller.js
@@ -25,14 +25,5 @@ angular.module('SEED.controller.analysis', []).controller('analysis_controller',
     $scope.views = views_payload.views;
     $scope.view_id = $stateParams.view_id;
     $scope.original_views = views_payload.original_views;
-
-    $scope.has_children = (value) => typeof value === 'object';
-
-    $scope.get_display_name = (inventory_state) => organization_service.get_inventory_display_value(
-      $scope.org,
-      // NOTE: hardcoding 'property' b/c you can only run analyses on properties
-      'property',
-      inventory_state
-    );
   }
 ]);

--- a/seed/static/seed/js/controllers/analysis_run_controller.js
+++ b/seed/static/seed/js/controllers/analysis_run_controller.js
@@ -32,7 +32,5 @@ angular.module('SEED.controller.analysis_run', []).controller('analysis_run_cont
     $scope.original_view = view_payload.original_view;
     $scope.original_views = {};
     $scope.original_views[view_payload.view.id] = view_payload.original_view;
-
-    $scope.has_children = (value) => typeof value === 'object';
   }
 ]);

--- a/seed/static/seed/js/controllers/inventory_detail_analyses_controller.js
+++ b/seed/static/seed/js/controllers/inventory_detail_analyses_controller.js
@@ -165,6 +165,5 @@ angular.module('SEED.controller.inventory_detail_analyses', []).controller('inve
           }
         });
     };
-    $scope.has_children = (value) => typeof value === 'object';
   }
 ]);

--- a/seed/static/seed/partials/analysis_runs.html
+++ b/seed/static/seed/partials/analysis_runs.html
@@ -13,9 +13,9 @@
         <td><a ui-sref="analysis_run(::{run_id: view.id, analysis_id: analysis.id, organization_id: org.id})" ui-sref-active="active">{$:: view.id $}</a></td>
         <td>
           <a ng-if="original_views[view.id]" ui-sref="inventory_detail({inventory_type: 'properties', view_id: original_views[view.id]})">
-            {$:: view.display_name || 'Property ' + original_views[view.id] $} <i class="glyphicon glyphicon-log-out"></i>
+            {$:: view.display_name || 'Property: Unknown' $} <i class="glyphicon glyphicon-log-out"></i>
           </a>
-          <span ng-if="!original_views[view.id]" uib-tooltip="Property no longer exists"> <i class="fa-solid fa-triangle-exclamation"></i> {$:: view.display_name || 'Unknown' $} </span>
+          <span ng-if="!original_views[view.id]" uib-tooltip="Property no longer exists"> <i class="fa-solid fa-triangle-exclamation"></i> {$:: view.display_name || 'Property: Unknown' $} </span>
         </td>
         <td>
           <ul>


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
Shows property default display field in the analyses table

#### How should this be manually tested?
- create an analysis
- property's default display field should be in the analyses table. If the property is missing the default display field, it will display "Property: Unknown"

#### What are the relevant tickets?
#4822

#### Screenshots (if appropriate)

![Screenshot 2025-01-14 at 2 14 28 PM](https://github.com/user-attachments/assets/e834902e-d8c0-42d1-9537-fe9ec1dffaa0)
