### PR TITLE
Fix exporting GeoJSON records with invalid footprints

### DIFF
--- a/seed/views/v3/tax_lot_properties.py
+++ b/seed/views/v3/tax_lot_properties.py
@@ -496,7 +496,7 @@ class TaxLotPropertyViewSet(GenericViewSet, OrgMixin):
                 else:
                     formatted_value = value
 
-                if formatted_value and any(k in key for k in polygon_fields):
+                if formatted_value and key in polygon_fields:
                     """
                     If object is a polygon and is populated, add the 'geometry'
                     key-value-pair in the appropriate GeoJSON format.


### PR DESCRIPTION
#### What's this PR do?
Fixes part 2 of #5013

SEED recognizes the polygon fields `"bounding_box", "centroid", "property_footprint", "taxlot_footprint", "long_lat"`, and during GeoJSON export any field that **even contains** that text (including the extra_data column `property_footprint (Invalid Footprint)` is run through `_serialized_coordinates` expecting valid WKT content without error handling.

#### How should this be manually tested?
1. Import a GeoJSON file with a MultiPolygon:

```json
{
  "type": "FeatureCollection",
  "features": [{
    "type": "Feature",
    "properties": {
      "Custom ID 1": 1
    },
    "geometry": {
      "type": "MultiPolygon",
      "coordinates": [
        [
          [
            [102, 2],
            [103, 2],
            [103, 3],
            [102, 3],
            [102, 2]
          ]
        ],
        [
          [
            [100, 0],
            [101, 0],
            [101, 1],
            [100, 1],
            [100, 0]
          ],
          [
            [100.2, 0.2],
            [100.2, 0.8],
            [100.8, 0.8],
            [100.8, 0.2],
            [100.2, 0.2]
          ]
        ]
      ]
    }
  }, {
    "type": "Feature",
    "properties": {
      "Custom ID 1": 2
    },
    "geometry": {
      "type": "Polygon",
      "coordinates": [
        [
          [100, 0],
          [101, 0],
          [101, 1],
          [100, 1],
          [100, 0]
        ]
      ]
    }
  }]
}
```

> SEED will incorrectly parse the footprint as `POLYGON (([102, 2] [103, 2]))` (that's part 1 of the issue which is not part of this PR)
> ![image](https://github.com/user-attachments/assets/e6159b3f-54f5-4bb6-97c2-1c3963440fa1)

2. Select the Property and export it as GeoJSON
3. Before: failure. After: success

#### What are the relevant tickets?
#5013