### PR TITLE
Update seed-angular submodule: Organization Sharing migration

### DIFF
--- a/seed/tests/test_analyses_views.py
+++ b/seed/tests/test_analyses_views.py
@@ -11,8 +11,14 @@ from django.urls import reverse_lazy
 from django.utils import timezone as tz
 
 from seed.landing.models import SEEDUser as User
-from seed.models import Analysis, AnalysisOutputFile, AnalysisPropertyView, Meter, MeterReading
-from seed.test_helpers.fake import FakeCycleFactory, FakePropertyFactory, FakePropertyStateFactory
+from seed.models import Analysis, AnalysisOutputFile, AnalysisPropertyView, Meter, MeterReading, PropertyView, TaxLotView
+from seed.test_helpers.fake import (
+    FakeCycleFactory,
+    FakePropertyFactory,
+    FakePropertyStateFactory,
+    FakeTaxLotFactory,
+    FakeTaxLotStateFactory,
+)
 from seed.tests.util import AccessLevelBaseTestCase
 from seed.utils.organizations import create_organization
 
@@ -263,6 +269,40 @@ class TestAnalysesView(TestCase):
         self.assertEqual(result["status"], "success")
         self.assertEqual(result["view"]["id"], self.analysis_property_view_d.id)
         self.assertEqual(len(result["view"]["output_files"]), 0)
+
+    def test_used_columns_includes_property_fields_alongside_taxlot_fields(self):
+        """Regression test for a bug where taxlot non-null counts completely overwrote (instead
+        of merging with) property non-null counts, so used_columns effectively never returned any
+        property fields for an org that also had tax lot data. Also covers a related bug where
+        merging the two tables' counts into a single dict keyed only by column_name let one
+        table's count clobber the other's for identically named columns (e.g. address_line_1,
+        which exists on both PropertyState and TaxLotState)."""
+        property_state = self.property_state_factory.get_property_state(site_eui=100, address_line_1="123 Main St")
+        PropertyView.objects.create(property=self.property_a, cycle=self.cycle_a, state=property_state)
+
+        taxlot_factory = FakeTaxLotFactory(organization=self.org)
+        taxlot_state_factory = FakeTaxLotStateFactory(organization=self.org)
+        taxlot = taxlot_factory.get_taxlot()
+        # left null on purpose -- the property's address_line_1 (above) is populated, so this
+        # checks that the two tables' non-null counts for the same column name stay independent
+        taxlot_state = taxlot_state_factory.get_taxlot_state(jurisdiction_tax_lot_id="123", address_line_1=None)
+        TaxLotView.objects.create(taxlot=taxlot, cycle=self.cycle_a, state=taxlot_state)
+
+        response = self.client.get(f"/api/v3/analyses/used_columns/?organization_id={self.org.pk}")
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content)
+        columns = result["columns"]
+
+        property_columns = {c["column_name"] for c in columns if c["table_name"] == "PropertyState"}
+        taxlot_columns = {c["column_name"] for c in columns if c["table_name"] == "TaxLotState"}
+
+        # property fields must survive even though tax lot views also exist for the org
+        self.assertIn("site_eui", property_columns)
+        self.assertIn("address_line_1", property_columns)
+        # the tax lot's own address_line_1 is null, so it must not appear as a tax lot column
+        # even though the identically named property column does have data
+        self.assertNotIn("address_line_1", taxlot_columns)
+        self.assertIn("jurisdiction_tax_lot_id", taxlot_columns)
 
 
 class TestAnalysesViewPermissions(AccessLevelBaseTestCase):

--- a/seed/views/v3/analyses.py
+++ b/seed/views/v3/analyses.py
@@ -384,10 +384,14 @@ class AnalysisViewSet(viewsets.ViewSet, OrgMixin):
     @action(detail=False, methods=["get"])
     def used_columns(self, request):
         org_id = self.get_organization(request)
-        access_level_instance = AccessLevelInstance.objects.get(pk=self.request.access_level_instance_id)
+        # Use the org's root AL instance (not the requester's own, possibly narrower, AL instance)
+        # -- this endpoint reports which columns have data anywhere "for an org" (see docstring),
+        # and its two callers (Organization Sharing, Data Quality Rules admin) are both org-wide
+        # settings screens, not scoped to a branch of the org's access level hierarchy.
+        access_level_instance = Organization.objects.get(pk=org_id).root
 
-        num_of_nonnulls_by_column_name = {}
-        tnum_of_nonnulls_by_column_name = {}
+        property_nonnulls_by_column_name = {}
+        taxlot_nonnulls_by_column_name = {}
 
         columns = Column.objects.none()
         tcolumns = Column.objects.none()
@@ -404,7 +408,7 @@ class AnalysisViewSet(viewsets.ViewSet, OrgMixin):
                 column_name__in=EXCLUDED_API_FIELDS
             )
 
-            num_of_nonnulls_by_column_name = Column.get_num_of_nonnulls_by_column_name(state_ids, PropertyState, columns)
+            property_nonnulls_by_column_name = Column.get_num_of_nonnulls_by_column_name(state_ids, PropertyState, columns)
 
         # Taxlots
         tstate_ids = TaxLotView.objects.filter(
@@ -418,16 +422,22 @@ class AnalysisViewSet(viewsets.ViewSet, OrgMixin):
             tcolumns = Column.objects.filter(organization_id=org_id, derived_column=None, table_name="TaxLotState").exclude(
                 column_name__in=EXCLUDED_API_FIELDS
             )
-            num_of_nonnulls_by_column_name = Column.get_num_of_nonnulls_by_column_name(tstate_ids, TaxLotState, tcolumns)
+            taxlot_nonnulls_by_column_name = Column.get_num_of_nonnulls_by_column_name(tstate_ids, TaxLotState, tcolumns)
 
-        # properties and taxlots together
-        num_of_nonnulls_by_column_name.update(tnum_of_nonnulls_by_column_name)
+        # Properties and taxlots together. Non-null counts are kept in separate per-table dicts
+        # (rather than merged into one dict keyed only by column_name) because PropertyState and
+        # TaxLotState share several identically named columns (e.g. "address_line_1", "city",
+        # "ubid") -- merging them into a single dict would let one table's count silently clobber
+        # the other's for those shared names.
         columns = columns | tcolumns
-
-        # keep only non-zero columns (return full columns)
-        nonzero_cols = [k for k, v in num_of_nonnulls_by_column_name.items() if v != 0]
-
-        columns_to_return = [c for c in columns if c.column_name in nonzero_cols]
+        columns_to_return = [
+            c
+            for c in columns
+            if (property_nonnulls_by_column_name if c.table_name == "PropertyState" else taxlot_nonnulls_by_column_name).get(
+                c.column_name, 0
+            )
+            != 0
+        ]
         # remove "excluded columns that shouldn't be returned":
         columns_to_return = [c for c in columns_to_return if c.column_name not in Column.COLUMN_EXCLUDE_FIELDS]
 


### PR DESCRIPTION
## Summary
Bumps the `ng_seed/seed-angular` submodule pointer to include the Organization Sharing migration
and its follow-up improvements: [SEED-platform/seed-angular#77](https://github.com/SEED-platform/seed-angular/pull/77).
Also includes a backend bug fix (below) discovered while testing that page against real data.

That PR ports the legacy AngularJS **Organization Sharing** page (`/accounts/:organization_id/sharing`, `organization_sharing_controller`) to the new Angular app under `organizations/settings/sharing` -- public column selection for the org's public data feed, a (now working) public query threshold field, the public feed URL/query-param documentation (now with "Test" buttons that open the URLs in a new tab), and an "Add a field" control to add any org column (not just already-populated ones) to the public-sharing list. It only calls existing `/api/v3/` endpoints already used by the legacy page -- no new backend endpoints.

## Backend fix: `used_columns` was dropping nearly all Property fields

While live-testing the Sharing page against real seeded data, a user noticed that fields they
knew had data weren't showing up as selectable/checked. Root-caused it to two bugs in
`seed/views/v3/analyses.py`'s `used_columns()` action (used by both the new Organization Sharing
page and the legacy Data Quality Rules admin page):

- The Tax Lot non-null-count computation **overwrote** the Property one instead of merging with
  it, so any org with Tax Lot views got almost no Property columns back at all. Verified live: an
  org with 131 populated Property fields returned just **1** column total from this endpoint
  before the fix.
- Non-null counts were merged into a single dict keyed only by `column_name`, so identically named
  columns on `PropertyState` and `TaxLotState` (e.g. `address_line_1`, `city`, `ubid`) could
  clobber each other's counts even after fixing the overwrite above.
- Also scoped the non-null check to the org's root access level instance instead of the requesting
  user's own (possibly narrower) one -- the docstring says it reports columns with data "for an
  org", and its two callers are both org-wide admin screens, not scoped to an AL branch.

Added a regression test (`test_used_columns_includes_property_fields_alongside_taxlot_fields`)
that fails against the old code and passes with the fix.

## Validation
- New backend test added and passing; ran the full `test_analyses_views`, `test_account_views`,
  `test_public_views`, and `test_columns` suites (110 tests) -- all pass, no regressions.
- Live-verified against this environment's real backend/data via Playwright: before the fix the
  Sharing page's field table showed only a handful of rows (backed by previously-shared fields,
  not `used_columns` itself); after the fix it correctly lists 131 Property + 1 Tax Lot fields,
  matching the org's actual populated columns, with no console errors.
- The submodule-side PR (#77 in `seed-angular`) has its own `pnpm lint` / `pnpm build` passes and
  was live-tested end-to-end via Playwright (save/reload, validation, permissions, dark mode,
  mobile, add-field autocomplete, public URL test buttons).

## Remaining risks
- The `seed-angular` PR (#77) is not yet merged; this submodule pointer references its branch tip
  commit. If that PR is amended further, this pointer will need another bump before merging here.
