### PR TITLE
Fix ARM builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,30 @@ on:
       - 'main'
 
 jobs:
+  docker-arm-build:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Cache Docker ARM layers
+        uses: actions/cache@v6
+        with:
+          path: /tmp/.buildx-cache-arm64
+          key: ${{ runner.os }}-buildx-arm64-v1-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-arm64-v1-
+      - name: Build Docker production image for ARM
+        run: |
+          /usr/bin/docker buildx build \
+            --progress=plain \
+            --cache-from type=local,src=/tmp/.buildx-cache-arm64 \
+            --cache-to type=local,dest=/tmp/.buildx-cache-arm64,mode=max \
+            --file Dockerfile \
+            .
+
   # Currently GH Actions provides no simple method for "sharing"
   # our setup steps. Ideally this would be in an action, but we would need to use
   # actions inside of our actions which you cannot currently do (see https://github.com/actions/runner/issues/438)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,29 +13,11 @@ on:
         required: true
 
 jobs:
-  publish:
+  prepare:
     runs-on: ubuntu-24.04
+    outputs:
+      seed_tags: ${{ steps.parse_tag.outputs.seed_tags }}
     steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          submodules: true
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Cache Docker layers
-        uses: actions/cache@v6
-        with:
-          path: /tmp/.buildx-cache
-          # using `v2` in key to clear old cache due to errors
-          # See: https://stackoverflow.com/questions/63521430/clear-cache-in-github-actions
-          key: ${{ runner.os }}-buildx-v2-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-v2-
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Parse tag
         id: parse_tag
         run: |
@@ -58,11 +40,89 @@ jobs:
             exit 1
           fi
           echo "seed_tags=${SEED_TAG}" >> $GITHUB_OUTPUT
-      - name: Build and push
+
+  build:
+    needs: prepare
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      # Each matrix leg writes only its own key; the empty value from the
+      # other leg does not overwrite it.
+      digest-amd64: ${{ steps.export.outputs.digest-amd64 }}
+      digest-arm64: ${{ steps.export.outputs.digest-arm64 }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Cache Docker ${{ matrix.arch }} layers
+        uses: actions/cache@v6
+        with:
+          path: /tmp/.buildx-cache-${{ matrix.arch }}
+          # using `v2` in key to clear old cache due to errors
+          # See: https://stackoverflow.com/questions/63521430/clear-cache-in-github-actions
+          key: ${{ runner.os }}-buildx-${{ matrix.arch }}-v2-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ matrix.arch }}-v2-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.arch }} image by digest
         id: docker_build
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          push: true
-          tags: ${{ steps.parse_tag.outputs.seed_tags }}
+          platforms: linux/${{ matrix.arch }}
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.arch }}
+          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.arch }},mode=max
+          outputs: type=image,name=seedplatform/seed,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        id: export
+        run: echo "digest-${{ matrix.arch }}=${{ steps.docker_build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: [prepare, build]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifests
+        env:
+          SEED_TAGS: ${{ needs.prepare.outputs.seed_tags }}
+          AMD64_DIGEST: ${{ needs.build.outputs.digest-amd64 }}
+          ARM64_DIGEST: ${{ needs.build.outputs.digest-arm64 }}
+        run: |
+          image_refs=(
+            "seedplatform/seed@${AMD64_DIGEST}"
+            "seedplatform/seed@${ARM64_DIGEST}"
+          )
+
+          IFS=',' read -ra tags <<< "${SEED_TAGS}"
+          for tag in "${tags[@]}"; do
+            docker buildx imagetools create \
+              --tag "${tag}" \
+              "${image_refs[@]}"
+          done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     # Matching / address parsing
     "jellyfish==1.2.1",
     "street-address==0.4.0",
-    "probablepeople==0.5.6",
+    "nameparser==1.4.0",
     "usaddress==0.5.16",
     # Geo / Building data
     "shapely==2.1.2",

--- a/seed/hpxml/hpxml.py
+++ b/seed/hpxml/hpxml.py
@@ -12,9 +12,9 @@ import os
 from copy import deepcopy
 from io import BytesIO
 
-import probablepeople as pp
 import usaddress
 from lxml import etree, objectify
+from nameparser import HumanName
 from quantityfield.units import ureg
 
 _log = logging.getLogger(__name__)
@@ -142,35 +142,16 @@ class HPXML:
 
         # Owner Name
         if property_state.owner is not None:
-            try:
-                owner_name, name_type = pp.tag(property_state.owner, type="person")
-            except pp.RepeatedLabelError:
-                pass
-            else:
-                if name_type.lower() == "person":
-                    owner.Name.clear()
-                    if "PrefixMarital" in owner_name or "PrefixOther" in owner_name:
-                        owner.Name.append(E.PrefixName(" ".join([owner_name.get("Prefix" + x, "") for x in ("Marital", "Other")]).strip()))
-                    if "GivenName" in owner_name:
-                        owner.Name.append(E.FirstName(owner_name["GivenName"]))
-                    elif "FirstInitial" in owner_name:
-                        owner.Name.append(E.FirstName(owner_name["FirstInitial"]))
-                    else:
-                        owner.Name.append(E.FirstName())
-                    if "MiddleName" in owner_name:
-                        owner.Name.append(E.MiddleName(owner_name["MiddleName"]))
-                    elif "MiddleInitial" in owner_name:
-                        owner.Name.append(E.MiddleName(owner_name["MiddleInitial"]))
-                    if "Surname" in owner_name:
-                        owner.Name.append(E.LastName(owner_name["Surname"]))
-                    elif "LastInitial" in owner_name:
-                        owner.Name.append(E.LastName(owner_name["LastInitial"]))
-                    else:
-                        owner.Name.append(E.LastName())
-                    if "SuffixGenerational" in owner_name or "SuffixOther" in owner_name:
-                        owner.Name.append(
-                            E.SuffixName(" ".join([owner_name.get("Suffix" + x, "") for x in ("Generational", "Other")]).strip())
-                        )
+            owner_name = HumanName(property_state.owner)
+            owner.Name.clear()
+            if owner_name.title:
+                owner.Name.append(E.PrefixName(owner_name.title))
+            owner.Name.append(E.FirstName(owner_name.first))
+            if owner_name.middle:
+                owner.Name.append(E.MiddleName(owner_name.middle))
+            owner.Name.append(E.LastName(owner_name.last))
+            if owner_name.suffix:
+                owner.Name.append(E.SuffixName(owner_name.suffix))
 
         # Owner Email
         if property_state.owner_email is not None:

--- a/seed/hpxml/tests/test_hpxml.py
+++ b/seed/hpxml/tests/test_hpxml.py
@@ -5,10 +5,13 @@ See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 
 import pathlib
 from os import path
+from types import SimpleNamespace
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
+from lxml import etree
 
+from seed.hpxml.hpxml import HPXML
 from seed.models import User
 from seed.models.building_file import BuildingFile
 from seed.utils.organizations import create_organization
@@ -37,3 +40,34 @@ class TestBuildingFiles(TestCase):
         self.assertEqual(property_state.owner, "Jane Customer")
         self.assertEqual(property_state.energy_score, 8)
         self.assertEqual(messages, {"errors": [], "warnings": []})
+
+    def test_hpxml_export_parses_owner_name(self):
+        property_state = SimpleNamespace(
+            extra_data={},
+            address_line_1=None,
+            address_line_2=None,
+            city=None,
+            state=None,
+            postal_code=None,
+            gross_floor_area=None,
+            year_built=None,
+            conditioned_floor_area=None,
+            occupied_floor_area=None,
+            energy_score=None,
+            owner="Dr. Jane Q. Customer Jr.",
+            owner_email=None,
+            owner_telephone=None,
+            owner_address=None,
+            owner_city_state=None,
+            owner_postal_code=None,
+            building_certification=None,
+        )
+
+        root = etree.fromstring(HPXML().export(property_state))
+        namespace = {"h": HPXML.NS}
+
+        self.assertEqual(root.xpath("string(//h:Customer/h:CustomerDetails/h:Person/h:Name/h:PrefixName)", namespaces=namespace), "Dr.")
+        self.assertEqual(root.xpath("string(//h:Customer/h:CustomerDetails/h:Person/h:Name/h:FirstName)", namespaces=namespace), "Jane")
+        self.assertEqual(root.xpath("string(//h:Customer/h:CustomerDetails/h:Person/h:Name/h:MiddleName)", namespaces=namespace), "Q.")
+        self.assertEqual(root.xpath("string(//h:Customer/h:CustomerDetails/h:Person/h:Name/h:LastName)", namespaces=namespace), "Customer")
+        self.assertEqual(root.xpath("string(//h:Customer/h:CustomerDetails/h:Person/h:Name/h:SuffixName)", namespaces=namespace), "Jr.")

--- a/uv.lock
+++ b/uv.lock
@@ -907,36 +907,6 @@ wheels = [
 ]
 
 [[package]]
-name = "doublemetaphone"
-version = "1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/b0/7d900c1b3171f7ca6dfa066002f8238d75e0895d9fab3b4851d40fc69a9f/doublemetaphone-1.2.tar.gz", hash = "sha256:9d93decfe5ecfbd7fe665224a8e949f9c1658d0e146589a4688cfe6243f628d2", size = 64555, upload-time = "2025-05-11T11:34:32.122Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/3f/fe7023f5e671dd7edf6d2fcbdc12e15ee8726e9a77aa5bb08f02af1a6c24/doublemetaphone-1.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cada83509ed865cb577eb80b72bbf8c5a10d329c2300c91aa26d3d0dfe5e3af4", size = 55590, upload-time = "2025-05-11T11:34:20.479Z" },
-    { url = "https://files.pythonhosted.org/packages/14/77/a9e42cddc69e80ba0575d3df5d17d667a9ea6943d9966b581c87996adca7/doublemetaphone-1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:854123364d737b364719a05d3b4bc232196f10ab8bbd22378941e58cd778035e", size = 30426, upload-time = "2025-05-11T11:34:21.66Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/0b/f8007b0990ee870378c6c848cd94377fb844c77ba6b1010f64e7b8209fbc/doublemetaphone-1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ee11fd0ad53d393f3aab25a9c3807995faa6704a8584eada0fc0da50d0360e59", size = 30646, upload-time = "2025-05-11T11:34:22.387Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f5/6a7c25023a6f53f9076a5c38e8bf1425e20c90d6b011e1b9b4dac68cef6b/doublemetaphone-1.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e2e640e130d8486ee8b5a4db4c5fcbf924b5296ad7fc3305c18ac484141621f", size = 173354, upload-time = "2025-05-11T12:03:43.417Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9d/2838fdd1e0bb91e7c72154f9b4faee4803c1166a3387a8f16bf9ec00d6f2/doublemetaphone-1.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:221bbf10e458ae2796f5000469cf85576dce4dbf6dbd8121305fdfdf2f068f76", size = 172678, upload-time = "2025-05-11T12:03:44.405Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/f7/3bef2d67a39e58b346645365504dad7afbe3cc56eef4215cd7a10fa72a95/doublemetaphone-1.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:53d6f7260379ee97357c5725cdf10eec9235f4036b04429a95fdc16984e528c8", size = 164784, upload-time = "2025-05-11T12:03:45.351Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/75/83768ac75e827f41cd408d55d83ac01f19cb725ecac8ca69dca0422bf3a1/doublemetaphone-1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:02fcebbb91f979a0a9a53acb52ec110848058785114abfd0e5c85b046303dc91", size = 1183417, upload-time = "2025-05-11T12:03:46.401Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/a7/ae20f597df41f302e6259f9eabf033416c2e51f74f947ccdb23eb2e5ae15/doublemetaphone-1.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:14945e8efaec0053c108341bb22f98e8914657fe891529fde6f4ea082b865044", size = 1336549, upload-time = "2025-05-11T12:03:47.679Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/d8/be15751a4424d84e6309d072be7a07782cf2d9c0a0f8ebd07e8481ede17e/doublemetaphone-1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:342be444efd904b67fcf3c18319e16d1b41d4d8860763e2158bef5d0a193228b", size = 1240109, upload-time = "2025-05-11T12:03:48.928Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/44/f3dfa941bb3de5588d1eca590b87f26d6ee87da937f810fd9596f843687b/doublemetaphone-1.2-cp312-cp312-win32.whl", hash = "sha256:cb69053be13473116024fe8b871f662e87bed49279b8109e36c2dfa911460c36", size = 28937, upload-time = "2025-05-11T11:38:02.605Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1d/ade88b7eb321dbd0b94019f6d00838b2a363437bcca92ae36b96d583d72e/doublemetaphone-1.2-cp312-cp312-win_amd64.whl", hash = "sha256:38400216e97a675cc9d9373c8c294117c59d141a46c4745dbd8b849de28a65aa", size = 31802, upload-time = "2025-05-11T11:38:03.325Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b4/c007f911688afc64fe822260eeb4e96e1990b34e70d585153ee8822aecb7/doublemetaphone-1.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4d0117d1a7ee2b3002eb623dc6e36b97b96705a8fd702056e00801445c2fb284", size = 55631, upload-time = "2025-05-11T11:34:23.377Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/98/eba9538b9a0ef6a2e246c3cf680efb40c76467c63bd893e53def8d637cb8/doublemetaphone-1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a5d9a5f97d6fa46e25285fe0937872482b71136c2564cabb3c7b6b205f0aebac", size = 30436, upload-time = "2025-05-11T11:34:24.265Z" },
-    { url = "https://files.pythonhosted.org/packages/50/3e/d4c456ad2694d7b4fbdc3bed52610a258d9f9bcca0e591110deb5c5ede49/doublemetaphone-1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d0df0450230090b539200f1f3b74c997c7ad78b3b8cc5d01a5334b79014d9a79", size = 30666, upload-time = "2025-05-11T11:34:25.249Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/57/d010b0ffa97c0463f30e1ca737e9aceba7fd776551f82b35a7f8ac8b749e/doublemetaphone-1.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42c7d5b13db0c5153164d59cf93643a9ab8404e032087b642f85a9b8b8b0679b", size = 172597, upload-time = "2025-05-11T12:03:50.109Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/74/a1e6a5b9cf0cc47b17e8f39142f03484f4b2edbf8be921acf853a3ac2d8d/doublemetaphone-1.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3092aefa4c10758696baff9ce04d836d5564ec80a90afaf47befd107cd7bdc0d", size = 172085, upload-time = "2025-05-11T12:03:51.092Z" },
-    { url = "https://files.pythonhosted.org/packages/51/06/b2bddc2d3eeed236eb06c34a58a300898695092d04053802c50030a33379/doublemetaphone-1.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e774018591b13bee6f5f65bf2ef20d32401b04ed7f684290615420ae26404e5", size = 163945, upload-time = "2025-05-11T12:03:52.112Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/45/c4f10bdc47b659450ad6b363ae6087abb2343ae8969ef4b628c045077285/doublemetaphone-1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8383b8a29e68fd79251731bb16569b20a6d1fa9dc6e7983e6e21cba231765185", size = 1182722, upload-time = "2025-05-11T12:03:53.095Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/5f/69b1ad4a72095979909c58503e352f29cbb0cec410bffd7b00f68aa0cf30/doublemetaphone-1.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:3e7b0369e87d5fc0a29103c4abdbf1fea5ce054bc090462fdb8ef8daac6d8326", size = 1335769, upload-time = "2025-05-11T12:03:54.495Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/8e/3532477b5f58de7ae3ee27f704e7b73aefb92f1202ea6e15d6080ab05e9d/doublemetaphone-1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2642379941a824bbd3e09dce7e52bbcce10fa127b1e1a72b263110ea2a0241d3", size = 1239255, upload-time = "2025-05-11T12:03:55.685Z" },
-    { url = "https://files.pythonhosted.org/packages/54/62/a9db121d63fb6611747a91597b6a1d452a87c5814dff8c40002ebb18e3dc/doublemetaphone-1.2-cp313-cp313-win32.whl", hash = "sha256:aa0416254db47a1681fc16ab48ced1756b76419d3b0e74912868b8507c9c7eff", size = 28902, upload-time = "2025-05-11T11:38:04.439Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/1f/70923d8aeb07714c3ff0ade2374b5326abff509b0139e37187f08ad99a2a/doublemetaphone-1.2-cp313-cp313-win_amd64.whl", hash = "sha256:e91994f556111930e2e215625ce4960a720340ebc8f87e369e60504540772dff", size = 31830, upload-time = "2025-05-11T11:38:05.582Z" },
-]
-
-[[package]]
 name = "drf-nested-routers"
 version = "0.95.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1526,6 +1496,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nameparser"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/6b/c3b4bdf39cd427143939a6f4ad012575e76c78755ceb88c0587899c598df/nameparser-1.4.0.tar.gz", hash = "sha256:a5b9105de7b879909656b6954e7066f06bc7a743a6e6771b19465b0bbbe6a4cf", size = 103018, upload-time = "2026-07-12T19:33:56.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/54/4531fc2cdec0aed15c7b329c42ec66d57ecb1139fd6f205f42d9ce993808/nameparser-1.4.0-py3-none-any.whl", hash = "sha256:b6fef3c8e9cf35e6195bfe7e1387f192b808003dac254896bd593442cd1cf906", size = 49377, upload-time = "2026-07-12T19:33:55.317Z" },
+]
+
+[[package]]
 name = "nh3"
 version = "0.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1852,20 +1831,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8b/26/5a86ac418ee4cecb127a4a6f98d6b202216b5ac4f6b519328ae81d07ba9e/probableparsing-0.0.1.tar.gz", hash = "sha256:8114bbf889e1f9456fe35946454c96e42a6ee2673a90d4f1f9c46a406f543767", size = 1722, upload-time = "2016-03-28T23:39:54.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/6b/91255cbf739a835df41af530a36798397d70342d152b773b5b0fe3001843/probableparsing-0.0.1-py2.py3-none-any.whl", hash = "sha256:509df25fdda4fd7c0b2a100f58cc971bd23daf26f3b3320aebf2616d2e10c69e", size = 3056, upload-time = "2016-12-19T15:04:32.102Z" },
-]
-
-[[package]]
-name = "probablepeople"
-version = "0.5.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "doublemetaphone" },
-    { name = "probableparsing" },
-    { name = "python-crfsuite" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/fd/bcd6ca7c4044b5705a316b98235537ffcd175075d4e0cd90a5440ce16ff2/probablepeople-0.5.6.tar.gz", hash = "sha256:4ae95e77f9fa7dceb116538500ab48c81a91bf68eb652d45207b794b450f4392", size = 571747, upload-time = "2024-10-29T15:23:34.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/b9/c5a6b83cad7f0e92f1c827007eaef528b02f3b95cf7e959b6315c4ac1540/probablepeople-0.5.6-py3-none-any.whl", hash = "sha256:1900ba5575669dd5a0b554a0d1cb66aa1ec2ab076c94a514519a2e42954bbcfc", size = 905483, upload-time = "2024-10-29T15:23:33.092Z" },
 ]
 
 [[package]]
@@ -2534,9 +2499,9 @@ dependencies = [
     { name = "jellyfish" },
     { name = "lark" },
     { name = "markdown" },
+    { name = "nameparser" },
     { name = "pandas" },
     { name = "polling" },
-    { name = "probablepeople" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pyotp" },
     { name = "python-dateutil" },
@@ -2614,9 +2579,9 @@ requires-dist = [
     { name = "jellyfish", specifier = "==1.2.1" },
     { name = "lark", specifier = "==1.3.1" },
     { name = "markdown", specifier = "==3.10.2" },
+    { name = "nameparser", specifier = "==1.4.0" },
     { name = "pandas", specifier = "<3" },
     { name = "polling", specifier = "==0.3.2" },
-    { name = "probablepeople", specifier = "==0.5.6" },
     { name = "psycopg", extras = ["binary"], specifier = "~=3.3.4" },
     { name = "pyotp", specifier = "==2.10.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },


### PR DESCRIPTION
#### What's this PR do?
Replaces the `probablepeople` dependency with `nameparser`, since its sub-dependency `doublemetaphone` fails to compile on ARM with Python 3.14.

It also adds ARM builds to the CI tests and publish step

#### How should this be manually tested?
Tests should pass, and the `publish` action should succeed