### PR TITLE
Dataset links

### DIFF
--- a/seed/audit_template/audit_template.py
+++ b/seed/audit_template/audit_template.py
@@ -358,12 +358,12 @@ class AuditTemplate:
                     em.Reports(
                         em.Report(
                             {"ID": report_id},
-                            em.Scenarios(
-                                *(
-                                    []
-                                    if not org.audit_template_export_meters
-                                    else _build_metering_scenarios(em, view.property.id, building_id)
-                                ),
+                             *(
+                                [em.Scenarios(
+                                    *_build_metering_scenarios(em, view.property.id, building_id)
+                                )]
+                                if org.audit_template_export_meters and _build_metering_scenarios(em, view.property.id, building_id)
+                                else []
                             ),
                             em.LinkedPremisesOrSystem(
                                 em.Building(em.LinkedBuildingID({"IDref": building_id})),
@@ -371,7 +371,7 @@ class AuditTemplate:
                             em.UserDefinedFields(
                                 em.UserDefinedField(
                                     em.FieldName("Audit Template Report Type"),
-                                    em.FieldValue(report_type),
+                                    em.FieldValue(str(report_type).strip()),
                                 ),
                             ),
                         )

--- a/seed/views/v3/media.py
+++ b/seed/views/v3/media.py
@@ -36,7 +36,10 @@ def check_file_permission(user, filepath):
     organization = None
     if base_dir == "uploads":
         try:
-            import_file = ImportFile.objects.get(file__in=[absolute_filepath, filepath], deleted=False)
+            # there could be more than one file of the same name if the same file was used to import properties and meters
+            import_file = ImportFile.objects.filter(file__in=[absolute_filepath, filepath], deleted=False).first()
+            if import_file is None:
+              raise ModelForFileNotFoundError("ImportFile not found")  
         except ImportFile.DoesNotExist:
             raise ModelForFileNotFoundError("ImportFile not found")
         organization = import_file.import_record.super_organization

--- a/seed/views/v3/media.py
+++ b/seed/views/v3/media.py
@@ -39,7 +39,7 @@ def check_file_permission(user, filepath):
             # there could be more than one file of the same name if the same file was used to import properties and meters
             import_file = ImportFile.objects.filter(file__in=[absolute_filepath, filepath], deleted=False).first()
             if import_file is None:
-              raise ModelForFileNotFoundError("ImportFile not found")  
+                raise ModelForFileNotFoundError("ImportFile not found")
         except ImportFile.DoesNotExist:
             raise ModelForFileNotFoundError("ImportFile not found")
         organization = import_file.import_record.super_organization


### PR DESCRIPTION
Fixes Dataset file download when imported both properties and meters from the same file (duplicate filename issue).
#5043 

How to test: from datasets page, import a file that has meters, then click on the "import meters from the same file" button. Then go back to datasets and try to download the original file.