### PR TITLE
Update agent documentation to ensure branching off develop, not main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,13 +33,13 @@ Django v6, and Postgres 18 upgrades) and is not a safe base for new work despite
   `main`: `gh repo view SEED-platform/seed --json defaultBranchRef` (or check
   `git remote show origin` under "HEAD branch"). As of this writing it is `develop`.
 - Always branch from an up-to-date `origin/develop` (`git fetch origin develop && git checkout -b
-  <branch> origin/develop`), not from a possibly-stale local `main`. A local `main` that hasn't
+<branch> origin/develop`), not from a possibly-stale local `main`. A local `main` that hasn't
   been pulled recently can be far behind without any error or warning — branching from it silently
   drags a huge, unrelated diff into your PR (e.g. files that look "deleted" simply because your
   stale base never had them).
 - After pushing, verify the PR actually landed with the base you expect and a minimal diff:
   `gh pr view <number> --json baseRefName,additions,deletions,changedFiles`. `gh pr create` targets
-  the repo's *default* branch automatically, which may silently differ from whatever local branch
+  the repo's _default_ branch automatically, which may silently differ from whatever local branch
   you happened to branch from.
 - This guidance is specific to **this** repo (`SEED-platform/seed`). The `ng_seed/seed-angular`
   submodule's default branch is `main` — verify independently there rather than assuming the same

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,28 @@ The end goal is to retire `seed/static/seed/` once every page has an equivalent 
 one to the other yet, so don't assume migrating a page's UI is enough to make it "live" — routing/
 cutover is a separate decision.
 
+## Git workflow — branch from `develop`, not `main`
+
+This repo's active integration branch is **`develop`** — that is where `main` is stale (it lags
+`develop` by hundreds of commits, e.g. it predates the `pyproject.toml` dependency migration,
+Django v6, and Postgres 18 upgrades) and is not a safe base for new work despite the name.
+
+- Before creating any branch or PR here, confirm the actual default branch rather than assuming
+  `main`: `gh repo view SEED-platform/seed --json defaultBranchRef` (or check
+  `git remote show origin` under "HEAD branch"). As of this writing it is `develop`.
+- Always branch from an up-to-date `origin/develop` (`git fetch origin develop && git checkout -b
+  <branch> origin/develop`), not from a possibly-stale local `main`. A local `main` that hasn't
+  been pulled recently can be far behind without any error or warning — branching from it silently
+  drags a huge, unrelated diff into your PR (e.g. files that look "deleted" simply because your
+  stale base never had them).
+- After pushing, verify the PR actually landed with the base you expect and a minimal diff:
+  `gh pr view <number> --json baseRefName,additions,deletions,changedFiles`. `gh pr create` targets
+  the repo's *default* branch automatically, which may silently differ from whatever local branch
+  you happened to branch from.
+- This guidance is specific to **this** repo (`SEED-platform/seed`). The `ng_seed/seed-angular`
+  submodule's default branch is `main` — verify independently there rather than assuming the same
+  convention applies, since the two repos can (and currently do) differ.
+
 ## Migration work
 
 If you're asked to migrate a page/feature from the legacy AngularJS app to the new Angular app:


### PR DESCRIPTION
## Summary
Documents a footgun discovered while working PR #5289 in this repo: an AI agent (or a human, for
that matter) can easily branch from a stale local `main` instead of the repo's actual active
integration branch, silently dragging a huge unrelated diff into a PR.

## What happened
- This repo's default/integration branch is **`develop`**, not `main`.
- `main` is a stale release snapshot, currently hundreds of commits behind `develop` (it predates
  the `pyproject.toml` dependency migration, the Django v6 upgrade, and the Postgres 18 upgrade).
- A PR was branched from local `main` while `gh pr create` (correctly) targeted `develop` as the
  base, so the resulting diff showed the entire `main`-vs-`develop` gap (e.g. `pyproject.toml`
  appearing "deleted") on top of the one intended line of change.

## Change
Adds a "Git workflow — branch from `develop`, not `main`" section to `AGENTS.md` with:
- How to confirm the actual default branch instead of assuming `main`.
- To always branch from an up-to-date `origin/develop`, not a possibly-stale local `main`.
- A post-push check (`gh pr view ... --json baseRefName,additions,deletions,changedFiles`) to
  confirm the PR base and diff size are what's expected.
- A note that this is specific to this repo — the `ng_seed/seed-angular` submodule's default
  branch is `main`, so the convention differs between the two repos.

No functional/code changes; documentation only.
