### PR TITLE
fix: consolidate gettext into main apk add to reduce network calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,7 @@ RUN apk add --no-cache \
         coreutils \
         gdal-dev \
         geos-dev \
+        gettext \
         git \
         libbz2 \
         libffi \
@@ -145,15 +146,13 @@ RUN git config --system --add safe.directory /seed
 COPY ./docker/nginx/*.conf /etc/nginx/
 COPY ./docker/nginx/nginx.conf.template /etc/nginx/nginx.conf.template
 
-# Install gettext temporarily for envsubst and then generate nginx.conf from the template.
-RUN apk add --no-cache --virtual .nginx-template-deps gettext && \
-    if [ -z "${NGINX_LISTEN_OPTS}" ]; then \
+# Generate nginx.conf from the template (gettext/envsubst installed above).
+RUN if [ -z "${NGINX_LISTEN_OPTS}" ]; then \
         echo "NGINX_LISTEN_OPTS is unset or empty, defaulting to: HTTP1.1"; \
     else \
         echo "NGINX_LISTEN_OPTS is set to: ${NGINX_LISTEN_OPTS}"; \
     fi && \
-    envsubst '${NGINX_LISTEN_OPTS}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && \
-    apk del .nginx-template-deps
+    envsubst '${NGINX_LISTEN_OPTS}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
 # symlink maintenance.html that nginx will serve in the case of a 503
 RUN ln -sf /seed/collected_static/maintenance.html /var/lib/nginx/html/maintenance.html && \


### PR DESCRIPTION
Move gettext from a separate `apk add --virtual` step into the main runtime apk add block. This eliminates a second network call to the Alpine CDN during Docker builds, reducing exposure to transient DNS failures in VPC-based CI environments (CodeBuild).

Previously, if the main apk add layer was cached but the gettext layer was not, a DNS failure would cause the build to fail even though all other packages were available. Now there is only one apk add layer to cache.

The tradeoff is gettext (~2MB) remains in the final image rather than being removed after use. This is negligible given the image already includes nginx, git, gdal, etc.