### PR TITLE
Freeze portfolio summary headers

### DIFF
--- a/seed/static/seed/scss/style.scss
+++ b/seed/static/seed/scss/style.scss
@@ -5318,7 +5318,8 @@ ul.r-list {
       display: flex;
       overflow-x: hidden;
       width: 100%;
-      height: 1570px !important;
+      height: 90vh !important;
+      margin-bottom: 10px;
     }
   }
 


### PR DESCRIPTION

#### Any background context you want to provide?

#### What's this PR do?
Changes the Portfolio Summary grid height, so the header row is always in view.

#### How should this be manually tested?
Open a portfolio summary and scroll down on multiple window sizes

#### What are the relevant tickets?
#5041

#### Screenshots (if appropriate)
