### PR TITLE
Fix `used_columns` error for taxlots

### DIFF
--- a/seed/views/v3/analyses.py
+++ b/seed/views/v3/analyses.py
@@ -374,7 +374,7 @@ class AnalysisViewSet(viewsets.ViewSet, OrgMixin):
             tcolumns = Column.objects.filter(organization_id=org_id, derived_column=None, table_name="TaxLotState").exclude(
                 column_name__in=EXCLUDED_API_FIELDS
             )
-            num_of_nonnulls_by_column_name = Column.get_num_of_nonnulls_by_column_name(state_ids, TaxLotState, columns)
+            num_of_nonnulls_by_column_name = Column.get_num_of_nonnulls_by_column_name(tstate_ids, TaxLotState, tcolumns)
 
         # properties and taxlots together
         num_of_nonnulls_by_column_name.update(tnum_of_nonnulls_by_column_name)


### PR DESCRIPTION
#### Any background context you want to provide?
The `/api/v3/analyses/used_columns/` endpoint was calling `get_num_of_nonnulls_by_column_name` with the wrong arguments for taxlots, and would fail for any organization containing taxlots.

#### What's this PR do?
- Fixes the `used_columns` endpoint

#### How should this be manually tested?
1. Create an org with taxlot data
2. Browse to `/api/v3/analyses/used_columns/?organization_id=X`

#### What are the relevant tickets?
#4979 