### PR TITLE
ci: add copilot-setup-steps for cloud agent test environment

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,4 +1,4 @@
-name: "Copilot Setup Steps"
+name: 'Copilot Setup Steps'
 
 # Prepares the environment for the GitHub Copilot coding agent so it can build
 # the SEED dev image, bring up the Docker stack, and run the Django test suite

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,95 @@
+name: "Copilot Setup Steps"
+
+# Prepares the environment for the GitHub Copilot coding agent so it can build
+# the SEED dev image, bring up the Docker stack, and run the Django test suite
+# (including the live Salesforce integration tests) exactly like CI does.
+#
+# The Salesforce tests in seed/tests/test_salesforce_views.py are guarded by
+# @skipUnless(HAS_LIVE_SALESFORCE_CREDENTIALS, ...) and only run when all of
+# SF_INSTANCE, SF_USERNAME, SF_PASSWORD and SF_SECURITY_TOKEN are set.
+#
+# Those values are NOT provided here. Add them (plus the SF_DOMAIN variable) to
+# the repository's `copilot` environment so Copilot injects them into the
+# agent's shell:
+#   Settings > Environments > copilot
+#     - Environment secrets: SF_INSTANCE, SF_USERNAME, SF_PASSWORD, SF_SECURITY_TOKEN
+#     - Environment variables: SF_DOMAIN
+#
+# The agent must then forward them into the container when running the tests, e.g.:
+#   docker exec --env SF_INSTANCE --env SF_USERNAME --env SF_PASSWORD \
+#     --env SF_SECURITY_TOKEN --env SF_DOMAIN seed_web /bin/bash -lc \
+#     'uv run python manage.py test seed.tests.test_salesforce_views \
+#        --settings=config.settings.docker_test'
+
+# Automatically run the setup steps when they are changed to allow for easy
+# validation, and allow manual testing through the repository's "Actions" tab.
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 59
+
+    # Lowest permissions needed for the steps below. Copilot gets its own token.
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Free up disk space
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          echo "Disk space after cleanup:"
+          df -h
+
+      - name: Build Docker dev image
+        run: |
+          docker buildx build \
+            --tag seedplatform/seed:develop \
+            --load \
+            --file Dockerfile-dev .
+
+      - name: Start the stack
+        env:
+          DJANGO_LOG_LEVEL: ERROR
+        run: |
+          docker volume create --name=seed_pgdata
+          docker volume create --name=seed_media
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+
+      - name: Migrate and seed default user
+        env:
+          DJANGO_LOG_LEVEL: ERROR
+        run: |
+          docker exec --env DJANGO_LOG_LEVEL seed_web uv run python manage.py migrate
+          docker exec --env DJANGO_LOG_LEVEL seed_web uv run python manage.py create_default_user --username=demo@example.com --password=demo
+          docker exec --env DJANGO_LOG_LEVEL seed_web /bin/bash -lc 'echo "y" | uv run python manage.py make_superuser --user demo@example.com'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install frontend dependencies
+        run: pnpm install


### PR DESCRIPTION
## What & why

Adds `.github/workflows/copilot-setup-steps.yml` so the GitHub Copilot coding agent lands in a ready-to-test environment instead of discovering the setup by trial and error. The steps mirror the CI `unittests` (django) job:

1. Checkout with submodules
2. Set up Docker Buildx + free disk space
3. Build the `seedplatform/seed:develop` dev image (`Dockerfile-dev`)
4. `docker compose up -d` the full stack
5. Run migrations + seed the default user
6. Install Node 24 + pnpm frontend deps

This unblocks running the Django suite — including the **live Salesforce integration tests** in `seed/tests/test_salesforce_views.py`, which are gated by `@skipUnless(HAS_LIVE_SALESFORCE_CREDENTIALS, ...)`.

## Required follow-up (not in this PR)

Credentials are intentionally **not** in this file. For the Salesforce tests to actually run, add them to the repo's **`copilot` environment** (Settings → Environments → `copilot`):

- **Secrets:** `SF_INSTANCE`, `SF_USERNAME`, `SF_PASSWORD`, `SF_SECURITY_TOKEN`
- **Variable:** `SF_DOMAIN`

All four secrets must be non-empty or the live tests are skipped.

The agent must also forward them into the `seed_web` container (tests run inside Docker), exactly like CI:

```
docker exec --env SF_INSTANCE --env SF_USERNAME --env SF_PASSWORD \
  --env SF_SECURITY_TOKEN --env SF_DOMAIN seed_web /bin/bash -lc \
  'uv run python manage.py test seed.tests.test_salesforce_views \
     --settings=config.settings.docker_test'
```

## Note

`copilot-setup-steps.yml` only takes effect once merged to the default branch (`develop`). After merge, it can also be triggered manually from the **Actions** tab (`workflow_dispatch`) to validate.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>