### PR TITLE
Fix ESPM download, change generateData from POST to GET

### DIFF
--- a/seed/views/v3/portfolio_manager.py
+++ b/seed/views/v3/portfolio_manager.py
@@ -430,7 +430,7 @@ class PortfolioManagerImport:
         new_authenticated_headers["Content-Type"] = "application/x-www-form-urlencoded"
 
         try:
-            response = requests.post(update_report_url, headers=self.authenticated_headers, timeout=300)
+            response = requests.get(update_report_url, headers=self.authenticated_headers, timeout=300)
         except requests.exceptions.SSLError:
             raise PMError("SSL Error in Portfolio Manager Query; check VPN/Network/Proxy.")
         if not response.status_code == status.HTTP_200_OK:
@@ -462,7 +462,7 @@ class PortfolioManagerImport:
         template_report_id = matched_template["id"]
         generation_url = f"https://portfoliomanager.energystar.gov/pm/reports/generateData/{template_report_id}"
         try:
-            response = requests.post(generation_url, headers=self.authenticated_headers, timeout=300)
+            response = requests.get(generation_url, headers=self.authenticated_headers, timeout=300)
         except requests.exceptions.SSLError:
             raise PMError("SSL Error in Portfolio Manager Query; check VPN/Network/Proxy.")
         if not response.status_code == status.HTTP_200_OK:


### PR DESCRIPTION
ESPM changed their api! This broke our [tests](https://github.com/SEED-platform/seed/actions/runs/13996604162/job/39200257219?pr=4956):
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/10d30adf-ba15-48f6-a2bc-89996a9ebffb" />

specifically, this line [broke](url):
<img width="885" alt="image" src="https://github.com/user-attachments/assets/33709371-9799-4576-a862-050167bee0af" />

I tried calling the same endpoint on [portfoliomanager.energystar.gov](portfoliomanager.energystar.gov), and it appears to be a get
<img width="1323" alt="image" src="https://github.com/user-attachments/assets/fd170207-264b-4842-95c4-d25afbce59dc" />

I changed it to a get and it worked!
