### PR TITLE
Add Simple JWT to authorization setup

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -61,7 +61,6 @@ TEMPLATES = [
     },
 ]
 MIDDLEWARE = (
-    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.gzip.GZipMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.locale.LocaleMiddleware",
@@ -88,7 +87,6 @@ DJANGO_CORE_APPS = (
     "django.contrib.staticfiles",
     "django.contrib.gis",
     "compressor",
-    "corsheaders",
     "django_extensions",
     "django_filters",
     "rest_framework",
@@ -289,7 +287,6 @@ REST_FRAMEWORK = {
     "EXCEPTION_HANDLER": "seed.exception_handler.custom_exception_handler",
 }
 
-
 SWAGGER_SETTINGS = {
     "TAGS_SORTER": "alpha",
     "DEFAULT_FIELD_INSPECTORS": [
@@ -316,8 +313,6 @@ SIMPLE_JWT = {
     "TOKEN_OBTAIN_SERIALIZER": "seed.landing.serializers.SeedTokenObtainPairSerializer",
     "ROTATE_REFRESH_TOKENS": True,
 }
-
-CORS_ALLOW_ALL_ORIGINS = True
 
 try:
     EEEJ_LOAD_SMALL_TEST_DATASET = bool(strtobool(os.environ.get("EEEJ_LOAD_SMALL_TEST_DATASET", "False")))

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -101,6 +101,7 @@ DJANGO_CORE_APPS = (
     "two_factor.plugins.phonenumber",  # <- if you want phone number capability.
     "two_factor.plugins.email",  # <- if you want email capability.
     # "two_factor.plugins.yubikey",  # <- for yubikey capability.
+    "rest_framework_simplejwt",
 )
 
 
@@ -268,6 +269,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # Django Rest Framework
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
         "rest_framework.authentication.SessionAuthentication",
         "seed.authentication.SEEDAuthentication",
     ),
@@ -283,6 +285,7 @@ REST_FRAMEWORK = {
     "DATETIME_INPUT_FORMATS": ("%Y:%m:%d", "iso-8601", "%Y-%m-%d"),
     "EXCEPTION_HANDLER": "seed.exception_handler.custom_exception_handler",
 }
+
 
 SWAGGER_SETTINGS = {
     "TAGS_SORTER": "alpha",
@@ -302,6 +305,10 @@ SWAGGER_SETTINGS = {
     ],
     "DOC_EXPANSION": "none",
     "LOGOUT_URL": "/accounts/logout",
+}
+
+SIMPLE_JWT = {
+    "AUTH_HEADER_TYPES": ("Bearer",),
 }
 
 try:

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -4,6 +4,7 @@ See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 """
 
 import os
+from datetime import timedelta
 from distutils.util import strtobool
 
 from django.utils.translation import gettext_lazy as _
@@ -310,8 +311,10 @@ SWAGGER_SETTINGS = {
 }
 
 SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=5),
     "AUTH_HEADER_TYPES": ("Bearer",),
     "TOKEN_OBTAIN_SERIALIZER": "seed.landing.serializers.SeedTokenObtainPairSerializer",
+    "ROTATE_REFRESH_TOKENS": True,
 }
 
 CORS_ALLOW_ALL_ORIGINS = True

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -60,6 +60,7 @@ TEMPLATES = [
     },
 ]
 MIDDLEWARE = (
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.gzip.GZipMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.locale.LocaleMiddleware",
@@ -86,6 +87,7 @@ DJANGO_CORE_APPS = (
     "django.contrib.staticfiles",
     "django.contrib.gis",
     "compressor",
+    "corsheaders",
     "django_extensions",
     "django_filters",
     "rest_framework",
@@ -309,7 +311,10 @@ SWAGGER_SETTINGS = {
 
 SIMPLE_JWT = {
     "AUTH_HEADER_TYPES": ("Bearer",),
+    "TOKEN_OBTAIN_SERIALIZER": "seed.landing.serializers.SeedTokenObtainPairSerializer",
 }
+
+CORS_ALLOW_ALL_ORIGINS = True
 
 try:
     EEEJ_LOAD_SMALL_TEST_DATASET = bool(strtobool(os.environ.get("EEEJ_LOAD_SMALL_TEST_DATASET", "False")))

--- a/config/urls.py
+++ b/config/urls.py
@@ -10,6 +10,7 @@ from django.urls import include, path, re_path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from two_factor.urls import urlpatterns as tf_urls
 
 from config.views import robots_txt
@@ -54,6 +55,8 @@ urlpatterns = [
     # API
     re_path(r"^api/health_check/$", health_check, name="health_check"),
     re_path(r"^api/swagger/$", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
+    re_path(r"^api/token/$", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    re_path(r"^api/token/refresh/$", TokenRefreshView.as_view(), name="token_refresh"),
     re_path(r"^api/version/$", version, name="version"),
     re_path(r"^api/", include((api, "seed"), namespace="api")),
     re_path(r"^account/login", CustomLoginView.as_view(), name="login"),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,6 +27,7 @@ django-pint==0.7.3
 
 # API
 djangorestframework==3.15.1  # Update after Django 4.2
+djangorestframework-simplejwt==5.3.1 # Update after Django 4.2
 django-post_office==3.8.0  # Update after Django 4.2
 drf-yasg==1.21.7
 django-filter==22.1  # Update after Django 4.2 and drf-spectacular

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,6 +28,7 @@ django-pint==0.7.3
 # API
 djangorestframework==3.15.1  # Update after Django 4.2
 djangorestframework-simplejwt==5.3.1 # Update after Django 4.2
+django-cors-headers==4.5.0 # Update after Django 4.2
 django-post_office==3.8.0  # Update after Django 4.2
 drf-yasg==1.21.7
 django-filter==22.1  # Update after Django 4.2 and drf-spectacular

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,6 @@ django-pint==0.7.3
 # API
 djangorestframework==3.15.1  # Update after Django 4.2
 djangorestframework-simplejwt==5.3.1 # Update after Django 4.2
-django-cors-headers==4.5.0 # Update after Django 4.2
 django-post_office==3.8.0  # Update after Django 4.2
 drf-yasg==1.21.7
 django-filter==22.1  # Update after Django 4.2 and drf-spectacular

--- a/seed/landing/models.py
+++ b/seed/landing/models.py
@@ -95,7 +95,7 @@ class SEEDUser(AbstractBaseUser, PermissionsMixin):
                 user = SEEDUser.objects.get(api_key=api_key, username=username)
                 return user
             elif auth_header.startswith("Bearer"):
-                at = AccessToken(auth_header.removeprefix("Bearer: "))
+                at = AccessToken(auth_header.removeprefix("Bearer "))
                 user = SEEDUser.objects.get(pk=at["user_id"])
                 return user
             else:

--- a/seed/landing/models.py
+++ b/seed/landing/models.py
@@ -15,6 +15,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions
+from rest_framework_simplejwt.tokens import AccessToken
 
 from seed.lib.superperms.orgs.models import Organization
 
@@ -82,23 +83,27 @@ class SEEDUser(AbstractBaseUser, PermissionsMixin):
             return None
 
         try:
-            if not auth_header.startswith("Basic"):
-                raise exceptions.AuthenticationFailed("Only Basic HTTP_AUTHORIZATION is supported")
+            if auth_header.startswith("Basic"):
+                auth_header = auth_header.split()[1]
+                auth_header = base64.urlsafe_b64decode(auth_header).decode("utf-8")
+                username, api_key = auth_header.split(":")
 
-            auth_header = auth_header.split()[1]
-            auth_header = base64.urlsafe_b64decode(auth_header).decode("utf-8")
-            username, api_key = auth_header.split(":")
+                valid_api_key = re.search("^[a-f0-9]{40}$", api_key)
+                if not valid_api_key:
+                    raise exceptions.AuthenticationFailed("Invalid API key")
 
-            valid_api_key = re.search("^[a-f0-9]{40}$", api_key)
-            if not valid_api_key:
-                raise exceptions.AuthenticationFailed("Invalid API key")
-
-            user = SEEDUser.objects.get(api_key=api_key, username=username)
-            return user
+                user = SEEDUser.objects.get(api_key=api_key, username=username)
+                return user
+            elif auth_header.startswith("Bearer"):
+                at = AccessToken(auth_header.removeprefix("Bearer: "))
+                user = SEEDUser.objects.get(pk=at["user_id"])
+                return user
+            else:
+                raise exceptions.AuthenticationFailed("Only Basic HTTP_AUTHORIZATION or BEARER Tokens are supported")
         except ValueError:
             raise exceptions.AuthenticationFailed("Invalid HTTP_AUTHORIZATION Header")
         except SEEDUser.DoesNotExist:
-            raise exceptions.AuthenticationFailed("Invalid API key")
+            raise exceptions.AuthenticationFailed("Invalid API key or Bearer Token")
 
     def get_absolute_url(self):
         return f"/users/{quote(self.username)}/"

--- a/seed/landing/serializers.py
+++ b/seed/landing/serializers.py
@@ -1,0 +1,14 @@
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+
+
+class SeedTokenObtainPairSerializer(TokenObtainPairSerializer):
+    @classmethod
+    def get_token(cls, user):
+        token = super().get_token(user)
+
+        # Add custom claims
+        token["name"] = f"{user.first_name} {user.last_name}"
+        token["username"] = user.username
+        token["email"] = user.email
+
+        return token

--- a/seed/landing/serializers.py
+++ b/seed/landing/serializers.py
@@ -7,7 +7,7 @@ class SeedTokenObtainPairSerializer(TokenObtainPairSerializer):
         token = super().get_token(user)
 
         # Add custom claims
-        token["name"] = f"{user.first_name} {user.last_name}"
+        token["name"] = f"{user.first_name} {user.last_name}".strip()
         token["username"] = user.username
         token["email"] = user.email
 

--- a/seed/landing/urls.py
+++ b/seed/landing/urls.py
@@ -6,6 +6,10 @@ See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 from django.conf import settings
 from django.contrib.auth.views import LogoutView, PasswordChangeDoneView, PasswordChangeView
 from django.urls import path, re_path
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+)
 
 from seed.landing.views import (
     account_activation_sent,
@@ -32,6 +36,8 @@ urlpatterns = [
     re_path(r"^accounts/setup/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/$", signup, name="signup"),
     path("password_change/", PasswordChangeView.as_view(), {"template_name": "landing/password_change_form.html"}, name="password_change"),
     path("password_change/done/", PasswordChangeDoneView.as_view(), {"template_name": "landing/password_change_done.html"}),
+    path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
 ]
 
 if settings.INCLUDE_ACCT_REG:

--- a/seed/landing/urls.py
+++ b/seed/landing/urls.py
@@ -6,10 +6,6 @@ See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 from django.conf import settings
 from django.contrib.auth.views import LogoutView, PasswordChangeDoneView, PasswordChangeView
 from django.urls import path, re_path
-from rest_framework_simplejwt.views import (
-    TokenObtainPairView,
-    TokenRefreshView,
-)
 
 from seed.landing.views import (
     account_activation_sent,
@@ -36,8 +32,6 @@ urlpatterns = [
     re_path(r"^accounts/setup/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/$", signup, name="signup"),
     path("password_change/", PasswordChangeView.as_view(), {"template_name": "landing/password_change_form.html"}, name="password_change"),
     path("password_change/done/", PasswordChangeDoneView.as_view(), {"template_name": "landing/password_change_done.html"}),
-    path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
-    path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
 ]
 
 if settings.INCLUDE_ACCT_REG:


### PR DESCRIPTION
#### What's this PR do?

Add simplejwt support to the authorization options, adds an additional block to handle bearer tokens

#### How to test

This PR enables you to get a set of authorization and refresh tokens by authenticating against SEED:

```bash
curl -X POST -H 'Content-Type: application/json' -d '{"username":"usernam@email.com", "password":"password"}' http://localhost/api/token/
```

That will return a refresh and access token:

```json
{
  "refresh": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTczNzA2MDk4MSwiaWF0IjoxNzM2OTc0NTgxLCJqdGkiOiIzNmRmZjhmMzYwNTc0NjBhYTk3MTJiNTYzZjgzNjg2MyIsInVzZXJfaWQiOjJ9.PampCBSI2djMnfmx8MZv4oocvEVfd_hrY4k238nX81Q",
  "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzM2OTc0ODgxLCJpYXQiOjE3MzY5NzQ1ODEsImp0aSI6ImIwYTdkMjYwODc4MDQ3ZmI4YmQ4NGIwMTJjM2JjZGJlIiwidXNlcl9pZCI6Mn0.3Dq7lQ1KVbEDkUn12Qyt2MhZXDpZmPdbjwyhu77PhmI"
}
```

The access token can then be used as a bearer token for authorization:

```bash
curl -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzM2OTcxMjEyLCJpYXQiOjE3MzY5NzA5MTIsImp0aSI6ImI2NWZjZDc5OWJlYTQyOGQ4ZGQzYzI1OWQxMzYxODJjIiwidXNlcl9pZCI6Mn0.q0gVvHpujfTPzB0Nye019AzNdPo6M1RPCK8A3uZfBME" -X POST "http://localhost/api/v3/properties/filter/?cycle=2&ids_only=false&include_related=true&organization_id=1&page=1&per_page=100"
```

These steps are taken from here: https://django-rest-framework-simplejwt.readthedocs.io/en/stable/getting_started.html