### PR TITLE
Fix dataset links for Chrome v138

### DIFF
--- a/seed/static/seed/partials/dataset_list.html
+++ b/seed/static/seed/partials/dataset_list.html
@@ -37,27 +37,25 @@
           <tbody>
             <tr ng-repeat="d in datasets" class="import_row">
               <td class="name container-fluid">
-                <span class="view" id="data-link-{$:: $index $}">
-                  <a
-                    ui-sref="dataset_detail(::{dataset_id: d.id})"
-                    class="import_name"
-                    ng-show="!d.edit_form_showing"
-                    >{$:: d.name $}</a
-                  >
-                  <a
-                    class="delete_link"
-                    ng-click="confirm_delete(d)"
-                    ng-show="!d.edit_form_showing"
-                    ><i class="fa-solid fa-trash-can"></i
-                  ></a>
-                  <a
-                    class="replace_file_button edit_file_name"
-                    ng-click="edit_dataset_name(d)"
-                    ng-show="!d.edit_form_showing"
-                    style="margin-right: 8px"
-                    ><i class="fa-solid fa-pencil"></i
-                  ></a>
-                </span>
+                <a
+                  ui-sref="dataset_detail(::{dataset_id: d.id})"
+                  class="import_name"
+                  ng-show="!d.edit_form_showing"
+                  >{$:: d.name $}</a
+                >
+                <a
+                  class="delete_link"
+                  ng-click="confirm_delete(d)"
+                  ng-show="!d.edit_form_showing"
+                  ><i class="fa-solid fa-trash-can"></i
+                ></a>
+                <a
+                  class="replace_file_button edit_file_name"
+                  ng-click="edit_dataset_name(d)"
+                  ng-show="!d.edit_form_showing"
+                  style="margin-right: 8px"
+                  ><i class="fa-solid fa-pencil"></i
+                ></a>
                 <form
                   class="row action edit_file_name form form-inline edit_import_meta_form"
                   role="form"


### PR DESCRIPTION
#### Any background context you want to provide?
For whatever reason, after updating from Chrome v137 to v138, the dataset-list links became unclickable

#### What's this PR do?
Moves the link outside of the `span` element, which fixes the problem

#### How should this be manually tested?
1. Update Chrome to the latest version
2. Check that dataset-list links are clickable

#### What are the relevant tickets?
#5037