### PR TITLE
Replace all OTP emails with null

### DIFF
--- a/seed/migrations/0251_null_emaildevice_email.py
+++ b/seed/migrations/0251_null_emaildevice_email.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+def null_otp_email(apps, schema_editor):
+    EmailDevice = apps.get_model("otp_email", "EmailDevice")
+    EmailDevice.objects.exclude(email__isnull=True).update(email=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("otp_email", "0006_add_timestamps"),
+        ("seed", "0250_remove_goal_current_cycle_goal_partner_note_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(null_otp_email, migrations.RunPython.noop),
+    ]

--- a/seed/utils/organizations.py
+++ b/seed/utils/organizations.py
@@ -196,4 +196,4 @@ def set_default_2fa_method(org):
     for user in org.users.iterator():
         devices = list(devices_for_user(user))
         if not devices:
-            EmailDevice.objects.create(user=user, name="default", email=user.username)
+            EmailDevice.objects.create(user=user, name="default")

--- a/seed/views/v3/two_factor_views.py
+++ b/seed/views/v3/two_factor_views.py
@@ -76,7 +76,7 @@ class TwoFactorViewSet(viewsets.ViewSet, OrgMixin):
 
         # token_active = type(devices[0]) == Token?
         if methods.get("email") is True and not email_active:
-            email_device = EmailDevice.objects.create(user=user, name="default", email=user.username)
+            email_device = EmailDevice.objects.create(user=user, name="default")
             if email_device:
                 [device.delete() for device in devices]
                 # just for user confirmation

--- a/seed/views/v3/users.py
+++ b/seed/views/v3/users.py
@@ -210,7 +210,7 @@ class UserViewSet(viewsets.ViewSet, OrgMixin):
             user.first_name = first_name
             user.last_name = last_name
             if org.require_2fa:
-                EmailDevice.objects.create(user=user, name="default", email=user.email)
+                EmailDevice.objects.create(user=user, name="default")
         user.save()
 
         try:


### PR DESCRIPTION
#### What's this PR do?
Deletes copied (and potentially stale) email addresses from the `otp_email_emaildevice` table so that `django-two-factor-auth` always uses the user's current email address

#### How should this be manually tested?
1. Checkout the develop branch
2. Enable 2fa via email
3. Change your email address on the profile page
4. Switch to this branch
5. Run the migration
6. Log out and log back in using the new email address
7. Confirm that the 2fa code was sent to the new email address

#### What are the relevant tickets?
#5208