### PR TITLE
Fix error when logging out

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -63,7 +63,8 @@ urlpatterns = [
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("api/version/", version, name="version"),
     path("api/", include((api, "seed"), namespace="api")),
-    path("account/login", CustomLoginView.as_view(), name="login"),
+    path("account/login/", CustomLoginView.as_view(), name="login"),
+    path("account/login", CustomLoginView.as_view()),
     path("", include(two_factor_urls)),
     # test sentry error
     path("sentry-debug/", trigger_error),

--- a/config/urls.py
+++ b/config/urls.py
@@ -64,7 +64,6 @@ urlpatterns = [
     path("api/version/", version, name="version"),
     path("api/", include((api, "seed"), namespace="api")),
     path("account/login/", CustomLoginView.as_view(), name="login"),
-    path("account/login", CustomLoginView.as_view()),
     path("", include(two_factor_urls)),
     # test sentry error
     path("sentry-debug/", trigger_error),

--- a/seed/landing/templates/two_factor/core/login.html
+++ b/seed/landing/templates/two_factor/core/login.html
@@ -18,8 +18,6 @@
   {% endif %}
 
   <form action="" method="post" class="signup_form">
-    <input type="hidden" name="username" value="{{username}}">
-
     {% block main_form_content %}
     {% csrf_token %}
     {% include "two_factor/_wizard_forms.html" %}

--- a/seed/landing/tests.py
+++ b/seed/landing/tests.py
@@ -23,9 +23,8 @@ class UserLoginTest(TestCase):
         self.assertTrue(response.status_code == 302)
         self.assertTrue(response.url == "/account/login/")
 
-    def test_two_factor_login_template_has_no_missing_username_context(self):
-        with self.assertNoLogs("django.template", level="DEBUG"):
-            response = self.client.get("/account/login/", secure=True)
+    def test_two_factor_login_template_has_expected_username_field(self):
+        response = self.client.get(reverse("login"), secure=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'id="id_auth-username"')

--- a/seed/landing/tests.py
+++ b/seed/landing/tests.py
@@ -22,3 +22,11 @@ class UserLoginTest(TestCase):
         response = self.client.post(self.login_url, self.user_details, secure=True)
         self.assertTrue(response.status_code == 302)
         self.assertTrue(response.url == "/account/login/")
+
+    def test_two_factor_login_template_has_no_missing_username_context(self):
+        with self.assertNoLogs("django.template", level="DEBUG"):
+            response = self.client.get("/account/login/", secure=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="id_auth-username"')
+        self.assertNotContains(response, 'name="username"')

--- a/seed/landing/views.py
+++ b/seed/landing/views.py
@@ -221,8 +221,13 @@ class CustomLoginView(LoginView):
             user.save()
         return HttpResponseRedirect(settings.LOGIN_REDIRECT_URL)
 
-    def render(self, form=None, **kwargs):
-        # Conditionally show the `Create my Account` button
-        kwargs.setdefault("context", {})["self_registration"] = settings.INCLUDE_ACCT_REG
+    def get_context_data(self, form, **kwargs):
+        context = super().get_context_data(form, **kwargs)
+        context.setdefault("other_devices", [])
+        context.setdefault("backup_tokens", 0)
+        context.setdefault("cancel_url", "")
 
-        return super().render(form, **kwargs)
+        # Conditionally show the `Create my Account` button
+        context.setdefault("context", {})["self_registration"] = settings.INCLUDE_ACCT_REG
+
+        return context


### PR DESCRIPTION
<!--Before opening the pull request, add one of the following labels to ensure the change logs are generated correctly: Feature, Bug, Enhancement, Maintenance, Documentation, Performance, Do not publish-->

#### Any background context you want to provide?
When clicking logout, the system would return an error. This branch fixed the logout-to-login error caused by /account/login/ rendering the two-factor login template without the context SEED expected.

The concrete error was a Django template variable lookup issue, especially the stale {{ username }} hidden input in the login template. The added test guards against django.template DEBUG errors on GET /account/login/ and checks that the page uses the real two-factor field id="id_auth-username" instead of name="username": seed/landing/tests.py:26.

The fix also makes /account/login/ route to CustomLoginView before the stock two-factor URLs: config/urls.py:66, and supplies default context for other_devices, backup_tokens, and cancel_url: seed/landing/views.py:224.


#### What's this PR do?
* fix the logout

#### How should this be manually tested?
* there is a new test added
* log in and then log out, make sure the terminal doesn't have any errors

#### What are the relevant tickets?

#### Screenshots (if appropriate)
