### PR TITLE
Fixes inventory groups add inventory bug

### DIFF
--- a/seed/static/seed/js/controllers/update_inventory_groups_modal_controller.js
+++ b/seed/static/seed/js/controllers/update_inventory_groups_modal_controller.js
@@ -30,7 +30,7 @@ angular.module('SEED.controller.update_inventory_groups_modal', [])
       $scope.inventory_type = inventory_type;
       $scope.org_id = org_id;
 
-      organization_service.filter_access_levels_by_inventory(org_id, inventory_type, view_ids).then((response) => {
+      organization_service.filter_access_levels_by_views(org_id, inventory_type, view_ids).then((response) => {
         $scope.inventory_access_level_instance_ids = response.access_level_instance_ids;
         $scope.inventory_access_level_instance_count = $scope.inventory_access_level_instance_ids.length;
 
@@ -89,10 +89,6 @@ angular.module('SEED.controller.update_inventory_groups_modal', [])
       $scope.create_permission = () => $scope.inventory_access_level_instance_count === 1;
 
       $scope.add_permission = (group) => {
-        // Wait for ali information to populate
-        if (!$scope.inventory_access_level_instance_count) {
-          return true;
-        }
         group.ali_match = group.access_level_instance === $scope.inventory_access_level_instance_ids[0];
         return (
           !group.has_views &&

--- a/seed/static/seed/js/services/organization_service.js
+++ b/seed/static/seed/js/services/organization_service.js
@@ -79,9 +79,9 @@ angular.module('SEED.service.organization', []).factory('organization_service', 
       { inventory_type, inventory_ids }
     ).then((response) => response.data);
 
-    organization_factory.filter_access_levels_by_inventory = (org_id, inventory_type, inventory_ids) => $http.post(
-      `/api/v3/organizations/${org_id}/access_levels/filter_by_inventory/`,
-      { inventory_type, inventory_ids }
+    organization_factory.filter_access_levels_by_views = (org_id, inventory_type, view_ids) => $http.post(
+      `/api/v3/organizations/${org_id}/access_levels/filter_by_views/`,
+      { inventory_type, view_ids }
     ).then((response) => response.data).catch((data) => {
       console.log(data);
     });

--- a/seed/static/seed/partials/update_inventory_groups_modal.html
+++ b/seed/static/seed/partials/update_inventory_groups_modal.html
@@ -76,18 +76,9 @@
         <div class="form-group" id="group-add-container" ng-class="{'has-error': newGroupForm.name.$invalid && newGroupForm.name.$dirty }">
           <div>
             <label class="control-group sectionGroup" style="padding-right: 20px" translate>Create new group</label>
-            <!-- <div class="input-group" style="padding-right: 20px"> -->
             <input id="newGroupName" type="text" name="name" class="form-control" ng-model="new_group.name" placeholder="{$:: 'Group Name' | translate $}" sd-check-label-exists="groups" required />
-            <!-- </div> -->
           </div>
-          <button
-            type="submit"
-            class="btn btn-primary"
-            ng-disabled="newGroupForm.$invalid || disabled || inventory_access_level_instance_count !== 1"
-            style="height: 40px; margin-top: 20px"
-            ng-disabled=""
-            translate
-          >
+          <button type="submit" class="btn btn-primary" ng-disabled="newGroupForm.$invalid || inventory_access_level_instance_count !== 1" style="height: 40px; margin-top: 20px" translate>
             Create group
           </button>
         </div>

--- a/seed/views/v3/access_levels.py
+++ b/seed/views/v3/access_levels.py
@@ -575,7 +575,7 @@ class AccessLevelViewSet(viewsets.ViewSet):
         if not view_ids:
             return JsonResponse({"status": "success", "access_level_instance_ids": []})
 
-        inventory_type, InventoryClass = ("taxlot", TaxLot) if inventory_type == "taxlots" else ("property", Property)
+        InventoryClass = TaxLot if inventory_type == "taxlots" else Property
         inventory_ids = InventoryClass.objects.filter(views__id__in=view_ids, organization_id=organization_pk).values_list("id", flat=True)
         access_level_instance_ids = AccessLevelInstance.objects.filter(properties__in=inventory_ids).distinct().values_list("id", flat=True)
 


### PR DESCRIPTION
#### Any background context you want to provide?
There was an argument mismatch between the frontend and backend when fetching the ALIs associated with a selection for the groups modal. The frontend passed view_ids while the backend interpreted them as inventory_ids (property_ids or taxlot_ids). On small DBs this wasn't noticeable as the view_ids and property_ids aligned. However, in larger dbs, the views and the properties did not align and the backend would return zero ALI matches. This led to the frontend form being disabled as it expects the ALI count to equal 1, not 0.

#### What's this PR do?
- This PR corrects the django db logic by converting the view_ids to inventory_ids before filtering for access level instances. 
- Fixes smaller syntax and swagger bugs

#### How should this be manually tested?
From the inventory list, select a few properties with the same access level and add them to a group. Check for console errors.

#### What are the relevant tickets?
I was not able to recreate the 500 error, however I'm hopeful this will correct it.
#4908 
#4928

#### Screenshots (if appropriate)
The below screenshot was taken from develop after attempting to add a single property to a group. The warning is misleading as a single property would have exactly 1 ALI
![Screenshot 2025-01-22 at 2 10 00 PM](https://github.com/user-attachments/assets/3ae5e77a-aa8e-4281-8727-ef1ee9b62cda)

