### PR TITLE
Remove dev dependencies

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,6 +1,6 @@
-FROM node:20-alpine3.16 AS node
+FROM node:20-alpine3.19 AS node
 
-FROM alpine:3.14
+FROM alpine:3.19 as build
 
 COPY --from=node /usr/lib /usr/lib
 COPY --from=node /usr/local/lib /usr/local/lib
@@ -8,7 +8,6 @@ COPY --from=node /usr/local/include /usr/local/include
 COPY --from=node /usr/local/bin /usr/local/bin
 
 RUN apk add --no-cache \
-        python3-dev \
         postgresql-dev \
         coreutils \
         alpine-sdk \
@@ -20,24 +19,56 @@ RUN apk add --no-cache \
         bash \
         bash-completion \
         nginx \
+        brotli \
+        nginx-mod-http-brotli \
         openssl-dev \
         geos-dev \
         gdal \
+        gdal-dev \
         gcc \
         musl-dev \
         cargo \
-        tzdata && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    python -m ensurepip && \
-    rm -r /usr/lib/python*/ensurepip && \
-    ln -sf /usr/bin/pip3 /usr/bin/pip && \
-    pip install --upgrade pip setuptools && \
-    pip install supervisor==4.2.5 && \
+        tzdata \
+        bzip2-dev \
+        readline-dev \
+        sqlite-dev \
+        ncurses-dev \
+        xz-dev \
+        zlib-dev \
+        libxml2-dev && \
     mkdir -p /var/log/supervisord && \
-    rm -r /root/.cache && \
+    rm -r /root/.cache || true && \
     addgroup -g 1000 uwsgi && \
     adduser -G uwsgi -H -u 1000 -S uwsgi && \
     mkdir -p /run/nginx
+
+## Note on some of the commands above:
+##   - create the uwsgi user and group to have id of 1000
+##   - copy over python3 as python
+##   - pip install --upgrade pip overwrites the pip so it is no longer a symlink
+##   - coreutils is required due to an issue with our wait-for-it.sch script:
+##     https://github.com/vishnubob/wait-for-it/issues/71
+
+# Install pyenv and Python globally
+ENV PYTHON_VERSION=3.9.17
+ENV PYENV_ROOT="/opt/pyenv"
+ENV PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+
+RUN git clone https://github.com/pyenv/pyenv.git $PYENV_ROOT && \
+    $PYENV_ROOT/bin/pyenv install $PYTHON_VERSION && \
+    $PYENV_ROOT/bin/pyenv global $PYTHON_VERSION && \
+    ln -sf $PYENV_ROOT/shims/python /usr/local/bin/python && \
+    ln -sf $PYENV_ROOT/shims/python3 /usr/local/bin/python3 && \
+    ln -sf $PYENV_ROOT/shims/pip /usr/local/bin/pip && \
+    ln -sf $PYENV_ROOT/shims/pip3 /usr/local/bin/pip3
+
+# Make sure non-root users inherit pyenv paths
+ENV PYENV_ROOT="/opt/pyenv"
+ENV PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+
+# Install pip 24.2 for Python
+RUN bash -c "python3 -m ensurepip --upgrade && python3 -m pip install --upgrade pip setuptools && \
+    pip install supervisor==4.2.5"
 
 ### Install python requirements
 WORKDIR /seed

--- a/Dockerfile.ecs
+++ b/Dockerfile.ecs
@@ -102,7 +102,7 @@ COPY ./package.json /seed/package.json
 COPY ./vendors/package.json /seed/vendors/package.json
 COPY ./README.md /seed/README.md
 # unsafe-perm allows the package.json postinstall script to run with the elevated permissions
-RUN npm install --unsafe-perm
+RUN npm install --unsafe-perm && npm prune --production
 
 ### Copy over the remaining part of the SEED application and some helpers
 WORKDIR /seed

--- a/Dockerfile.ecs
+++ b/Dockerfile.ecs
@@ -4,7 +4,7 @@ ARG NGINX_LISTEN_OPTS
 # DESCRIPTION:      Image with seed platform and dependencies running in development mode
 # TO_BUILD_AND_RUN: docker compose build && docker compose up
 
-FROM node:20-alpine3.16 AS node
+FROM node:20-alpine3.19 AS node
 
 # Install necessary dependencies (curl and ca-certificates)
 RUN apk add --no-cache curl ca-certificates && \
@@ -12,7 +12,7 @@ curl -fsSLk -o /usr/local/share/ca-certificates/nrel_root.crt https://raw.github
 curl -fsSLk -o /usr/local/share/ca-certificates/nrel_xca1.crt https://raw.github.nrel.gov/TADA/nrel-certs/v20180329/certs/nrel_xca1.pem && \
 update-ca-certificates
 
-FROM alpine:3.14 as build
+FROM alpine:3.19 as build
 
 ARG NGINX_LISTEN_OPTS
 
@@ -26,7 +26,6 @@ COPY --from=node /usr/local/include /usr/local/include
 COPY --from=node /usr/local/bin /usr/local/bin
 
 RUN apk add --no-cache \
-        python3-dev \
         postgresql-dev \
         coreutils \
         alpine-sdk \
@@ -43,18 +42,20 @@ RUN apk add --no-cache \
         openssl-dev \
         geos-dev \
         gdal \
+        gdal-dev \
         gcc \
         musl-dev \
         cargo \
-        tzdata && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    python -m ensurepip && \
-    rm -r /usr/lib/python*/ensurepip && \
-    ln -sf /usr/bin/pip3 /usr/bin/pip && \
-    pip install --upgrade pip setuptools && \
-    pip install supervisor==4.2.5 && \
+        tzdata \
+        bzip2-dev \
+        readline-dev \
+        sqlite-dev \
+        ncurses-dev \
+        xz-dev \
+        zlib-dev \
+        libxml2-dev && \
     mkdir -p /var/log/supervisord && \
-    rm -r /root/.cache && \
+    rm -r /root/.cache || true && \
     addgroup -g 1000 uwsgi && \
     adduser -G uwsgi -H -u 1000 -S uwsgi && \
     mkdir -p /run/nginx
@@ -65,6 +66,27 @@ RUN apk add --no-cache \
 ##   - pip install --upgrade pip overwrites the pip so it is no longer a symlink
 ##   - coreutils is required due to an issue with our wait-for-it.sch script:
 ##     https://github.com/vishnubob/wait-for-it/issues/71
+
+# Install pyenv and Python globally
+ENV PYTHON_VERSION=3.9.17
+ENV PYENV_ROOT="/opt/pyenv"
+ENV PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+
+RUN git clone https://github.com/pyenv/pyenv.git $PYENV_ROOT && \
+    $PYENV_ROOT/bin/pyenv install $PYTHON_VERSION && \
+    $PYENV_ROOT/bin/pyenv global $PYTHON_VERSION && \
+    ln -sf $PYENV_ROOT/shims/python /usr/local/bin/python && \
+    ln -sf $PYENV_ROOT/shims/python3 /usr/local/bin/python3 && \
+    ln -sf $PYENV_ROOT/shims/pip /usr/local/bin/pip && \
+    ln -sf $PYENV_ROOT/shims/pip3 /usr/local/bin/pip3
+
+# Make sure non-root users inherit pyenv paths
+ENV PYENV_ROOT="/opt/pyenv"
+ENV PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+
+# Install pip 24.2 for Python
+RUN bash -c "python3 -m ensurepip --upgrade && python3 -m pip install --upgrade pip setuptools && \
+    pip install supervisor==4.2.5"
 
 ### Install python requirements
 WORKDIR /seed
@@ -116,4 +138,4 @@ ENTRYPOINT ["seed-entrypoint"]
 
 EXPOSE 80
 
-CMD ["supervisord"]
+CMD ["supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/docker/start_uwsgi_docker.sh
+++ b/docker/start_uwsgi_docker.sh
@@ -42,4 +42,4 @@ chown -R uwsgi /seed/collected_static
 echo "Creating default user"
 ./manage.py create_default_user --username=$SEED_ADMIN_USER --password=$SEED_ADMIN_PASSWORD --organization=$SEED_ADMIN_ORG
 
-/usr/bin/uwsgi --ini /seed/docker/uwsgi.ini
+uwsgi --ini /seed/docker/uwsgi.ini

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ django-pint==0.7.3
 djangorestframework==3.15.1  # Update after Django 4.2
 djangorestframework-simplejwt==5.3.1 # Update after Django 4.2
 django-post_office==3.8.0  # Update after Django 4.2
-drf-yasg==1.21.7
+drf-yasg==1.21.8
 django-filter==22.1  # Update after Django 4.2 and drf-spectacular
 drf-nested-routers==0.94.0  # Update after Django 4.2
 


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### Any background context you want to provide?

This fix for Dockerfile.ecs doesn't install node dev dependencies into the prod ECS image used in AWS.


#### What's this PR do?

It removes all critical vulnerabilities including a KEV and reduces high vulnerabilities from 45 to 12 and medium from 46 to 22.

#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
