### PR TITLE
Custom SMTP backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
       - id: check-toml
       - id: check-xml
       - id: check-yaml
+        exclude: '(pnpm-lock\.yaml|pnpm-workspace\.yaml)'
       - id: debug-statements
       - id: end-of-file-fixer
         exclude: seed/static/seed/locales/

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -316,6 +316,10 @@ SIMPLE_JWT = {
 }
 
 
+def env_var(key, default=None):
+    return os.environ.get(key, default)
+
+
 def yn(s: Union[bool, str]) -> bool:
     if isinstance(s, bool):
         return s

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -32,7 +32,7 @@ DATABASES = {
     },
 }
 
-MIDDLEWARE = ("seed.utils.nocache.DisableClientSideCachingMiddleware", *MIDDLEWARE)  # noqa: F405
+MIDDLEWARE = ("seed.utils.nocache.DisableClientSideCachingMiddleware", *MIDDLEWARE)
 
 LOGGING = {
     "version": 1,

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -12,11 +12,6 @@ from kombu import Exchange, Queue
 
 from config.settings.common import *  # noqa: F403
 
-
-def env_var(key, default=None):
-    return os.environ.get(key, default)
-
-
 # Gather all the settings from the docker environment variables
 ENV_VARS = [
     "POSTGRES_DB",
@@ -57,10 +52,10 @@ for loc in ENV_VARS:
 BOOL_ENV_VARS = ["EMAIL_USE_TLS", "EMAIL_USE_SSL"]
 
 for loc in BOOL_ENV_VARS:
-    locals()[loc] = locals().get(loc, "").lower() == "true"
+    locals()[loc] = yn(locals().get(loc, ""))
 
 # TLS certificate verification is optional
-EMAIL_VERIFY_TLS = env_var("EMAIL_VERIFY_TLS", "true").lower() == "true"
+EMAIL_VERIFY_TLS = yn(env_var("EMAIL_VERIFY_TLS", "true"))
 
 DEBUG = env_var("Debug", False)
 COMPRESS_ENABLED = True
@@ -81,8 +76,8 @@ else:
 # another backend (e.g., SMTP), then please update this model to support both and
 # create a pull request.
 EMAIL_BACKEND = env_var("DJANGO_EMAIL_BACKEND", "django_ses.SESBackend")
-PASSWORD_RESET_EMAIL = SERVER_EMAIL  # noqa: F405
-DEFAULT_FROM_EMAIL = SERVER_EMAIL  # noqa: F405
+PASSWORD_RESET_EMAIL = SERVER_EMAIL
+DEFAULT_FROM_EMAIL = SERVER_EMAIL
 POST_OFFICE = {
     "BACKENDS": {
         "default": EMAIL_BACKEND,
@@ -154,7 +149,7 @@ LOGGING = {
     },
 }
 
-if "default" in SECRET_KEY:  # noqa: F405
+if "default" in SECRET_KEY:
     print("WARNING: SECRET_KEY is defaulted. Makes sure to override SECRET_KEY in local_untracked or env var")
 
 if "SENTRY_RAVEN_DSN" in os.environ:

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -53,6 +53,14 @@ for loc in ENV_VARS:
     if not locals().get(loc):
         raise Exception(f"{loc} Not defined as env variables")
 
+# Add any env variables that should be booleans to this list
+BOOL_ENV_VARS = ["EMAIL_USE_TLS", "EMAIL_USE_SSL"]
+
+for loc in BOOL_ENV_VARS:
+    locals()[loc] = locals().get(loc, "").lower() == "true"
+
+# TLS certificate verification is optional
+EMAIL_VERIFY_TLS = env_var("EMAIL_VERIFY_TLS", "true").lower() == "true"
 
 DEBUG = env_var("Debug", False)
 COMPRESS_ENABLED = True

--- a/config/settings/docker_dev.py
+++ b/config/settings/docker_dev.py
@@ -16,11 +16,6 @@ from kombu import Exchange, Queue
 
 from config.settings.common import *  # noqa: F403
 
-
-def env_var(key, default=None):
-    return os.environ.get(key, default)
-
-
 # override MEDIA_URL (requires nginx which dev stack doesn't use)
 MEDIA_URL = "/media/"
 

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -86,4 +86,4 @@ if "SF_INSTANCE" not in vars():
     SF_SECURITY_TOKEN = os.environ.get("SF_SECURITY_TOKEN", "")
 
 # load small EEEJ dataset for testing
-EEEJ_LOAD_SMALL_TEST_DATASET = yn(os.environ.get("EEEJ_LOAD_SMALL_TEST_DATASET", "True"))  # noqa: F405
+EEEJ_LOAD_SMALL_TEST_DATASET = yn(os.environ.get("EEEJ_LOAD_SMALL_TEST_DATASET", "True"))

--- a/ruff.toml
+++ b/ruff.toml
@@ -78,6 +78,9 @@ ignore = [
     "S105", # hardcoded-password-string
     "S307", # suspicious-eval-usage
 ]
+"config/settings/*.py" = [
+    "F405", # undefined-local-with-import-star-usage
+]
 "seed/**/migrations/*" = [
     "ARG001", # unused-function-argument
     "RUF012", # mutable-class-default

--- a/seed/backends/smtp.py
+++ b/seed/backends/smtp.py
@@ -1,0 +1,41 @@
+# seed/backends/smtp.py
+from django.conf import settings
+from django.core.mail.backends.smtp import EmailBackend as BaseBackend
+from django.core.mail.utils import DNS_NAME
+
+
+class EmailBackend(BaseBackend):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.verify_tls = kwargs.get("verify_tls") or settings.EMAIL_VERIFY_TLS
+
+    def open(self):
+        if self.connection:
+            # Nothing to do if the connection is already open.
+            return False
+
+        # If local_hostname is not specified, socket.getfqdn() gets used.
+        # For performance, we use the cached FQDN for local_hostname.
+        connection_params = {"local_hostname": DNS_NAME.get_fqdn()}
+        if self.timeout is not None:
+            connection_params["timeout"] = self.timeout
+        if self.use_ssl:
+            connection_params["context"] = self.ssl_context
+        try:
+            self.connection = self.connection_class(
+                self.host, self.port, **connection_params
+            )
+
+            # TLS/SSL are mutually exclusive, so only attempt TLS over
+            # non-secure connections.
+            if not self.use_ssl and self.use_tls:
+                if self.verify_tls:
+                    self.connection.starttls(context=self.ssl_context)
+                else:
+                    self.connection.starttls()
+            if self.username and self.password:
+                self.connection.login(self.username, self.password)
+            return True
+        except OSError:
+            if not self.fail_silently:
+                raise

--- a/seed/backends/smtp.py
+++ b/seed/backends/smtp.py
@@ -1,4 +1,8 @@
-# seed/backends/smtp.py
+"""
+SEED Platform (TM), Copyright (c) Alliance for Energy Innovation, LLC, and other contributors.
+See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
+"""
+
 from django.conf import settings
 from django.core.mail.backends.smtp import EmailBackend as BaseBackend
 from django.core.mail.utils import DNS_NAME
@@ -22,9 +26,7 @@ class EmailBackend(BaseBackend):
         if self.use_ssl:
             connection_params["context"] = self.ssl_context
         try:
-            self.connection = self.connection_class(
-                self.host, self.port, **connection_params
-            )
+            self.connection = self.connection_class(self.host, self.port, **connection_params)
 
             # TLS/SSL are mutually exclusive, so only attempt TLS over
             # non-secure connections.

--- a/seed/management/commands/update_site.py
+++ b/seed/management/commands/update_site.py
@@ -3,8 +3,8 @@ SEED Platform (TM), Copyright (c) Alliance for Energy Innovation, LLC, and other
 See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 """
 
-from django.core.management.base import BaseCommand
 from django.contrib.sites.models import Site
+from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):

--- a/seed/management/commands/update_site.py
+++ b/seed/management/commands/update_site.py
@@ -1,0 +1,27 @@
+"""
+SEED Platform (TM), Copyright (c) Alliance for Energy Innovation, LLC, and other contributors.
+See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
+"""
+
+from django.core.management.base import BaseCommand
+from django.contrib.sites.models import Site
+
+
+class Command(BaseCommand):
+    help = "Updates the django site"
+
+    def add_arguments(self, parser):
+        parser.add_argument("-n", "--name", help="Sets the site name")
+        parser.add_argument(
+            "-d",
+            "--domain",
+            help="Sets the site domain",
+        )
+
+    def handle(self, *_, **options):
+        site = Site.objects.first()
+        if options["name"] is not None:
+            site.name = options["name"]
+        if options["domain"] is not None:
+            site.domain = options["domain"]
+        site.save()


### PR DESCRIPTION
#### Any background context you want to provide?
Corporate networks sometimes use internally signed certificates for smtp servers. In this case, Django either needs the certfile/keyfile, or to ignore the ssl context. This works in a dev environment with self-signed certificates as well.

#### What's this PR do?
- Added a custom smtp email backend that allows the user to toggle off TLS context.
- This bypasses certificate verification for smtp servers with internally signed (or self-signed) certificates.
- Realistically this should only be used in a development or highly trusted environment.
- This backend can easily be expanded on.
- Added an environment variable to toggle the TLS context (defaults to true)
- Added some logic for handling boolean environment variables, specifically smtp related for now.

#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
