### PR TITLE
Fix the ability to click invite links

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -41,7 +41,8 @@ CSRF_COOKIE_SAMESITE = "Strict"
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 # Default to expiring cookies after 2 weeks
 SESSION_COOKIE_AGE = int(os.environ.get("COOKIE_EXPIRATION", 1_209_600))  # noqa: PLW1508
-SESSION_COOKIE_SAMESITE = "Strict"
+# This must be `Lax` so that emailed invitation links work as expected
+SESSION_COOKIE_SAMESITE = "Lax"
 
 TEMPLATES = [
     {


### PR DESCRIPTION
#### Any background context you want to provide?
After adding a new user, when they clicked the emailed invite link it failed with `The invite link was invalid, possibly because it has already been used. Please request a new invitation.` However, copying/pasting the link worked as expected.

#### What's this PR do?
Changes the session cookie's SameSite attribute from `Strict` to `Lax`. With strict:
> When the user is on your site, the cookie is sent with the request as expected. However, if the user follows a link into your site from another one, the cookie isn't sent on that initial request.

The problem is that clicking the link always returns a 302 redirect, but also sets the initial session cookie, which isn't compatible with the strict policy.

#### How should this be manually tested?
1. Invite a new email to a SEED instance
2. Click the emailed link from a browser tab (e.g. gmail or Outlook online)