### PR TITLE
Show previously mapped data types

### DIFF
--- a/seed/models/columns.py
+++ b/seed/models/columns.py
@@ -1126,6 +1126,7 @@ class Column(models.Model):
                         "from_units": mapping.get("from_units"),
                         "to_field": mapping["to_field"],
                         "to_table_name": mapping["to_table_name"],
+                        "to_data_type": mapping.get("to_data_type"),
                     }
                 )
             else:

--- a/seed/static/seed/js/controllers/mapping_controller.js
+++ b/seed/static/seed/js/controllers/mapping_controller.js
@@ -899,6 +899,7 @@ angular.module('SEED.controller.mapping', []).controller('mapping_controller', [
         col.suggestion_column_name = cached_col.to_field;
         col.suggestion_table_name = cached_col.to_table_name;
         col.from_units = cached_col.from_units;
+        col.data_type = cached_col.to_data_type;
 
         // If available, use display_name, else use raw field name.
         const mappable_column = _.find($scope.mappable_property_columns.concat($scope.mappable_taxlot_columns), { column_name: cached_col.to_field, table_name: cached_col.to_table_name });


### PR DESCRIPTION
#### Any background context you want to provide?

#### What's this PR do?
- Adds a "to_data_type" field to cached column mappings that can populate the data type field when reviewing an existing mapping

`NOTE`: This is forward only. It does not work with existing import file mappings.

#### How should this be manually tested?
- Import a file
- Go to data
- Click dataset name
- Click Data Mapping of newly imported file
- Ensure data types are populated

#### What are the relevant tickets?
#5119

#### Screenshots (if appropriate)
