### PR TITLE
Fix 404 on public feed/geojson URLs by disabling trailing slash

### DIFF
--- a/seed/api/v3/urls.py
+++ b/seed/api/v3/urls.py
@@ -188,7 +188,10 @@ property_measures_router.register(r"measures", PropertyMeasureViewSet, basename=
 taxlots_router = nested_routers.NestedSimpleRouter(api_v3_router, r"taxlots", lookup="taxlot")
 taxlots_router.register(r"notes", NoteViewSet, basename="taxlot-notes")
 
-public_organizations_router = routers.DefaultRouter()
+# Disable the trailing slash so the documented/shared public feed URLs (e.g.
+# "feed.json", "feed.html", "geo.json") resolve directly instead of 404ing and
+# relying on a 301 redirect to "feed.json/" etc.
+public_organizations_router = routers.DefaultRouter(trailing_slash=False)
 public_organizations_router.register(
     r"public/organizations",
     PublicOrganizationViewSet,


### PR DESCRIPTION
## What
Disables DRF's automatic trailing slash on the public organization router (`public_organizations_router`), which is inherited by the nested `public_cycles_router`.

## Why
The public feed endpoints are documented and shared with users as (no trailing slash):
- `/api/v3/public/organizations/{id}/feed.json`
- `/api/v3/public/organizations/{id}/feed.html`
- `/api/v3/public/organizations/{id}/cycles/{cycle_id}/geo.json`

But DRF's router appended a trailing slash by default, so the actual registered route was `feed.json/` (with a slash). Requesting the advertised URL without the slash resulted in a `Resolver404`, which Django's DEBUG technical-404 page rendered (surfacing noisy/harmless template-variable-resolution debug traces for `URLResolver` objects lacking a `.name` attribute), before `CommonMiddleware`'s `APPEND_SLASH` logic issued a 301 redirect to the correct slash-suffixed URL.

While browsers/API clients that follow redirects still eventually reached the endpoint, this:
- Added an unnecessary redirect round-trip on every request to a public, potentially externally-consumed feed URL.
- Broke clients that don't follow redirects (common for automated feed readers/integrations).
- Produced confusing 404/exception noise in logs for otherwise valid requests.

## Fix
Set `trailing_slash=False` on `public_organizations_router`. The nested `public_cycles_router` (built via `rest_framework_nested`) automatically inherits this setting from its parent router, so all three public endpoints now resolve directly without a redirect.

## Testing
- Confirmed via Django shell that `/api/v3/public/organizations/{id}/feed.json`, `feed.html`, and `.../geo.json` now return `200` directly (previously `404` requiring redirect).
- `reverse()` for `api:v3:public-organizations-feed-json`, `-feed-html`, and `-cycles-geojson` produce the correct slash-free URLs.
- Ran `seed.tests.test_public_views` — all existing tests pass unchanged (they use `reverse_lazy`, so they're agnostic to the trailing slash).