### PR TITLE
Stop embedding units in public feed values; add "<field>_units" sibling key

### DIFF
--- a/seed/tests/test_public_views.py
+++ b/seed/tests/test_public_views.py
@@ -98,6 +98,12 @@ class TestPublicViews(DataMappingBaseTestCase):
         assert len(data["properties"]) == 6
         assert len(data["taxlots"]) == 0
 
+        # pint-aware fields (e.g. gross_floor_area) should be unit-less numbers, with the units
+        # reported in a sibling "<field>_units" key instead of embedded in the value itself
+        for prop in data["properties"]:
+            assert isinstance(prop["gross_floor_area"], (int, float))
+            assert "foot" in prop["gross_floor_area_units"]
+
         url = reverse_lazy("api:v3:public-organizations-feed-html", args=[self.org.id])
         response = self.client.get(url, content_type="application/json")
         assert response.status_code == 200

--- a/seed/utils/public.py
+++ b/seed/utils/public.py
@@ -118,14 +118,19 @@ def _add_states_to_data(base_url, state_class, view_string, page, per_page, labe
                 value = getattr(state, name, None)
             else:
                 value = state.extra_data.get(name, None)
+            units = None
             if isinstance(value, pint.Quantity):
-                # convert pint to string with units (json cannot display exponents)
-                value = f"{value.m} {value.u}"
+                # keep the value unit-less (a plain number); put the units in a sibling
+                # "<name>_units" field instead of embedding them in the value itself
+                units = str(value.u)
+                value = value.m
             if isinstance(value, datetime.datetime):
                 # convert datetime to readable format
                 value = value.strftime("%Y/%m/%d, %H:%M:%S")
 
             state_data[name] = value
+            if units is not None:
+                state_data[f"{name}_units"] = units
 
         json_link = f"{base_url}api/v3/{'properties' if isinstance(state, PropertyState) else 'taxlots'}/{view.id}/?organization_id={view.cycle.organization.id}"
         html_link = f"{base_url}app/#/{'properties' if isinstance(state, PropertyState) else 'taxlots'}/{view.id}"

--- a/seed/utils/public.py
+++ b/seed/utils/public.py
@@ -122,8 +122,8 @@ def _add_states_to_data(base_url, state_class, view_string, page, per_page, labe
             if isinstance(value, pint.Quantity):
                 # keep the value unit-less (a plain number); put the units in a sibling
                 # "<name>_units" field instead of embedding them in the value itself
-                units = str(value.u)
-                value = value.m
+                units = str(value.units)
+                value = value.magnitude
             if isinstance(value, datetime.datetime):
                 # convert datetime to readable format
                 value = value.strftime("%Y/%m/%d, %H:%M:%S")


### PR DESCRIPTION
## Summary
The public feed (`/api/v3/public/organizations/{id}/feed.json` and `feed.html`) was embedding
units directly into pint-aware field values as a single string, e.g.:

```json
"site_eui": "87.3 kilobritish_thermal_unit / foot ** 2 / year"
```

This fixes it to leave the value as a plain, unit-less number and report the units in a new
sibling `"<field>_units"` key instead:

```json
"site_eui": 87.3,
"site_eui_units": "kilobritish_thermal_unit / foot ** 2 / year"
```

Applies to every pint-aware public field (`site_eui`, `source_eui`, `gross_floor_area`, GHG
fields, etc.) — anywhere `_add_states_to_data()` in `seed/utils/public.py` previously stringified
a `pint.Quantity` before adding it to the response.

## Files touched
- `seed/utils/public.py` — `_add_states_to_data()`: split the combined "value + unit" string into
  a unit-less numeric value plus a new `"<field>_units"` key.
- `seed/tests/test_public_views.py` — added assertions to `test_public_feed` covering the new
  shape for a pint-aware field (`gross_floor_area`).

## Validation
- New assertions confirmed to fail against the old code and pass with the fix.
- `python manage.py test seed.tests.test_public_views` — 2/2 pass.
- `ruff check` / `ruff format --check` on both changed files — clean.
- Live-verified against this environment's real backend/data: `feed.json` for a real org now
  returns `"site_eui": 87.3, "site_eui_units": "kilobritish_thermal_unit / foot ** 2 / year"`
  instead of the old combined string, with no console/response errors.

## Remaining risks
- This changes the public feed's response shape (new key, changed value type for pint fields) for
  any external consumer that was parsing the old combined string — flagging as a minor breaking
  change to the public API contract, even though the old format was arguably a bug (embedding
  units in a value meant for numeric consumption).
