### PR TITLE
Remove server settings from the session cookie

### DIFF
--- a/seed/landing/forms.py
+++ b/seed/landing/forms.py
@@ -5,22 +5,8 @@ See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 
 from django import forms
 from django.contrib.auth.forms import UserCreationForm
-from django.utils.translation import gettext_lazy as _
 
 from seed.landing.models import SEEDUser
-
-
-class LoginForm(forms.Form):
-    email = forms.EmailField(
-        label=_("Email"),
-        help_text=_("ex: joe@company.com"),
-        widget=forms.TextInput(attrs={"class": "field", "placeholder": _("Email Address")}),
-    )
-    password = forms.CharField(
-        label=_("Password"),
-        widget=forms.PasswordInput(attrs={"class": "field", "placeholder": _("Password"), "autocomplete": "off"}),
-        required=True,
-    )
 
 
 class CustomCreateUserForm(UserCreationForm):

--- a/seed/landing/templates/two_factor/core/login.html
+++ b/seed/landing/templates/two_factor/core/login.html
@@ -80,7 +80,7 @@
     {% if wizard.steps.current == 'auth' %}
 
     <a class="forgot_password" href="{% url "landing:password_reset" %}">{% trans "Forgot password?" %}</a>
-      {% if request.session.include_acct_reg%}
+      {% if context.self_registration %}
       <div>
         <a class="create_account btn btn-secondary" href="{% url "landing:create_account" %}">{% trans "Create my Account" %}</a>
       </div>
@@ -107,13 +107,10 @@
 
 {% block js %}
   <script>
-    const toggleTerms = function () {
+    const toggleTerms = () => {
       const terms = document.getElementById('terms-and-conditions');
       const hidden = ['', 'none'].includes(terms.style.display);
       terms.style.display = hidden ? 'block' : 'none';
-    }
-    const resendToken = function () {
-      console.log('yup')
     }
   </script>
 {% endblock %}

--- a/seed/landing/views.py
+++ b/seed/landing/views.py
@@ -222,7 +222,8 @@ class CustomLoginView(LoginView):
             user.save()
         return HttpResponseRedirect("/app/#/profile/two_factor_profile")
 
-    def get(self, request, *args, **kwargs):
-        # add env var to session for conditional frontend display
-        request.session["include_acct_reg"] = settings.INCLUDE_ACCT_REG
-        return super().get(request, *args, **kwargs)
+    def render(self, form=None, **kwargs):
+        # Conditionally show the `Create my Account` button
+        kwargs.setdefault("context", {})["self_registration"] = settings.INCLUDE_ACCT_REG
+
+        return super().render(form, **kwargs)


### PR DESCRIPTION
#### Any background context you want to provide?
The `sessionid` cookie should have only the minimal session-specific data necessary, and not server settings that can become out-of-sync if stored in session tokens

#### What's this PR do?
Overrides the `two_factor.views.core.LoginView.render` method to make the backend setting `INCLUDE_ACCT_REG` available to the view template without storing it in each user's session cookie

#### How should this be manually tested?
1. In `local_untracked.py` toggle the `INCLUDE_ACCT_REG = True` variable and check that the login page correctly renders (or hides) the `Create my Account` button
2. Optionally inspect the session cookie data and ensure the `include_acct_reg` is no longer included. Copy your `sessionid` cookie value and run the following commands:
   ```bash
   # shell
   export DJANGO_SETTINGS_MODULE="config.settings.local_untracked"
   ```
   
   ```python
   # python
   from django.conf import settings
   from django.core import signing

   cookie_value = "YOUR_SESSIONID_COOKIE_VALUE"

   decoded = signing.loads(
       cookie_value,
       key=settings.SECRET_KEY,
       salt="django.contrib.sessions.backends.signed_cookies",
   )

   print(decoded)
   ```
   
   The new session data (for a logged-out user) should show the following:
   ```json
   {
     "wizard_custom_login_view": {
       "step": "auth",
       "step_data": {},
       "step_files": {},
       "extra_data": {},
       "validated_step_data": {}
     }
   }
   ```