### PR TITLE
Fix default cycle creation when cycles already exist

### DIFF
--- a/seed/models/cycles.py
+++ b/seed/models/cycles.py
@@ -29,15 +29,14 @@ class Cycle(models.Model):
 
     @classmethod
     def get_or_create_default(cls, organization):
+        existing = Cycle.objects.filter(organization=organization).first()
+        if existing:
+            return existing
+
         year = date.today().year - 1
-        cycle_name = f"{year} Calendar Year"
-        cycle = Cycle.objects.filter(name=cycle_name, organization=organization).first()
-        if not cycle:
-            return Cycle.objects.create(
-                name=cycle_name,
-                organization=organization,
-                start=datetime(year, 1, 1, tzinfo=timezone.get_current_timezone()),
-                end=datetime(year + 1, 1, 1, tzinfo=timezone.get_current_timezone()),
-            )
-        else:
-            return cycle
+        return Cycle.objects.create(
+            name=f"{year} Calendar Year",
+            organization=organization,
+            start=datetime(year, 1, 1, tzinfo=timezone.get_current_timezone()),
+            end=datetime(year + 1, 1, 1, tzinfo=timezone.get_current_timezone()),
+        )

--- a/seed/tests/test_cycle.py
+++ b/seed/tests/test_cycle.py
@@ -3,9 +3,10 @@ SEED Platform (TM), Copyright (c) Alliance for Energy Innovation, LLC, and other
 See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 """
 
-from datetime import date
+from datetime import date, datetime
 
 from django.test import TestCase
+from django.utils import timezone
 
 from seed.lib.superperms.orgs.models import Organization
 from seed.models import Cycle
@@ -27,3 +28,31 @@ class TestCycle(TestCase):
 
         cycle = Cycle.get_or_create_default(self.org)
         self.assertEqual(self.org.cycles.count(), 1)
+
+    def test_default_cycle_not_recreated_when_other_cycles_exist(self):
+        """If a user deletes the default Calendar Year cycle and creates their
+        own, get_or_create_default should not recreate it."""
+        year = date.today().year - 1
+        default_name = f"{year} Calendar Year"
+
+        self.org = Organization.objects.create()
+        self.assertEqual(self.org.cycles.count(), 1)
+
+        # delete the auto-created default cycle
+        Cycle.objects.filter(name=default_name, organization=self.org).delete()
+        self.assertEqual(self.org.cycles.count(), 0)
+
+        # create a custom cycle covering the same year
+        Cycle.objects.create(
+            name=f"Reporting Period {year}",
+            organization=self.org,
+            start=datetime(year, 1, 1, tzinfo=timezone.get_current_timezone()),
+            end=datetime(year, 12, 31, tzinfo=timezone.get_current_timezone()),
+        )
+        self.assertEqual(self.org.cycles.count(), 1)
+
+        # get_or_create_default should return the existing cycle, not create a new one
+        result = Cycle.get_or_create_default(self.org)
+        self.assertEqual(self.org.cycles.count(), 1)
+        self.assertEqual(result.name, f"Reporting Period {year}")
+        self.assertFalse(Cycle.objects.filter(name=default_name, organization=self.org).exists())


### PR DESCRIPTION
Previously, on get_or_create_default cycle, the code would create a new cycle called "Calendar Year 2025" if that cycle didn't exist. But some organizations want to use different cycle names. 

Now: if there are no cycles, it will create this default Calendar Year 2025, otherwise it will return the latest cycle.

This fixes the issue of the calendar year 2025 cycle getting automatically recreated each time this function was called, even though a user might not want that cycle name.
