### PR TITLE
Django settings endpoint

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -16,7 +16,7 @@ from two_factor.urls import urlpatterns as tf_urls
 from config.views import robots_txt
 from seed.api.base.urls import urlpatterns as api
 from seed.landing.views import CustomLoginView, password_reset_complete, password_reset_confirm, password_reset_done
-from seed.views.main import angular_js_tests, health_check, version, noauth_settings
+from seed.views.main import angular_js_tests, health_check, noauth_settings, version
 
 schema_view = get_schema_view(
     openapi.Info(

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,7 +16,7 @@ from two_factor.urls import urlpatterns as tf_urls
 from config.views import robots_txt
 from seed.api.base.urls import urlpatterns as api
 from seed.landing.views import CustomLoginView, password_reset_complete, password_reset_confirm, password_reset_done
-from seed.views.main import angular_js_tests, health_check, noauth_settings, version
+from seed.views.main import angular_js_tests, config, health_check, version
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -52,9 +52,10 @@ urlpatterns = [
     # root configuration items
     re_path(r"^i18n/", include("django.conf.urls.i18n")),
     re_path(r"^robots\.txt", robots_txt, name="robots_txt"),
-    # API
+    # API (explicit no-auth)
+    re_path(r"^api/config/$", config, name="config"),
     re_path(r"^api/health_check/$", health_check, name="health_check"),
-    re_path(r"^api/noauth_settings/$", noauth_settings, name="noauth_settings"),
+    # API
     re_path(r"^api/swagger/$", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
     re_path(r"^api/token/$", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     re_path(r"^api/token/refresh/$", TokenRefreshView.as_view(), name="token_refresh"),

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,7 +16,7 @@ from two_factor.urls import urlpatterns as tf_urls
 from config.views import robots_txt
 from seed.api.base.urls import urlpatterns as api
 from seed.landing.views import CustomLoginView, password_reset_complete, password_reset_confirm, password_reset_done
-from seed.views.main import angular_js_tests, health_check, version
+from seed.views.main import angular_js_tests, health_check, version, noauth_settings
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -54,6 +54,7 @@ urlpatterns = [
     re_path(r"^robots\.txt", robots_txt, name="robots_txt"),
     # API
     re_path(r"^api/health_check/$", health_check, name="health_check"),
+    re_path(r"^api/noauth_settings/$", noauth_settings, name="noauth_settings"),
     re_path(r"^api/swagger/$", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
     re_path(r"^api/token/$", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     re_path(r"^api/token/refresh/$", TokenRefreshView.as_view(), name="token_refresh"),

--- a/seed/landing/models.py
+++ b/seed/landing/models.py
@@ -15,6 +15,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions
+from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import AccessToken
 
 from seed.lib.superperms.orgs.models import Organization
@@ -102,6 +103,8 @@ class SEEDUser(AbstractBaseUser, PermissionsMixin):
                 raise exceptions.AuthenticationFailed("Only Basic HTTP_AUTHORIZATION or BEARER Tokens are supported")
         except ValueError:
             raise exceptions.AuthenticationFailed("Invalid HTTP_AUTHORIZATION Header")
+        except TokenError:
+            raise exceptions.AuthenticationFailed("Invalid Bearer Token")
         except SEEDUser.DoesNotExist:
             raise exceptions.AuthenticationFailed("Invalid API key or Bearer Token")
 

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -156,6 +156,18 @@ def health_check(request):
         status=(200 if success else 418),
     )
 
+@api_endpoint
+@ajax_request
+@api_view(["GET"])
+def noauth_settings(request):
+    """
+    Returns django settings needed to render no-auth pages
+    """
+    # include sign-up page?
+    enable_sign_up = settings.INCLUDE_ACCT_REG
+
+    return JsonResponse({"include_signup": enable_sign_up})
+
 
 @api_endpoint
 @ajax_request

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -156,6 +156,7 @@ def health_check(request):
         status=(200 if success else 418),
     )
 
+
 @api_endpoint
 @ajax_request
 @api_view(["GET"])

--- a/seed/views/main.py
+++ b/seed/views/main.py
@@ -14,6 +14,7 @@ from django.core.cache import cache
 from django.db import connection
 from django.http import JsonResponse
 from django.shortcuts import redirect, render
+from django.views.decorators.http import require_GET
 from rest_framework import status
 from rest_framework.decorators import api_view
 
@@ -157,17 +158,16 @@ def health_check(request):
     )
 
 
-@api_endpoint
 @ajax_request
-@api_view(["GET"])
-def noauth_settings(request):
+@require_GET
+def config(request):
     """
-    Returns django settings needed to render no-auth pages
+    Returns readonly django settings
     """
-    # include sign-up page?
-    enable_sign_up = settings.INCLUDE_ACCT_REG
 
-    return JsonResponse({"include_signup": enable_sign_up})
+    return {
+        "allow_signup": settings.INCLUDE_ACCT_REG,
+    }
 
 
 @api_endpoint


### PR DESCRIPTION
Adds an API endpoint to retrieve Django settings needed to render unauthenticated pages

Endpoint: `GET /api/config/`

Currently only returns the setting `allow_signup` but we can expand as needed.