### PR TITLE
test: prove Docker build broken on aarch64 (ARM) with Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,40 @@ jobs:
         if: ${{ always() }}
         run: docker logs seed_web
 
+  # Validates that the Dockerfile builds from scratch on Alpine (musl libc).
+  # This replicates the CodeBuild environment for doeseed-seedweb where:
+  #   - CodeBuild uses aws/codebuild/standard:7.0 (Ubuntu) as the HOST
+  #   - But the Dockerfile itself uses FROM node:24-alpine (musl libc)
+  #   - Python deps are compiled INSIDE the Alpine container, not on the host
+  #   - uv downloads cpython-3.14-linux-musl which embeds --rtlib=compiler-rt
+  #   - Alpine's g++ doesn't support this clang flag
+  #   - doublemetaphone has no cp314 musllinux wheels on PyPI
+  #
+  # This also fails on Docker Desktop (macOS/Windows) for the same reason:
+  # Docker Desktop runs containers in a Linux VM using the Alpine image.
+  #
+  # Why it appears to work on bare Linux hosts (Alex's Ubuntu machines):
+  # `docker buildx build` still builds INSIDE the Alpine container, so it
+  # should also fail. If it didn't fail, the only explanation is Docker layer
+  # cache from a previous build where doublemetaphone was compiled with an
+  # older Python version. `docker builder prune -af` removes build cache but
+  # NOT image layer cache. A full `docker system prune -af` is required.
+  docker-build-no-cache:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build Dockerfile (no cache, Alpine/musl)
+        run: |
+          docker buildx build \
+            --no-cache \
+            --tag seed:test \
+            --load \
+            .
+
   formatting:
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,23 @@ jobs:
           submodules: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      - name: Build Dockerfile (no cache, Alpine/musl)
+      - name: Build Dockerfile (no cache, Alpine/musl, x86_64)
+        run: |
+          docker buildx build \
+            --no-cache \
+            --tag seed:test \
+            --load \
+            .
+
+  docker-build-no-cache-arm:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build Dockerfile (no cache, Alpine/musl, aarch64)
         run: |
           docker buildx build \
             --no-cache \


### PR DESCRIPTION
## Purpose

This PR adds two CI jobs that run `docker buildx build --no-cache` against the current `Dockerfile` on the `develop` branch. It demonstrates an architecture-specific build failure.

## Results

| Job | Architecture | Result |
|-----|-------------|--------|
| `docker-build-no-cache` | x86_64 | **PASS** |
| `docker-build-no-cache-arm` | aarch64 (ARM) | **FAIL** |

## What fails and why

```
c++: error: unrecognized command-line option '--rtlib=compiler-rt'
```

`doublemetaphone==1.2` (via `probablepeople`) fails to compile from source on **aarch64 Alpine only**.

### Root cause:

1. `.python-version` = `3.14`
2. uv's managed `cpython-3.14.4-linux-aarch64-musl` is built with **clang** and embeds `--rtlib=compiler-rt` in sysconfig
3. uv's managed `cpython-3.14.4-linux-x86_64-musl` is built with **gcc** - no such flag
4. `doublemetaphone==1.2` on PyPI has wheels for cp310-cp313 only - no cp314 wheels exist
5. On aarch64: source build fails because Alpine's g++ doesn't support the clang flag
6. On x86_64: source build succeeds because no incompatible flag is present

### Who is affected:

- Docker Desktop on Apple Silicon (macOS) - containers run aarch64
- ARM-based CodeBuild/ECS compute
- Any cross-build with `--platform linux/arm64`

### To reproduce on an x86_64 Linux machine:

```bash
docker buildx build --no-cache --platform linux/arm64 --tag seed:test-arm64 .
```

### Why Alex's x86_64 Ubuntu machines succeeded:

The x86_64 musl Python 3.14 binary uses gcc-compatible compiler flags. The build only fails on aarch64 where the musl Python binary was compiled with clang.

## Fix

See #5271 which pins `--python 3.13` in the ECS Dockerfiles, using pre-built cp313 musllinux wheels (available for both architectures).

## Action

Close this PR without merging - it only proves the bug exists on develop for ARM builds.