### PR TITLE
Add env variable to configure server to redirect to new UI vs old after Salesforce authentication

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -349,6 +349,11 @@ BETTER_HOST = os.environ.get("BETTER_HOST", "https://better.lbl.gov")
 # Audit Template Production Host
 AUDIT_TEMPLATE_HOST = os.environ.get("AUDIT_TEMPLATE_HOST", "https://buildingenergyscore.energy.gov")
 
+# Path appended to the site domain for the Salesforce OAuth callback. Unset means the
+# legacy AngularJS UI; set to "/ng-app/salesforce-login" to send a deployment to the Angular UI.
+# Must match a callback URL registered on the Salesforce external client app.
+SALESFORCE_REDIRECT_URI_ENDING = os.environ.get("SALESFORCE_REDIRECT_URI_ENDING")
+
 # Google reCAPTCHA env variable for self-registration. SITE_KEY defaults
 # to the key registered for SEED. Override it needing to test.
 # https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do

--- a/seed/tests/test_bb_salesforce.py
+++ b/seed/tests/test_bb_salesforce.py
@@ -69,9 +69,11 @@ class BBSalesforceViewSetTests(AccessLevelBaseTestCase):
 
     @responses.activate
     @override_settings(SALESFORCE_REDIRECT_URI_ENDING="/ng-app/salesforce-login")
-    def test_login_url_honors_redirect_uri_ending_override(self):
+    def test_login_url_and_get_token_honor_redirect_uri_ending_override(self):
         example_code_verifier = "example_code_verifier"
         example_code_challenge = "example_code_challenge"
+        example_code = "example code"
+
         responses.add(
             responses.GET,
             f"{self.salesforce_url}/oauth2/pkce/generator",
@@ -79,13 +81,42 @@ class BBSalesforceViewSetTests(AccessLevelBaseTestCase):
             status=200,
         )
 
-        url = reverse_lazy("api:v3:bb_salesforce-login-url") + "?organization_id=" + str(self.org.id)
-        response = self.client.get(url, content_type="application/json")
+        login_url = reverse_lazy("api:v3:bb_salesforce-login-url") + "?organization_id=" + str(self.org.id)
+        login_response = self.client.get(login_url, content_type="application/json")
 
-        assert response.status_code == 200
-        assert quote_plus("https://127.0.0.1:8000/ng-app/salesforce-login") in response.json()["url"]
-        assert quote_plus(REDIRECT_URI_ENDING) not in response.json()["url"]
+        assert login_response.status_code == 200
+        assert quote_plus("https://127.0.0.1:8000/ng-app/salesforce-login") in login_response.json()["url"]
+        assert quote_plus(REDIRECT_URI_ENDING) not in login_response.json()["url"]
+        assert get_cache_raw(f"code_verifier_{self.org.id}") == example_code_verifier
 
+        responses.add(
+            responses.POST,
+            f"{self.salesforce_url}/oauth2/token",
+            json={"access_token": "example access token"},
+            status=200,
+            match=[
+                matchers.query_param_matcher(
+                    {
+                        "grant_type": "authorization_code",
+                        "code": example_code,
+                        "client_id": self.org.bb_salesforce_config.client_id,
+                        "client_secret": self.org.bb_salesforce_config.client_secret,
+                        "redirect_uri": "https://127.0.0.1:8000/ng-app/salesforce-login",
+                        "code_verifier": example_code_verifier,
+                    }
+                )
+            ],
+        )
+
+        token_url = reverse_lazy("api:v3:bb_salesforce-get-token")
+        token_response = self.client.get(
+            token_url,
+            {"organization_id": str(self.org.id), "code": example_code},
+            content_type="application/json",
+        )
+
+        assert token_response.status_code == 200
+        assert get_cache_raw(f"access_token_{self.org.id}") == "example access token"
     def test_login_url_no_connection(self):
         # Set Up
         BBSalesforceConfig.objects.filter(organization=self.org).delete()

--- a/seed/tests/test_bb_salesforce.py
+++ b/seed/tests/test_bb_salesforce.py
@@ -6,6 +6,7 @@ See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 from urllib.parse import quote_plus
 
 import responses
+from django.test import override_settings
 from django.urls import reverse_lazy
 from responses import matchers
 
@@ -65,6 +66,25 @@ class BBSalesforceViewSetTests(AccessLevelBaseTestCase):
         )
 
         assert get_cache_raw(f"code_verifier_{self.org.id}") == example_code_verifier
+
+    @responses.activate
+    @override_settings(SALESFORCE_REDIRECT_URI_ENDING="/ng-app/salesforce-login")
+    def test_login_url_honors_redirect_uri_ending_override(self):
+        example_code_verifier = "example_code_verifier"
+        example_code_challenge = "example_code_challenge"
+        responses.add(
+            responses.GET,
+            f"{self.salesforce_url}/oauth2/pkce/generator",
+            json={"code_verifier": example_code_verifier, "code_challenge": example_code_challenge},
+            status=200,
+        )
+
+        url = reverse_lazy("api:v3:bb_salesforce-login-url") + "?organization_id=" + str(self.org.id)
+        response = self.client.get(url, content_type="application/json")
+
+        assert response.status_code == 200
+        assert quote_plus("https://127.0.0.1:8000/ng-app/salesforce-login") in response.json()["url"]
+        assert quote_plus(REDIRECT_URI_ENDING) not in response.json()["url"]
 
     def test_login_url_no_connection(self):
         # Set Up

--- a/seed/tests/test_bb_salesforce.py
+++ b/seed/tests/test_bb_salesforce.py
@@ -117,6 +117,7 @@ class BBSalesforceViewSetTests(AccessLevelBaseTestCase):
 
         assert token_response.status_code == 200
         assert get_cache_raw(f"access_token_{self.org.id}") == "example access token"
+
     def test_login_url_no_connection(self):
         # Set Up
         BBSalesforceConfig.objects.filter(organization=self.org).delete()

--- a/seed/views/v3/bb_salesforce.py
+++ b/seed/views/v3/bb_salesforce.py
@@ -44,9 +44,7 @@ def _get_redirect_uri_ending():
 
     # This setting is intended to be a path appended to the site domain, not a full URL.
     if "://" in ending:
-        logger.error(
-            "SALESFORCE_REDIRECT_URI_ENDING must be a path (e.g. /ng-app/salesforce-login); falling back to legacy UI"
-        )
+        logger.error("SALESFORCE_REDIRECT_URI_ENDING must be a path (e.g. /ng-app/salesforce-login); falling back to legacy UI")
         return REDIRECT_URI_ENDING
 
     if not ending.startswith("/"):

--- a/seed/views/v3/bb_salesforce.py
+++ b/seed/views/v3/bb_salesforce.py
@@ -36,7 +36,23 @@ def _get_redirect_uri_ending():
     URL on the Salesforce external client app, and must be identical for the authorize
     request and the token exchange.
     """
-    return getattr(settings, "SALESFORCE_REDIRECT_URI_ENDING", None) or REDIRECT_URI_ENDING
+    ending = getattr(settings, "SALESFORCE_REDIRECT_URI_ENDING", None)
+    if not ending:
+        return REDIRECT_URI_ENDING
+
+    ending = ending.strip()
+
+    # This setting is intended to be a path appended to the site domain, not a full URL.
+    if "://" in ending:
+        logger.error(
+            "SALESFORCE_REDIRECT_URI_ENDING must be a path (e.g. /ng-app/salesforce-login); falling back to legacy UI"
+        )
+        return REDIRECT_URI_ENDING
+
+    if not ending.startswith("/"):
+        ending = f"/{ending}"
+
+    return ending
 
 
 def _get_redirect_uri():

--- a/seed/views/v3/bb_salesforce.py
+++ b/seed/views/v3/bb_salesforce.py
@@ -6,6 +6,7 @@ See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 import logging
 
 import requests
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
@@ -25,6 +26,17 @@ from seed.utils.cache import get_cache_raw, set_cache_raw
 logger = logging.getLogger(__name__)
 
 REDIRECT_URI_ENDING = "/app/#/salesforce_login"
+
+
+def _get_redirect_uri_ending():
+    """Callback path for the Salesforce OAuth flow, defaulting to the legacy UI.
+
+    Deployments that prefer the Angular UI set SALESFORCE_REDIRECT_URI_ENDING to
+    "/ng-app/salesforce-login". Whatever this returns must be registered as a callback
+    URL on the Salesforce external client app, and must be identical for the authorize
+    request and the token exchange.
+    """
+    return getattr(settings, "SALESFORCE_REDIRECT_URI_ENDING", None) or REDIRECT_URI_ENDING
 
 
 def _get_redirect_uri():
@@ -93,14 +105,14 @@ class BBSalesforceViewSet(viewsets.ViewSet, OrgMixin):
             # will need to use ENV VAR to define the domain name b/c right now
             # it's coming in as the raw AWS domain
             redirect_uri = "https://dev1.seed-platform.org"
-        logger.warning(f"BB SALESFORCE REDIRECT URI: {redirect_uri + REDIRECT_URI_ENDING}")
+        logger.warning(f"BB SALESFORCE REDIRECT URI: {redirect_uri + _get_redirect_uri_ending()}")
 
         request = PreparedRequest()
         request.prepare_url(
             url=f"{bb_salesforce_config.salesforce_url}/oauth2/authorize",
             params={
                 "client_id": bb_salesforce_config.client_id,
-                "redirect_uri": redirect_uri + REDIRECT_URI_ENDING,
+                "redirect_uri": redirect_uri + _get_redirect_uri_ending(),
                 "response_type": "code",
                 "code_challenge": code_challenge,
             },
@@ -156,7 +168,7 @@ class BBSalesforceViewSet(viewsets.ViewSet, OrgMixin):
                 "code": code,
                 "client_id": bb_salesforce_config.client_id,
                 "client_secret": bb_salesforce_config.client_secret,
-                "redirect_uri": redirect_uri + REDIRECT_URI_ENDING,
+                "redirect_uri": redirect_uri + _get_redirect_uri_ending(),
                 "code_verifier": code_verifier,
             },
             headers={"accept": "application/json"},


### PR DESCRIPTION
Salesforce external client Apps use a redirect URL that must match both during the request from SEED and in the response from Salesforce.  The redirect path is slightly different in the old vs new UI. This PR allows us to configure which UI to prioritize during redirection via an environment variable. The default is the old UI, but if the environment variable SALESFORCE_REDIRECT_URI_ENDING is set to something else (e.g. /ng-app/salesforce-login for the new UI), then that value will override the default.