### PR TITLE
Fix inventory list date filters

### DIFF
--- a/seed/models/columns.py
+++ b/seed/models/columns.py
@@ -9,7 +9,6 @@ import locale
 import logging
 import os.path
 from collections import OrderedDict
-from datetime import datetime
 from typing import Any, Callable, Literal, Optional
 
 from django.apps import apps
@@ -23,6 +22,7 @@ from seed.lib.superperms.orgs.models import Organization as SuperOrganization
 from seed.lib.superperms.orgs.models import OrganizationUser
 from seed.models.column_mappings import ColumnMapping
 from seed.models.models import Unit
+from seed.utils.generic import parse_date
 
 INVENTORY_DISPLAY = {
     "PropertyState": "Property",
@@ -206,8 +206,8 @@ class Column(models.Model):
         "integer": lambda v: int(v.replace(",", "") if isinstance(v, str) else v),
         "string": str,
         "geometry": str,
-        "datetime": datetime.fromisoformat,
-        "date": lambda v: datetime.fromisoformat(v).date(),
+        "datetime": parse_date,
+        "date": lambda v: parse_date(v).date(),
         "boolean": lambda v: v.lower() == "true",
         "area": lambda v: float(v.replace(",", "") if isinstance(v, str) else v),
         "eui": lambda v: float(v.replace(",", "") if isinstance(v, str) else v),

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -1915,7 +1915,7 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
     };
 
     // https://regexr.com/6cka2
-    const combinedRegex = /^(!?)=\s*(-?\d+(?:\.\d+)?)$|^(!?)=?\s*"((?:[^"]|\\")*)"$|^(<=?|>=?)\s*((-?\d+(?:\.\d+)?)|(\d{4}-\d{2}-\d{2}))$/;
+    const combinedRegex = /^(!?)=\s*(-?\d+(?:\.\d+)?)$|^(!?)=?\s*"((?:[^"]|\\")*)"$|^(<=?|>=?)\s*((-?\d+(?:\.\d+)?)|(\d{4}-\d{2}(?:-\d{2})?))$/;
     const parseFilter = (expression) => {
       // parses an expression string into an object containing operator and value
       const filterData = expression.match(combinedRegex);

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -1915,7 +1915,11 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
     };
 
     // https://regexr.com/6cka2
-    const combinedRegex = /^(!?)=\s*(-?\d+(?:\.\d+)?)$|^(!?)=?\s*"((?:[^"]|\\")*)"$|^(<=|>=|!=|=|<|>|!)\s*((-?\d+(?:\.\d+)?)|(\d{4}-\d{2}(?:-\d{2})?))$/;
+    const numericComparison = /^(!?)=\s*(-?\d+(?:\.\d+)?)$/;
+    const stringComparison = /^(!?)=?\s*"((?:[^"]|\\")*)"$/;
+    const dateComparison = /^(<=|>=|!=|=|<|>|!)\s*((-?\d+(?:\.\d+)?)|(\d{4}(?:-\d{2}(?:-\d{2}(?: \d{1,2}(?::\d{2}(?::\d{2})?)?)?)?)?))$/;
+    const combinedRegex = new RegExp(`${numericComparison.source}|${stringComparison.source}|${dateComparison.source}`);
+    // const combinedRegex = /^(!?)=\s*(-?\d+(?:\.\d+)?)$|^(!?)=?\s*"((?:[^"]|\\")*)"$|^(<=|>=|!=|=|<|>|!)\s*((-?\d+(?:\.\d+)?)|(\d{4}-\d{2}(?:-\d{2})?))$/;
     const parseFilter = (expression) => {
       // parses an expression string into an object containing operator and value
       const filterData = expression.match(combinedRegex);

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -1915,7 +1915,7 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
     };
 
     // https://regexr.com/6cka2
-    const combinedRegex = /^(!?)=\s*(-?\d+(?:\.\d+)?)$|^(!?)=?\s*"((?:[^"]|\\")*)"$|^(<=?|>=?)\s*((-?\d+(?:\.\d+)?)|(\d{4}-\d{2}(?:-\d{2})?))$/;
+    const combinedRegex = /^(!?)=\s*(-?\d+(?:\.\d+)?)$|^(!?)=?\s*"((?:[^"]|\\")*)"$|^(<=?|>=?|!?=)\s*((-?\d+(?:\.\d+)?)|(\d{4}-\d{2}(?:-\d{2})?))$/;
     const parseFilter = (expression) => {
       // parses an expression string into an object containing operator and value
       const filterData = expression.match(combinedRegex);
@@ -1965,6 +1965,10 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
               return { string: '>', operator: 'gt', value };
             case '>=':
               return { string: '>=', operator: 'gte', value };
+            case '!=':
+              return { string: 'is not', operator: 'ne', value };
+            case '=':
+              return { string: 'is', operator: 'exact', value };
           }
         }
       } else {

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -1915,7 +1915,7 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
     };
 
     // https://regexr.com/6cka2
-    const combinedRegex = /^(!?)=\s*(-?\d+(?:\.\d+)?)$|^(!?)=?\s*"((?:[^"]|\\")*)"$|^(<=?|>=?|!?=)\s*((-?\d+(?:\.\d+)?)|(\d{4}-\d{2}(?:-\d{2})?))$/;
+    const combinedRegex = /^(!?)=\s*(-?\d+(?:\.\d+)?)$|^(!?)=?\s*"((?:[^"]|\\")*)"$|^(<=|>=|!=|=|<|>|!)\s*((-?\d+(?:\.\d+)?)|(\d{4}-\d{2}(?:-\d{2})?))$/;
     const parseFilter = (expression) => {
       // parses an expression string into an object containing operator and value
       const filterData = expression.match(combinedRegex);
@@ -1966,6 +1966,8 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
             case '>=':
               return { string: '>=', operator: 'gte', value };
             case '!=':
+              return { string: 'is not', operator: 'ne', value };
+            case '!':
               return { string: 'is not', operator: 'ne', value };
             case '=':
               return { string: 'is', operator: 'exact', value };

--- a/seed/static/seed/js/controllers/inventory_list_controller.js
+++ b/seed/static/seed/js/controllers/inventory_list_controller.js
@@ -1306,6 +1306,9 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
         $scope.gridApi.core.notifyDataChange(uiGridConstants.dataChange.EDIT);
         $scope.select_none();
         spinner_utility.hide();
+      }).catch(() => {
+        spinner_utility.hide();
+        Notification.error('Invalid Filter. Update filter and try again.');
       });
     };
 
@@ -1917,9 +1920,8 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
     // https://regexr.com/6cka2
     const numericComparison = /^(!?)=\s*(-?\d+(?:\.\d+)?)$/;
     const stringComparison = /^(!?)=?\s*"((?:[^"]|\\")*)"$/;
-    const dateComparison = /^(<=|>=|!=|=|<|>|!)\s*((-?\d+(?:\.\d+)?)|(\d{4}(?:-\d{2}(?:-\d{2}(?: \d{1,2}(?::\d{2}(?::\d{2})?)?)?)?)?))$/;
+    const dateComparison = /^(<=|>=|!=|=|<|>|!)\s*((-?\d+(?:\.\d+)?)|(\d{4}(?:[-/]\d{2}(?:[-/]\d{2}(?: \d{1,2}(?::\d{2}(?::\d{2})?)?)?)?)?))$/;
     const combinedRegex = new RegExp(`${numericComparison.source}|${stringComparison.source}|${dateComparison.source}`);
-    // const combinedRegex = /^(!?)=\s*(-?\d+(?:\.\d+)?)$|^(!?)=?\s*"((?:[^"]|\\")*)"$|^(<=|>=|!=|=|<|>|!)\s*((-?\d+(?:\.\d+)?)|(\d{4}-\d{2}(?:-\d{2})?))$/;
     const parseFilter = (expression) => {
       // parses an expression string into an object containing operator and value
       const filterData = expression.match(combinedRegex);
@@ -1959,7 +1961,7 @@ angular.module('SEED.controller.inventory_list', []).controller('inventory_list_
         } else {
           // Date Comparison
           const operator = filterData[5];
-          const value = filterData[8];
+          const value = filterData[8].replace(/\//g, '-'); // transform d/m/yyyy to d-m-yyyy
           switch (operator) {
             case '<':
               return { string: '<', operator: 'lt', value };

--- a/seed/tests/test_column_views.py
+++ b/seed/tests/test_column_views.py
@@ -350,7 +350,13 @@ class ColumnsViewPermissionsTests(AccessLevelBaseTestCase, DeleteModelsTestCase)
 
     def test_column_update_permissions(self):
         url = reverse_lazy("api:v3:columns-detail", args=[self.column.id]) + "?organization_id=" + str(self.org.id)
-        payload = {"column_name": "boo", "table_name": "PropertyState", "sharedFieldType": "None", "comstock_mapping": None}
+        payload = {
+            "column_name": "boo",
+            "table_name": "PropertyState",
+            "sharedFieldType": "None",
+            "comstock_mapping": None,
+            "is_extra_data": True,
+        }
 
         # child user cannot
         self.login_as_child_member()

--- a/seed/tests/test_columns.py
+++ b/seed/tests/test_columns.py
@@ -10,6 +10,7 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.test import TestCase
+from django.utils import timezone
 from quantityfield.units import ureg
 
 from seed import models as seed_models
@@ -1226,7 +1227,7 @@ class TestColumnCasting(TestCase):
         r = Column.cast_column_value("geometry", "POLY 123, 456")
         self.assertEqual("POLY 123, 456", r)
         r = Column.cast_column_value("datetime", "2020-01-01T00:00:00")
-        self.assertEqual(datetime(2020, 1, 1, 0, 0, 0), r)
+        self.assertEqual(timezone.make_aware(datetime(2020, 1, 1, 0, 0, 0)), r)
         r = Column.cast_column_value("date", "2020-01-01")
         self.assertEqual(date(2020, 1, 1), r)
         r = Column.cast_column_value("boolean", "true")
@@ -1261,7 +1262,7 @@ class TestColumnCasting(TestCase):
             r = Column.cast_column_value("date", date_str)
             self.assertEqual(date(2010, 1, 1), r)
             r = Column.cast_column_value("datetime", date_str)
-            self.assertEqual(datetime(2010, 1, 1), r)
+            self.assertEqual(timezone.make_aware(datetime(2010, 1, 1)), r)
 
     def test_cast_values_with_errors(self):
         with pytest.raises(ColumnCastError) as exc:

--- a/seed/tests/test_columns.py
+++ b/seed/tests/test_columns.py
@@ -1246,6 +1246,23 @@ class TestColumnCasting(TestCase):
         r = Column.cast_column_value("eui", None)
         self.assertEqual(None, r)
 
+    def test_cast_partial_date(self):
+        dates = [
+            "2010",
+            "2010-01",
+            "2010-01-01",
+            "=2010",
+            "=2010-01",
+            "!=2010-01-01",
+            ">=2010",
+            "<2010-01",
+        ]
+        for date_str in dates:
+            r = Column.cast_column_value("date", date_str)
+            self.assertEqual(date(2010, 1, 1), r)
+            r = Column.cast_column_value("datetime", date_str)
+            self.assertEqual(datetime(2010, 1, 1), r)
+
     def test_cast_values_with_errors(self):
         with pytest.raises(ColumnCastError) as exc:
             Column.cast_column_value("integer", "abc")

--- a/seed/tests/test_search.py
+++ b/seed/tests/test_search.py
@@ -60,7 +60,7 @@ class TestInventoryViewSearchParsers(TestCase):
             TestCase(
                 "canonical column with datetime data_type",
                 QueryDict(f"updated_{updated_id}=2022-01-01 10:11:12"),
-                Q(state__updated=datetime(2022, 1, 1, 10, 11, 12)),
+                Q(state__updated=timezone.make_aware(datetime(2022, 1, 1, 10, 11, 12))),
             ),
             TestCase(
                 "canonical column with date data_type",

--- a/seed/tests/test_search.py
+++ b/seed/tests/test_search.py
@@ -20,6 +20,7 @@ from seed.models import Column, PropertyView
 from seed.test_helpers.fake import FakePropertyViewFactory
 from seed.utils.organizations import create_organization
 from seed.utils.search import FilterError, build_view_filters_and_sorts
+from seed.serializers.columns import ColumnSerializer
 
 
 class TestInventoryViewSearchParsers(TestCase):
@@ -349,6 +350,96 @@ class TestInventoryViewSearchParsers(TestCase):
         # -- Assert
         # evaluate the queryset -- no exception should be raised!
         list(cast_property_views)
+
+    def test_filter_dates(self):
+        extra_date = Column.objects.create(
+            table_name="PropertyState",
+            column_name="Extra Date",
+            organization=self.fake_org,
+            data_type="date",
+            is_extra_data=True,
+        )
+        col_name = ColumnSerializer(extra_date).data["name"]
+        columns = Column.retrieve_all(self.fake_org, "property", only_used=False, include_related=False)
+
+        eq = QueryDict(f'{col_name}=2000-02-01')
+        gt = QueryDict(f'{col_name}__gt=2000-02-01')
+        gte = QueryDict(f'{col_name}__gte=2000-02-01')
+        date_range = QueryDict(f'{col_name}__gte=2000-02-01&{col_name}__lt=2000-04-01')
+        neq = QueryDict(f'{col_name}__ne=2000-02-01')
+
+        for month in range(1, 6):
+            date_str = f"2000-0{month}-01 00:00:00"
+            self.property_view_factory.get_property_view(extra_data={"Extra Date": date_str})
+
+        self.assertEqual(PropertyView.objects.count(), 5)
+
+        # Test equal 
+        filters, annotations, _ = build_view_filters_and_sorts(eq, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 1)
+        # Test gt 
+        filters, annotations, _ = build_view_filters_and_sorts(gt, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 3)
+        # Test gte
+        filters, annotations, _ = build_view_filters_and_sorts(gte, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 4)
+        # Test date range
+        filters, annotations, _ = build_view_filters_and_sorts(date_range, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 2)
+        # Test not equal
+        filters, annotations, _ = build_view_filters_and_sorts(neq, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 4)
+
+    def test_filter_datetimes(self):
+        extra_datetime = Column.objects.create(
+            table_name="PropertyState",
+            column_name="Extra Date Time",
+            organization=self.fake_org,
+            data_type="datetime",
+            is_extra_data=True,
+        )
+        col_name = ColumnSerializer(extra_datetime).data["name"]
+        columns = Column.retrieve_all(self.fake_org, "property", only_used=False, include_related=False)
+
+        eq = QueryDict(f'{col_name}=2000-02-01')
+        gt = QueryDict(f'{col_name}__gt=2000-02-01')
+        gte = QueryDict(f'{col_name}__gte=2000-02-01')
+        date_range = QueryDict(f'{col_name}__gte=2000-02-01&{col_name}__lt=2000-04-01')
+        neq = QueryDict(f'{col_name}__ne=2000-02-01')
+
+        for month in range(1, 6):
+            date_str = f"2000-{month:02d}-01T00:00:00+00:00"
+            self.property_view_factory.get_property_view(extra_data={"Extra Date Time": date_str})
+
+        self.assertEqual(PropertyView.objects.count(), 5)
+
+        # Test equal 
+        filters, annotations, _ = build_view_filters_and_sorts(eq, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 1)
+        # Test gt 
+        filters, annotations, _ = build_view_filters_and_sorts(gt, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 3)
+        # Test gte
+        filters, annotations, _ = build_view_filters_and_sorts(gte, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 4)
+        # Test date range
+        filters, annotations, _ = build_view_filters_and_sorts(date_range, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 2)
+        # Test not equal
+        filters, annotations, _ = build_view_filters_and_sorts(neq, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 4)
+
+
 
 
 class TestInventoryViewSearchParsersAccessLevelInstances(TestCase):

--- a/seed/tests/test_search.py
+++ b/seed/tests/test_search.py
@@ -17,10 +17,10 @@ from django.test import TestCase
 
 from seed.landing.models import SEEDUser as User
 from seed.models import Column, PropertyView
+from seed.serializers.columns import ColumnSerializer
 from seed.test_helpers.fake import FakePropertyViewFactory
 from seed.utils.organizations import create_organization
 from seed.utils.search import FilterError, build_view_filters_and_sorts
-from seed.serializers.columns import ColumnSerializer
 
 
 class TestInventoryViewSearchParsers(TestCase):
@@ -362,11 +362,11 @@ class TestInventoryViewSearchParsers(TestCase):
         col_name = ColumnSerializer(extra_date).data["name"]
         columns = Column.retrieve_all(self.fake_org, "property", only_used=False, include_related=False)
 
-        eq = QueryDict(f'{col_name}=2000-02-01')
-        gt = QueryDict(f'{col_name}__gt=2000-02-01')
-        gte = QueryDict(f'{col_name}__gte=2000-02-01')
-        date_range = QueryDict(f'{col_name}__gte=2000-02-01&{col_name}__lt=2000-04-01')
-        neq = QueryDict(f'{col_name}__ne=2000-02-01')
+        eq = QueryDict(f"{col_name}=2000-02-01")
+        gt = QueryDict(f"{col_name}__gt=2000-02-01")
+        gte = QueryDict(f"{col_name}__gte=2000-02-01")
+        date_range = QueryDict(f"{col_name}__gte=2000-02-01&{col_name}__lt=2000-04-01")
+        neq = QueryDict(f"{col_name}__ne=2000-02-01")
 
         for month in range(1, 6):
             date_str = f"2000-0{month}-01 00:00:00"
@@ -374,11 +374,11 @@ class TestInventoryViewSearchParsers(TestCase):
 
         self.assertEqual(PropertyView.objects.count(), 5)
 
-        # Test equal 
+        # Test equal
         filters, annotations, _ = build_view_filters_and_sorts(eq, columns, "property")
         property_views = PropertyView.objects.annotate(**annotations).filter(filters)
         self.assertEqual(property_views.count(), 1)
-        # Test gt 
+        # Test gt
         filters, annotations, _ = build_view_filters_and_sorts(gt, columns, "property")
         property_views = PropertyView.objects.annotate(**annotations).filter(filters)
         self.assertEqual(property_views.count(), 3)
@@ -406,11 +406,11 @@ class TestInventoryViewSearchParsers(TestCase):
         col_name = ColumnSerializer(extra_datetime).data["name"]
         columns = Column.retrieve_all(self.fake_org, "property", only_used=False, include_related=False)
 
-        eq = QueryDict(f'{col_name}=2000-02-01')
-        gt = QueryDict(f'{col_name}__gt=2000-02-01')
-        gte = QueryDict(f'{col_name}__gte=2000-02-01')
-        date_range = QueryDict(f'{col_name}__gte=2000-02-01&{col_name}__lt=2000-04-01')
-        neq = QueryDict(f'{col_name}__ne=2000-02-01')
+        eq = QueryDict(f"{col_name}=2000-02-01")
+        gt = QueryDict(f"{col_name}__gt=2000-02-01")
+        gte = QueryDict(f"{col_name}__gte=2000-02-01")
+        date_range = QueryDict(f"{col_name}__gte=2000-02-01&{col_name}__lt=2000-04-01")
+        neq = QueryDict(f"{col_name}__ne=2000-02-01")
 
         for month in range(1, 6):
             date_str = f"2000-{month:02d}-01T00:00:00+00:00"
@@ -418,11 +418,11 @@ class TestInventoryViewSearchParsers(TestCase):
 
         self.assertEqual(PropertyView.objects.count(), 5)
 
-        # Test equal 
+        # Test equal
         filters, annotations, _ = build_view_filters_and_sorts(eq, columns, "property")
         property_views = PropertyView.objects.annotate(**annotations).filter(filters)
         self.assertEqual(property_views.count(), 1)
-        # Test gt 
+        # Test gt
         filters, annotations, _ = build_view_filters_and_sorts(gt, columns, "property")
         property_views = PropertyView.objects.annotate(**annotations).filter(filters)
         self.assertEqual(property_views.count(), 3)
@@ -438,8 +438,6 @@ class TestInventoryViewSearchParsers(TestCase):
         filters, annotations, _ = build_view_filters_and_sorts(neq, columns, "property")
         property_views = PropertyView.objects.annotate(**annotations).filter(filters)
         self.assertEqual(property_views.count(), 4)
-
-
 
 
 class TestInventoryViewSearchParsersAccessLevelInstances(TestCase):

--- a/seed/tests/test_search.py
+++ b/seed/tests/test_search.py
@@ -14,6 +14,7 @@ from django.db.models.fields.json import KeyTextTransform
 from django.db.models.functions import Cast, Coalesce, Collate, Replace
 from django.http.request import QueryDict
 from django.test import TestCase
+from django.utils import timezone
 
 from seed.landing.models import SEEDUser as User
 from seed.models import Column, PropertyView
@@ -351,7 +352,7 @@ class TestInventoryViewSearchParsers(TestCase):
         # evaluate the queryset -- no exception should be raised!
         list(cast_property_views)
 
-    def test_filter_dates(self):
+    def test_filter_extra_dates(self):
         extra_date = Column.objects.create(
             table_name="PropertyState",
             column_name="Extra Date",
@@ -396,6 +397,46 @@ class TestInventoryViewSearchParsers(TestCase):
         self.assertEqual(property_views.count(), 4)
 
     def test_filter_datetimes(self):
+        col = Column.objects.get(column_name="release_date")
+        col_name = ColumnSerializer(col).data["name"]
+        columns = Column.retrieve_all(self.fake_org, "property", only_used=False, include_related=False)
+
+        eq = QueryDict(f"{col_name}=2000-02-01")
+        gt = QueryDict(f"{col_name}__gt=2000-02-01")
+        gte = QueryDict(f"{col_name}__gte=2000-02-01")
+        date_range = QueryDict(f"{col_name}__gte=2000-02-01&{col_name}__lt=2000-04-01")
+        neq = QueryDict(f"{col_name}__ne=2000-02-01")
+
+        for month in range(1, 6):
+            date_str = f"2000-{month:02d}-01"
+            naive = datetime.fromisoformat(date_str)
+            aware = timezone.make_aware(naive)
+            self.property_view_factory.get_property_view(release_date=aware)
+
+        self.assertEqual(PropertyView.objects.count(), 5)
+
+        # Test equal
+        filters, annotations, _ = build_view_filters_and_sorts(eq, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 1)
+        # Test gt
+        filters, annotations, _ = build_view_filters_and_sorts(gt, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 3)
+        # Test gte
+        filters, annotations, _ = build_view_filters_and_sorts(gte, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 4)
+        # Test date range
+        filters, annotations, _ = build_view_filters_and_sorts(date_range, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 2)
+        # Test not equal
+        filters, annotations, _ = build_view_filters_and_sorts(neq, columns, "property")
+        property_views = PropertyView.objects.annotate(**annotations).filter(filters)
+        self.assertEqual(property_views.count(), 4)
+
+    def test_filter_extra_datetimes(self):
         extra_datetime = Column.objects.create(
             table_name="PropertyState",
             column_name="Extra Date Time",

--- a/seed/utils/generic.py
+++ b/seed/utils/generic.py
@@ -154,7 +154,11 @@ def parse_date(value):
     except (ValueError, TypeError):
         pass
 
-    pattern = re.compile(r"^(=|!=?)?\s*(" "|\d{4}(?:-\d{2}(?:-\d{2})?)?)$|^(<=?|>=?)\s*(\d{4}(?:-\d{2}(?:-\d{2})?)?)$")
+    # pattern = re.compile(r"^(=|!=?)?\s*(" "|\d{4}(?:-\d{2}(?:-\d{2})?)?)$|^(<=?|>=?)\s*(\d{4}(?:-\d{2}(?:-\d{2})?)?)$")
+    pattern = re.compile(
+    r'^(=|!=?)?\s*(".*?"|\d{4}(?:-\d{2}(?:-\d{2}(?: \d{1,2}(?::\d{1,2}(?::\d{1,2})?)?)?)?)?)$'
+    r'|^(<=?|>=?)\s*(\d{4}(?:-\d{2}(?:-\d{2}(?: \d{1,2}(?::\d{1,2}(?::\d{1,2})?)?)?)?)?)$'
+)
     match = pattern.match(str(value))
     if not match:
         raise ValueError(f'Unable to parse date from value "{value}". Expected format: YYYY, YYYY-MM, YYYY-MM-DD, or ISO format.')
@@ -165,5 +169,8 @@ def parse_date(value):
     year = int(parts[0])
     month = int(parts[1]) if len(parts) > 1 else 1
     day = int(parts[2]) if len(parts) > 2 else 1
-    date_string = f"{year:04d}-{month:02d}-{day:02d}"
+    hour = int(parts[3]) if len(parts) > 3 else 0
+    minute = int(parts[4]) if len(parts) > 4 else 0
+    second = int(parts[5]) if len(parts) > 5 else 0
+    date_string = f"{year:04d}-{month:02d}-{day:02d} {hour:02d}:{minute:02d}:{second:02d}"
     return datetime.fromisoformat(date_string)

--- a/seed/utils/generic.py
+++ b/seed/utils/generic.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 from django.core import serializers
 from django.db import IntegrityError, models
+from django.utils import timezone
 from pint import UnitRegistry
 
 ureg = UnitRegistry()
@@ -150,11 +151,11 @@ def parse_date(value):
     Parse a date string in the format YYYY, YYYY-MM, YYYY-MM-DD, or ISO format and return it as as datetime object.
     """
     try:
-        return datetime.fromisoformat(value)
+        naive = datetime.fromisoformat(value)
+        return timezone.make_aware(naive)
     except (ValueError, TypeError):
         pass
 
-    # pattern = re.compile(r"^(=|!=?)?\s*(" "|\d{4}(?:-\d{2}(?:-\d{2})?)?)$|^(<=?|>=?)\s*(\d{4}(?:-\d{2}(?:-\d{2})?)?)$")
     pattern = re.compile(
         r'^(=|!=?)?\s*(".*?"|\d{4}(?:-\d{2}(?:-\d{2}(?: \d{1,2}(?::\d{1,2}(?::\d{1,2})?)?)?)?)?)$'
         r"|^(<=?|>=?)\s*(\d{4}(?:-\d{2}(?:-\d{2}(?: \d{1,2}(?::\d{1,2}(?::\d{1,2})?)?)?)?)?)$"
@@ -173,4 +174,6 @@ def parse_date(value):
     minute = int(parts[4]) if len(parts) > 4 else 0
     second = int(parts[5]) if len(parts) > 5 else 0
     date_string = f"{year:04d}-{month:02d}-{day:02d} {hour:02d}:{minute:02d}:{second:02d}"
-    return datetime.fromisoformat(date_string)
+
+    naive = datetime.fromisoformat(date_string)
+    return timezone.make_aware(naive)

--- a/seed/utils/generic.py
+++ b/seed/utils/generic.py
@@ -156,9 +156,9 @@ def parse_date(value):
 
     # pattern = re.compile(r"^(=|!=?)?\s*(" "|\d{4}(?:-\d{2}(?:-\d{2})?)?)$|^(<=?|>=?)\s*(\d{4}(?:-\d{2}(?:-\d{2})?)?)$")
     pattern = re.compile(
-    r'^(=|!=?)?\s*(".*?"|\d{4}(?:-\d{2}(?:-\d{2}(?: \d{1,2}(?::\d{1,2}(?::\d{1,2})?)?)?)?)?)$'
-    r'|^(<=?|>=?)\s*(\d{4}(?:-\d{2}(?:-\d{2}(?: \d{1,2}(?::\d{1,2}(?::\d{1,2})?)?)?)?)?)$'
-)
+        r'^(=|!=?)?\s*(".*?"|\d{4}(?:-\d{2}(?:-\d{2}(?: \d{1,2}(?::\d{1,2}(?::\d{1,2})?)?)?)?)?)$'
+        r"|^(<=?|>=?)\s*(\d{4}(?:-\d{2}(?:-\d{2}(?: \d{1,2}(?::\d{1,2}(?::\d{1,2})?)?)?)?)?)$"
+    )
     match = pattern.match(str(value))
     if not match:
         raise ValueError(f'Unable to parse date from value "{value}". Expected format: YYYY, YYYY-MM, YYYY-MM-DD, or ISO format.')

--- a/seed/utils/generic.py
+++ b/seed/utils/generic.py
@@ -6,6 +6,7 @@ See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 import json
 import logging
 import math
+import re
 from datetime import datetime
 
 from django.core import serializers
@@ -142,3 +143,27 @@ def get_int(value, default=None):
         return result if result > 0 else default
     except (ValueError, TypeError):
         return default
+
+
+def parse_date(value):
+    """
+    Parse a date string in the format YYYY, YYYY-MM, YYYY-MM-DD, or ISO format and return it as as datetime object.
+    """
+    try:
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        pass
+
+    pattern = re.compile(r"^(=|!=?)?\s*(" "|\d{4}(?:-\d{2}(?:-\d{2})?)?)$|^(<=?|>=?)\s*(\d{4}(?:-\d{2}(?:-\d{2})?)?)$")
+    match = pattern.match(str(value))
+    if not match:
+        raise ValueError(f'Unable to parse date from value "{value}". Expected format: YYYY, YYYY-MM, YYYY-MM-DD, or ISO format.')
+
+    groups = match.groups()
+    date_string = groups[1] if groups[1] else groups[3]
+    parts = date_string.split("-")
+    year = int(parts[0])
+    month = int(parts[1]) if len(parts) > 1 else 1
+    day = int(parts[2]) if len(parts) > 2 else 1
+    date_string = f"{year:04d}-{month:02d}-{day:02d}"
+    return datetime.fromisoformat(date_string)

--- a/seed/utils/search.py
+++ b/seed/utils/search.py
@@ -297,7 +297,7 @@ def _build_extra_data_annotations(column_name: str, data_type: str) -> tuple[str
             }
         )
     elif data_type in {"date", "datetime"}:
-        annotations.update({final_field_name: Cast(text_field_name, output_field=models.DateTimeField())})
+        annotations.update({final_field_name: Cast(text_field_name, output_field=models.DateField())})
     elif data_type == "boolean":
         annotations.update({final_field_name: Cast(text_field_name, output_field=models.BooleanField())})
     else:


### PR DESCRIPTION
#### Any background context you want to provide?
Partial dates were causing the inventory list filter to fail. For example, filtering a date/dateime field with ">2025" would fail when trying to convert it to a datetime object.

#### What's this PR do?
Adds a `parse_date` function that can convert partial date strings to datetime objs.
- 2025
- 2025-01 (or 2025/01)
- 2025-01-01
- Full ISO format
Allows for the following comparisons: `=, !=, <, >, <=, >=`. However, all canonical datetime values are stored in the database as timezone-aware UTC datetimes with millisecond precision, direct equality comparisons (`=, !=`) are unreliable. It's recommended users use a date range to narrow in on a specific date (ex: `>2025-01-01, <2025-01-02`).

If an invalid or unexpected filter is caught (ex: `@#$%^`), an error message will appear, the spinner is hidden, and the filter is ignored.

#### How should this be manually tested?
Test the above partial dates and various operators on columns of data type date and datetime.
Input an invalid filter.

#### What are the relevant tickets?

#### Screenshots (if appropriate)
Extra Data:
<img width="539" height="257" alt="Screenshot 2025-09-10 at 10 15 40 AM" src="https://github.com/user-attachments/assets/9078b207-55fe-466a-beec-5738412b8910" />
Canonical:
<img width="346" height="210" alt="Screenshot 2025-09-16 at 9 14 09 AM" src="https://github.com/user-attachments/assets/29d04d28-026b-418f-aa5a-7c8a5109dbd2" />
