### PR TITLE
XML Updates for AT Workflow

### DIFF
--- a/seed/audit_template/audit_template.py
+++ b/seed/audit_template/audit_template.py
@@ -238,7 +238,7 @@ class AuditTemplate:
         url = f"{self.API_URL}/building_sync/upload"
         display_field = getattr(state, self.org.property_display_field)
 
-        if state.audit_template_building_id:
+        if state.audit_template_building_id and file_only is False:
             return None, ["info", f"{display_field}: Existing Audit Template Property"]
 
         try:

--- a/seed/audit_template/audit_template.py
+++ b/seed/audit_template/audit_template.py
@@ -334,8 +334,6 @@ class AuditTemplate:
                             em.Buildings(
                                 em.Building(
                                     {"ID": building_id},
-                                    # Conditionally include FederalBuilding element
-                                    *(_build_federal_element(em, state, org) if org.audit_template_export_federal else []),
                                     em.PremisesName(state.property_name),
                                     em.PremisesIdentifiers(
                                         em.PremisesIdentifier(
@@ -345,6 +343,8 @@ class AuditTemplate:
                                         )
                                     ),
                                     _build_address(em, state),
+                                    # Conditionally include FederalBuilding element
+                                    *(_build_federal_element(em, state, org) if org.audit_template_export_federal else []),
                                     em.FloorAreas(
                                         em.FloorArea(
                                             em.FloorAreaType("Gross"),

--- a/seed/audit_template/audit_template.py
+++ b/seed/audit_template/audit_template.py
@@ -238,7 +238,7 @@ class AuditTemplate:
         url = f"{self.API_URL}/building_sync/upload"
         display_field = getattr(state, self.org.property_display_field)
 
-        if state.audit_template_building_id and file_only is False:
+        if state.audit_template_building_id and not file_only:
             return None, ["info", f"{display_field}: Existing Audit Template Property"]
 
         try:


### PR DESCRIPTION
- Allow AT XML file download even when building has already been pushed to AT (there is an error when trying to push to AT when building already exists, but we should still be able to download the file just for inspection)
- Reorder new Federal buildingsync fields to build a valid XML file